### PR TITLE
Fix/javascript errors on nils

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -326,7 +326,7 @@ getAndSetCharacterData = function(characterId, options) {
       $("#swap-alias").hide();
     }
 
-    if (restore_alias) {
+    if (restore_alias && selectedAliasID) {
       var correctName = $("#character_alias option[value="+selectedAliasID+"]").text();
       $("#post-editor .post-character #name").html(correctName);
       $("#post-editor .post-character").data('alias-id', selectedAliasID);

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -338,7 +338,7 @@ getAndSetCharacterData = function(characterId, options) {
     }
 
     // Display no icon if no default set
-    if (resp.default === undefined) {
+    if (!resp.default) {
       $("#current-icon").removeClass('pointer');
       setIcon('');
       return;


### PR DESCRIPTION
As [mentioned by Pedro](http://alicorn.elcenia.com/board/viewtopic.php?f=12&t=459&start=1860#p31912), there were issues around switching to iconless characters (fixed in commit 6e7f027).

In addition, when I reloaded a reply which had no character alias set (in Firefox), it threw an error:

    Error: Syntax error, unrecognized expression: #character_alias option[value=]

This caused the rest of the reloading to fail (re-setting the icon, etc), and is fixed in d491ea9.