### PR TITLE
Save alias also for characters that aren't the most recent one

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -336,12 +336,6 @@ getAndSetCharacterData = function(characterId, options) {
       for(var i=0; i<resp['aliases'].length; i++) {
         $("#character_alias").append($("<option>").attr({value: resp['aliases'][i]['id']}).append(resp['aliases'][i]['name']));
       }
-      // Restore active alias, but only if not already restoring an alias
-      if(resp.alias_id_for_post !== undefined && !restore_alias) {
-        restore_alias = true;
-        selectedAliasID = resp.alias_id_for_post;
-        $("#reply_character_alias_id").val(selectedAliasID);
-      }
     } else {
       $("#swap-alias").hide();
     }
@@ -351,6 +345,13 @@ getAndSetCharacterData = function(characterId, options) {
       $("#post-editor .post-character #name").html(correctName);
       $("#post-editor .post-character").data('alias-id', selectedAliasID);
       $("#character_alias").val(selectedAliasID).trigger("change.select2");
+    } else if (resp.active_alias) {
+      var aliasID = resp.active_alias.id;
+      var correctName = $("#character_alias option[value="+aliasID+"]").text();
+      $("#post-editor .post-character #name").html(correctName);
+      $("#post-editor .post-character").data('alias-id', aliasID);
+      $("#character_alias").val(aliasID).trigger("change.select2");
+      $("#reply_character_alias_id").val(aliasID);
     } else {
       $("#post-editor .post-character").data('alias-id', '');
       $("#character_alias").val('').trigger("change.select2");

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -102,6 +102,16 @@ class Post < ActiveRecord::Base
     return reply
   end
 
+  def active_alias_for(character)
+    char_replies = replies.where(character_id: character.id).order('id asc')
+
+    if char_replies.exists?
+      char_replies.last.character_alias
+    elsif self.character == character
+      self.character_alias
+    end
+  end
+
   def first_unread_for(user)
     return @first_unread if @first_unread
     viewed_at = last_read(user) || board.last_read(user)

--- a/app/presenters/character_presenter.rb
+++ b/app/presenters/character_presenter.rb
@@ -7,17 +7,8 @@ class CharacterPresenter
 
   def as_json(options={})
     return {} unless character
-
     char_json = character.as_json_without_presenter(only: [:id, :name, :screenname])
-    return char_json unless options[:include].present? || options[:post_for_alias].present?
-
-    if options[:post_for_alias].present?
-      post = options[:post_for_alias]
-      most_recent_use = post.replies.where(character_id: @character.id).order('id desc').first
-      most_recent_use = post if most_recent_use.nil? && post.character_id == character.id
-      char_json.merge!(alias_id_for_post: most_recent_use.try(:character_alias_id))
-      return char_json unless options[:include].present?
-    end
+    return char_json unless options[:include].present?
 
     char_json.merge!(default: character.icon.try(:as_json)) if options[:include].include?(:default)
     char_json.merge!(aliases: character.aliases) if options[:include].include?(:aliases)


### PR DESCRIPTION
Builds on #157. It adds a new parameter to the character endpoint of the API (`post_id`), which when given will provide an `active_alias` attribute in the resulting JSON that can then be used in the `posts.js` file to update to it when it gets the character. (If no active alias is found, it acts as before.)

Manual testing showed the Javascript to work properly when replying to a post (various different characters, swapping from 'no alias' to 'has alias' and back, testing preview also), and creating a post still seems to work without modifying the alias.

I wasn't sure if modifying the API endpoint for characters was the best place to put this – perhaps could've created a subroute on the posts controller? I'd be happy to move it if you want.