### PR TITLE
Add a link to the reports page

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -86,6 +86,7 @@
             %li= link_to 'Unread', unread_posts_path
             %li= link_to 'Tags Owed', owed_posts_path
           %li= link_to 'Contribute', contribute_path
+          %li= link_to 'Report', report_path(id: :daily)
     - if content_for?(:breadcrumbs)
       .flash.subber= content_for :breadcrumbs
     - if flash[:error].is_a?(Hash)


### PR DESCRIPTION
I was reminded we didn't have a link to it, so I've added one. It might be worth using "Activity Reports" instead of just "Reports" to make it clear it's not a "report something bad" kind of feature?