### PR TITLE
Create 5 boards & users, then destroy them, before tests

### DIFF
--- a/features/support/fix_boards.rb
+++ b/features/support/fix_boards.rb
@@ -1,0 +1,9 @@
+require 'factory_girl_rails'
+
+# make 5 boards so site_testing doesn't screw up tests
+5.times do
+  user = FactoryGirl.create(:user)
+  board = FactoryGirl.create(:board, creator: user)
+  board.destroy
+  user.destroy
+end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PostsController do
     end
 
     it "paginates" do
-      27.times do create(:post) end # so that if a site_testing post is ignore it's still two pages
+      26.times do create(:post) end
       get :index
       num_posts_fetched = controller.instance_variable_get('@posts').total_pages
       expect(num_posts_fetched).to eq(2)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,8 @@ end
 require 'factory_girl_rails'
 require 'rails_helper'
 require 'support/spec_test_helper'
+$LOAD_PATH << '.'
+require 'features/support/fix_boards.rb'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
This is done so there is never a 'Site testing' board, as that screws with various other tests and meant I had to fix them in at least one other place. Here it's used because I was writing a Cucumber feature that failed specifically because the fourth post made will be in the fourth board made will be treated as site testing and hence does not show up in the "Unread" list, breaking the test.

I don't know if there's a neater way to do this – if we could mock the IDs when we *do* want to use site testing, and guarantee it'll never expect it to be a site testing board otherwise, that'd be much nicer, but I don't know how we'd go about doing that. Stubbing the constant in Board doesn't seem to work neatly.