### PR TITLE
Add a paginator to the top of post lists

### DIFF
--- a/app/assets/stylesheets/layouts/dark.scss
+++ b/app/assets/stylesheets/layouts/dark.scss
@@ -57,6 +57,9 @@ a, a:visited, #content a, #content a:visited { color: #66997D; }
 .link-box { color: #DDDDDD; }
 #swap-icon, #swap-alias { opacity: 0.7; } /* make the white less contrasty */
 
+/* make the compact paginator less ugly */
+#content .paginator.paginator-compact { border-bottom: none; }
+
 /* Hovering help box on post editor */
 .ui-widget-content { background-color: #333; color: #A2A2A2; }
 .ui-widget.ui-widget-content { border-color: #444; }

--- a/app/assets/stylesheets/layouts/starry.css
+++ b/app/assets/stylesheets/layouts/starry.css
@@ -49,3 +49,6 @@ a:visited { color: #484357; }
 .pagination a { color: #F3F3F3; }
 .pagination a:visited { color: #9C9AA4; }
 .pagination .disabled { color: #58546B; }
+
+/* make the compact paginator less ugly */
+#content .paginator.paginator-compact { border-bottom: none; }

--- a/app/assets/stylesheets/layouts/starrydark.scss
+++ b/app/assets/stylesheets/layouts/starrydark.scss
@@ -45,6 +45,9 @@ body { background-color: #211E2F; color: $FONT_COLOR; }
 .pagination a:visited { color: #9C9AA4; }
 .pagination .disabled { color: #58546B; }
 
+/* make the compact paginator less ugly */
+#content .paginator.paginator-compact { border-bottom: none; }
+
 .post-character, .post-screenname { background-color: #111842; }
 
 #post-menu-box { background-color: #191919; }

--- a/app/assets/stylesheets/replies.css
+++ b/app/assets/stylesheets/replies.css
@@ -162,7 +162,7 @@ div.char-access-icon {
 .pagination .disabled { color: #101010; text-align: left; }
 .pagination a { color: #EEEEEE; }
 .pagination a:hover { background-color: #a3a1a0; }
-.pagination a:visited { color: #8B8687; }
+.pagination a:visited { color: #6b6567; }
 #content .paginator.paginator-compact { padding: 0; border-bottom: solid 1px rgba(96,96,96,0.3); }
 .paginator .left-align { vertical-align: middle; padding: 10px; }
 .paginator.paginator-compact a, .paginator.paginator-compact .current, .paginator.paginator-compact .disabled { padding: 5px 7px; }

--- a/app/assets/stylesheets/replies.css
+++ b/app/assets/stylesheets/replies.css
@@ -155,13 +155,17 @@ div.char-access-icon {
 }
 
 /* Pagination */
-.pagination { font-size: 14px; padding: 5px; display: inline-block; }
+.pagination, #content .paginator.paginator-compact { font-size: 14px; }
+.pagination { padding: 5px; display: inline-block; vertical-align: middle; }
 .pagination .current { font-weight: bold; font-style: normal; background: #3f7055; }
 .pagination a, .pagination .current, .pagination .disabled { display: inline-block; padding: 5px 10px; }
 .pagination .disabled { color: #101010; text-align: left; }
 .pagination a { color: #EEEEEE; }
 .pagination a:hover { background-color: #a3a1a0; }
 .pagination a:visited { color: #8B8687; }
+#content .paginator.paginator-compact { padding: 0; border-bottom: solid 1px rgba(128,128,128,0.3); /*border-top: solid 1px rgba(128,128,128,0.3); */}
+.paginator.paginator-compact .left-align { color: #101010; vertical-align: middle; padding: 10px; }
+.paginator.paginator-compact a, .paginator.paginator-compact .current, .paginator.paginator-compact .disabled { padding: 5px 7px; }
 .paginator .left-align { float: left; display: inline-block; padding: 10px; }
 .paginator .right-align { padding: 2px; padding-right: 10px; display: inline-block; float: right; }
 .paginator .right-align a { color: black; }

--- a/app/assets/stylesheets/replies.css
+++ b/app/assets/stylesheets/replies.css
@@ -163,8 +163,8 @@ div.char-access-icon {
 .pagination a { color: #EEEEEE; }
 .pagination a:hover { background-color: #a3a1a0; }
 .pagination a:visited { color: #8B8687; }
-#content .paginator.paginator-compact { padding: 0; border-bottom: solid 1px rgba(128,128,128,0.3); /*border-top: solid 1px rgba(128,128,128,0.3); */}
-.paginator.paginator-compact .left-align { color: #101010; vertical-align: middle; padding: 10px; }
+#content .paginator.paginator-compact { padding: 0; border-bottom: solid 1px rgba(96,96,96,0.3); }
+.paginator .left-align { vertical-align: middle; padding: 10px; }
 .paginator.paginator-compact a, .paginator.paginator-compact .current, .paginator.paginator-compact .disabled { padding: 5px 7px; }
 .paginator .left-align { float: left; display: inline-block; padding: 10px; }
 .paginator .right-align { padding: 2px; padding-right: 10px; display: inline-block; float: right; }

--- a/app/views/posts/_list.haml
+++ b/app/views/posts/_list.haml
@@ -16,6 +16,10 @@
       %tr
         %td.continuity-spacer{colspan: col_count}
     %tr
+      %th.sub{colspan: col_count, style: 'padding: 0;'}
+        - if posts.methods.include?(:total_pages) && posts.total_pages > 1
+          = render partial: 'posts/paginator', locals: { paginated: posts, path: (local_assigns[:path] || :posts_path), compact: true, hide_total: true }
+    %tr
       %th.sub.width-15
       %th.sub Thread
       - unless local_assigns[:hide_continuity]
@@ -36,4 +40,4 @@
   - if posts.methods.include?(:total_pages) && posts.total_pages > 1
     %tfoot
       %tr
-        %td{colspan: col_count}= render partial: 'posts/paginator', locals: { paginated: posts }
+        %td{colspan: col_count}= render partial: 'posts/paginator', locals: { paginated: posts, compact: true }

--- a/app/views/posts/_paginator.haml
+++ b/app/views/posts/_paginator.haml
@@ -1,8 +1,9 @@
-.paginator.centered.sub
+.paginator.centered.sub{class: (local_assigns[:compact] ? 'paginator-compact' : '')}
   - unless browser.device.mobile?
-    .left-align
-      Total:
-      %span.reply-count=paginated.total_entries
+    - unless local_assigns[:hide_total]
+      .left-align
+        Total:
+        %span.reply-count=paginated.total_entries
     .right-align
       - if paginated.klass == Reply && !local_assigns[:no_per]
         Posts Per Page:

--- a/app/views/posts/unread.haml
+++ b/app/views/posts/unread.haml
@@ -18,7 +18,7 @@
   - unless @posts.empty?
     %table
       %tr
-        %td.right-align.padding-5{colspan: 8, class: cycle('even', 'odd')}
+        %td.right-align.padding-5.sub{colspan: 8}
           = submit_tag "Hide from Unread", class: 'button'
           = submit_tag "Mark Read", class: 'button'
 %br
@@ -29,7 +29,7 @@
       %th Mark Entire Continuity
     %tr
       %td.even.padding-5.centered
-        = select_tag :board_id, 
+        = select_tag :board_id,
                      options_from_collection_for_select(Board.order('LOWER(name)'), :id, :name, params[:board_id]),
                      {class: 'chosen-select', prompt: '— Choose Continuity —'}
     %tr


### PR DESCRIPTION
* Add a paginator to the top of post-lists; make other style changes

* Fix styling with various themes and the new compact paginator

* Darken pagination visited links (on the default style)

Addresses part of #45, but should perhaps wait until layouts (#43) are properly implemented.