### PR TITLE
Alter messagescollapsible

### DIFF
--- a/app/assets/stylesheets/global.css
+++ b/app/assets/stylesheets/global.css
@@ -54,6 +54,7 @@ button, .button {
 .left-align { text-align: left; }
 .right-align { text-align: right; }
 .hidden { display: none; }
+.float-left { float: left; }
 .float-right { float: right; }
 .float-none { float: none !important; }
 .clear { clear: both; }

--- a/app/assets/stylesheets/messages.css
+++ b/app/assets/stylesheets/messages.css
@@ -1,7 +1,7 @@
 #message_form tr#message-row { width: 75%; max-width: 900px; min-width: 300px; }
 #message_form textarea { min-width: 200px; width: 100%; box-sizing: border-box; min-height: 250px; }
 .message-collapse .message { margin-left: 10px; float: left; }
-.message-collapse .author { float: left; width: 100px; padding-bottom: 10px; text-align: center; }
+.message-collapse .author { float: left; width: 100px; padding-bottom: 10px; text-align: center; word-wrap: break-word; }
 .message-collapse, .message-menu { cursor: pointer; }
 .message-expand, .message-menu { min-height: 40px; }
 .message-expand { z-index: 0; background-color: rgba(0,0,0,0.1); }
@@ -10,7 +10,7 @@
 .message-expanded .post-icon { z-index: 2; }
 .message-time { font-size: 80%; }
 .message-collapse .message { max-width: 80%; }
-.message-expanded .post-info-box { margin-top: 0; }
+.message-expanded .post-info-box { margin-top: 0; word-wrap: break-word; }
 
 @media (max-width: 600px) {
   .message-menu { overflow: overlay; } /* to get it to redraw the boundaries */

--- a/app/assets/stylesheets/messages.css
+++ b/app/assets/stylesheets/messages.css
@@ -3,19 +3,16 @@
 .message-collapse .message { margin-left: 10px; float: left; }
 .message-collapse .author { float: left; width: 100px; padding-bottom: 10px; text-align: center; }
 .message-collapse, .message-menu { cursor: pointer; }
-.message-expand, .message-menu { height: 40px; width: 100%; position: absolute; }
-.message-expand { z-index: 0; background-color: #000000; opacity: 0.1; }
-.message-menu { z-index: 1; }
-.message-menu .centered { margin-top: 10px;  }
-.message-content { margin-top: 35px; }
-.message-expanded, .message-expanded .post-info-box { position: relative; }
+.message-expand, .message-menu { min-height: 40px; }
+.message-expand { z-index: 0; background-color: rgba(0,0,0,0.1); }
+.message-menu { z-index: 1; padding: 10px 10px 10px 10px; box-sizing: border-box; }
+.message-menu .text { width: 55%; text-align: right; margin-bottom: 5px; }
 .message-expanded .post-icon { z-index: 2; }
-.message-time { position: absolute; right: 10px; top: 10px; }
+.message-time { font-size: 80%; }
 .message-collapse .message { max-width: 80%; }
 .message-expanded .post-info-box { margin-top: 0; }
 
 @media (max-width: 600px) {
-  .message-content { margin-top: 0; }
-  .message-menu .centered { text-align: left !important; margin-left: 10px;  }
-  .message-expanded .post-info-box { margin-top: 30px; }
+  .message-menu { overflow: overlay; } /* to get it to redraw the boundaries */
+  .message-menu .text { text-align: left; margin: 0 10px 0 10px; width: auto; }
 }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -58,11 +58,15 @@ class MessagesController < ApplicationController
 
     @page_title = message.unempty_subject
     @box = message.box(current_user)
-    if message.unread? and message.recipient_id == current_user.id
-      message.update_attributes(unread: false)
-    end
 
     @messages = Message.where(thread_id: message.thread_id).order('id asc')
+    if @messages.any? { |m| m.recipient_id == current_user.id && m.unread? }
+      @messages.each do |m|
+        next unless m.unread?
+        next unless m.recipient_id == current_user.id
+        m.update_attributes(unread: false)
+      end
+    end
     @message = Message.new
     set_message_parent(message.last_in_thread)
     use_javascript('messages')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -118,6 +118,12 @@ module ApplicationHelper
     Sanitize.fragment(content, Glowfic::POST_CONTENT_SANITIZER)
   end
 
+  def generate_short(msg)
+    short_msg = Sanitize.fragment(msg) # strip all tags, replacing appropriately with spaces
+    return short_msg if short_msg.length <= 75
+    short_msg[0...73] + '…' # make the absolute max length 75 characters
+  end
+
   def post_privacy_settings
     { 'Public'              => Post::PRIVACY_PUBLIC,
       'Constellation Users' => Post::PRIVACY_REGISTERED,

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -18,11 +18,6 @@ class Message < ActiveRecord::Base
     subject
   end
 
-  def short_message
-    return message if message.length <= 75
-    message[0...75] + '...'
-  end
-
   def last_in_thread
     return self if thread_id == id
     @last ||= self.class.where(thread_id: thread_id).order('id desc').first

--- a/app/views/messages/_single.haml
+++ b/app/views/messages/_single.haml
@@ -13,16 +13,16 @@
     .message= generate_short(message.message).html_safe
     .float-right
       - if message.created_at
-        Sent #{pretty_time(message.created_at)}
+        .message-time Sent #{pretty_time(message.created_at)}
 
 .post-container.message-expanded{class: exp_klass, id: "expanded-#{message.id}"}
   - if message.id && local_assigns[:message_counter].present?
     .message-expand
-    .message-menu{data: {id: message.id}}
-      .centered
-        %span.text Click to collapse
-        - if message.created_at
-          .message-time Sent #{pretty_time(message.created_at)}
+      .message-menu{data: {id: message.id}}
+        .float-left.text Click to collapse
+        .float-right
+          - if message.created_at
+            .message-time Sent #{pretty_time(message.created_at)}
   .padding-10
     .post-info-box
       - if message.sender.avatar

--- a/app/views/messages/_single.haml
+++ b/app/views/messages/_single.haml
@@ -10,7 +10,7 @@
 .post-container{class: col_klass, id: "collapsed-#{message.id}", data: {id: message.id}}
   .padding-10
     .author= link_to(message.sender.username, user_path(message.sender))
-    .message= sanitize_written_content(message.short_message).html_safe
+    .message= generate_short(message.message).html_safe
     .float-right
       - if message.created_at
         Sent #{pretty_time(message.created_at)}
@@ -25,7 +25,8 @@
           .message-time Sent #{pretty_time(message.created_at)}
   .padding-10
     .post-info-box
-      .post-icon= icon_tag message.sender.avatar
+      - if message.sender.avatar
+        .post-icon= icon_tag message.sender.avatar
       .post-info-text
         .post-character
           %b From:
@@ -36,5 +37,5 @@
             = link_to(message.recipient.username, user_path(message.recipient))
     .message-content= sanitize_written_content(message.message).html_safe
   .post-footer
-    .right-align> 
+    .right-align>
       .padding-5>

--- a/features/step_definitions/navigation.rb
+++ b/features/step_definitions/navigation.rb
@@ -64,7 +64,7 @@ end
 
 Then(/^I should see the shortened message$/) do
   within(".message-collapse") do
-    expect(page).to have_content("abcde" * 15 + "...")
+    expect(page).to have_content(("abcde" * 15)[0...73] + "…")
     expect(page).not_to have_content("abcde" * 20)
   end
 end


### PR DESCRIPTION
Builds on PR #127. The first commit (9734481) is probably not controversial (… you may want to cherry-pick it, sorry), and the second one modifies the UI not to use a ton of `position: absolute`s at also makes the bar appear *above* the other items (`post-info-box`, etc.), and also shrinks the `message-time` text to 80%.

Old UI:
![screenshot from 2017-02-26 20-41-18](https://cloud.githubusercontent.com/assets/577128/23343478/1a833dea-fc64-11e6-8cb6-4a71865981bf.png)
![screenshot from 2017-02-26 20-41-41](https://cloud.githubusercontent.com/assets/577128/23343479/1c379ae6-fc64-11e6-918f-0bd1cddc1d66.png)

New UI:
![screenshot from 2017-02-26 20-42-23](https://cloud.githubusercontent.com/assets/577128/23343480/20a956e6-fc64-11e6-968d-2d0456f0fcd2.png)
![screenshot from 2017-02-26 20-42-01](https://cloud.githubusercontent.com/assets/577128/23343481/22247046-fc64-11e6-89de-aef51bbbc972.png)
