### PR TITLE
Test boards#show (with a cucumber test) for flat boards

### DIFF
--- a/features/boards/view_board.feature
+++ b/features/boards/view_board.feature
@@ -1,0 +1,10 @@
+Feature: View Board
+As a reader
+I want to be able to see a list of posts in a continuity
+So that I can read this glowfic
+
+Scenario: Viewing a flat board
+Given there is a board "Test board" with 5 posts
+When I view the board "Test board"
+Then I should see "Test board"
+And I should see 5 posts

--- a/features/posts/view_unread.feature
+++ b/features/posts/view_unread.feature
@@ -11,13 +11,16 @@ And I should not see "Unread Posts"
 Scenario: Viewing all unread
 Given I am logged in
 And I have 2 unread posts
+And I have 3 partially-read posts
+And I have 4 read posts
 When I view my unread posts
 Then I should see "Unread Posts"
+And I should see 5 posts
 
 Scenario: Dark layout uses appropriate images
 Given I am logged in
 And my account uses the starry dark layout
-And I have 2 unread posts
+And I have 2 partially-read posts
 When I view my unread posts
 Then I should see the bullet icon
 And I should not see the note icon

--- a/features/step_definitions/board_steps.rb
+++ b/features/step_definitions/board_steps.rb
@@ -1,0 +1,4 @@
+Given(/^there is a board "(.*)" with (\d+) posts?$/) do |name, count|
+  board = create(:board, name: name)
+  count.to_i.times { create(:post, board: board, user: board.creator) }
+end

--- a/features/step_definitions/navigation.rb
+++ b/features/step_definitions/navigation.rb
@@ -17,8 +17,25 @@ end
 Given(/^I have (\d) unread posts?$/) do |num|
   num.to_i.times do
     unread = create(:post)
-    unread.mark_read(current_user, Time.now - 1.day)
     create(:reply, user: unread.user, post: unread)
+  end
+end
+
+Given(/^I have (\d) partially-read posts?$/) do |num|
+  num.to_i.times do
+    unread = Timecop.freeze(Time.now - 1.day) do
+      unread = create(:post)
+      unread.mark_read(current_user)
+      unread
+    end
+    create(:reply, user: unread.user, post: unread)
+  end
+end
+
+Given(/^I have (\d) read posts?$/) do |num|
+  num.to_i.times do
+    read = create(:post)
+    read.mark_read(current_user)
   end
 end
 

--- a/features/step_definitions/navigation.rb
+++ b/features/step_definitions/navigation.rb
@@ -58,6 +58,10 @@ When(/^I view my unread posts$/) do
   visit unread_posts_path
 end
 
+When(/^I view the board "(.*)"$/) do |name|
+  visit board_path(Board.where(name: name).first)
+end
+
 Then(/^I should see "(.*)"$/) do |content|
   expect(page).to have_content(content)
 end

--- a/features/step_definitions/post_list_steps.rb
+++ b/features/step_definitions/post_list_steps.rb
@@ -1,0 +1,3 @@
+Then(/^I should see (\d+) posts?$/) do |num|
+  expect(page).to have_selector('.post-subject', count: num)
+end


### PR DESCRIPTION
Builds on #153 since it uses the `Then(/^I should see (\d+) posts?/)` step found there. Tests the display of a flat board (e.g. Sandboxes) with 5 posts.

Fails intermittently if 9195874 isn't applied due to Postgres arbitrary ordering.