### PR TITLE
Allow user to select icons to add to gallery on gallery#new

### DIFF
--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -199,7 +199,7 @@ class GalleriesController < ApplicationController
   end
 
   def gallery_params
-    params.fetch(:gallery, {}).permit(:name, galleries_icons_attributes: [:id, :_destroy, icon_attributes: [:url, :keyword, :credit, :id, :_destroy]])
+    params.fetch(:gallery, {}).permit(:name, galleries_icons_attributes: [:id, :_destroy, icon_attributes: [:url, :keyword, :credit, :id, :_destroy]], icon_ids: [])
   end
 
   def icon_params(paramset)

--- a/app/views/galleries/new.haml
+++ b/app/views/galleries/new.haml
@@ -1,9 +1,22 @@
 = form_for @gallery, url: galleries_path, method: :post do |f|
-  %table.form-table
+  - icons_present = current_user.galleryless_icons.present?
+  %table.form-table{style: (icons_present ? 'width: 100%;' : nil)}
     %tr
       %th.centered{colspan: 2}New Gallery
     %tr
-      %th.sub Name
+      %th.vtop.sub Name
       %td.even= f.text_field :name, placeholder: "Gallery Name", class: 'text'
+    - if icons_present
+      %tr
+        %th.vtop.sub Icons
+        %td.odd
+          - current_user.galleryless_icons.each do |icon|
+            = label_tag "gallery_icon_ids_#{icon.id}" do
+              .gallery-icon
+                = icon_tag icon, id: icon.id, pointer: true
+                %br>
+                %span.icon-keyword= icon.keyword
+                - box_selected = params[:gallery].try(:[], :icon_ids).try(:include?, icon.id.to_s)
+                .select-button= check_box_tag "gallery[icon_ids][]", icon.id, box_selected, id: "gallery_icon_ids_#{icon.id}"
     %tr
       %th.subber{colspan: 2}= submit_tag "Create", class: 'button'

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -74,15 +74,28 @@ RSpec.describe GalleriesController do
       expect(flash[:error]).to eq('Your gallery could not be saved.')
     end
 
+    it "does not set icon has_gallery on failure" do
+      icon = create(:icon)
+      login_as(icon.user)
+      post :create, gallery: {icon_ids: [icon.id]}
+      expect(response).to have_http_status(200)
+      expect(assigns(:page_title)).to eq('New Gallery')
+      expect(flash[:error]).to eq('Your gallery could not be saved.')
+      expect(icon.reload.has_gallery).not_to be_true
+    end
+
     it "succeeds" do
       expect(Gallery.count).to be_zero
-      login
-      post :create, gallery: {name: 'Test Gallery'}
+      icon = create(:icon)
+      login_as(icon.user)
+      post :create, gallery: {name: 'Test Gallery', icon_ids: [icon.id]}
       expect(Gallery.count).to eq(1)
       gallery = assigns(:gallery).reload
       expect(response).to redirect_to(gallery_url(gallery))
       expect(flash[:success]).to eq('Gallery saved successfully.')
       expect(gallery.name).to eq('Test Gallery')
+      expect(Gallery.first.icons).to match_array([icon])
+      expect(icon.reload.has_gallery).to be_true
     end
   end
 


### PR DESCRIPTION
Also has tests to ensure `has_gallery` is set appropriately. (Unfortunately with just the `has_many_and_belongs_to` relation, saving without a title but with icon IDs ends up setting them to `has_gallery` true, despite not having a gallery for them to be part of. The workaround in this prevents that being an issue.)