### PR TITLE
Warn if trying to commit a reply with unread replies in the post

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,6 +88,16 @@ class ApplicationController < ActionController::Base
     redirect_to glowfic_url, status: :moved_permanently
   end
 
+  def post_or_reply_link(reply)
+    return unless reply.id.present?
+    if reply.is_a?(Reply)
+      reply_path(reply, anchor: "reply-#{reply.id}")
+    else
+      post_path(reply)
+    end
+  end
+  helper_method :post_or_reply_link
+
   def posts_from_relation(relation, no_tests=true, with_pagination=true)
     posts = relation
       .select('posts.*, boards.name as board_name, users.username as last_user_name')

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -101,9 +101,9 @@ class RepliesController < WritableController
     reply = Reply.new(params[:reply])
     reply.user = current_user
 
-    if reply.post.try(:first_unread_for, current_user) && !params[:reply_warned]
+    if reply.post.try(:first_unread_for, current_user) && !params[:unread_warned]
       # There are unreads and the user has not been warned.
-      params[:reply_warned] = true
+      params[:unread_warned] = true
       flash[:error] = "There are unread replies not shown here. (Click 'post' again if you wish to ignore this warning.)"
       preview(reply) and return
     end

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -100,6 +100,14 @@ class RepliesController < WritableController
 
     reply = Reply.new(params[:reply])
     reply.user = current_user
+
+    if reply.post.try(:first_unread_for, current_user) && !params[:reply_warned]
+      # There are unreads and the user has not been warned.
+      params[:reply_warned] = true
+      flash[:error] = "There are unread replies not shown here. (Click 'post' again if you wish to ignore this warning.)"
+      preview(reply) and return
+    end
+
     if reply.save
       flash[:success] = "Posted!"
       redirect_to reply_path(reply, anchor: "reply-#{reply.id}")

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -110,23 +110,6 @@ class WritableController < ApplicationController
     render 'posts/show'
   end
 
-  def reply_warning
-    return @reply_warning unless @reply_warning.nil?
-    unread_time = @post.last_read(current_user) || @post.board.last_read(current_user)
-    unread_reply = if unread_time
-      @post.replies.order('created_at asc').detect { |reply| unread_time < reply.created_at }
-    else
-      @post
-    end
-    unless unread_reply
-      @reply_warning = false
-      return @reply_warning
-    end
-    # Get unread_reply separately from @post.first_unread_for because that caches (and sometimes does "halfway down the page you just loaded" when we want 'first unread after the whole page has loaded')
-    @reply_warning = "Post has <a href=\"#{post_or_reply_link(unread_reply)}\" target=\"_blank\">unread replies</a>."
-  end
-  helper_method :reply_warning
-
   def display_warnings?
     return false if session[:ignore_warnings]
 

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -110,6 +110,23 @@ class WritableController < ApplicationController
     render 'posts/show'
   end
 
+  def reply_warning
+    return @reply_warning unless @reply_warning.nil?
+    unread_time = @post.last_read(current_user) || @post.board.last_read(current_user)
+    unread_reply = if unread_time
+      @post.replies.order('created_at asc').detect { |reply| unread_time < reply.created_at }
+    else
+      @post
+    end
+    unless unread_reply
+      @reply_warning = false
+      return @reply_warning
+    end
+    # Get unread_reply separately from @post.first_unread_for because that caches (and sometimes does "halfway down the page you just loaded" when we want 'first unread after the whole page has loaded')
+    @reply_warning = "Post has <a href=\"#{post_or_reply_link(unread_reply)}\" target=\"_blank\">unread replies</a>."
+  end
+  helper_method :reply_warning
+
   def display_warnings?
     return false if session[:ignore_warnings]
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,15 +107,6 @@ module ApplicationHelper
     options_for_select(time_displays, default)
   end
 
