### PR TITLE
Improve the dropdowns and JS of the reply editor

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -133,7 +133,7 @@ $(document).ready(function() {
       var correctName = $("#character_alias option[value="+selectedAliasID+"]").text();
       $("#post-editor .post-character #name").html(correctName);
       $("#post-editor .post-character").data('alias-id', selectedAliasID);
-      $("#character_alias").val(selectedAliasID);
+      $("#character_alias").val(selectedAliasID).trigger("change.select2");
     }
   }
 
@@ -416,7 +416,7 @@ getAndSetCharacterData = function(characterId, options) {
       var correctName = $("#character_alias option[value="+selectedAliasID+"]").text();
       $("#post-editor .post-character #name").html(correctName);
       $("#post-editor .post-character").data('alias-id', selectedAliasID);
-      $("#character_alias").val(selectedAliasID);
+      $("#character_alias").val(selectedAliasID).trigger("change.select2");
     } else {
       $("#post-editor .post-character").data('alias-id', '');
       $("#character_alias").val('').trigger("change.select2");

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -120,7 +120,7 @@ $(document).ready(function() {
   var displayAliasID = $("#post-editor .post-character").data('alias-id');
   if (selectedCharID != displayCharID) {
     getAndSetCharacterData(selectedCharID, {restore_icon: true, restore_alias: true});
-    $("#active_character").val(selectedCharID).trigger("change");
+    $("#active_character").val(selectedCharID).trigger("change.select2");
   } else {
     if ($(".gallery-icon").length > 1) { /* Bind icon & gallery only if not resetting character, else it duplicate binds */
       bindIcon();

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -120,7 +120,7 @@ $(document).ready(function() {
   var displayAliasID = $("#post-editor .post-character").data('alias-id');
   if (selectedCharID != displayCharID) {
     getAndSetCharacterData(selectedCharID, {restore_icon: true, restore_alias: true});
-    $("#active_character").val(selectedCharID);
+    $("#active_character").val(selectedCharID).trigger("change");
   } else {
     if ($(".gallery-icon").length > 1) { /* Bind icon & gallery only if not resetting character, else it duplicate binds */
       bindIcon();
@@ -355,6 +355,7 @@ getAndSetCharacterData = function(characterId, options) {
       if (!restore_icon) setIcon(aid, url, keyword, keyword);
       $("#post-editor #post-author-spacer").show();
     } else {
+      if (!restore_icon) setIcon("");
       $("#post-editor #post-author-spacer").hide();
     }
     if (restore_icon) setIconFromId(selectedIconID);

--- a/app/concerns/writable.rb
+++ b/app/concerns/writable.rb
@@ -16,7 +16,7 @@ module Writable
       return user.avatar_id? unless character
       return true if character.default_icon
       return false unless character.galleries.present?
-      return character.galleries.includes(:icons).map(&:icons).flatten.present?
+      return character.icons.exists?
     end
 
     def editable_by?(editor)

--- a/app/concerns/writable.rb
+++ b/app/concerns/writable.rb
@@ -16,7 +16,7 @@ module Writable
       return user.avatar_id? unless character
       return true if character.default_icon
       return false unless character.galleries.present?
-      return character.galleries.map(&:icons).flatten.present?
+      return character.galleries.includes(:icons).map(&:icons).flatten.present?
     end
 
     def editable_by?(editor)

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -54,7 +54,7 @@ class GalleriesController < ApplicationController
           render json: {name: 'Galleryless', icons: user.try(:galleryless_icons) || []}
         else
           @gallery = Gallery.find_by_id(params[:id])
-          render json: {name: @gallery.name, icons: @gallery.icons.sort_by{|i| i.keyword.downcase }}
+          render json: {name: @gallery.name, icons: @gallery.icons}
         end
       end
       format.html do

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -6,7 +6,7 @@ class WritableController < ApplicationController
   def build_template_groups
     return unless logged_in?
 
-    templates = current_user.templates.includes(:characters).order('LOWER(name)')
+    templates = current_user.templates.includes(:ordered_characters).order('LOWER(name)')
     faked = Struct.new(:name, :id, :ordered_characters)
     templateless = faked.new('Templateless', nil, current_user.characters.where(:template_id => nil).to_a.sort_by(&:name))
     @templates = templates + [templateless]

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -74,13 +74,13 @@ class Character < ActiveRecord::Base
       v.each { |val| errors.add('group '+k.to_s, val) }
     end
   end
-  
+
   def valid_galleries
     if galleries.present? && galleries.detect{|g| g.user_id != user.id}
       errors.add(:galleries, "must be yours")
     end
   end
-  
+
   def valid_default_icon
     if default_icon.present? && default_icon.user_id != user_id
       errors.add(:default_icon, "must be yours")

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -1,8 +1,7 @@
 class Gallery < ActiveRecord::Base
   belongs_to :user
   belongs_to :cover_icon, class_name: Icon
-  has_and_belongs_to_many :icons, after_add: :set_has_gallery, after_remove: :unset_has_gallery
-  has_and_belongs_to_many :ordered_icons, after_add: :set_has_gallery, after_remove: :unset_has_gallery, order: 'LOWER(keyword)', class_name: Icon
+  has_and_belongs_to_many :icons, after_add: :set_has_gallery, after_remove: :unset_has_gallery, order: 'LOWER(keyword)'
 
   has_many :characters_galleries
   has_many :characters, through: :characters_galleries

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -1,7 +1,8 @@
 class Gallery < ActiveRecord::Base
   belongs_to :user
-  belongs_to :cover_icon, :class_name => Icon
+  belongs_to :cover_icon, class_name: Icon
   has_and_belongs_to_many :icons, after_add: :set_has_gallery, after_remove: :unset_has_gallery
+  has_and_belongs_to_many :ordered_icons, after_add: :set_has_gallery, after_remove: :unset_has_gallery, order: 'LOWER(keyword)', class_name: Icon
 
   has_many :characters_galleries
   has_many :characters, through: :characters_galleries

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -1,14 +1,11 @@
 class Template < ActiveRecord::Base
   belongs_to :user, inverse_of: :templates
   has_many :characters
+  has_many :ordered_characters, order: 'LOWER(name)', class_name: Character
 
   validates_presence_of :name
 
   before_destroy :clear_character_templates
-
-  def ordered_characters
-    characters.order('LOWER(name)')
-  end
 
   private
 

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -1,15 +1,14 @@
 class Template < ActiveRecord::Base
   belongs_to :user, inverse_of: :templates
-  has_many :characters
-  has_many :ordered_characters, order: 'LOWER(name)', class_name: Character
+  has_many :characters, order: 'LOWER(name) ASC'
 
   validates_presence_of :name
 
-  before_destroy :clear_character_templates
+  after_destroy :clear_character_templates
 
   private
 
   def clear_character_templates
-    characters.update_all(template_id: nil)
+    Character.where(template_id: id).update_all(template_id: nil)
   end
 end

--- a/app/presenters/character_presenter.rb
+++ b/app/presenters/character_presenter.rb
@@ -23,11 +23,11 @@ class CharacterPresenter
   end
 
   def multi_gallery_json
-    galleries = character.galleries.ordered.includes(:ordered_icons)
+    galleries = character.galleries.ordered.includes(:icons)
     galleries_json = galleries.map do |gallery|
       {
         name: gallery.name,
-        icons: gallery.ordered_icons
+        icons: gallery.icons
       }
     end
   end

--- a/app/presenters/character_presenter.rb
+++ b/app/presenters/character_presenter.rb
@@ -23,11 +23,11 @@ class CharacterPresenter
   end
 
   def multi_gallery_json
-    galleries = character.galleries.ordered.includes(:icons)
+    galleries = character.galleries.ordered.includes(:ordered_icons)
     galleries_json = galleries.map do |gallery|
       {
         name: gallery.name,
-        icons: gallery.icons.order('LOWER(keyword)')
+        icons: gallery.ordered_icons
       }
     end
   end

--- a/app/presenters/character_presenter.rb
+++ b/app/presenters/character_presenter.rb
@@ -34,7 +34,7 @@ class CharacterPresenter
 
   def single_gallery_json
     if character.galleries.present?
-      [{icons: character.galleries.map(&:icons).flatten.uniq.sort_by {|i| i.keyword}}]
+      [{icons: character.icons}]
     elsif character.icon.present?
       [{icons: [character.icon]}]
     else

--- a/app/views/characters/_editor.haml
+++ b/app/views/characters/_editor.haml
@@ -46,7 +46,7 @@
           %b.gallery-name= gallery.name
           %br
           .gallery-icons
-            - gallery.icons.order('LOWER(keyword)').each do |icon|
+            - gallery.icons.each do |icon|
               - klass = 'icon character-icon'
               - klass += ' selected-icon' if icon == @character.default_icon
               = icon_tag icon, class: klass, id: icon.id

--- a/app/views/galleries/_add_existing.haml
+++ b/app/views/galleries/_add_existing.haml
@@ -28,7 +28,7 @@
         %td.padding-5{class: cycle('even', 'odd')}
           %b= gallery.name
           %br
-          - gallery.icons.order('LOWER(keyword)').each do |icon|
+          - gallery.icons.each do |icon|
             = icon_tag icon, class: 'add-gallery-icon', :'data-id' => icon.id
     %tr
       %td.subber.centered.padding-5

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -22,8 +22,7 @@
   %td.green
     .gallery{id: "gallery#{gallery.id.to_s}"}
       = form_tag delete_multiple_icons_path, method: :delete do
-        - icons = gallery.icons.order('LOWER(keyword)')
-        - icons.each do |icon|
+        - gallery.icons.each do |icon|
           .gallery-icon
             = link_to icon_path(icon) do
               = icon_tag icon
@@ -31,7 +30,7 @@
               %span.icon-keyword= icon.keyword
             - if gallery.user_id == current_user.try(:id) and not defined? skip_forms
               .select-button= check_box_tag :"marked_ids[]", icon.id
-        - if icons.empty?
+        - if gallery.icons.empty?
           .centered.no-icons — No icons yet —
         - elsif gallery.user_id == current_user.try(:id) and not defined? skip_forms
           .clear.centered.icons-remove

--- a/app/views/galleries/edit.haml
+++ b/app/views/galleries/edit.haml
@@ -15,7 +15,7 @@
       %td.even{colspan: 2}= f.text_field :name, placeholder: "Gallery Name", class: 'text'
     %tr
       %th.subber{colspan: 3} Edit Icons
-    - @gallery.icons.order('LOWER(keyword)').each do |icon|
+    - @gallery.icons.each do |icon|
       = f.fields_for "icons_attributes[]", icon do |i|
         %tr
           %td.green.centered{rowspan: 3}

--- a/app/views/posts/_editor.haml
+++ b/app/views/posts/_editor.haml
@@ -1,4 +1,4 @@
-- character_galleries = item.character.galleries.includes(:ordered_icons).ordered if item.character && current_user.icon_picker_grouping? && item.character.galleries.count > 1
+- character_galleries = item.character.galleries.includes(:icons).ordered if item.character && current_user.icon_picker_grouping? && item.character.galleries.count > 1
 #post-editor.padding-10
   .post-info-box
     #current-icon-holder.post-icon
@@ -12,7 +12,7 @@
     #current-icon-dropdown
       - if item.character
         - if current_user.icon_picker_grouping? && item.character.galleries.count > 1
-          - icons = character_galleries.map(&:ordered_icons).flatten.map{|i| [i.keyword, i.id]}
+          - icons = character_galleries.map(&:icons).flatten.map{|i| [i.keyword, i.id]}
         - else
           - icons = item.character.icons.map{|i| [i.keyword, i.id]}
         - unless icons.present?
@@ -52,8 +52,7 @@
         - character_galleries.each do |gallery|
           .gallery-group
             .gallery-name= gallery.name
-            - gallery_icons = gallery.ordered_icons
-            - gallery_icons.each do |icon, icon_index|
+            - gallery.icons.each do |icon, icon_index|
               .gallery-icon
                 = icon_tag icon, id: icon.id, pointer: true
                 %br>

--- a/app/views/posts/_editor.haml
+++ b/app/views/posts/_editor.haml
@@ -1,4 +1,4 @@
-- character_galleries = item.character.galleries.includes(:icons).ordered if item.character && item.character.galleries.present?
+- character_galleries = item.character.galleries.includes(:icons).ordered if item.character && current_user.icon_picker_grouping? && item.character.galleries.count > 1
 #post-editor.padding-10
   .post-info-box
     #current-icon-holder.post-icon

--- a/app/views/posts/_editor.haml
+++ b/app/views/posts/_editor.haml
@@ -1,4 +1,4 @@
-- character_galleries = item.character.galleries.includes(:icons).ordered if item.character && current_user.icon_picker_grouping? && item.character.galleries.count > 1
+- character_galleries = item.character.galleries.includes(:ordered_icons).ordered if item.character && current_user.icon_picker_grouping? && item.character.galleries.count > 1
 #post-editor.padding-10
   .post-info-box
     #current-icon-holder.post-icon
@@ -12,7 +12,7 @@
     #current-icon-dropdown
       - if item.character
         - if current_user.icon_picker_grouping? && item.character.galleries.count > 1
-          - icons = character_galleries.map {|gallery| gallery.icons.order('LOWER(keyword)')}.flatten.map{|i| [i.keyword, i.id]}
+          - icons = character_galleries.map(&:ordered_icons).flatten.map{|i| [i.keyword, i.id]}
         - else
           - icons = item.character.icons.map{|i| [i.keyword, i.id]}
         - unless icons.present?
@@ -52,7 +52,7 @@
         - character_galleries.each do |gallery|
           .gallery-group
             .gallery-name= gallery.name
-            - gallery_icons = gallery.icons.order('LOWER(keyword)')
+            - gallery_icons = gallery.ordered_icons
             - gallery_icons.each do |icon, icon_index|
               .gallery-icon
                 = icon_tag icon, id: icon.id, pointer: true

--- a/app/views/posts/_editor.haml
+++ b/app/views/posts/_editor.haml
@@ -1,3 +1,4 @@
+- character_galleries = item.character.galleries.includes(:icons).ordered if item.character && item.character.galleries.present?
 #post-editor.padding-10
   .post-info-box
     #current-icon-holder.post-icon
@@ -10,7 +11,14 @@
       #icon-overlay
     #current-icon-dropdown
       - if item.character
-        = select_tag :icon_dropdown, options_for_select(item.character.icons.map{|i| [i.keyword, i.id]}, item.icon_id), prompt: "No Icon"
+        - if current_user.icon_picker_grouping? && item.character.galleries.count > 1
+          - icons = character_galleries.map {|gallery| gallery.icons.order('LOWER(keyword)')}.flatten.map{|i| [i.keyword, i.id]}
+        - else
+          - icons = item.character.icons.map{|i| [i.keyword, i.id]}
+        - unless icons.present?
+          - icon = item.character.icon
+          - icons = [[icon.keyword, icon.id]] unless icon.nil?
+        = select_tag :icon_dropdown, options_for_select(icons, item.icon_id), prompt: "No Icon"
       - elsif current_user.avatar
         = select_tag :icon_dropdown, options_for_select([[current_user.avatar.keyword, current_user.avatar.id]], current_user.avatar.id), prompt: "No Icon"
     .post-info-text
@@ -41,8 +49,7 @@
           = current_user.avatar.keyword
     - elsif item.character.galleries.present?
       - if current_user.icon_picker_grouping && item.character.galleries.count > 1
-        - galleries = item.character.galleries.includes(:icons).ordered
-        - galleries.each do |gallery|
+        - character_galleries.each do |gallery|
           .gallery-group
             .gallery-name= gallery.name
             - gallery_icons = gallery.icons.order('LOWER(keyword)')
@@ -52,7 +59,7 @@
                 %br>
                 = icon.keyword
       - else
-        - icons = item.character.galleries.map(&:icons).flatten.uniq.sort_by{|i| i.keyword.downcase }
+        - icons = item.character.icons
         - icons.each do |icon|
           .gallery-icon
             = icon_tag icon, id: icon.id, pointer: true

--- a/app/views/templates/_editor.haml
+++ b/app/views/templates/_editor.haml
@@ -8,7 +8,7 @@
   %th.sub.vtop Characters
   %td.even
     - unless @template.new_record?
-      - @template.characters.order('LOWER(name)').each do |char|
+      - @template.characters.each do |char|
         = check_box_tag "template[character_ids][]", char.id, true, id: "template_character_ids_#{char.id}"
         = label_tag "template_character_ids_#{char.id}", char.name
         %br

--- a/app/views/templates/show.haml
+++ b/app/views/templates/show.haml
@@ -32,7 +32,7 @@
   - if page_view == 'list'
     = render partial: 'characters/list_view'
   - else
-    = render partial: 'characters/icon_view', locals: {characters: @template.characters.order('name asc').includes(:default_icon)}
+    = render partial: 'characters/icon_view', locals: {characters: @template.characters.includes(:default_icon)}
 - if @posts.present?
   %br
   - content_for :posts_title do 'Posts with Template Instances' end


### PR DESCRIPTION
In the post/reply editor:

* On page load, when restoring a form (from Firefox saving), update the `active_character` dropdown to display the proper character.  
(Further commit to scope the change event to `select2`.)

* Display no icon if switching to an avatarless user account.  
(Previously the icon would not disappear if switching to a user with no icon.)

* Make the icon dropdown consistent between JS and HAML  
  * Order icons in the dropdown by gallery if `icon_picker_grouping?` – matches the JSON behavior when swapping to characters with many galleries.  
  * Display `character.icon` in the dropdown if there are no galleries – matches the JSON behavior when swapping to a character with no galleries but a default icon.

* Use `character.icons` in a few places where the HAML was mapping galleries to icons, then flattening them and sorting them – this is for speed and memory purposes.