### PR TITLE
Fix post.build_new_reply_for not to save icons from post

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -86,20 +86,17 @@ class Post < ActiveRecord::Base
       last_user_reply = user_replies.last
       reply.character_id = last_user_reply.character_id
       reply.character_alias_id = last_user_reply.character_alias_id
-      if reply.character_id.nil?
-        reply.icon_id = user.avatar_id
-      else
-        reply.icon_id = reply.character.icon.try(:id)
-      end
     elsif self.user == user
       reply.character_id = self.character_id
       reply.character_alias_id = self.character_alias_id
-      reply.icon_id = self.icon_id
     elsif user.active_character_id.present?
       reply.character_id = user.active_character_id
-      reply.icon = user.active_character.icon
-    else
+    end
+
+    if reply.character_id.nil?
       reply.icon_id = user.avatar_id
+    else
+      reply.icon_id = reply.character.icon.try(:id)
     end
 
     return reply

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -88,10 +88,16 @@ FactoryGirl.define do
   end
 
   factory :character do
+    transient do
+      with_default_icon false
+    end
     user
     name 'test character'
     factory :template_character do
       template { build(:template, user: user) }
+    end
+    before(:create) do |character, evaluator|
+      character.default_icon = create(:icon, user: character.user) if evaluator.with_default_icon
     end
   end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -558,13 +558,13 @@ RSpec.describe Post do
       reply = post.build_new_reply_for(post.user)
       expect(reply).to be_a_new_record
       expect(reply.user).to eq(post.user)
-      expect(reply.icon_id).to eq(post.icon_id)
+      expect(reply.icon_id).to eq(post.character.default_icon_id)
       expect(reply.character_id).to eq(post.character_id)
     end
 
     it "uses active character if available" do
       post = create(:post)
-      character = create(:character)
+      character = create(:character, with_default_icon: true)
       character.user.active_character = character
       character.user.save
 
@@ -572,7 +572,7 @@ RSpec.describe Post do
 
       expect(reply).to be_a_new_record
       expect(reply.user).to eq(character.user)
-      expect(reply.icon_id).to be_nil
+      expect(reply.icon_id).to eq(character.default_icon_id)
       expect(reply.character_id).to eq(character.id)
     end
 


### PR DESCRIPTION
There was a fix previously so it didn't copy it between replies, but this neglected the scenario where people
reply to a post. This moves the icon_id logic to below the rest of the logic, and sets it to:
1. the avatar if it exists and the character doesn't
2. the character's default icon