### PR TITLE
Fix reply#preview then using replies_path

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -84,10 +84,9 @@ class PostsController < WritableController
   end
 
   def create
-    preview(:post, posts_path) and return if params[:button_preview].present?
-
     @post = Post.new(params[:post])
     @post.user = current_user
+    preview(@post) and return if params[:button_preview].present?
 
     create_new_tags if @post.valid?
 
@@ -115,12 +114,10 @@ class PostsController < WritableController
   def stats
   end
 
-  def preview(method, path)
-    @written = Post.new(params[:post])
+  def preview(written)
+    @written = written
     @post = @written
     @written.user = current_user
-    @url = path
-    @method = method
 
     editor_setup
 
@@ -140,10 +137,11 @@ class PostsController < WritableController
 
     change_status and return if params[:status].present?
     change_authors_locked and return if params[:authors_locked].present?
-    preview(:put, post_path(params[:id])) and return if params[:button_preview].present?
 
     @post.assign_attributes(params[:post])
     @post.board ||= Board.find(3)
+
+    preview(@post) and return if params[:button_preview].present?
 
     create_new_tags if @post.valid?
 

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -64,7 +64,7 @@ class RepliesController < WritableController
   end
 
   def create
-    preview and return if params[:button_preview]
+    preview(Reply.new(params[:reply])) and return if params[:button_preview]
 
     if params[:button_draft]
       if draft = ReplyDraft.draft_for(params[:reply][:post_id], current_user.id)
@@ -113,7 +113,11 @@ class RepliesController < WritableController
   end
 
   def update
-    preview and return if params[:button_preview]
+    if params[:button_preview]
+      @reply.assign_attributes(params[:reply])
+      preview(@reply) and return
+    end
+
     @reply.skip_post_update = true unless @reply.post.last_reply_id == @reply.id
     @reply.update_attributes(params[:reply])
     flash[:success] = "Post updated"
@@ -154,10 +158,10 @@ class RepliesController < WritableController
     end
   end
 
-  def preview
+  def preview(written)
     build_template_groups
 
-    @written = Reply.new(params[:reply])
+    @written = written
     @post = @written.post
     @written.user = current_user
 

--- a/app/views/posts/_write_post.haml
+++ b/app/views/posts/_write_post.haml
@@ -1,5 +1,5 @@
 - content_for :form do
-  = form_for post, :url => url, :method => method, :html => { :id => 'post_form' } do |f|
+  = form_for post, :html => { :id => 'post_form' } do |f|
     = f.label :board_id, 'Continuity:'
     = f.select :board_id, options_from_collection_for_select(Board.order('pinned DESC, LOWER(name)').select {|b| current_user.writes_in?(b) }, :id, :name, post.board_id)
     %br
@@ -40,7 +40,7 @@
         = f.hidden_field :character_id, id: 'reply_character_id'
         = f.hidden_field :icon_id, id: 'reply_icon_id'
         = f.hidden_field :character_alias_id, id: 'reply_character_alias_id'
-        = submit_tag (method == :put ? 'Save' : "Post"), class: 'button', id: 'submit_button', disable_with: 'Saving...'
+        = submit_tag (post.new_record? ? 'Post' : 'Save'), class: 'button', id: 'submit_button', disable_with: 'Saving...'
         = submit_tag "Preview", class: 'button', id: 'preview_button', name: 'button_preview'
 
 - if post.id.present? && !post.editable_by?(current_user)

--- a/app/views/posts/_write_reply.haml
+++ b/app/views/posts/_write_reply.haml
@@ -14,9 +14,9 @@
       = hidden_field_tag :per_page, params[:per_page]
     #post-form-wrapper
       = f.text_area :content, class: 'tinymce'
-      = submit_tag (method == :put ? 'Save' : "Post"), class: 'button', id: 'submit_button', disable_with: 'Saving...'
+      = submit_tag (reply.new_record? ? 'Post' : 'Save'), class: 'button', id: 'submit_button', disable_with: 'Saving...'
       = submit_tag "Preview", class: 'button', id: 'preview_button', name: 'button_preview'
-      - if method == :post
+      - if reply.new_record?
         = submit_tag "Save Draft", class: 'button', id: 'draft_button', disable_with: 'Saving...', name: 'button_draft'
 
 = render partial: 'posts/editor', locals: {item: reply}

--- a/app/views/posts/preview.haml
+++ b/app/views/posts/preview.haml
@@ -4,4 +4,4 @@
   .post-subheader
     .padding-15= sanitize_post_description(@post.description).html_safe
 = render partial: 'replies/single', locals: {reply: @written, show_edit: false}
-= render partial: 'write_post', locals: { post: @post, url: @url, method: @method }
+= render partial: 'write_post', locals: { post: @post }

--- a/app/views/replies/preview.haml
+++ b/app/views/replies/preview.haml
@@ -4,4 +4,4 @@
   .post-subheader
     .padding-15= sanitize_post_description(@post.description).html_safe
 = render partial: 'replies/single', locals: {reply: @written, show_edit: false}
-= render partial: 'posts/write_reply', locals: { reply: @written, url: @url, method: @method }
+= render partial: 'posts/write_reply', locals: { reply: @written }

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -157,8 +157,6 @@ RSpec.describe PostsController do
         expect(assigns(:written)).to be_a_new_record
         expect(assigns(:written).user).to eq(user)
         expect(assigns(:post)).to eq(assigns(:written))
-        expect(assigns(:url)).to eq(posts_path)
-        expect(assigns(:method)).to eq(:post)
         expect(assigns(:page_title)).to eq('Previewing: test')
         # TODO editor setup
       end


### PR DESCRIPTION
And associated fixes.

Adelene reported an issue in which editing a reply, pressing preview, and then saving would create a new reply. I confirmed that it happened (every time), investigated the code, and didn't really understand why it was being done the way it was. This makes it use the inbuilt system to handle the paths instead of manually setting it (by retaining the ID on the replies/posts).

I tested it manually and everything seems to work (Reply/Post saving from #new, saving from #preview, previewing from #preview and then saving from there).