### PR TITLE
API updates

### DIFF
--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -73,11 +73,11 @@ $(document).ready(function() {
 
 function displayGallery(new_id){
   $.get('/galleries/'+new_id, function (resp) {
-    html_string = "<div id='gallery"+new_id+"' data-id='"+new_id+"'><br /><b class='gallery-name'>"+resp['name']+"</b><br /><div class='gallery-icons'>";
-    for(var i = 0; i < resp['icons'].length; i++) {
-      var url = resp['icons'][i]['url'];
-      var keyword = resp['icons'][i]['keyword'];
-      var id = resp['icons'][i]['id'];
+    html_string = "<div id='gallery"+new_id+"' data-id='"+new_id+"'><br /><b class='gallery-name'>"+resp.name+"</b><br /><div class='gallery-icons'>";
+    for(var i = 0; i < resp.icons.length; i++) {
+      var url = resp.icons[i].url;
+      var keyword = resp.icons[i].keyword;
+      var id = resp.icons[i].id;
       html_string += '<img src="'+url+'" alt="'+keyword+'" title="'+keyword+'" class="icon character-icon" id="'+id+'" />';
     }
     html_string += "</div>";

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -235,7 +235,7 @@ bindIcon = function() {
 
 galleryString = function(gallery, multiGallery) {
   var iconsString = "";
-  var icons = gallery["icons"];
+  var icons = gallery.icons;
 
   for (var i=0; i<icons.length; i++) {
     iconsString += iconString(icons[i]);
@@ -243,16 +243,16 @@ galleryString = function(gallery, multiGallery) {
 
   if(!multiGallery) { return iconsString; }
 
-  var nameString = "<div class='gallery-name'>" + gallery['name'] + "</div>"
+  var nameString = "<div class='gallery-name'>" + gallery.name + "</div>"
   return "<div class='gallery-group'>" + nameString + iconsString + "</div>"
 };
 
 iconString = function(icon) {
-  var img_id = icon["id"];
-  var img_url = icon["url"];
-  var img_key = icon["keyword"];
+  var img_id = icon.id;
+  var img_url = icon.url;
+  var img_key = icon.keyword;
 
-  if (!icon['skip_dropdown']) $("#icon_dropdown").append($("<option>").attr({value: img_id}).append(img_key));
+  if (!icon.skip_dropdown) $("#icon_dropdown").append($("<option>").attr({value: img_id}).append(img_key));
   var icon_img = $("<img>").attr({src: img_url, id: img_id, alt: img_key, title: img_key, 'class': 'icon'});
   return $("<div>").attr('class', 'gallery-icon').append(icon_img).append("<br />").append(img_key)[0].outerHTML;
 };
@@ -292,8 +292,9 @@ setupTinyMCE = function() {
 getAndSetCharacterData = function(characterId, options) {
   var restore_icon = false;
   if (typeof options != 'undefined') {
-    if (options['restore_icon']) restore_icon = options['restore_icon'];
+    restore_icon = options.restore_icon;
   }
+
   // Handle page interactions
   var selectedIconID = $("#reply_icon_id").val();
   $("#character-selector").hide();
@@ -328,15 +329,15 @@ getAndSetCharacterData = function(characterId, options) {
   $.get('/api/v1/characters/' + characterId, {}, function (resp) {
     // Display the correct name/screenname fields
     $("#post-editor #post-author-spacer").hide();
-    $("#post-editor .post-character").show().html(resp['name']).data('character-id', characterId);
-    if(resp['screenname'] == undefined) {
+    $("#post-editor .post-character").show().html(resp.name).data('character-id', characterId);
+    if(resp.screenname == undefined) {
       $("#post-editor .post-screenname").hide();
     } else {
-      $("#post-editor .post-screenname").show().html(resp['screenname']);
+      $("#post-editor .post-screenname").show().html(resp.screenname);
     }
 
     // Display no icon if no default set
-    if (resp['default'] == undefined) {
+    if (resp.default == undefined) {
       $("#current-icon").removeClass('pointer');
       setIcon('');
       return;
@@ -347,11 +348,9 @@ getAndSetCharacterData = function(characterId, options) {
 
     // Calculate new galleries
     $("#gallery").html("");
-    var galleries = resp['galleries'];
-    var multiGallery = galleries.length > 1;
-    for(var i=0; i<galleries.length; i++) {
-      var gallery = galleries[i];
-      $("#gallery").append(galleryString(gallery, multiGallery));
+    var multiGallery = resp.galleries.length > 1;
+    for(var i = 0; i < resp.galleries.length; i++) {
+      $("#gallery").append(galleryString(resp.galleries[i], multiGallery));
     }
 
     $("#gallery").append(iconString({id: '', url: '/images/no-icon.png', keyword: 'No Icon', skip_dropdown: true}));
@@ -360,7 +359,7 @@ getAndSetCharacterData = function(characterId, options) {
     if (restore_icon)
       setIconFromId(selectedIconID);
     else
-      setIcon(resp['default']['id'], resp['default']['url'], resp['default']['keyword'], resp['default']['keyword']);
+      setIcon(resp.default.id, resp.default.url, resp.default.keyword, resp.default.keyword);
   }, 'json');
 };
 
@@ -397,12 +396,12 @@ setIcon = function(id, url, title, alt) {
 setSections = function() {
   var board_id = $("#post_board_id").val();
   $.get("/api/v1/boards/"+board_id, {}, function(resp) {
-    var sections = resp['board_sections'];
+    var sections = resp.board_sections;
     if (sections.length > 0) {
       $("#section").show();
       $("#post_section_id").empty().append('<option value="">— Choose Section —</option>');
       for(var i = 0; i < sections.length; i++) {
-        $("#post_section_id").append('<option value="'+sections[i]['id']+'">'+sections[i]['name']+'</option>');
+        $("#post_section_id").append('<option value="'+sections[i].id+'">'+sections[i].name+'</option>');
       }
       $("#post_section_id").trigger("change");
     } else {

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -326,19 +326,17 @@ getAndSetCharacterData = function(characterId, options) {
   }
 
   $.get('/api/v1/characters/' + characterId, {}, function (resp) {
-    var character = resp['data'];
-
     // Display the correct name/screenname fields
     $("#post-editor #post-author-spacer").hide();
-    $("#post-editor .post-character").show().html(character['name']).data('character-id', characterId);
-    if(character['screenname'] == undefined) {
+    $("#post-editor .post-character").show().html(resp['name']).data('character-id', characterId);
+    if(resp['screenname'] == undefined) {
       $("#post-editor .post-screenname").hide();
     } else {
-      $("#post-editor .post-screenname").show().html(character['screenname']);
+      $("#post-editor .post-screenname").show().html(resp['screenname']);
     }
 
     // Display no icon if no default set
-    if (character['default'] == undefined) {
+    if (resp['default'] == undefined) {
       $("#current-icon").removeClass('pointer');
       setIcon('');
       return;
@@ -349,7 +347,7 @@ getAndSetCharacterData = function(characterId, options) {
 
     // Calculate new galleries
     $("#gallery").html("");
-    var galleries = character['galleries'];
+    var galleries = resp['galleries'];
     var multiGallery = galleries.length > 1;
     for(var i=0; i<galleries.length; i++) {
       var gallery = galleries[i];
@@ -362,7 +360,7 @@ getAndSetCharacterData = function(characterId, options) {
     if (restore_icon)
       setIconFromId(selectedIconID);
     else
-      setIcon(character['default']['id'], character['default']['url'], character['default']['keyword'], character['default']['keyword']);
+      setIcon(resp['default']['id'], resp['default']['url'], resp['default']['keyword'], resp['default']['keyword']);
   }, 'json');
 };
 
@@ -399,7 +397,7 @@ setIcon = function(id, url, title, alt) {
 setSections = function() {
   var board_id = $("#post_board_id").val();
   $.get("/api/v1/boards/"+board_id, {}, function(resp) {
-    var sections = resp['data']['board_sections'];
+    var sections = resp['board_sections'];
     if (sections.length > 0) {
       $("#section").show();
       $("#post_section_id").empty().append('<option value="">— Choose Section —</option>');

--- a/app/assets/javascripts/users/new.js
+++ b/app/assets/javascripts/users/new.js
@@ -46,7 +46,7 @@ validateUsername = function() {
   }
 
   $.post('/users/username', {'username':username}, function(resp) {
-    if(!resp['username_free']){
+    if(!resp.username_free){
       addAlertAfter('user_username', 'That username has already been taken.');
       return false;
     }

--- a/app/controllers/api/v1/board_sections_controller.rb
+++ b/app/controllers/api/v1/board_sections_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::BoardSectionsController < Api::ApiController
     description 'Viewing and editing subcontinuities'
   end
 
-  api :POST, '/board_sections/reorder', 'Update the order of subcontinuities (or, confusingly, posts). This may be moved or renamed and should not be trusted.'
+  api! 'Update the order of subcontinuities (or, confusingly, posts). This may be moved or renamed and should not be trusted.'
   error 401, "You must be logged in"
   param :changes, Hash do
     param :section_id, Hash do

--- a/app/controllers/api/v1/boards_controller.rb
+++ b/app/controllers/api/v1/boards_controller.rb
@@ -4,11 +4,11 @@ class Api::V1::BoardsController < Api::ApiController
     description 'Viewing and editing continuities'
   end
 
-  api :GET, '/boards/:id', 'Load a single continuity as a JSON resource.'
+  api! 'Load a single continuity as a JSON resource.'
   param :id, :number, required: true, desc: 'Continuity ID'
   error 404, "Continuity not found"
   example "'errors': [{'message': 'Continuity could not be found.'}]"
-  example "'data': {
+  example "{
   'id': 1,
   'name': 'Continuity',
   'board_sections': [{
@@ -27,6 +27,6 @@ class Api::V1::BoardsController < Api::ApiController
       render json: {errors: [error]}, status: :not_found and return
     end
 
-    render json: {data: board.as_json(include: [:board_sections])}
+    render json: board.as_json(include: [:board_sections])
   end
 end

--- a/app/controllers/api/v1/characters_controller.rb
+++ b/app/controllers/api/v1/characters_controller.rb
@@ -7,11 +7,11 @@ class Api::V1::CharactersController < Api::ApiController
     description 'Viewing and editing characters'
   end
 
-  api :GET, '/characters/:id', 'Load a single character as a JSON resource'
+  api! 'Load a single character as a JSON resource'
   param :id, :number, required: true, desc: 'Character ID'
   error 404, "Character not found"
   example "'errors': [{'message': 'Character could not be found.'}]"
-  example "'data': {
+  example "{
   'id': 1,
   'name': 'Character Example',
   'screenname': 'char-example',
@@ -39,10 +39,10 @@ class Api::V1::CharactersController < Api::ApiController
   }]
 }"
   def show
-    render json: {data: @character.as_json(include: [:galleries, :default])}
+    render json: @character.as_json(include: [:galleries, :default])
   end
 
-  api :PUT, '/characters/:id', 'Update a given character'
+  api! 'Update a given character'
   param :id, :number, required: true, desc: 'Character ID'
   error 401, "You must be logged in"
   error 403, "Character is not editable by the user"
@@ -52,7 +52,7 @@ class Api::V1::CharactersController < Api::ApiController
   example "'errors': [{'message': 'You do not have permission to perform this action.'}]"
   example "'errors': [{'message': 'Character could not be found.'}]"
   example "'errors': [{'message': \"Name can't be blank\"}, {'message': 'Default icon could not be found'}]"
-  example "'data': {
+  example "{
   'id': 1,
   'name': 'Character Example',
   'screenname': 'char-example',
@@ -75,7 +75,7 @@ class Api::V1::CharactersController < Api::ApiController
     render json: {errors: errors}, status: :unprocessable_entity and return unless errors.empty?
 
     @character.save
-    render json: {data: @character.as_json(include: [:default])}
+    render json: @character.as_json(include: [:default])
   end
 
   private

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -5,8 +5,6 @@ class Api::V1::PostsController < Api::ApiController
 
   api! 'Load a single post as a JSON resource'
   param :id, :number, required: true, desc: "Post ID"
-  param :page, :number, required: false, desc: 'Page in results'
-  param :per_page, :number, required: false, desc: 'Number of replies to load per page. Defaults to 25, accepts values from 1-100 inclusive.'
   error 403, "Post is not visible to the user"
   error 404, "Post not found"
   example "'errors': [{'message': 'Post could not be found.'}]"

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -38,34 +38,11 @@ class Api::V1::PostsController < Api::ApiController
     'name': 'Character Example',
     'screenname': 'char-example'
   },
-  'icon': null,
-  'replies': [{
-    'id': 1,
-    'content': 'dolor sit amet',
-    'created_at': '2000-01-07T01:05:03Z',
-    'updated_at': '2000-01-07T01:05:03Z',
-    'character': null,
-    'icon': null,
-    'user': {
-      'id': 2,
-      'username': 'Marri2'
-    }
-  }, {
-    'id': 2,
-    'content': 'consectetur adipiscing elit',
-    'created_at': '2000-01-08T01:02:03Z',
-    'updated_at': '2000-01-08T01:02:03Z',
-    'character': null,
-    'icon': {
-      'id': 7,
-      'url': 'http://www.example.com/image.png',
-      'keyword': 'icon'
-    },
-    'user': {
-      'id': 1,
-      'username': 'Marri1'
-    }
-  }],
+  'icon': {
+    'id': 4,
+    'url': 'http://www.example.com/image.png',
+    'keyword': 'icon'
+  }
 }"
   def show
     unless post = Post.find_by_id(params[:id])
@@ -74,13 +51,6 @@ class Api::V1::PostsController < Api::ApiController
     end
 
     access_denied and return unless post.visible_to?(current_user)
-
-    replies = paginate(post.replies
-      .select('replies.*, characters.name AS character_name, characters.screenname AS character_screenname, icons.keyword, icons.url, users.username')
-      .joins(:user)
-      .joins("LEFT OUTER JOIN characters ON characters.id = replies.character_id")
-      .joins("LEFT OUTER JOIN icons ON icons.id = replies.icon_id")
-      .order('id asc'), per_page: per_page)
-    render json: post.as_json(replies: replies)
+    render json: post
   end
 end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::PostsController < Api::ApiController
     description 'Viewing and editing posts'
   end
 
-  api :GET, '/posts/:id', 'Load a single post as a JSON resource'
+  api! 'Load a single post as a JSON resource'
   param :id, :number, required: true, desc: "Post ID"
   param :page, :number, required: false, desc: 'Page in results'
   param :per_page, :number, required: false, desc: 'Number of replies to load per page. Defaults to 25, accepts values from 1-100 inclusive.'
@@ -11,7 +11,7 @@ class Api::V1::PostsController < Api::ApiController
   error 404, "Post not found"
   example "'errors': [{'message': 'Post could not be found.'}]"
   example "'errors': [{'message': 'You do not have permission to perform this action.'}]"
-  example "'data': {
+  example "{
   'id': 1,
   'user': {
     'id': 1,
@@ -81,6 +81,6 @@ class Api::V1::PostsController < Api::ApiController
       .joins("LEFT OUTER JOIN characters ON characters.id = replies.character_id")
       .joins("LEFT OUTER JOIN icons ON icons.id = replies.icon_id")
       .order('id asc'), per_page: per_page)
-    render json: {data: post.as_json(replies: replies)}
+    render json: post.as_json(replies: replies)
   end
 end

--- a/app/controllers/api/v1/replies_controller.rb
+++ b/app/controllers/api/v1/replies_controller.rb
@@ -1,0 +1,59 @@
+class Api::V1::RepliesController < Api::ApiController
+  resource_description do
+    description 'Viewing replies to a post'
+  end
+
+  api! 'Load all the replies for a given post as JSON resources'
+  param :post_id, :number, required: true, desc: "Post ID"
+  param :page, :number, required: false, desc: 'Page in results'
+  param :per_page, :number, required: false, desc: 'Number of replies to load per page. Defaults to 25, accepts values from 1-100 inclusive.'
+  error 403, "Post is not visible to the user"
+  error 404, "Post not found"
+  example "'errors': [{'message': 'Post could not be found.'}]"
+  example "'errors': [{'message': 'You do not have permission to perform this action.'}]"
+  example "[
+  {
+    'id': 1,
+    'content': 'dolor sit amet',
+    'created_at': '2000-01-07T01:05:03Z',
+    'updated_at': '2000-01-07T01:05:03Z',
+    'character': null,
+    'icon': null,
+    'user': {
+      'id': 2,
+      'username': 'Marri2'
+    }
+  }, {
+    'id': 2,
+    'content': 'consectetur adipiscing elit',
+    'created_at': '2000-01-08T01:02:03Z',
+    'updated_at': '2000-01-08T01:02:03Z',
+    'character': null,
+    'icon': {
+      'id': 7,
+      'url': 'http://www.example.com/image.png',
+      'keyword': 'icon'
+    },
+    'user': {
+      'id': 1,
+      'username': 'Marri1'
+    }
+  }
+]"
+  def index
+    unless post = Post.find_by_id(params[:post_id])
+      error = {message: "Post could not be found."}
+      render json: {errors: [error]}, status: :not_found and return
+    end
+
+    access_denied and return unless post.visible_to?(current_user)
+
+    replies = post.replies
+      .select('replies.*, characters.name, characters.screenname, icons.keyword, icons.url, users.username')
+      .joins(:user)
+      .joins("LEFT OUTER JOIN characters ON characters.id = replies.character_id")
+      .joins("LEFT OUTER JOIN icons ON icons.id = replies.icon_id")
+      .order('id asc')
+    paginate json: replies, per_page: per_page
+  end
+end

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -15,7 +15,6 @@ class PostPresenter
       section: post.section,
       user: post.user,
       character: post.character,
-      icon: post.icon,
-      replies: options[:replies] || post.replies.order('id asc') })
+      icon: post.icon})
   end
 end

--- a/app/presenters/reply_presenter.rb
+++ b/app/presenters/reply_presenter.rb
@@ -19,8 +19,8 @@ class ReplyPresenter
   def character(reply)
     return unless reply.character_id
     { id: reply.character_id,
-      name: reply.character_name,
-      screenname: reply.character_screenname }
+      name: reply.name,
+      screenname: reply.screenname }
   end
 
   def icon(reply)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,9 @@ Rails.application.routes.draw do
         collection { post :reorder }
       end
       resources :characters, only: [:show, :update]
-      resources :posts, only: :show
+      resources :posts, only: :show do
+        resources :replies, only: :index
+      end
     end
   end
 

--- a/spec/controllers/api/v1/boards_controller_spec.rb
+++ b/spec/controllers/api/v1/boards_controller_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe Api::V1::BoardsController do
       section2 = create(:board_section, board: board)
       get :show, id: board.id
       expect(response).to have_http_status(200)
-      expect(response.json['data']['id']).to eq(board.id)
-      expect(response.json['data']['board_sections'].size).to eq(2)
-      expect(response.json['data']['board_sections'][0]['id']).to eq(section1.id)
-      expect(response.json['data']['board_sections'][1]['id']).to eq(section2.id)
+      expect(response.json['id']).to eq(board.id)
+      expect(response.json['board_sections'].size).to eq(2)
+      expect(response.json['board_sections'][0]['id']).to eq(section1.id)
+      expect(response.json['board_sections'][1]['id']).to eq(section2.id)
     end
 
     it "succeeds for logged in users with valid board" do
@@ -28,10 +28,10 @@ RSpec.describe Api::V1::BoardsController do
       section2 = create(:board_section, board: board)
       get :show, id: board.id
       expect(response).to have_http_status(200)
-      expect(response.json['data']['id']).to eq(board.id)
-      expect(response.json['data']['board_sections'].size).to eq(2)
-      expect(response.json['data']['board_sections'][0]['id']).to eq(section1.id)
-      expect(response.json['data']['board_sections'][1]['id']).to eq(section2.id)
+      expect(response.json['id']).to eq(board.id)
+      expect(response.json['board_sections'].size).to eq(2)
+      expect(response.json['board_sections'][0]['id']).to eq(section1.id)
+      expect(response.json['board_sections'][1]['id']).to eq(section2.id)
     end
 
     it "orders sections by section_order" do
@@ -44,12 +44,12 @@ RSpec.describe Api::V1::BoardsController do
       section2.save
       get :show, id: board.id
       expect(response).to have_http_status(200)
-      expect(response.json['data']['id']).to eq(board.id)
-      expect(response.json['data']['board_sections'].size).to eq(2)
-      expect(response.json['data']['board_sections'][0]['id']).to eq(section2.id)
-      expect(response.json['data']['board_sections'][0]['order']).to eq(0)
-      expect(response.json['data']['board_sections'][1]['id']).to eq(section1.id)
-      expect(response.json['data']['board_sections'][1]['order']).to eq(1)
+      expect(response.json['id']).to eq(board.id)
+      expect(response.json['board_sections'].size).to eq(2)
+      expect(response.json['board_sections'][0]['id']).to eq(section2.id)
+      expect(response.json['board_sections'][0]['order']).to eq(0)
+      expect(response.json['board_sections'][1]['id']).to eq(section1.id)
+      expect(response.json['board_sections'][1]['order']).to eq(1)
     end
   end
 end

--- a/spec/controllers/api/v1/characters_controller_spec.rb
+++ b/spec/controllers/api/v1/characters_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::CharactersController do
       character = create(:character)
       get :show, id: character.id
       expect(response).to have_http_status(200)
-      expect(response.json['data']['name']).to eq(character.name)
+      expect(response.json['name']).to eq(character.name)
     end
 
     it "succeeds for logged in users with valid character" do
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::CharactersController do
       login
       get :show, id: character.id
       expect(response).to have_http_status(200)
-      expect(response.json['data']['name']).to eq(character.name)
+      expect(response.json['name']).to eq(character.name)
     end
 
     it "has single gallery when present" do
@@ -29,7 +29,7 @@ RSpec.describe Api::V1::CharactersController do
       character.galleries << create(:gallery, user: character.user)
       get :show, id: character.id
       expect(response).to have_http_status(200)
-      expect(response.json['data']['galleries'].size).to eq(1)
+      expect(response.json['galleries'].size).to eq(1)
     end
 
     it "has single gallery when icon present" do
@@ -38,7 +38,7 @@ RSpec.describe Api::V1::CharactersController do
       character.save
       get :show, id: character.id
       expect(response).to have_http_status(200)
-      expect(response.json['data']['galleries'].size).to eq(1)
+      expect(response.json['galleries'].size).to eq(1)
     end
 
     it "has galleries when present" do
@@ -47,7 +47,7 @@ RSpec.describe Api::V1::CharactersController do
       character.galleries << create(:gallery, user: character.user, icon_count: 1)
       get :show, id: character.id
       expect(response).to have_http_status(200)
-      expect(response.json['data']['galleries'].size).to eq(2)
+      expect(response.json['galleries'].size).to eq(2)
     end
 
     it "has galleries when icon_picker_grouping is false" do
@@ -58,7 +58,7 @@ RSpec.describe Api::V1::CharactersController do
       login_as(user)
       get :show, id: character.id
       expect(response).to have_http_status(200)
-      expect(response.json['data']['galleries'].size).to eq(1)
+      expect(response.json['galleries'].size).to eq(1)
     end
   end
 
@@ -110,7 +110,7 @@ RSpec.describe Api::V1::CharactersController do
       login_as(character.user)
       put :update, id: character.id, character: {default_icon_id: ''}
       expect(response.status).to eq(200)
-      expect(response.json['data']['name']).to eq(character.name)
+      expect(response.json['name']).to eq(character.name)
       expect(character.reload.default_icon_id).to be_nil
     end
 
@@ -123,7 +123,7 @@ RSpec.describe Api::V1::CharactersController do
       put :update, id: character.id, character: {default_icon_id: new_icon.id}
 
       expect(response.status).to eq(200)
-      expect(response.json['data']['name']).to eq(character.name)
+      expect(response.json['name']).to eq(character.name)
       expect(character.reload.default_icon_id).to eq(new_icon.id)
     end
 

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe Api::V1::PostsController do
       reply = create(:reply, post: post, with_character: true, with_icon: true)
       get :show, id: post.id
       expect(response).to have_http_status(200)
-      expect(response.json['data']['id']).to eq(post.id)
-      expect(response.json['data']['icon']['id']).to eq(post.icon_id)
-      expect(response.json['data']['character']['id']).to eq(post.character_id)
-      expect(response.json['data']['replies'].size).to eq(3)
-      expect(response.json['data']['replies'][2]['id']).to eq(reply.id)
-      expect(response.json['data']['replies'][2]['icon']['id']).to eq(reply.icon_id)
-      expect(response.json['data']['replies'][2]['character']['id']).to eq(reply.character_id)
+      expect(response.json['id']).to eq(post.id)
+      expect(response.json['icon']['id']).to eq(post.icon_id)
+      expect(response.json['character']['id']).to eq(post.character_id)
+      expect(response.json['replies'].size).to eq(3)
+      expect(response.json['replies'][2]['id']).to eq(reply.id)
+      expect(response.json['replies'][2]['icon']['id']).to eq(reply.icon_id)
+      expect(response.json['replies'][2]['character']['id']).to eq(reply.character_id)
     end
 
     it "paginates" do
@@ -38,7 +38,7 @@ RSpec.describe Api::V1::PostsController do
       expect(response.headers['Page'].to_i).to eq(3)
       expect(response.headers['Total'].to_i).to eq(5)
       expect(response.headers['Link']).not_to be_nil
-      expect(response.json['data']['replies'].size).to eq(1)
+      expect(response.json['replies'].size).to eq(1)
     end
   end
 end

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -17,28 +17,13 @@ RSpec.describe Api::V1::PostsController do
     end
 
     it "succeeds with valid post" do
-      post = create(:post, num_replies: 2, with_icon: true, with_character: true)
+      post = create(:post, with_icon: true, with_character: true)
       reply = create(:reply, post: post, with_character: true, with_icon: true)
       get :show, id: post.id
       expect(response).to have_http_status(200)
       expect(response.json['id']).to eq(post.id)
       expect(response.json['icon']['id']).to eq(post.icon_id)
       expect(response.json['character']['id']).to eq(post.character_id)
-      expect(response.json['replies'].size).to eq(3)
-      expect(response.json['replies'][2]['id']).to eq(reply.id)
-      expect(response.json['replies'][2]['icon']['id']).to eq(reply.icon_id)
-      expect(response.json['replies'][2]['character']['id']).to eq(reply.character_id)
-    end
-
-    it "paginates" do
-      post = create(:post, num_replies: 5, with_icon: true, with_character: true)
-      get :show, id: post.id, per_page: 2, page: 3
-      expect(response).to have_http_status(200)
-      expect(response.headers['Per-Page'].to_i).to eq(2)
-      expect(response.headers['Page'].to_i).to eq(3)
-      expect(response.headers['Total'].to_i).to eq(5)
-      expect(response.headers['Link']).not_to be_nil
-      expect(response.json['replies'].size).to eq(1)
     end
   end
 end

--- a/spec/controllers/api/v1/replies_controller_spec.rb
+++ b/spec/controllers/api/v1/replies_controller_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+RSpec.describe Api::V1::RepliesController do
+  describe "GET index" do
+    it "requires valid post" do
+      get :index, post_id: 0
+      expect(response).to have_http_status(404)
+      expect(response.json['errors'].size).to eq(1)
+      expect(response.json['errors'][0]['message']).to eq("Post could not be found.")
+    end
+
+    it "requires access to post" do
+      post = create(:post, privacy: Post::PRIVACY_PRIVATE)
+      get :index, post_id: post.id
+      expect(response).to have_http_status(403)
+      expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
+    end
+
+    it "succeeds with valid post" do
+      post = create(:post, num_replies: 2, with_icon: true, with_character: true)
+      reply = create(:reply, post: post, with_character: true, with_icon: true)
+      get :index, post_id: post.id
+      expect(response).to have_http_status(200)
+      expect(response.json.size).to eq(3)
+      expect(response.json[2]['id']).to eq(reply.id)
+      expect(response.json[2]['icon']['id']).to eq(reply.icon_id)
+      expect(response.json[2]['character']['id']).to eq(reply.character_id)
+    end
+
+    it "paginates" do
+      post = create(:post, num_replies: 5, with_icon: true, with_character: true)
+      get :index, post_id: post.id, per_page: 2, page: 3
+      expect(response).to have_http_status(200)
+      expect(response.headers['Per-Page'].to_i).to eq(2)
+      expect(response.headers['Page'].to_i).to eq(3)
+      expect(response.headers['Total'].to_i).to eq(5)
+      expect(response.headers['Link']).not_to be_nil
+      expect(response.json.size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
- Don't use `'data': {}` enveloping around JSON responses
- Update Javascript not to look for the `data` key when querying the API
- Use `api!` shorthand when documenting the API
- Move replies from `api/v1/posts/:id` to their own controller, since paginating a post on a child collection doesn't make sense