-  def post_or_reply_link(reply)
-    return unless reply.id.present?
-    if reply.is_a?(Reply)
-      reply_path(reply, anchor: "reply-#{reply.id}")
-    else
-      post_path(reply)
-    end
-  end
-
   def sanitize_post_description(desc)
     Sanitize.fragment(desc, elements: ['a'], attributes: {'a' => ['href']})
   end

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -1,0 +1,14 @@
+module WritableHelper
+  def unread_warning
+    return @unread_warning unless @unread_warning.nil?
+    # Get unread_reply separately from @post.first_unread_for because that caches (and sometimes does "halfway down the page you just loaded" when we want 'first unread after the whole page has loaded')
+    viewed_at = @post.last_read(current_user) || @post.board.last_read(current_user)
+    unread_reply = if viewed_at
+      @post.replies.where('created_at > ?', viewed_at).order('id asc').first
+    else
+      @post
+    end
+    return (@unread_warning = false) unless unread_reply
+    @unread_warning = content_tag :a, 'Post has unread replies', href: post_or_reply_link(unread_reply), class: 'unread-warning'
+  end
+end

--- a/app/views/posts/_write_reply.haml
+++ b/app/views/posts/_write_reply.haml
@@ -4,6 +4,10 @@
     .view-button#rtf{class: ('selected' if (params[:editor_mode] || current_user.default_editor) == 'rtf')} Rich Text
     .view-button#html{class: ('selected' if (params[:editor_mode] || current_user.default_editor) == 'html')} HTML
     %br
+    - if reply_warning
+      .reply-warning
+        = reply_warning.html_safe
+      = hidden_field_tag :reply_warned, true
     %br
     = f.hidden_field :post_id
     = f.hidden_field :character_id

--- a/app/views/posts/_write_reply.haml
+++ b/app/views/posts/_write_reply.haml
@@ -4,10 +4,9 @@
     .view-button#rtf{class: ('selected' if (params[:editor_mode] || current_user.default_editor) == 'rtf')} Rich Text
     .view-button#html{class: ('selected' if (params[:editor_mode] || current_user.default_editor) == 'html')} HTML
     %br
-    - if reply_warning
-      .reply-warning
-        = reply_warning.html_safe
-      = hidden_field_tag :reply_warned, true
+    - if unread_warning
+      = unread_warning
+      = hidden_field_tag :unread_warned, true
     %br
     = f.hidden_field :post_id
     = f.hidden_field :character_id

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe RepliesController do
       expect(flash[:error][:message]).to eq("Your post could not be saved because of the following problems:")
     end
 
-    it "requires post read if no reply_warned param" do
+    it "requires post read if no unread_warned param" do
       user_id = login
       reply_post = create(:post)
 
@@ -78,7 +78,7 @@ RSpec.describe RepliesController do
       expect(flash[:error]).to eq("There are unread replies not shown here. (Click 'post' again if you wish to ignore this warning.)")
     end
 
-    it "requires valid params if read and without a reply_warned param" do
+    it "requires valid params if read" do
       user = create(:user)
       login_as(user)
       character = create(:character)
@@ -91,14 +91,14 @@ RSpec.describe RepliesController do
       expect(flash[:error][:message]).to eq("Your post could not be saved because of the following problems:")
     end
 
-    it "requires valid params with a reply_warned param if not read" do
+    it "requires valid params with an unread_warned param if not read" do
       user = create(:user)
       login_as(user)
       character = create(:character)
       reply_post = create(:post)
 
       expect(character.user_id).not_to eq(user.id)
-      post :create, reply: {character_id: character.id, post_id: reply_post.id}, reply_warned: true
+      post :create, reply: {character_id: character.id, post_id: reply_post.id}, unread_warned: true
       expect(response).to redirect_to(post_url(reply_post))
       expect(flash[:error][:message]).to eq("Your post could not be saved because of the following problems:")
     end
@@ -118,13 +118,13 @@ RSpec.describe RepliesController do
       expect(flash[:success]).to eq("Posted!")
     end
 
-    it "saves a new reply successfully with a reply_warned param if not read" do
+    it "saves a new reply successfully with an unread_warned param if not read" do
       user = create(:user)
       login_as(user)
       reply_post = create(:post)
       expect(Reply.count).to eq(0)
 
-      post :create, reply: {post_id: reply_post.id}, reply_warned: true, content: 'test!'
+      post :create, reply: {post_id: reply_post.id}, unread_warned: true, content: 'test!'
 
       reply = Reply.first
       expect(reply).not_to be_nil


### PR DESCRIPTION
Squashed version of the previous improvement-warn-on-unread branch,
also rebased to fit onto master appropriately.

- Make post_or_reply_link into a controller method (with helper_method)
- Warn the user if they submit with unread replies
- Warn the user in the reply editor if there are unread replies
- Cache @reply_warning
- Add tests for this warning