### PR TITLE
Add a post paginator to posts#hidden

### DIFF
--- a/app/views/posts/hidden.haml
+++ b/app/views/posts/hidden.haml
@@ -26,3 +26,7 @@
       %tr
         %td.right-align.padding-5{class: cycle('even', 'odd'), colspan: 7}
           = submit_tag "Show in Unread", class: 'button'
+      - if @hidden_posts.methods.include?(:total_pages) && @hidden_posts.total_pages > 1
+        %tfoot
+          %tr
+            %td{colspan: 7}= render partial: 'posts/paginator', locals: { paginated: @hidden_posts }


### PR DESCRIPTION
Teceler couldn't find a post on her `posts#hidden` page earlier – turns out it was on another page, but the paginator wasn't displayed. This should fix that happening.

(The boards list does not seem to be paginated and so does not need a paginator.)