### PR TITLE
Add a 'mark hiatus' button to autohiatused threads

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -107,7 +107,11 @@ class Post < ActiveRecord::Base
   end
 
   def on_hiatus?
-    status == STATUS_HIATUS || (active? && tagged_at < 1.month.ago)
+    marked_hiatus? || (active? && tagged_at < 1.month.ago)
+  end
+
+  def marked_hiatus?
+    status == STATUS_HIATUS
   end
 
   def active?

--- a/app/views/posts/show.haml
+++ b/app/views/posts/show.haml
@@ -70,16 +70,19 @@
             %div
               = image_tag '/images/book.png'.freeze
               Mark Complete
-        - unless @post.on_hiatus?
+        - unless @post.marked_hiatus?
           = link_to post_path(@post, status: 'hiatus'.freeze), method: :put do
             %div
               = image_tag '/images/hourglass.png'.freeze
-              Put On Hiatus
+              Mark On Hiatus
         - unless @post.active?
           = link_to post_path(@post, status: 'active'.freeze), method: :put do
             %div
               = image_tag '/images/book_open.png'.freeze
-              Mark In Progress
+              - if @post.marked_hiatus?
+                Unmark Hiatus
+              - else
+                Mark In Progress
         - unless @post.abandoned?
           = link_to post_path(@post, status: 'abandoned'.freeze), method: :put do
             %div

--- a/app/views/posts/show.haml
+++ b/app/views/posts/show.haml
@@ -79,10 +79,7 @@
           = link_to post_path(@post, status: 'active'.freeze), method: :put do
             %div
               = image_tag '/images/book_open.png'.freeze
-              - if @post.marked_hiatus?
-                Unmark Hiatus
-              - else
-                Mark In Progress
+              Mark In Progress
         - unless @post.abandoned?
           = link_to post_path(@post, status: 'abandoned'.freeze), method: :put do
             %div

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -599,7 +599,7 @@ RSpec.describe PostsController do
 
             it "works for creator" do
               login_as(post.user)
-              expect(post.tagged_at).to eq(time)
+              expect(post.reload.tagged_at).to be_the_same_time_as(time)
               put :update, id: post.id, status: status
               expect(response).to redirect_to(post_url(post))
               expect(flash[:success]).to eq("Post has been marked #{status}.")
@@ -609,7 +609,7 @@ RSpec.describe PostsController do
 
             it "works for coauthor" do
               login_as(reply.user)
-              expect(post.tagged_at).to eq(time)
+              expect(post.reload.tagged_at).to be_the_same_time_as(time)
               put :update, id: post.id, status: status
               expect(response).to redirect_to(post_url(post))
               expect(flash[:success]).to eq("Post has been marked #{status}.")
@@ -619,7 +619,7 @@ RSpec.describe PostsController do
 
             it "works for admin" do
               login_as(create(:admin_user))
-              expect(post.tagged_at).to eq(time)
+              expect(post.reload.tagged_at).to be_the_same_time_as(time)
               put :update, id: post.id, status: status
               expect(response).to redirect_to(post_url(post))
               expect(flash[:success]).to eq("Post has been marked #{status}.")


### PR DESCRIPTION
It seems slightly obscure (or perhaps more than slightly obscure) if you're trying to remove a thread from your tags owed page – currently you have to mark it some non-active status, then mark it hiatus, as the "mark hiatus" button doesn't show up when it's technically active (and hence on your tags owed page) but automatically hiatus.

This also tries to keep the text clear – if the thread is explicitly marked on hiatus, marking it 'active' might not actually make it 'active' per se (if it's been more than a month since the latest reply), so if it's on hiatus, the text will show "Unmark Hiatus" instead of "Mark In Progress".

Fixes issue #88?