### PR TITLE
Test posts#unread (with cucumber tests) for partially-read posts and fully-read posts

### DIFF
--- a/features/posts/view_unread.feature
+++ b/features/posts/view_unread.feature
@@ -11,13 +11,16 @@ And I should not see "Unread Posts"
 Scenario: Viewing all unread
 Given I am logged in
 And I have 2 unread posts
+And I have 3 partially-read posts
+And I have 4 read posts
 When I view my unread posts
 Then I should see "Unread Posts"
+And I should see 5 posts
 
 Scenario: Dark layout uses appropriate images
 Given I am logged in
 And my account uses the starry dark layout
-And I have 2 unread posts
+And I have 2 partially-read posts
 When I view my unread posts
 Then I should see the bullet icon
 And I should not see the note icon

--- a/features/step_definitions/navigation.rb
+++ b/features/step_definitions/navigation.rb
@@ -17,8 +17,25 @@ end
 Given(/^I have (\d) unread posts?$/) do |num|
   num.to_i.times do
     unread = create(:post)
-    unread.mark_read(current_user, Time.now - 1.day)
     create(:reply, user: unread.user, post: unread)
+  end
+end
+
+Given(/^I have (\d) partially-read posts?$/) do |num|
+  num.to_i.times do
+    unread = Timecop.freeze(Time.now - 1.day) do
+      unread = create(:post)
+      unread.mark_read(current_user)
+      unread
+    end
+    create(:reply, user: unread.user, post: unread)
+  end
+end
+
+Given(/^I have (\d) read posts?$/) do |num|
+  num.to_i.times do
+    read = create(:post)
+    read.mark_read(current_user)
   end
 end
 

--- a/features/step_definitions/post_list_steps.rb
+++ b/features/step_definitions/post_list_steps.rb
@@ -1,0 +1,3 @@
+Then(/^I should see (\d+) posts?$/) do |num|
+  expect(page).to have_selector('.post-subject', count: num)
+end


### PR DESCRIPTION
Builds on #152 and #164. Fails if the first patch isn't applied since it ends up creating a fourth post (that then isn't shown in unread, because it's a site testing post). Maybe fails intermittently if the second isn't applied, I think due to Postgres arbitrary ordering.