### PR TITLE
Move the 'set avatar' text on users#edit to a row instead of a subheader

### DIFF
--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -49,7 +49,7 @@
       %td.centered{class: cycle('even', 'odd')}
         = link_to avatar_icon_path(@icon), method: :post do
           = image_tag '/images/status_online.png'
-          Set as Default
+          Make Avatar
     %tr
       %td.centered{class: cycle('even', 'odd')}
         = link_to replace_icon_path(@icon) do

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -3,9 +3,6 @@
     %tr
       %th.centered{colspan: 2} Account Settings
     %tr
-      %td.odd.centered{colspan: 2}
-        .details *Please set your avatar directly from the desired icon's page*
-    %tr
       %th.sub Username
       %td{class: cycle('even', 'odd')}= f.text_field :username, placeholder: "Username", class: 'text', disabled: current_user.salt_uuid.nil?
     %tr
@@ -16,6 +13,10 @@
       %td{class: cycle('even', 'odd')}
         = f.check_box :email_notifications, class: 'width-15 vmid'
         = f.label :email_notifications, "Email about new tags"
+    %tr
+      %th.sub Avatar
+      %td{class: cycle('even', 'odd')}
+        .details Please set your avatar directly from the desired icon's page.
     %tr
       %th.sub Paging
       %td{class: cycle('even', 'odd')}= f.select(:per_page, per_page_options(current_user.per_page))

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -13,10 +13,11 @@
       %td{class: cycle('even', 'odd')}
         = f.check_box :email_notifications, class: 'width-15 vmid'
         = f.label :email_notifications, "Email about new tags"
-    %tr
-      %th.sub Avatar
-      %td{class: cycle('even', 'odd')}
-        .details Please set your avatar directly from the desired icon's page.
+    - unless current_user.avatar.present?
+      %tr
+        %th.sub Avatar
+        %td{class: cycle('even', 'odd')}
+          .details Please set your avatar directly from the desired icon's page.
     %tr
       %th.sub Paging
       %td{class: cycle('even', 'odd')}= f.select(:per_page, per_page_options(current_user.per_page))


### PR DESCRIPTION
The previous text was quite noticeable, which was… good-ish, but for those of us who have set an avatar and really don't care for the message, I think it makes more sense for it to be a small bit of text inline with the rest of the table.