### PR TITLE
Update rubocop to use project style, fix a ton of stylistic things

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,26 +1,46 @@
 AllCops:
   TargetRubyVersion: 2.3
+  TargetRailsVersion: 4.1
   DisabledByDefault: true
+  Exclude:
+    - 'config/initializers/resque.rb'
+    - 'config/initializers/rack_cors.rb'
+    - 'config/initializers/will_paginate.rb'
+    - 'db/seeds.rb'
+    - 'lib/tasks/cucumber.rake'
+    - 'features/support/env.rb'
+    - 'spec/spec_helper.rb'
+
+#################### Bundler ################################
+
+Bundler/DuplicatedGem:
+  Description: >-
+                 A Gem's requirements should be listed only once in a
+                 Gemfile.
+  Enabled: true
 
 #################### Layout ##############################
 
 Layout/AccessModifierIndentation:
   Description: Check indentation of private/protected visibility modifiers.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected'
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: 'indent'
 
 Layout/AlignArray:
   Description: >-
                  Align the elements of an array literal if they span more than
                  one line.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays'
-  Enabled: false
+  Enabled: true
 
 Layout/AlignHash:
   Description: >-
                  Align the elements of a hash literal if they span more than
                  one line.
   Enabled: false
+  EnforcedHashRocketStyle: 'key'
+  EnforcedColonStyle: 'key'
 
 Layout/AlignParameters:
   Description: >-
@@ -28,15 +48,18 @@ Layout/AlignParameters:
                  than one line.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
   Enabled: false
+  EnforcedStyle: 'with_first_parameter'
 
 Layout/BlockEndNewline:
   Description: 'Put end statement of multiline block on its own line.'
-  Enabled: false
+  Enabled: true
 
 Layout/CaseIndentation:
   Description: 'Indentation of when in a case/when/[else/]end.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-when-to-case'
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: 'end'
+  IndentOneStep: true
 
 Layout/ClosingParenthesisIndentation:
   Description: 'Checks the indentation of hanging closing parentheses.'
@@ -44,21 +67,25 @@ Layout/ClosingParenthesisIndentation:
 
 Layout/CommentIndentation:
   Description: 'Indentation of comments.'
-  Enabled: false
+  Enabled: true
 
 Layout/DotPosition:
   Description: 'Checks the position of the dot in multi-line method calls.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
-  Enabled: false
+  Enabled: true
 
 Layout/ElseAlignment:
   Description: 'Align elses and elsifs correctly.'
+  Enabled: true
+
+Layout/EmptyLineAfterMagicComment:
   Enabled: false
 
 Layout/EmptyLineBetweenDefs:
   Description: 'Use empty lines between defs.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods'
   Enabled: false
+  AllowAdjacentOneLineDefs: false
 
 Layout/EmptyLines:
   Description: "Don't use several empty lines in a row."
@@ -66,23 +93,32 @@ Layout/EmptyLines:
 
 Layout/EmptyLinesAroundAccessModifier:
   Description: "Keep blank lines around access modifiers."
-  Enabled: false
+  Enabled: true
+
+Layout/EmptyLinesAroundBeginBody:
+  Enabled: true
 
 Layout/EmptyLinesAroundBlockBody:
   Description: "Keeps track of empty lines around block bodies."
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: 'no_empty_lines'
 
 Layout/EmptyLinesAroundClassBody:
   Description: "Keeps track of empty lines around class bodies."
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: 'no_empty_lines'
 
-Layout/EmptyLinesAroundModuleBody:
-  Description: "Keeps track of empty lines around module bodies."
-  Enabled: false
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Enabled: true
 
 Layout/EmptyLinesAroundMethodBody:
   Description: "Keeps track of empty lines around method bodies."
-  Enabled: false
+  Enabled: true
+
+Layout/EmptyLinesAroundModuleBody:
+  Description: "Keeps track of empty lines around module bodies."
+  Enabled: true
+  EnforcedStyle: 'no_empty_lines'
 
 Layout/EndOfLine:
   Description: 'Use Unix-style line endings.'
@@ -91,43 +127,80 @@ Layout/EndOfLine:
 
 Layout/ExtraSpacing:
   Description: 'Do not use unnecessary spacing.'
+  Enabled: true
+  AllowForAlignment: true
+
+Layout/FirstArrayElementLineBreak:
   Enabled: false
 
-Layout/InitialIndentation:
-  Description: >-
-    Checks the indentation of the first non-blank non-comment line in a file.
+Layout/FirstHashElementLineBreak:
+  Enabled: false
+
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: false
+
+Layout/FirstMethodParameterLineBreak:
   Enabled: false
 
 Layout/FirstParameterIndentation:
   Description: 'Checks the indentation of the first parameter in a method call.'
   Enabled: false
 
+Layout/IndentAssignment:
+  Enabled: true
+
+Layout/IndentHeredoc:
+  Enabled: true
+
 Layout/IndentationConsistency:
   Description: 'Keep indentation straight.'
-  Enabled: false
+  Enabled: true
 
 Layout/IndentationWidth:
   Description: 'Use 2 spaces for indentation.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
-  Enabled: false
+  Enabled: true
+  Width: 2
 
 Layout/IndentArray:
   Description: >-
                  Checks the indentation of the first element in an array
                  literal.
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: 'consistent'
 
 Layout/IndentHash:
   Description: 'Checks the indentation of the first key in a hash literal.'
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: 'consistent'
+
+Layout/InitialIndentation:
+  Description: >-
+    Checks the indentation of the first non-blank non-comment line in a file.
+  Enabled: true
 
 Layout/LeadingCommentSpace:
   Description: 'Comments should start with a space.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-space'
+  Enabled: true
+
+Layout/MultilineArrayBraceLayout:
   Enabled: false
 
 Layout/MultilineBlockLayout:
   Description: 'Ensures newlines after multiline block do statements.'
+  Enabled: true
+
+Layout/MultilineHashBraceLayout:
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/MultilineMethodDefinitionBraceLayout:
   Enabled: false
 
 Layout/MultilineOperationIndentation:
@@ -138,71 +211,34 @@ Layout/MultilineOperationIndentation:
 
 Layout/RescueEnsureAlignment:
   Description: 'Align rescues and ensures correctly.'
-  Enabled: false
-
-Layout/SpaceBeforeFirstArg:
-  Description: >-
-                 Checks that exactly one space is used between a method name
-                 and the first argument for method calls without parentheses.
   Enabled: true
 
 Layout/SpaceAfterColon:
   Description: 'Use spaces after colons.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
+  Enabled: true
 
 Layout/SpaceAfterComma:
   Description: 'Use spaces after commas.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Layout/SpaceAroundKeyword:
-  Description: 'Use spaces around keywords.'
-  Enabled: false
+  Enabled: true
 
 Layout/SpaceAfterMethodName:
   Description: >-
                  Do not put a space between a method name and the opening
                  parenthesis in a method definition.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
-  Enabled: false
+  Enabled: true
 
 Layout/SpaceAfterNot:
   Description: Tracks redundant space after the ! operator.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-bang'
-  Enabled: false
+  Enabled: true
 
 Layout/SpaceAfterSemicolon:
   Description: 'Use spaces after semicolons.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Layout/SpaceBeforeBlockBraces:
-  Description: >-
-                 Checks that the left block brace has or doesn't have space
-                 before it.
-  Enabled: false
-
-Layout/SpaceBeforeComma:
-  Description: 'No spaces before commas.'
-  Enabled: false
-
-Layout/SpaceBeforeComment:
-  Description: >-
-                 Checks for missing space between code and a comment on the
-                 same line.
-  Enabled: false
-
-Layout/SpaceBeforeSemicolon:
-  Description: 'No spaces before semicolons.'
-  Enabled: false
-
-Layout/SpaceInsideBlockBraces:
-  Description: >-
-                 Checks that block braces have or don't have surrounding space.
-                 For blocks taking parameters, checks that the left brace has
-                 or doesn't have trailing space.
-  Enabled: false
+  Enabled: true
 
 Layout/SpaceAroundBlockParameters:
   Description: 'Checks the spacing inside and after block parameters pipes.'
@@ -216,15 +252,58 @@ Layout/SpaceAroundEqualsInParameterDefault:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-around-equals'
   Enabled: false
 
+Layout/SpaceAroundKeyword:
+  Description: 'Use spaces around keywords.'
+  Enabled: true
+
 Layout/SpaceAroundOperators:
   Description: 'Use a single space around operators.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: false
 
+Layout/SpaceBeforeBlockBraces:
+  Description: >-
+                 Checks that the left block brace has or doesn't have space
+                 before it.
+  Enabled: false
+
+Layout/SpaceBeforeComma:
+  Description: 'No spaces before commas.'
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Description: >-
+                 Checks for missing space between code and a comment on the
+                 same line.
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Description: >-
+                 Checks that exactly one space is used between a method name
+                 and the first argument for method calls without parentheses.
+  Enabled: true
+
+Layout/SpaceBeforeSemicolon:
+  Description: 'No spaces before semicolons.'
+  Enabled: true
+
+Layout/SpaceInLambdaLiteral:
+  Enabled: false
+
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+
+Layout/SpaceInsideBlockBraces:
+  Description: >-
+                 Checks that block braces have or don't have surrounding space.
+                 For blocks taking parameters, checks that the left brace has
+                 or doesn't have trailing space.
+  Enabled: false
+
 Layout/SpaceInsideBrackets:
   Description: 'No spaces after [ or before ].'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
-  Enabled: false
+  Enabled: true
 
 Layout/SpaceInsideHashLiteralBraces:
   Description: "Use spaces inside hash literal braces - or don't."
@@ -234,6 +313,9 @@ Layout/SpaceInsideHashLiteralBraces:
 Layout/SpaceInsideParens:
   Description: 'No spaces after ( or before ).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
+  Enabled: true
+
+Layout/SpaceInsidePercentLiteralDelimiters:
   Enabled: false
 
 Layout/SpaceInsideRangeLiteral:
@@ -244,12 +326,12 @@ Layout/SpaceInsideRangeLiteral:
 Layout/SpaceInsideStringInterpolation:
   Description: 'Checks for padding/surrounding spaces inside string interpolation.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#string-interpolation'
-  Enabled: false
+  Enabled: true
 
 Layout/Tab:
   Description: 'No hard tabs.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
-  Enabled: false
+  Enabled: true
 
 Layout/TrailingBlankLines:
   Description: 'Checks trailing blank lines and final newline.'
@@ -259,9 +341,15 @@ Layout/TrailingBlankLines:
 Layout/TrailingWhitespace:
   Description: 'Avoid trailing whitespace.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
-  Enabled: false
+  Enabled: true
 
 #################### Lint ################################
+
+Lint/AmbiguousBlockAssociation:
+  Description: >-
+                 Checks for ambiguous block association with method when
+                 param passed without parentheses.
+  Enabled: true
 
 Lint/AmbiguousOperator:
   Description: >-
@@ -308,8 +396,16 @@ Lint/DeprecatedClassMethods:
   Description: 'Check for deprecated class method calls.'
   Enabled: true
 
+Lint/DuplicateCaseCondition:
+  Description: 'Check that there are no repeated conditions used in case when expressions.'
+  Enabled: true
+
 Lint/DuplicateMethods:
   Description: 'Check for duplicate methods calls.'
+  Enabled: true
+
+Lint/DuplicatedKey:
+  Description: 'This cop checks for duplicated keys in hash literals.'
   Enabled: true
 
 Lint/EachWithObjectArgument:
@@ -324,13 +420,22 @@ Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'
   Enabled: true
 
+Lint/EmptyExpression:
+  Description: 'Checksfor the presence of empty expressions.'
+  Enabled: true
+
 Lint/EmptyInterpolation:
   Description: 'Checks for empty string interpolation.'
+  Enabled: true
+
+Lint/EmptyWhen:
+  Description: 'Check for the presence of when branches without a body.'
   Enabled: true
 
 Lint/EndAlignment:
   Description: 'Align ends correctly.'
   Enabled: true
+  EnforcedStyleAlignWith: 'variable'
 
 Lint/EndInMethod:
   Description: 'END blocks should not be placed inside method definitions.'
@@ -341,6 +446,10 @@ Lint/EnsureReturn:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-return-ensure'
   Enabled: true
 
+Lint/FloatOutOfRange:
+  Description: 'Identify Float literals which are, like, really really really really really really really really big.'
+  Enabled: true
+
 Lint/FormatParameterMismatch:
   Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: true
@@ -348,6 +457,18 @@ Lint/FormatParameterMismatch:
 Lint/HandleExceptions:
   Description: "Don't suppress exception."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
+  Enabled: true
+
+Lint/ImplicitStringConcatenation:
+  Description: 'Check for implicit string concatenation of string literals which are on the same line.'
+  Enabled: true
+
+Lint/IneffectiveAccessModifier:
+  Description: 'Check for private or protected access modifiers which are applied to a singleton method.'
+  Enabled: true
+
+Lint/InheritException:
+  Description: 'Look for error classes inheriting from Exception and its standard library subclasses, excluding subclasses of StandardError.'
   Enabled: true
 
 Lint/InvalidCharacterLiteral:
@@ -371,9 +492,19 @@ Lint/Loop:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#loop-with-break'
   Enabled: true
 
+Lint/MultipleCompare:
+  Description: 'Check for the x < y < z style of comparison to compare multiple values.'
+  Enabled: true
+
 Lint/NestedMethodDefinition:
   Description: 'Do not use nested method definitions.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-methods'
+  Enabled: true
+
+Lint/NextWithoutAccumulator:
+  Description: >-
+                 Don't omit the accumulator when calling next in a reduce
+                 block.
   Enabled: true
 
 Lint/NonLocalExitFromIterator:
@@ -385,6 +516,22 @@ Lint/ParenthesesAsGroupedExpression:
                  Checks for method calls with a space before the opening
                  parenthesis.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
+  Enabled: false
+
+Lint/PercentStringArray:
+  Description: >-
+                 This cop checks for quotes and commas in %w, e.g. %w('foo',
+                 "bar")
+  Enabled: true
+
+Lint/PercentSymbolArray:
+  Description: >-
+                 This cop checks for colons and commas in %i, e.g. %i(:foo,
+                 :bar)
+  Enabled: true
+
+Lint/RandOne:
+  Description: 'Check for rand(1) calls. Such calls always return 0.'
   Enabled: true
 
 Lint/RequireParentheses:
@@ -396,6 +543,17 @@ Lint/RequireParentheses:
 Lint/RescueException:
   Description: 'Avoid rescuing the Exception class.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-blind-rescues'
+  Enabled: true
+
+Lint/SafeNavigationChain:
+  Description: 'We should use a safe navigation operator after a safe navigation operator.'
+  Enabled: true
+
+Lint/ShadowedException:
+  Description: >-
+                 Check for a rescued exception that get shadowed by a less
+                 specific exception being rescued before a more specific
+                 exception is rescued.
   Enabled: true
 
 Lint/ShadowingOuterLocalVariable:
@@ -420,6 +578,14 @@ Lint/UnneededDisable:
                  It must be explicitly disabled.
   Enabled: true
 
+Lint/UnneededSplatExpansion:
+  Description: 'This cop checks for unneeded usages of splat expansion.'
+  Enabled: true
+
+Lint/UnreachableCode:
+  Description: 'Unreachable code.'
+  Enabled: true
+
 Lint/UnusedBlockArgument:
   Description: 'Checks for unused block arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
@@ -428,10 +594,6 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   Description: 'Checks for unused method arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
-  Enabled: true
-
-Lint/UnreachableCode:
-  Description: 'Unreachable code.'
   Enabled: true
 
 Lint/UselessAccessModifier:
@@ -477,14 +639,14 @@ Metrics/BlockNesting:
 
 Metrics/ClassLength:
   Description: 'Avoid classes longer than 250 lines of code.'
-  Enabled: true
+  Enabled: false
   Max: 250
 
 Metrics/CyclomaticComplexity:
   Description: >-
                  A complexity metric that is strongly correlated to the number
                  of test cases needed to validate a method.
-  Enabled: true
+  Enabled: false
 
 Metrics/LineLength:
   Description: 'Limit lines to 80 characters.'
@@ -494,18 +656,18 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 30 lines of code.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#short-methods'
-  Enabled: true
+  Enabled: false
   Max: 30
 
 Metrics/ModuleLength:
   Description: 'Avoid modules longer than 250 lines of code.'
-  Enabled: true
+  Enabled: false
   Max: 250
 
 Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
-  Enabled: true
+  Enabled: false
 
 Metrics/PerceivedComplexity:
   Description: >-
@@ -514,6 +676,15 @@ Metrics/PerceivedComplexity:
   Enabled: false
 
 ##################### Performance #############################
+
+Performance/CaseWhenSplat:
+  Enabled: true
+
+Performance/Casecmp:
+  Enabled: true
+
+Performance/CompareWithBlock:
+  Enabled: true
 
 Performance/Count:
   Description: >-
@@ -529,6 +700,15 @@ Performance/Detect:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
   Enabled: true
 
+Performance/DoubleStartEndWith:
+  Enabled: true
+
+Performance/EndWith:
+  Enabled: true
+
+Performance/FixedSize:
+  Enabled: true
+
 Performance/FlatMap:
   Description: >-
                   Use `Enumerable#flat_map`
@@ -541,6 +721,27 @@ Performance/FlatMap:
   # `flatten` being called without any parameters.
   # This can be dangerous since `flat_map` will only flatten 1 level, and
   # `flatten` without any parameters can flatten multiple levels.
+
+Performance/HashEachMethods:
+  Enabled: true
+
+Performance/LstripRstrip:
+  Enabled: true
+
+Performance/RangeInclude:
+  Enabled: true
+
+Performance/RedundantBlockCall:
+  Enabled: true
+
+Performance/RedundantMatch:
+  Enabled: true
+
+Performance/RedundantMerge:
+  Enabled: true
+
+Performance/RedundantSortBy:
+  Enabled: true
 
 Performance/ReverseEach:
   Description: 'Use `reverse_each` instead of `reverse.each`.'
@@ -561,6 +762,9 @@ Performance/Size:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code'
   Enabled: true
 
+Performance/StartWith:
+  Enabled: true
+
 Performance/StringReplacement:
   Description: >-
                   Use `tr` instead of `gsub` when you are replacing the same
@@ -569,62 +773,138 @@ Performance/StringReplacement:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
   Enabled: true
 
+Performance/TimesMap:
+  Enabled: true
+
 ##################### Rails ##################################
 
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
-  Enabled: false
+  Enabled: true
+
+Rails/ActiveSupportAliases:
+  Enabled: true
+
+Rails/Blank:
+  Enabled: true
 
 Rails/Date:
   Description: >-
                   Checks the correct usage of date aware methods,
                   such as Date.today, Date.current etc.
-  Enabled: false
+  Enabled: true
 
 Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
-  Enabled: false
+  Enabled: true
+
+Rails/DelegateAllowBlank:
+  Enabled: true
+
+Rails/DynamicFindBy:
+  Enabled: true
+
+Rails/Exit:
+  Enabled: true
+
+Rails/FilePath:
+  Enabled: true
 
 Rails/FindBy:
   Description: 'Prefer find_by over where.first.'
-  Enabled: false
+  Enabled: true
 
 Rails/FindEach:
-  Description: 'Prefer all.find_each over all.find.'
-  Enabled: false
+  Description: 'Prefer all.find_each over all.each.'
+  Enabled: true
 
 Rails/HasAndBelongsToMany:
   Description: 'Prefer has_many :through to has_and_belongs_to_many.'
-  Enabled: false
+  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#has-many-through'
+  Enabled: true
+
+Rails/NotNullColumn:
+  Enabled: true
+
+# ?
 
 Rails/Output:
   Description: 'Checks for calls to puts, print, etc.'
-  Enabled: false
+  Enabled: true
+
+Rails/OutputSafety:
+  Description: 'This cop checks for the use of output safety calls like html_safe and raw.'
+  Enabled: true
+
+Rails/PluralizationGrammar:
+  Enabled: true
+
+Rails/Present:
+  Enabled: true
 
 Rails/ReadWriteAttribute:
   Description: >-
                  Checks for read_attribute(:attr) and
                  write_attribute(:attr, val).
-  Enabled: false
+  Enabled: true
+
+Rails/RelativeDateConstant:
+  Enabled: true
+
+Rails/RequestReferer:
+  Enabled: true
+
+Rails/ReversibleMigration:
+  Enabled: true
+
+Rails/SafeNavigation:
+  Enabled: true
+
+Rails/SaveBang:
+  Enabled: true
 
 Rails/ScopeArgs:
   Description: 'Checks the arguments of ActiveRecord scopes.'
   Enabled: false
 
+Rails/SkipsModelValidations:
+  Enabled: true
+
 Rails/TimeZone:
   Description: 'Checks the correct usage of time zone aware methods.'
   StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
   Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
-  Enabled: false
+  Enabled: true
+
+Rails/UniqBeforePluck:
+  Enabled: true
 
 Rails/Validation:
   Description: 'Use validates :attribute, hash of validations.'
-  Enabled: false
+  Enabled: true
 
 ################## Security ##############################
 
 Security/Eval:
   Description: 'The use of eval represents a serious security risk.'
+  Enabled: true
+
+Security/JSONLoad:
+  Description: 'This cop checks for the use of JSON class methods which have potential security issues.'
+  Enabled: true
+
+Security/MarshalLoad:
+  Description: >-
+                 This cop checks for the use of Marshal class methods which
+                 have potential security issues leading to remote code
+                 execution when loading from an untrusted source.
+  Enabled: true
+
+Security/YAMLLoad:
+  Description: >-
+                 This cop checks for the use of YAML class methods which
+                 have potential security issues leading to remote code
+                 execution when loading from an untrusted source.
   Enabled: true
 
 ################## Style #################################
@@ -661,22 +941,26 @@ Style/AsciiIdentifiers:
 Style/Attr:
   Description: 'Checks for uses of Module#attr.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr'
-  Enabled: false
+  Enabled: true
+
+Style/AutoResourceCleanup:
+  Enabled: true
+
+Style/BarePercentLiterals:
+  Description: 'Checks if usage of %() or %Q() matches configuration.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand'
+  Enabled: true
 
 Style/BeginBlock:
   Description: 'Avoid the use of BEGIN blocks.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-BEGIN-blocks'
   Enabled: false
 
-Style/BarePercentLiterals:
-  Description: 'Checks if usage of %() or %Q() matches configuration.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand'
-  Enabled: false
-
 Style/BlockComments:
   Description: 'Do not use block comments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-block-comments'
-  Enabled: false
+  Enabled: true
+
 Style/BlockDelimiters:
   Description: >-
                 Avoid using {...} for multi-line blocks (multiline chaining is
@@ -692,17 +976,17 @@ Style/BracesAroundHashParameters:
 Style/CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-case-equality'
-  Enabled: false
+  Enabled: true
 
 Style/CharacterLiteral:
   Description: 'Checks for uses of character literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-character-literals'
-  Enabled: false
+  Enabled: true
 
 Style/ClassAndModuleCamelCase:
   Description: 'Use CamelCase for classes and modules.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#camelcase-classes'
-  Enabled: false
+  Enabled: true
 
 Style/ClassAndModuleChildren:
   Description: 'Checks style of children classes and modules.'
@@ -710,22 +994,26 @@ Style/ClassAndModuleChildren:
 
 Style/ClassCheck:
   Description: 'Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.'
-  Enabled: false
+  Enabled: true
 
 Style/ClassMethods:
   Description: 'Use self when defining module/class methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#def-self-class-methods'
-  Enabled: false
+  Enabled: true
 
 Style/ClassVars:
   Description: 'Avoid the use of class variables.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-class-vars'
   Enabled: false
 
+Style/CollectionMethods:
+  Description: 'This cop enforces the use of consistent method names from the Enumerable module.'
+  Enabled: false
+
 Style/ColonMethodCall:
   Description: 'Do not use :: for method call.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#double-colons'
-  Enabled: false
+  Enabled: true
 
 Style/CommandLiteral:
   Description: 'Use `` or %x around command literals.'
@@ -737,23 +1025,31 @@ Style/CommentAnnotation:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#annotate-keywords'
   Enabled: false
 
+Style/ConditionalAssignment:
+  Description: >-
+                 Check for if and case statements where each branch is used
+                 for assignment to the same variable when using the return
+                 of the condition can be used instead.
+  Enabled: false
+
 Style/ConstantName:
   Description: 'Constants should use SCREAMING_SNAKE_CASE.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#screaming-snake-case'
+  Enabled: true
+
+Style/Copyright:
   Enabled: false
 
 Style/DefWithParentheses:
   Description: 'Use def with parentheses when there are arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
-  Enabled: false
-
-Style/PreferredHashMethods:
-  Description: 'Checks for use of deprecated Hash methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-key'
-  Enabled: false
+  Enabled: true
 
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
+  Enabled: false
+
+Style/DocumentationMethod:
   Enabled: false
 
 Style/DoubleNegation:
@@ -761,47 +1057,63 @@ Style/DoubleNegation:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
   Enabled: false
 
+Style/EachForSimpleLoop:
+  Enabled: true
+
 Style/EachWithObject:
   Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
-  Enabled: false
+  Enabled: true
+
+Style/EmptyCaseCondition:
+  Enabled: true
 
 Style/EmptyElse:
   Description: 'Avoid empty else-clauses.'
-  Enabled: false
+  Enabled: true
 
 Style/EmptyLiteral:
   Description: 'Prefer literals to Array.new/Hash.new/String.new.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#literal-array-hash'
+  Enabled: true
+
+Style/EmptyMethod:
+  Enabled: false
+  EnforcedStyle: 'compact'
+
+Style/Encoding:
   Enabled: false
 
 Style/EndBlock:
   Description: 'Avoid the use of END blocks.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-END-blocks'
-  Enabled: false
+  Enabled: true
 
 Style/EvenOdd:
   Description: 'Favor the use of Fixnum#even? && Fixnum#odd?'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
-  Enabled: false
+  Enabled: true
 
 Style/FileName:
   Description: 'Use snake_case for source file names.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
-  Enabled: false
+  Enabled: true
 
 Style/FlipFlop:
   Description: 'Checks for flip flops'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
-  Enabled: false
+  Enabled: true
 
 Style/For:
   Description: 'Checks use of for or each in multiline loops.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-for-loops'
-  Enabled: false
+  Enabled: true
 
 Style/FormatString:
   Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#sprintf'
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
   Enabled: false
 
 Style/GlobalVars:
@@ -822,55 +1134,40 @@ Style/HashSyntax:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-literals'
   Enabled: false
 
+Style/IdenticalConditionalBranches:
+  Enabled: true
+
+Style/IfInsideElse:
+  Enabled: true
+
 Style/IfUnlessModifier:
   Description: >-
                  Favor modifier if/unless usage when you have a
                  single-line body.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier'
-  Enabled: false
+  Enabled: true
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: true
 
 Style/IfWithSemicolon:
   Description: 'Do not use if x; .... Use the ternary operator instead.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs'
   Enabled: false
 
-Style/LineEndConcatenation:
-  Description: >-
-                 Use \ instead of + or << to concatenate two string literals at
-                 line end.
-  Enabled: false
-
-Style/MethodCallWithoutArgsParentheses:
-  Description: 'Do not use parentheses for method calls with no arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
-  Enabled: false
-
-Style/MethodDefParentheses:
-  Description: >-
-                 Checks if the method definitions have or don't have
-                 parentheses.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
-  Enabled: false
-
-Style/MethodName:
-  Description: 'Use the configured style when naming methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
-  Enabled: false
-
-Style/ModuleFunction:
-  Description: 'Checks for usage of `extend self` in modules.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
-  Enabled: false
-
-Style/MultilineBlockChain:
-  Description: 'Avoid multi-line chains of blocks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
+Style/ImplicitRuntimeError:
   Enabled: false
 
 Style/InfiniteLoop:
   Description: 'Use Kernel#loop for infinite loops.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#infinite-loop'
   Enabled: false
+
+Style/InlineComment:
+  Enabled: false
+
+Style/InverseMethods:
+  Enabled: true
 
 Style/Lambda:
   Description: 'Use the new lambda literal syntax for single-line blocks.'
@@ -880,11 +1177,60 @@ Style/Lambda:
 Style/LambdaCall:
   Description: 'Use lambda.call(...) instead of lambda.(...).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc-call'
+  Enabled: true
+
+Style/LineEndConcatenation:
+  Description: >-
+                 Use \ instead of + or << to concatenate two string literals at
+                 line end.
+  Enabled: true
+
+Style/MethodCallWithArgsParentheses:
   Enabled: false
+  IgnoreMacros: true
+
+Style/MethodCallWithoutArgsParentheses:
+  Description: 'Do not use parentheses for method calls with no arguments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
+  Enabled: true
+
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+
+Style/MethodDefParentheses:
+  Description: >-
+                 Checks if the method definitions have or don't have
+                 parentheses.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
+  Enabled: true
+
+Style/MethodMissing:
+  Enabled: true
+
+Style/MethodName:
+  Description: 'Use the configured style when naming methods.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
+  Enabled: true
+
+Style/ModuleFunction:
+  Description: 'Checks for usage of `extend self` in modules.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Description: 'Avoid multi-line chains of blocks.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
+  Enabled: true
+
+Style/MultilineIfModifier:
+  Enabled: true
 
 Style/MultilineIfThen:
   Description: 'Do not use then for multi-line if/unless.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-then'
+  Enabled: true
+
+Style/MultilineMemoization:
   Enabled: false
 
 Style/MultilineTernaryOperator:
@@ -892,6 +1238,9 @@ Style/MultilineTernaryOperator:
                  Avoid multi-line ?: (the ternary operator);
                  use if/unless instead.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-multiline-ternary'
+  Enabled: true
+
+Style/MutableConstant:
   Enabled: false
 
 Style/NegatedIf:
@@ -899,43 +1248,55 @@ Style/NegatedIf:
                  Favor unless over if for negative conditions
                  (or control flow or).
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#unless-for-negatives'
-  Enabled: false
+  Enabled: true
 
 Style/NegatedWhile:
   Description: 'Favor until over while for negative conditions.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#until-for-negatives'
-  Enabled: false
+  Enabled: true
+
+Style/NestedModifier:
+  Enabled: true
+
+Style/NestedParenthesizedCalls:
+  Enabled: true
 
 Style/NestedTernaryOperator:
   Description: 'Use one expression per branch in a ternary operator.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-ternary'
-  Enabled: false
+  Enabled: true
 
 Style/Next:
   Description: 'Use `next` to skip iteration instead of a condition at the end.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
-  Enabled: false
+  Enabled: true
 
 Style/NilComparison:
   Description: 'Prefer x.nil? to x == nil.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
-  Enabled: false
+  Enabled: true
 
 Style/NonNilCheck:
   Description: 'Checks for redundant nil checks.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-non-nil-checks'
-  Enabled: false
+  Enabled: true
 
 Style/Not:
   Description: 'Use ! instead of not.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bang-not-not'
-  Enabled: false
+  Enabled: true
+
+Style/NumericLiteralPrefix:
+  Enabled: true
 
 Style/NumericLiterals:
   Description: >-
                  Add underscores to large numeric literals to improve their
                  readability.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
+  Enabled: true
+
+Style/NumericPredicate:
   Enabled: false
 
 Style/OneLineConditional:
@@ -948,6 +1309,9 @@ Style/OneLineConditional:
 Style/OpMethod:
   Description: 'When defining binary operators, name the argument other.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
+  Enabled: true
+
+Style/OptionHash:
   Enabled: false
 
 Style/OptionalArguments:
@@ -955,7 +1319,7 @@ Style/OptionalArguments:
                  Checks for optional arguments that do not appear at the end
                  of the argument list
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#optional-arguments'
-  Enabled: false
+  Enabled: true
 
 Style/ParallelAssignment:
   Description: >-
@@ -971,7 +1335,7 @@ Style/ParenthesesAroundCondition:
                  Don't use parentheses around the condition of an
                  if/unless/while.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-parens-if'
-  Enabled: false
+  Enabled: true
 
 Style/PercentLiteralDelimiters:
   Description: 'Use `%`-literal delimiters consistently'
@@ -985,12 +1349,17 @@ Style/PercentQLiterals:
 Style/PerlBackrefs:
   Description: 'Avoid Perl-style regex back references.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers'
-  Enabled: false
+  Enabled: true
 
 Style/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
-  Enabled: false
+  Enabled: true
+
+Style/PreferredHashMethods:
+  Description: 'Checks for use of deprecated Hash methods.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-key'
+  Enabled: true
 
 Style/Proc:
   Description: 'Use proc instead of Proc.new.'
@@ -1005,17 +1374,23 @@ Style/RaiseArgs:
 Style/RedundantBegin:
   Description: "Don't use begin blocks when they are not needed."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#begin-implicit'
-  Enabled: false
+  Enabled: true
 
 Style/RedundantException:
   Description: "Checks for an obsolete RuntimeException argument in raise/fail."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-explicit-runtimeerror'
   Enabled: false
 
+Style/RedundantFreeze:
+  Enabled: true
+
+Style/RedundantParentheses:
+  Enabled: true
+
 Style/RedundantReturn:
   Description: "Don't use return where it's not required."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-explicit-return'
-  Enabled: false
+  Enabled: true
 
 Style/RedundantSelf:
   Description: "Don't use self where it's not needed."
@@ -1030,18 +1405,24 @@ Style/RegexpLiteral:
 Style/RescueModifier:
   Description: 'Avoid using rescue in its modifier form.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers'
-  Enabled: false
+  Enabled: true
+
+Style/SafeNavigation:
+  Enabled: true
 
 Style/SelfAssignment:
   Description: >-
                  Checks for places where self-assignment shorthand should have
                  been used.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#self-assignment'
-  Enabled: false
+  Enabled: true
 
 Style/Semicolon:
   Description: "Don't use semicolons to terminate expressions."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon'
+  Enabled: true
+
+Style/Send:
   Enabled: false
 
 Style/SignalException:
@@ -1062,68 +1443,88 @@ Style/SingleLineMethods:
 Style/SpecialGlobalVars:
   Description: 'Avoid Perl-style global variables.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms'
-  Enabled: false
+  Enabled: true
+
+Style/StabbyLambdaParentheses:
+  Enabled: true
+  EnforcedStyle: 'require_parentheses'
 
 Style/StringLiterals:
   Description: 'Checks if uses of quotes match the configured preference.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-string-literals'
   Enabled: false
+  EnforcedStyle: 'single_quotes'
 
 Style/StringLiteralsInInterpolation:
   Description: >-
                  Checks if uses of quotes inside expressions in interpolated
                  strings match the configured preference.
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: 'single_quotes'
+
+Style/StringMethods:
+  Enabled: true
 
 Style/StructInheritance:
   Description: 'Checks for inheritance from Struct.new.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new'
+  Enabled: true
+
+Style/SymbolArray:
   Enabled: false
 
 Style/SymbolLiteral:
   Description: 'Use plain symbols instead of string symbols when possible.'
-  Enabled: false
+  Enabled: true
 
 Style/SymbolProc:
   Description: 'Use symbols as procs instead of blocks when possible.'
+  Enabled: true
+
+Style/TernaryParentheses:
   Enabled: false
 
 Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in parameter lists.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
-  Enabled: false
+  Enabled: true
+  EnforcedStyleForMultiline: 'no_comma'
 
 Style/TrailingCommaInLiteral:
   Description: 'Checks for trailing comma in literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: false
+  EnforcedStyleForMultiline: 'no_comma'
+
+Style/TrailingUnderscoreVariable:
+  Description: >-
+                 Checks for the usage of unneeded trailing underscores at the
+                 end of parallel variable assignment.
+  Enabled: true
 
 Style/TrivialAccessors:
   Description: 'Prefer attr_* methods to trivial readers/writers.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr_family'
-  Enabled: false
+  Enabled: true
 
 Style/UnlessElse:
   Description: >-
                  Do not use unless with else. Rewrite these with the positive
                  case first.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-else-with-unless'
-  Enabled: false
+  Enabled: true
 
 Style/UnneededCapitalW:
   Description: 'Checks for %W when interpolation is not needed.'
   Enabled: false
 
+Style/UnneededInterpolation:
+  Enabled: true
+
 Style/UnneededPercentQ:
   Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-q'
-  Enabled: false
-
-Style/TrailingUnderscoreVariable:
-  Description: >-
-                 Checks for the usage of unneeded trailing underscores at the
-                 end of parallel variable assignment.
-  Enabled: false
+  Enabled: true
 
 Style/VariableInterpolation:
   Description: >-
@@ -1135,6 +1536,10 @@ Style/VariableInterpolation:
 Style/VariableName:
   Description: 'Use the configured style when naming variables.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
+  Enabled: true
+  EnforcedStyle: 'snake_case'
+
+Style/VariableNumber:
   Enabled: false
 
 Style/WhenThen:
@@ -1145,7 +1550,7 @@ Style/WhenThen:
 Style/WhileUntilDo:
   Description: 'Checks for redundant do after while or until.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-multiline-while-do'
-  Enabled: false
+  Enabled: true
 
 Style/WhileUntilModifier:
   Description: >-
@@ -1158,3 +1563,6 @@ Style/WordArray:
   Description: 'Use %w or %W for arrays of words.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-w'
   Enabled: false
+
+Style/ZeroLengthPredicate:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,265 @@ AllCops:
   TargetRubyVersion: 2.3
   DisabledByDefault: true
 
+#################### Layout ##############################
+
+Layout/AccessModifierIndentation:
+  Description: Check indentation of private/protected visibility modifiers.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected'
+  Enabled: false
+
+Layout/AlignArray:
+  Description: >-
+                 Align the elements of an array literal if they span more than
+                 one line.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays'
+  Enabled: false
+
+Layout/AlignHash:
+  Description: >-
+                 Align the elements of a hash literal if they span more than
+                 one line.
+  Enabled: false
+
+Layout/AlignParameters:
+  Description: >-
+                 Align the parameters of a method call if they span more
+                 than one line.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
+  Enabled: false
+
+Layout/BlockEndNewline:
+  Description: 'Put end statement of multiline block on its own line.'
+  Enabled: false
+
+Layout/CaseIndentation:
+  Description: 'Indentation of when in a case/when/[else/]end.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-when-to-case'
+  Enabled: false
+
+Layout/ClosingParenthesisIndentation:
+  Description: 'Checks the indentation of hanging closing parentheses.'
+  Enabled: false
+
+Layout/CommentIndentation:
+  Description: 'Indentation of comments.'
+  Enabled: false
+
+Layout/DotPosition:
+  Description: 'Checks the position of the dot in multi-line method calls.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
+  Enabled: false
+
+Layout/ElseAlignment:
+  Description: 'Align elses and elsifs correctly.'
+  Enabled: false
+
+Layout/EmptyLineBetweenDefs:
+  Description: 'Use empty lines between defs.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods'
+  Enabled: false
+
+Layout/EmptyLines:
+  Description: "Don't use several empty lines in a row."
+  Enabled: false
+
+Layout/EmptyLinesAroundAccessModifier:
+  Description: "Keep blank lines around access modifiers."
+  Enabled: false
+
+Layout/EmptyLinesAroundBlockBody:
+  Description: "Keeps track of empty lines around block bodies."
+  Enabled: false
+
+Layout/EmptyLinesAroundClassBody:
+  Description: "Keeps track of empty lines around class bodies."
+  Enabled: false
+
+Layout/EmptyLinesAroundModuleBody:
+  Description: "Keeps track of empty lines around module bodies."
+  Enabled: false
+
+Layout/EmptyLinesAroundMethodBody:
+  Description: "Keeps track of empty lines around method bodies."
+  Enabled: false
+
+Layout/EndOfLine:
+  Description: 'Use Unix-style line endings.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#crlf'
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Description: 'Do not use unnecessary spacing.'
+  Enabled: false
+
+Layout/InitialIndentation:
+  Description: >-
+    Checks the indentation of the first non-blank non-comment line in a file.
+  Enabled: false
+
+Layout/FirstParameterIndentation:
+  Description: 'Checks the indentation of the first parameter in a method call.'
+  Enabled: false
+
+Layout/IndentationConsistency:
+  Description: 'Keep indentation straight.'
+  Enabled: false
+
+Layout/IndentationWidth:
+  Description: 'Use 2 spaces for indentation.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
+  Enabled: false
+
+Layout/IndentArray:
+  Description: >-
+                 Checks the indentation of the first element in an array
+                 literal.
+  Enabled: false
+
+Layout/IndentHash:
+  Description: 'Checks the indentation of the first key in a hash literal.'
+  Enabled: false
+
+Layout/LeadingCommentSpace:
+  Description: 'Comments should start with a space.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-space'
+  Enabled: false
+
+Layout/MultilineBlockLayout:
+  Description: 'Ensures newlines after multiline block do statements.'
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Description: >-
+                 Checks indentation of binary operations that span more than
+                 one line.
+  Enabled: false
+
+Layout/RescueEnsureAlignment:
+  Description: 'Align rescues and ensures correctly.'
+  Enabled: false
+
+Layout/SpaceBeforeFirstArg:
+  Description: >-
+                 Checks that exactly one space is used between a method name
+                 and the first argument for method calls without parentheses.
+  Enabled: true
+
+Layout/SpaceAfterColon:
+  Description: 'Use spaces after colons.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: false
+
+Layout/SpaceAfterComma:
+  Description: 'Use spaces after commas.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: false
+
+Layout/SpaceAroundKeyword:
+  Description: 'Use spaces around keywords.'
+  Enabled: false
+
+Layout/SpaceAfterMethodName:
+  Description: >-
+                 Do not put a space between a method name and the opening
+                 parenthesis in a method definition.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
+  Enabled: false
+
+Layout/SpaceAfterNot:
+  Description: Tracks redundant space after the ! operator.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-bang'
+  Enabled: false
+
+Layout/SpaceAfterSemicolon:
+  Description: 'Use spaces after semicolons.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: false
+
+Layout/SpaceBeforeBlockBraces:
+  Description: >-
+                 Checks that the left block brace has or doesn't have space
+                 before it.
+  Enabled: false
+
+Layout/SpaceBeforeComma:
+  Description: 'No spaces before commas.'
+  Enabled: false
+
+Layout/SpaceBeforeComment:
+  Description: >-
+                 Checks for missing space between code and a comment on the
+                 same line.
+  Enabled: false
+
+Layout/SpaceBeforeSemicolon:
+  Description: 'No spaces before semicolons.'
+  Enabled: false
+
+Layout/SpaceInsideBlockBraces:
+  Description: >-
+                 Checks that block braces have or don't have surrounding space.
+                 For blocks taking parameters, checks that the left brace has
+                 or doesn't have trailing space.
+  Enabled: false
+
+Layout/SpaceAroundBlockParameters:
+  Description: 'Checks the spacing inside and after block parameters pipes.'
+  Enabled: false
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Description: >-
+                 Checks that the equals signs in parameter default assignments
+                 have or don't have surrounding space depending on
+                 configuration.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-around-equals'
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  Description: 'Use a single space around operators.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: false
+
+Layout/SpaceInsideBrackets:
+  Description: 'No spaces after [ or before ].'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
+  Enabled: false
+
+Layout/SpaceInsideHashLiteralBraces:
+  Description: "Use spaces inside hash literal braces - or don't."
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: false
+
+Layout/SpaceInsideParens:
+  Description: 'No spaces after ( or before ).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
+  Enabled: false
+
+Layout/SpaceInsideRangeLiteral:
+  Description: 'No spaces inside range literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals'
+  Enabled: false
+
+Layout/SpaceInsideStringInterpolation:
+  Description: 'Checks for padding/surrounding spaces inside string interpolation.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#string-interpolation'
+  Enabled: false
+
+Layout/Tab:
+  Description: 'No hard tabs.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
+  Enabled: false
+
+Layout/TrailingBlankLines:
+  Description: 'Checks trailing blank lines and final newline.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#newline-eof'
+  Enabled: false
+
+Layout/TrailingWhitespace:
+  Description: 'Avoid trailing whitespace.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
+  Enabled: false
+
 #################### Lint ################################
 
 Lint/AmbiguousOperator:
@@ -80,10 +339,6 @@ Lint/EndInMethod:
 Lint/EnsureReturn:
   Description: 'Do not use return in an ensure block.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-return-ensure'
-  Enabled: true
-
-Lint/Eval:
-  Description: 'The use of eval represents a serious security risk.'
   Enabled: true
 
 Lint/FormatParameterMismatch:
@@ -366,12 +621,13 @@ Rails/Validation:
   Description: 'Use validates :attribute, hash of validations.'
   Enabled: false
 
-################## Style #################################
+################## Security ##############################
 
-Style/AccessModifierIndentation:
-  Description: Check indentation of private/protected visibility modifiers.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected'
-  Enabled: false
+Security/Eval:
+  Description: 'The use of eval represents a serious security risk.'
+  Enabled: true
+
+################## Style #################################
 
 Style/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
@@ -380,26 +636,6 @@ Style/AccessorMethodName:
 Style/Alias:
   Description: 'Use alias_method instead of alias.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#alias-method'
-  Enabled: false
-
-Style/AlignArray:
-  Description: >-
-                 Align the elements of an array literal if they span more than
-                 one line.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays'
-  Enabled: false
-
-Style/AlignHash:
-  Description: >-
-                 Align the elements of a hash literal if they span more than
-                 one line.
-  Enabled: false
-
-Style/AlignParameters:
-  Description: >-
-                 Align the parameters of a method call if they span more
-                 than one line.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
   Enabled: false
 
 Style/AndOr:
@@ -441,11 +677,6 @@ Style/BlockComments:
   Description: 'Do not use block comments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-block-comments'
   Enabled: false
-
-Style/BlockEndNewline:
-  Description: 'Put end statement of multiline block on its own line.'
-  Enabled: false
-
 Style/BlockDelimiters:
   Description: >-
                 Avoid using {...} for multi-line blocks (multiline chaining is
@@ -461,11 +692,6 @@ Style/BracesAroundHashParameters:
 Style/CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-case-equality'
-  Enabled: false
-
-Style/CaseIndentation:
-  Description: 'Indentation of when in a case/when/[else/]end.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-when-to-case'
   Enabled: false
 
 Style/CharacterLiteral:
@@ -496,10 +722,6 @@ Style/ClassVars:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-class-vars'
   Enabled: false
 
-Style/ClosingParenthesisIndentation:
-  Description: 'Checks the indentation of hanging closing parentheses.'
-  Enabled: false
-
 Style/ColonMethodCall:
   Description: 'Do not use :: for method call.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#double-colons'
@@ -513,10 +735,6 @@ Style/CommandLiteral:
 Style/CommentAnnotation:
   Description: 'Checks formatting of annotation comments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#annotate-keywords'
-  Enabled: false
-
-Style/CommentIndentation:
-  Description: 'Indentation of comments.'
   Enabled: false
 
 Style/ConstantName:
@@ -538,11 +756,6 @@ Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: false
 
-Style/DotPosition:
-  Description: 'Checks the position of the dot in multi-line method calls.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
-  Enabled: false
-
 Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
@@ -552,41 +765,8 @@ Style/EachWithObject:
   Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
   Enabled: false
 
-Style/ElseAlignment:
-  Description: 'Align elses and elsifs correctly.'
-  Enabled: false
-
 Style/EmptyElse:
   Description: 'Avoid empty else-clauses.'
-  Enabled: false
-
-Style/EmptyLineBetweenDefs:
-  Description: 'Use empty lines between defs.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods'
-  Enabled: false
-
-Style/EmptyLines:
-  Description: "Don't use several empty lines in a row."
-  Enabled: false
-
-Style/EmptyLinesAroundAccessModifier:
-  Description: "Keep blank lines around access modifiers."
-  Enabled: false
-
-Style/EmptyLinesAroundBlockBody:
-  Description: "Keeps track of empty lines around block bodies."
-  Enabled: false
-
-Style/EmptyLinesAroundClassBody:
-  Description: "Keeps track of empty lines around class bodies."
-  Enabled: false
-
-Style/EmptyLinesAroundModuleBody:
-  Description: "Keeps track of empty lines around module bodies."
-  Enabled: false
-
-Style/EmptyLinesAroundMethodBody:
-  Description: "Keeps track of empty lines around method bodies."
   Enabled: false
 
 Style/EmptyLiteral:
@@ -599,32 +779,14 @@ Style/EndBlock:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-END-blocks'
   Enabled: false
 
-Style/EndOfLine:
-  Description: 'Use Unix-style line endings.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#crlf'
-  Enabled: false
-
 Style/EvenOdd:
   Description: 'Favor the use of Fixnum#even? && Fixnum#odd?'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
   Enabled: false
 
-Style/ExtraSpacing:
-  Description: 'Do not use unnecessary spacing.'
-  Enabled: false
-
 Style/FileName:
   Description: 'Use snake_case for source file names.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
-  Enabled: false
-
-Style/InitialIndentation:
-  Description: >-
-    Checks the indentation of the first non-blank non-comment line in a file.
-  Enabled: false
-
-Style/FirstParameterIndentation:
-  Description: 'Checks the indentation of the first parameter in a method call.'
   Enabled: false
 
 Style/FlipFlop:
@@ -672,52 +834,13 @@ Style/IfWithSemicolon:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs'
   Enabled: false
 
-Style/IndentationConsistency:
-  Description: 'Keep indentation straight.'
-  Enabled: false
-
-Style/IndentationWidth:
-  Description: 'Use 2 spaces for indentation.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
-  Enabled: false
-
-Style/IndentArray:
-  Description: >-
-                 Checks the indentation of the first element in an array
-                 literal.
-  Enabled: false
-
-Style/IndentHash:
-  Description: 'Checks the indentation of the first key in a hash literal.'
-  Enabled: false
-
-Style/InfiniteLoop:
-  Description: 'Use Kernel#loop for infinite loops.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#infinite-loop'
-  Enabled: false
-
-Style/Lambda:
-  Description: 'Use the new lambda literal syntax for single-line blocks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#lambda-multi-line'
-  Enabled: false
-
-Style/LambdaCall:
-  Description: 'Use lambda.call(...) instead of lambda.(...).'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc-call'
-  Enabled: false
-
-Style/LeadingCommentSpace:
-  Description: 'Comments should start with a space.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-space'
-  Enabled: false
-
 Style/LineEndConcatenation:
   Description: >-
                  Use \ instead of + or << to concatenate two string literals at
                  line end.
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
   Enabled: false
@@ -744,19 +867,24 @@ Style/MultilineBlockChain:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
   Enabled: false
 
-Style/MultilineBlockLayout:
-  Description: 'Ensures newlines after multiline block do statements.'
+Style/InfiniteLoop:
+  Description: 'Use Kernel#loop for infinite loops.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#infinite-loop'
+  Enabled: false
+
+Style/Lambda:
+  Description: 'Use the new lambda literal syntax for single-line blocks.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#lambda-multi-line'
+  Enabled: false
+
+Style/LambdaCall:
+  Description: 'Use lambda.call(...) instead of lambda.(...).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc-call'
   Enabled: false
 
 Style/MultilineIfThen:
   Description: 'Do not use then for multi-line if/unless.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-then'
-  Enabled: false
-
-Style/MultilineOperationIndentation:
-  Description: >-
-                 Checks indentation of binary operations that span more than
-                 one line.
   Enabled: false
 
 Style/MultilineTernaryOperator:
@@ -899,10 +1027,6 @@ Style/RegexpLiteral:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
   Enabled: false
 
-Style/RescueEnsureAlignment:
-  Description: 'Align rescues and ensures correctly.'
-  Enabled: false
-
 Style/RescueModifier:
   Description: 'Avoid using rescue in its modifier form.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers'
@@ -935,112 +1059,6 @@ Style/SingleLineMethods:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-single-line-methods'
   Enabled: false
 
-Style/SpaceBeforeFirstArg:
-  Description: >-
-                 Checks that exactly one space is used between a method name
-                 and the first argument for method calls without parentheses.
-  Enabled: true
-
-Style/SpaceAfterColon:
-  Description: 'Use spaces after colons.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Style/SpaceAfterComma:
-  Description: 'Use spaces after commas.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Style/SpaceAroundKeyword:
-  Description: 'Use spaces around keywords.'
-  Enabled: false
-
-Style/SpaceAfterMethodName:
-  Description: >-
-                 Do not put a space between a method name and the opening
-                 parenthesis in a method definition.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
-  Enabled: false
-
-Style/SpaceAfterNot:
-  Description: Tracks redundant space after the ! operator.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-bang'
-  Enabled: false
-
-Style/SpaceAfterSemicolon:
-  Description: 'Use spaces after semicolons.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Style/SpaceBeforeBlockBraces:
-  Description: >-
-                 Checks that the left block brace has or doesn't have space
-                 before it.
-  Enabled: false
-
-Style/SpaceBeforeComma:
-  Description: 'No spaces before commas.'
-  Enabled: false
-
-Style/SpaceBeforeComment:
-  Description: >-
-                 Checks for missing space between code and a comment on the
-                 same line.
-  Enabled: false
-
-Style/SpaceBeforeSemicolon:
-  Description: 'No spaces before semicolons.'
-  Enabled: false
-
-Style/SpaceInsideBlockBraces:
-  Description: >-
-                 Checks that block braces have or don't have surrounding space.
-                 For blocks taking parameters, checks that the left brace has
-                 or doesn't have trailing space.
-  Enabled: false
-
-Style/SpaceAroundBlockParameters:
-  Description: 'Checks the spacing inside and after block parameters pipes.'
-  Enabled: false
-
-Style/SpaceAroundEqualsInParameterDefault:
-  Description: >-
-                 Checks that the equals signs in parameter default assignments
-                 have or don't have surrounding space depending on
-                 configuration.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-around-equals'
-  Enabled: false
-
-Style/SpaceAroundOperators:
-  Description: 'Use a single space around operators.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Style/SpaceInsideBrackets:
-  Description: 'No spaces after [ or before ].'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
-  Enabled: false
-
-Style/SpaceInsideHashLiteralBraces:
-  Description: "Use spaces inside hash literal braces - or don't."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Style/SpaceInsideParens:
-  Description: 'No spaces after ( or before ).'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
-  Enabled: false
-
-Style/SpaceInsideRangeLiteral:
-  Description: 'No spaces inside range literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals'
-  Enabled: false
-
-Style/SpaceInsideStringInterpolation:
-  Description: 'Checks for padding/surrounding spaces inside string interpolation.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#string-interpolation'
-  Enabled: false
-
 Style/SpecialGlobalVars:
   Description: 'Avoid Perl-style global variables.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms'
@@ -1070,16 +1088,6 @@ Style/SymbolProc:
   Description: 'Use symbols as procs instead of blocks when possible.'
   Enabled: false
 
-Style/Tab:
-  Description: 'No hard tabs.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
-  Enabled: false
-
-Style/TrailingBlankLines:
-  Description: 'Checks trailing blank lines and final newline.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#newline-eof'
-  Enabled: false
-
 Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in parameter lists.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
@@ -1088,11 +1096,6 @@ Style/TrailingCommaInArguments:
 Style/TrailingCommaInLiteral:
   Description: 'Checks for trailing comma in literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
-  Enabled: false
-
-Style/TrailingWhitespace:
-  Description: 'Avoid trailing whitespace.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
   Enabled: false
 
 Style/TrivialAccessors:

--- a/app/concerns/presentable.rb
+++ b/app/concerns/presentable.rb
@@ -15,13 +15,11 @@ module Presentable
 
   included do
     def as_json_with_presenter(options={})
-      begin
-        presenter = (self.class.name + "Presenter").constantize
-      rescue NameError
-        as_json_without_presenter(options)
-      else
-        presenter.new(self).as_json(options)
-      end
+      presenter = (self.class.name + "Presenter").constantize
+    rescue NameError
+      as_json_without_presenter(options)
+    else
+      presenter.new(self).as_json(options)
     end
     alias_method_chain :as_json, :presenter
   end

--- a/app/concerns/writable.rb
+++ b/app/concerns/writable.rb
@@ -16,7 +16,7 @@ module Writable
       return user.avatar_id? unless character
       return true if character.default_icon
       return false unless character.galleries.present?
-      return character.icons.exists?
+      character.icons.exists?
     end
 
     def editable_by?(editor)

--- a/app/controllers/aliases_controller.rb
+++ b/app/controllers/aliases_controller.rb
@@ -34,7 +34,7 @@ class AliasesController < ApplicationController
   private
 
   def find_character
-    unless @character = Character.find_by_id(params[:character_id])
+    unless (@character = Character.find_by_id(params[:character_id]))
       flash[:error] = "Character could not be found."
       redirect_to characters_path and return
     end
@@ -46,7 +46,7 @@ class AliasesController < ApplicationController
   end
 
   def find_alias
-    unless @alias = CharacterAlias.find_by_id(params[:id])
+    unless (@alias = CharacterAlias.find_by_id(params[:id]))
       flash[:error] = "Alias could not be found."
       redirect_to edit_character_path(@character) and return
     end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -32,7 +32,6 @@ class Api::ApiController < ActionController::Base
     end
   end
 
-
   def access_denied
     error = {message: "You do not have permission to perform this action."}
     render json: {errors: [error]}, status: :forbidden

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -27,7 +27,7 @@ class Api::ApiController < ActionController::Base
   def handle_param_validation
     yield
   rescue Apipie::ParamMissing, Apipie::ParamInvalid => error
-    render json: {errors: [Sanitize.fragment(error.message.gsub('"', "'"))]}, status: :unprocessable_entity
+    render json: {errors: [Sanitize.fragment(error.message.tr('"', "'"))]}, status: :unprocessable_entity
   end
 
   def access_denied

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -25,11 +25,9 @@ class Api::ApiController < ActionController::Base
   end
 
   def handle_param_validation
-    begin
-      yield
-    rescue Apipie::ParamMissing, Apipie::ParamInvalid => error
-      render json: {errors: [Sanitize.fragment(error.message.gsub('"', "'"))]}, status: :unprocessable_entity
-    end
+    yield
+  rescue Apipie::ParamMissing, Apipie::ParamInvalid => error
+    render json: {errors: [Sanitize.fragment(error.message.gsub('"', "'"))]}, status: :unprocessable_entity
   end
 
   def access_denied

--- a/app/controllers/api/v1/boards_controller.rb
+++ b/app/controllers/api/v1/boards_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::BoardsController < Api::ApiController
   param :id, :number, required: true, desc: 'Continuity ID'
   error 404, "Continuity not found"
   def show
-    unless board = Board.find_by_id(params[:id])
+    unless (board = Board.find_by_id(params[:id]))
       error = {message: "Continuity could not be found."}
       render json: {errors: [error]}, status: :not_found and return
     end

--- a/app/controllers/api/v1/characters_controller.rb
+++ b/app/controllers/api/v1/characters_controller.rb
@@ -60,7 +60,7 @@ class Api::V1::CharactersController < Api::ApiController
   private
 
   def find_character
-    unless @character = Character.find_by_id(params[:id])
+    unless (@character = Character.find_by_id(params[:id]))
       error = {message: "Character could not be found."}
       render json: {errors: [error]}, status: :not_found and return
     end

--- a/app/controllers/api/v1/galleries_controller.rb
+++ b/app/controllers/api/v1/galleries_controller.rb
@@ -22,10 +22,10 @@ class Api::V1::GalleriesController < Api::ApiController
 
   def show_galleryless
     user = if params[:user_id].present?
-             User.find_by_id(params[:user_id])
-           else
-             current_user
-           end
+      User.find_by_id(params[:user_id])
+    else
+      current_user
+    end
 
     unless user
       error = {message: "Gallery user could not be found."}

--- a/app/controllers/api/v1/galleries_controller.rb
+++ b/app/controllers/api/v1/galleries_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::GalleriesController < Api::ApiController
   def show
     show_galleryless and return if params[:id].to_s == '0'
 
-    unless gallery = Gallery.find_by_id(params[:id])
+    unless (gallery = Gallery.find_by_id(params[:id]))
       error = {message: "Gallery could not be found."}
       render json: {errors: [error]}, status: :not_found and return
     end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::PostsController < Api::ApiController
   error 403, "Post is not visible to the user"
   error 404, "Post not found"
   def show
-    unless post = Post.find_by_id(params[:id])
+    unless (post = Post.find_by_id(params[:id]))
       error = {message: "Post could not be found."}
       render json: {errors: [error]}, status: :not_found and return
     end

--- a/app/controllers/api/v1/replies_controller.rb
+++ b/app/controllers/api/v1/replies_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::RepliesController < Api::ApiController
   error 403, "Post is not visible to the user"
   error 404, "Post not found"
   def index
-    unless post = Post.find_by_id(params[:post_id])
+    unless (post = Post.find_by_id(params[:post_id]))
       error = {message: "Post could not be found."}
       render json: {errors: [error]}, status: :not_found and return
     end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -7,7 +7,7 @@ class BoardsController < ApplicationController
 
   def index
     if params[:user_id].present?
-      unless @user = User.find_by_id(params[:user_id]) || current_user
+      unless (@user = User.find_by_id(params[:user_id]) || current_user)
         flash[:error] = "User could not be found."
         redirect_to root_path and return
       end
@@ -89,7 +89,7 @@ class BoardsController < ApplicationController
   end
 
   def mark
-    unless board = Board.find_by_id(params[:board_id])
+    unless (board = Board.find_by_id(params[:board_id]))
       flash[:error] = "Continuity could not be found."
       redirect_to unread_posts_path and return
     end
@@ -123,7 +123,7 @@ class BoardsController < ApplicationController
   end
 
   def find_board
-    unless @board = Board.find_by_id(params[:id])
+    unless (@board = Board.find_by_id(params[:id]))
       flash[:error] = "Continuity could not be found."
       redirect_to boards_path and return
     end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -16,10 +16,10 @@ class CharactersController < ApplicationController
     end
 
     @page_title = if @user.id == current_user.try(:id)
-                    "Your Characters"
-                  else
-                    @user.username + "'s Characters"
-                  end
+      "Your Characters"
+    else
+      @user.username + "'s Characters"
+    end
   end
 
   def new

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -134,7 +134,7 @@ class CharactersController < ApplicationController
   end
 
   def do_replace
-    unless params[:icon_dropdown].blank? || new_char = Character.find_by_id(params[:icon_dropdown])
+    unless params[:icon_dropdown].blank? || (new_char = Character.find_by_id(params[:icon_dropdown]))
       flash[:error] = "Character could not be found."
       redirect_to replace_character_path(@character) and return
     end
@@ -222,7 +222,7 @@ class CharactersController < ApplicationController
   private
 
   def find_character
-    unless @character = Character.find_by_id(params[:id])
+    unless (@character = Character.find_by_id(params[:id]))
       flash[:error] = "Character could not be found."
       redirect_to characters_path and return
     end
@@ -252,11 +252,11 @@ class CharactersController < ApplicationController
 
   def save_character_with_extras
     Character.transaction do
-      if template = @character.instance_variable_get('@template')
+      if (template = @character.instance_variable_get('@template'))
         template.save
         @character.template = template
       end
-      if group = @character.instance_variable_get('@group')
+      if (group = @character.instance_variable_get('@group'))
         group.save
         @character.character_group = group
       end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -32,19 +32,19 @@ class FavoritesController < ApplicationController
     favorite = nil
 
     if params[:user_id].present?
-      unless favorite = User.find_by_id(params[:user_id])
+      unless (favorite = User.find_by_id(params[:user_id]))
         flash[:error] = "User could not be found."
         redirect_to users_path and return
       end
       fav_path = user_path(favorite)
     elsif params[:board_id].present?
-      unless favorite = Board.find_by_id(params[:board_id])
+      unless (favorite = Board.find_by_id(params[:board_id]))
         flash[:error] = "Continuity could not be found."
         redirect_to boards_path and return
       end
       fav_path = board_path(favorite)
     elsif params[:post_id].present?
-      unless favorite = Post.find_by_id(params[:post_id])
+      unless (favorite = Post.find_by_id(params[:post_id]))
         flash[:error] = "Post could not be found."
         redirect_to posts_path and return
       end
@@ -71,7 +71,7 @@ class FavoritesController < ApplicationController
   end
 
   def destroy
-    unless fav = Favorite.find_by_id(params[:id])
+    unless (fav = Favorite.find_by_id(params[:id]))
       flash[:error] = "Favorite could not be found."
       redirect_to favorites_path and return
     end

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -7,7 +7,7 @@ class GalleriesController < ApplicationController
 
   def index
     if params[:user_id].present?
-      unless @user = User.find_by_id(params[:user_id]) || current_user
+      unless (@user = User.find_by_id(params[:user_id]) || current_user)
         flash[:error] = 'User could not be found.'
         redirect_to root_path and return
       end

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -17,10 +17,10 @@ class GalleriesController < ApplicationController
     end
 
     @page_title = if @user.id == current_user.try(:id)
-                    "Your Galleries"
-                  else
-                    @user.username + "'s Galleries"
-                  end
+      "Your Galleries"
+    else
+      @user.username + "'s Galleries"
+    end
     use_javascript('galleries/expander')
     gon.user_id = @user.id
   end

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -80,7 +80,7 @@ class IconsController < ApplicationController
   end
 
   def do_replace
-    unless params[:icon_dropdown].blank? || new_icon = Icon.find_by_id(params[:icon_dropdown])
+    unless params[:icon_dropdown].blank? || (new_icon = Icon.find_by_id(params[:icon_dropdown]))
       flash[:error] = "Icon could not be found."
       redirect_to replace_icon_path(@icon) and return
     end
@@ -124,7 +124,7 @@ class IconsController < ApplicationController
   private
 
   def find_icon
-    unless @icon = Icon.find_by_id(params[:id])
+    unless (@icon = Icon.find_by_id(params[:id]))
       flash[:error] = "Icon could not be found."
       redirect_to galleries_path
     end

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -66,10 +66,10 @@ class IconsController < ApplicationController
   def replace
     @page_title = "Replace Icon: " + @icon.keyword
     all_icons = if @icon.has_gallery?
-                  @icon.galleries.map(&:icons).flatten.uniq.compact - [@icon]
-                else
-                  current_user.galleryless_icons - [@icon]
-                end
+      @icon.galleries.map(&:icons).flatten.uniq.compact - [@icon]
+    else
+      current_user.galleryless_icons - [@icon]
+    end
     @alts = all_icons.sort_by{|i| i.keyword.downcase }
     use_javascript('icons')
     gon.gallery = Hash[all_icons.map { |i| [i.id, {url: i.url, keyword: i.keyword}] }]

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -6,7 +6,7 @@ class IconsController < ApplicationController
 
   def delete_multiple
     icon_ids = (params[:marked_ids] || []).map(&:to_i).reject(&:zero?)
-    if icon_ids.empty? or (icons = Icon.where(id: icon_ids)).empty?
+    if icon_ids.empty? || (icons = Icon.where(id: icon_ids)).empty?
       flash[:error] = "No icons selected."
       redirect_to galleries_path and return
     end
@@ -17,7 +17,8 @@ class IconsController < ApplicationController
         flash[:error] = "Gallery could not be found."
         redirect_to galleries_path and return
       end
-      if gallery.user_id != current_user.id
+
+      unless gallery.user_id == current_user.id
         flash[:error] = "That is not your gallery."
         redirect_to galleries_path and return
       end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,11 +7,11 @@ class MessagesController < ApplicationController
     if params[:view] == 'outbox'
       @view = 'outbox'
       @page_title = 'Outbox'
-      @messages = current_user.sent_messages.where(visible_outbox: true).order('id desc').uniq! {|m| m.thread_id }
+      @messages = current_user.sent_messages.where(visible_outbox: true).order('id desc').uniq!(&:thread_id)
     else
       @view = 'inbox'
       @page_title = 'Inbox'
-      @messages = current_user.messages.where(visible_inbox: true).order('id desc').uniq! {|m| m.thread_id }
+      @messages = current_user.messages.where(visible_inbox: true).order('id desc').uniq!(&:thread_id)
     end
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -47,7 +47,7 @@ class MessagesController < ApplicationController
   end
 
   def show
-    unless message = Message.find_by_id(params[:id])
+    unless (message = Message.find_by_id(params[:id]))
       flash[:error] = "Message could not be found."
       redirect_to messages_path(view: 'inbox') and return
     end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -19,7 +19,7 @@ class PasswordResetsController < ApplicationController
       render :new and return
     end
 
-    unless user = User.where(email: params[:email], username: params[:username]).first
+    unless (user = User.where(email: params[:email], username: params[:username]).first)
       flash.now[:error] = "Account could not be found."
       render :new and return
     end
@@ -76,7 +76,7 @@ class PasswordResetsController < ApplicationController
   end
 
   def find_reset
-    unless @password_reset = PasswordReset.where(auth_token: params[:id]).first
+    unless (@password_reset = PasswordReset.where(auth_token: params[:id]).first)
       flash[:error] = "Authentication token not found."
       redirect_to root_url and return
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -33,7 +33,7 @@ class PostsController < WritableController
     @posts = @posts.where("board_views.user_id IS NULL OR ((board_views.read_at IS NULL OR (date_trunc('second', board_views.read_at) < date_trunc('second', posts.tagged_at))) AND board_views.ignored = '0')")
     @posts = posts_from_relation(@posts.order('tagged_at desc'), true, false)
     @posts = @posts.select { |p| p.visible_to?(current_user) }
-    @posts = @posts.select { |p|  @opened_ids.include?(p.id) } if @started
+    @posts = @posts.select { |p| @opened_ids.include?(p.id) } if @started
     @posts = @posts.paginate(per_page: 25, page: page)
     @hide_quicklinks = true
     @page_title = @started ? 'Opened Threads' : 'Unread Threads'

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -348,9 +348,9 @@ class PostsController < WritableController
     existing_saved = @post.send(klass.to_s.underscore.pluralize) || []
     return existing_saved unless @post.send(method)
 
-    existing_unsaved = klass.where(id: @post.send(method) - existing_saved.map { |es| es.id.to_s })
+    existing_unsaved = klass.where(id: @post.send(method) - (existing_saved.map { |es| es.id.to_s }))
     new_tags = @post.send(method).reject { |t| t.blank? || !t.to_i.zero? }
-    existing_saved + existing_unsaved + new_tags.map { |t| faked.new(t, t) }
+    existing_saved + existing_unsaved + (new_tags.map { |t| faked.new(t, t) })
   end
 
   def create_new_tags

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -77,7 +77,7 @@ class RepliesController < WritableController
   end
 
   def make_draft
-    if draft = ReplyDraft.draft_for(params[:reply][:post_id], current_user.id)
+    if (draft = ReplyDraft.draft_for(params[:reply][:post_id], current_user.id))
       draft.assign_attributes(params[:reply])
     else
       draft = ReplyDraft.new(params[:reply])

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -40,7 +40,7 @@ class TagsController < ApplicationController
   private
 
   def find_tag
-    unless @tag = Tag.find_by_id(params[:id])
+    unless (@tag = Tag.find_by_id(params[:id]))
       flash[:error] = "Tag could not be found."
       redirect_to tags_path
     end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -11,7 +11,7 @@ class TagsController < ApplicationController
 
   def show
     @posts = posts_from_relation(@tag.posts)
-    @page_title = "#{@tag.name}"
+    @page_title = @tag.name.to_s
   end
 
   def edit

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -55,7 +55,7 @@ class TemplatesController < ApplicationController
   private
 
   def find_template
-    unless @template = Template.find_by_id(params[:id])
+    unless (@template = Template.find_by_id(params[:id]))
       flash[:error] = "Template could not be found."
       redirect_to characters_path and return
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    unless @user = User.find_by_id(params[:id])
+    unless (@user = User.find_by_id(params[:id]))
       flash[:error] = "User could not be found."
       redirect_to users_path and return
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -83,7 +83,7 @@ module ApplicationHelper
     default ||= per_page
     default = nil if default.to_i > 100
 
-    options = [10,25,50,100]
+    options = [10, 25, 50, 100]
     options << default unless default.nil? || default.zero? || options.include?(default)
     options = Hash[*(options * 2).sort]
     options_for_select(options, default)
@@ -127,7 +127,7 @@ module ApplicationHelper
   end
 
   def sanitize_written_content(content)
-    content = (content.include?("<p>".freeze) || content[/<br ?\/?>/]) ? content : content.gsub("\n".freeze,"<br/>".freeze)
+    content = (content.include?("<p>".freeze) || content[/<br ?\/?>/]) ? content : content.gsub("\n".freeze, "<br/>".freeze)
     Sanitize.fragment(content, Glowfic::POST_CONTENT_SANITIZER)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -91,7 +91,7 @@ module ApplicationHelper
 
   def timezone_options(default=nil)
     default ||= 'Eastern Time (US & Canada)'
-    zones = ActiveSupport::TimeZone.all()
+    zones = ActiveSupport::TimeZone.all
     options_from_collection_for_select(zones, :name, :to_s, default)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,7 @@ module ApplicationHelper
     return '' if url.nil?
     klass = ICON
     klass += ' pointer' if args.delete(:pointer)
-    if supplied_class = args.delete(:class)
+    if (supplied_class = args.delete(:class))
       klass += ' ' + supplied_class
     end
 

--- a/app/jobs/base_job.rb
+++ b/app/jobs/base_job.rb
@@ -12,7 +12,7 @@ class BaseJob < Object
     Resque.enqueue(self, *args)
   end
 
-  def self.process(*args)
+  def self.process(*_args)
     raise NotImplementedError
   end
 

--- a/app/jobs/generate_flat_post_job.rb
+++ b/app/jobs/generate_flat_post_job.rb
@@ -5,7 +5,7 @@ class GenerateFlatPostJob < BaseJob
 
   def self.process(post_id)
     Rails.logger.info("[GenerateFlatPostJob] updating flat post for post #{post_id}")
-    return unless post = Post.find_by_id(post_id)
+    return unless (post = Post.find_by_id(post_id))
 
     lock_key = self.lock_key(post_id)
 

--- a/app/jobs/notify_followers_of_new_post_job.rb
+++ b/app/jobs/notify_followers_of_new_post_job.rb
@@ -4,7 +4,7 @@ class NotifyFollowersOfNewPostJob < BaseJob
   @expire_retry_key_after = 3600
 
   def self.process(post_id)
-    return unless post = Post.find_by_id(post_id)
+    return unless (post = Post.find_by_id(post_id))
 
     users_favoriting_user = Favorite.where(favorite: post.user).pluck(:user_id)
     users_favoriting_continuity = Favorite.where(favorite: post.board).pluck(:user_id)

--- a/app/jobs/scrape_post_job.rb
+++ b/app/jobs/scrape_post_job.rb
@@ -12,7 +12,7 @@ class ScrapePostJob < BaseJob
   end
 
   def self.notify_exception(exception, url, board_id, section_id, status, threaded, importer_id)
-    if (importer = User.find_by_id(importer_id))
+    if User.find_by_id(importer_id)
       message = "The url #{url} could not be successfully scraped. "
       message += exception.message if exception.is_a?(UnrecognizedUsernameError)
       message += "Your post was already imported! #{view_post(exception.post_id)}" if exception.is_a?(AlreadyImportedError)

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -37,7 +37,7 @@ class Character < ActiveRecord::Base
     [name, template_name, screenname].compact.join(' | ')
   end
 
-  def reorder_galleries(gallery=nil)
+  def reorder_galleries(_gallery=nil)
     # public so that it can be called from CharactersGallery.after_destroy
     galleries = CharactersGallery.where(character_id: id).order('section_order asc')
     return unless galleries.present?

--- a/app/models/character_alias.rb
+++ b/app/models/character_alias.rb
@@ -3,7 +3,7 @@ class CharacterAlias < ActiveRecord::Base
   validates_presence_of :character, :name
   after_destroy :clear_alias_ids
 
-  def as_json(options={})
+  def as_json(_options={})
     { id: id, name: name }
   end
 

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -33,7 +33,7 @@ class Icon < ActiveRecord::Base
 
   def delete_from_s3
     return unless uploaded?
-    resp = S3_BUCKET.delete_objects(delete: {objects: [{key: s3_key}], quiet: true})
+    S3_BUCKET.delete_objects(delete: {objects: [{key: s3_key}], quiet: true})
   end
 
   def uploaded_url_not_in_use

--- a/app/models/password_reset.rb
+++ b/app/models/password_reset.rb
@@ -18,7 +18,7 @@ class PasswordReset < ActiveRecord::Base
   def generate_unique_auth_token
     return if auth_token.present?
     return unless user
-    loop do 
+    loop do
       self.auth_token = generate_auth_token
       break unless self.class.where(auth_token: self.auth_token).exists?
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -116,7 +116,7 @@ class Post < ActiveRecord::Base
       reply.icon_id = reply.character.default_icon.try(:id)
     end
 
-    return reply
+    reply
   end
 
   def first_unread_for(user)
@@ -158,7 +158,7 @@ class Post < ActiveRecord::Base
 
   def show_warnings_for?(user)
     return false if user.hide_warnings
-    !(view_for(user).try(:warnings_hidden))
+    !view_for(user).try(:warnings_hidden)
   end
 
   def completed?
@@ -272,7 +272,7 @@ class Post < ActiveRecord::Base
   end
 
   def skip_edited
-    @skip_edited || !EDITED_ATTRS.any?{ |edit| send(edit + "_changed?")}
+    @skip_edited || EDITED_ATTRS.none? { |edit| send(edit + "_changed?") }
   end
 
   def timestamp_attributes_for_create

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -288,7 +288,7 @@ class Post < ActiveRecord::Base
     true
   end
 
-  def reset_warnings(warning)
+  def reset_warnings(_warning)
     PostView.where(post_id: id).update_all(warnings_hidden: false)
   end
 

--- a/app/models/reply_draft.rb
+++ b/app/models/reply_draft.rb
@@ -10,7 +10,7 @@ class ReplyDraft < ActiveRecord::Base
   end
 
   def self.draft_reply_for(post, user)
-    return unless draft = draft_for(post.id, user.id)
+    return unless (draft = draft_for(post.id, user.id))
     ReplyDraft.reply_from_draft(draft)
   end
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -8,7 +8,7 @@
 class Report < Object
   def self.mark_read(user, at_time)
     view = view_for(user)
-    
+
     if view.new_record?
       view.read_at = at_time
       return view.save

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -12,7 +12,7 @@ class Tag < ActiveRecord::Base
     user.try(:admin?)
   end
 
-  def as_json(*args, **kwargs)
+  def as_json(*)
     {id: self.id, text: self.name}
   end
 

--- a/app/presenters/board_section_presenter.rb
+++ b/app/presenters/board_section_presenter.rb
@@ -5,7 +5,7 @@ class BoardSectionPresenter
     @board_section = board_section
   end
 
-  def as_json(options={})
+  def as_json(_options={})
     return {} unless board_section
     { id: board_section.id,
       name: board_section.name,

--- a/app/presenters/character_presenter.rb
+++ b/app/presenters/character_presenter.rb
@@ -33,7 +33,7 @@ class CharacterPresenter
 
   def multi_gallery_json
     galleries = character.galleries.ordered
-    galleries_json = galleries.map do |gallery|
+    galleries.map do |gallery|
       {
         name: gallery.name,
         icons: gallery.icons

--- a/app/presenters/character_presenter.rb
+++ b/app/presenters/character_presenter.rb
@@ -15,12 +15,12 @@ class CharacterPresenter
       post = options[:post_for_alias]
       most_recent_use = post.replies.where(character_id: @character.id).order('id desc').first
       most_recent_use = post if most_recent_use.nil? && post.character_id == character.id
-      char_json.merge!(alias_id_for_post: most_recent_use.try(:character_alias_id))
+      char_json[:alias_id_for_post] = most_recent_use.try(:character_alias_id)
       return char_json unless options[:include].present?
     end
 
-    char_json.merge!(default: character.default_icon.try(:as_json)) if options[:include].include?(:default)
-    char_json.merge!(aliases: character.aliases) if options[:include].include?(:aliases)
+    char_json[:default] = character.default_icon.try(:as_json) if options[:include].include?(:default)
+    char_json[:aliases] = character.aliases if options[:include].include?(:aliases)
     return char_json unless options[:include].include?(:galleries)
 
     galleries = if character.galleries.present? && character.user.icon_picker_grouping?

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -5,7 +5,7 @@ class PostPresenter
     @post = post
   end
 
-  def as_json(options={})
+  def as_json(_options={})
     return {} unless post
 
     attrs = %w(id status subject description content created_at edited_at tagged_at)

--- a/app/presenters/reply_presenter.rb
+++ b/app/presenters/reply_presenter.rb
@@ -5,7 +5,7 @@ class ReplyPresenter
     @reply = reply
   end
 
-  def as_json(options={})
+  def as_json(_options={})
     return {} unless reply
     { id: reply.id,
       content: reply.content,

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module Glowfic
-  ALLOWED_TAGS = ["b", "i", "u", "sub", "sup", "del", "hr", "p", "br", "div", "span", "pre", "code", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "dl", "dt", "dd", "a", "img", "blockquote", "q", "table", "td", "th", "tr", "strike", "s", "strong", "em", "big", "small", "font",  "cite", "abbr", "var", "samp", "kbd", "mark", "ruby", "rp", "rt", "bdo", "wbr"]
+  ALLOWED_TAGS = ["b", "i", "u", "sub", "sup", "del", "hr", "p", "br", "div", "span", "pre", "code", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "dl", "dt", "dd", "a", "img", "blockquote", "q", "table", "td", "th", "tr", "strike", "s", "strong", "em", "big", "small", "font", "cite", "abbr", "var", "samp", "kbd", "mark", "ruby", "rp", "rt", "bdo", "wbr"]
   POST_CONTENT_SANITIZER = Sanitize::Config.merge(Sanitize::Config::RELAXED,
     :elements => ALLOWED_TAGS,
     :attributes => {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,7 +13,7 @@ Glowfic::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send. 
+  # Don't care if the mailer can't send.
   # Swap these lines with the commented lines to send mail.
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.perform_deliveries = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Glowfic::Application.configure do
   # For large-scale production use, consider using a caching reverse proxy like
   # NGINX, varnish or squid.
   # config.action_dispatch.rack_cache = true
-  
+
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
   config.static_cache_control = 'public, max-age=31536000'
 

--- a/db/migrate/20160410024710_add_last_fields_to_post.rb
+++ b/db/migrate/20160410024710_add_last_fields_to_post.rb
@@ -13,7 +13,7 @@ class AddLastFieldsToPost < ActiveRecord::Migration
           post.last_user_id = post.user_id
         end
 
-        last_edit = post.audits.where(action:'update').reject { |a| a.audited_changes.keys == ['privacy'] }.last
+        last_edit = post.audits.where(action: 'update').reject { |a| a.audited_changes.keys == ['privacy'] }.last
         if last_edit
           post.edited_at = last_edit.created_at
         else

--- a/db/migrate/20160410024710_add_last_fields_to_post.rb
+++ b/db/migrate/20160410024710_add_last_fields_to_post.rb
@@ -6,7 +6,7 @@ class AddLastFieldsToPost < ActiveRecord::Migration
     ActiveRecord::Base.record_timestamps = false
     begin
       Post.all.each do |post|
-        if last_reply = post.replies.order('created_at desc').first
+        if (last_reply = post.replies.order('created_at desc').first)
           post.last_reply_id = last_reply.id
           post.last_user_id = last_reply.user_id
         else

--- a/db/migrate/20160410060405_add_moiety_to_user.rb
+++ b/db/migrate/20160410060405_add_moiety_to_user.rb
@@ -22,7 +22,7 @@ class AddMoietyToUser < ActiveRecord::Migration
     31 => '860018',
     33 => '006000',
   }
-  #this constant was removed from the model but is still needed here.
+  # this constant was removed from the model but is still needed here.
 
   def change
     add_column :users, :moiety, :string

--- a/features/step_definitions/message_steps.rb
+++ b/features/step_definitions/message_steps.rb
@@ -5,7 +5,7 @@ end
 Given(/^I have a message thread$/) do
   first = create(:message, sender: current_user)
   second = create(:message, thread_id: first.id, sender: first.recipient, recipient: first.sender, parent: first)
-  last = create(:message, thread_id: first.id, sender: first.sender, recipient: first.recipient, parent: second)
+  create(:message, thread_id: first.id, sender: first.sender, recipient: first.recipient, parent: second) # last
 end
 
 When(/^I go to my (in|out)box$/) do |box|

--- a/features/step_definitions/navigation.rb
+++ b/features/step_definitions/navigation.rb
@@ -40,7 +40,7 @@ Given(/^I have (\d) read posts?$/) do |num|
 end
 
 Given(/^my account uses the (.+) layout$/) do |layout|
-  layout_name = layout.gsub(" ", "")
+  layout_name = layout.delete(' ')
   user = current_user
   user.layout = layout_name
   user.save!

--- a/lib/post_scraper.rb
+++ b/lib/post_scraper.rb
@@ -263,10 +263,10 @@ class PostScraper < Object
   end
 end
 
-class UnrecognizedUsernameError < Exception
+class UnrecognizedUsernameError < RuntimeError
 end
 
-class AlreadyImportedError < Exception
+class AlreadyImportedError < RuntimeError
   attr_reader :post_id
   def initialize(msg, post_id)
     @post_id = post_id

--- a/lib/post_scraper.rb
+++ b/lib/post_scraper.rb
@@ -22,8 +22,8 @@ class PostScraper < Object
     @board_id = board_id || SANDBOX_ID
     @section_id = section_id
     @status = status || Post::STATUS_COMPLETE
-    url = url + (url.include?('?') ? '&' : '?') + 'style=site' unless url.include?('style=site')
-    url = url + '&view=flat' unless url.include?('view=flat') || threaded_import
+    url += (url.include?('?') ? '&' : '?') + 'style=site' unless url.include?('style=site')
+    url += '&view=flat' unless url.include?('view=flat') || threaded_import
     @url = url
     @console_import = console_import
     @threaded_import = threaded_import # boolean

--- a/script/character_scraper.rb
+++ b/script/character_scraper.rb
@@ -8,7 +8,7 @@ unless comm_name.present? && user_id.present?
   exit 0
 end
 
-unless user = User.find_by_id(user_id)
+unless (user = User.find_by_id(user_id))
   puts "That user does not exist"
   exit 0
 end
@@ -25,11 +25,11 @@ characters.each do |username|
   html_doc = Nokogiri::HTML(response.body)
   name = html_doc.at_css('#basics_body .profile td').content.strip
 
-  unless gallery = Gallery.where(name: username).first
+  unless (gallery = Gallery.where(name: username).first)
     gallery = Gallery.create!(user: user, name: username)
   end
 
-  unless character = Character.where(screenname: username).first
+  unless (character = Character.where(screenname: username).first)
     character = Character.create!(user: user, name: name, screenname: username)
   end
 

--- a/script/character_scraper.rb
+++ b/script/character_scraper.rb
@@ -20,7 +20,7 @@ html_doc = Nokogiri::HTML(response.body)
 characters = html_doc.at_css('#members_people_body').css('a').map(&:content).map(&:strip)
 characters.each do |username|
   puts "  -" + username
-  url_name = username.gsub('_','-')
+  url_name = username.gsub('_', '-')
   response = HTTParty.get("http://#{url_name}.dreamwidth.org/profile")
   html_doc = Nokogiri::HTML(response.body)
   name = html_doc.at_css('#basics_body .profile td').content.strip

--- a/script/character_scraper.rb
+++ b/script/character_scraper.rb
@@ -20,7 +20,7 @@ html_doc = Nokogiri::HTML(response.body)
 characters = html_doc.at_css('#members_people_body').css('a').map(&:content).map(&:strip)
 characters.each do |username|
   puts "  -" + username
-  url_name = username.gsub('_', '-')
+  url_name = username.tr('_', '-')
   response = HTTParty.get("http://#{url_name}.dreamwidth.org/profile")
   html_doc = Nokogiri::HTML(response.body)
   name = html_doc.at_css('#basics_body .profile td').content.strip

--- a/script/scraper_incandescence.rb
+++ b/script/scraper_incandescence.rb
@@ -28,7 +28,7 @@ main_list.each do |section|
 
   links = section.parent.css('li')
   board_section = BoardSection.create!(board_id: board_id, name: section_title, section_order: section_index, status: 1)
-  links.each_with_index do |link, index|
+  links.each do |link|
     url = link.at_css('a').attribute('href').value
     scraper = PostScraper.new(url, board_id, board_section.id)
     scraper.scrape

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ApplicationController do
     end
 
     it "will return a blank array if applicable" do
-      post = create(:post)
+      create(:post)
       relation = Post.where('posts.id IS NULL')
       expect(controller.send(:posts_from_relation, relation)).to be_blank
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ApplicationController do
   describe "#set_timezone" do
     it "uses the user's time zone within the block" do
       current_zone = Time.zone.name
-      different_zone = ActiveSupport::TimeZone.all().detect { |z| z.name != Time.zone.name }.name
+      different_zone = ActiveSupport::TimeZone.all.detect { |z| z.name != Time.zone.name }.name
       session[:user_id] = create(:user, timezone: different_zone).id
 
       expect(Time.zone.name).to eq(current_zone)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe ApplicationController do
       expect(controller.send(:posts_from_relation, relation), false).not_to be_blank
     end
 
-    let(:default_post_ids) { 26.times.collect do create(:post) end.map(&:id) }
+    let(:default_post_ids) { Array.new(26) do create(:post).id end }
 
     it "paginates by default" do
       relation = Post.where(id: default_post_ids)

--- a/spec/controllers/board_sections_controller_spec.rb
+++ b/spec/controllers/board_sections_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe BoardSectionsController do
 
     it "does not require login" do
       section = create(:board_section)
-      posts = 2.times.collect do create(:post, board: section.board, section: section) end
+      posts = Array.new(2) { create(:post, board: section.board, section: section) }
       create(:post)
       create(:post, board: section.board)
       get :show, id: section.id
@@ -93,7 +93,7 @@ RSpec.describe BoardSectionsController do
 
     it "works with login" do
       section = create(:board_section)
-      posts = 2.times.collect do create(:post, board: section.board, section: section) end
+      posts = Array.new(2) { create(:post, board: section.board, section: section) }
       create(:post)
       create(:post, board: section.board)
       get :show, id: section.id

--- a/spec/controllers/boards_controller_spec.rb
+++ b/spec/controllers/boards_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe BoardsController do
     it "sets correct variables" do
       user_id = login
       current_user = User.find(user_id)
-      other_users = 3.times.collect do create(:user) end
+      other_users = Array.new(3) { create(:user) }
 
       get :new
 
@@ -124,7 +124,7 @@ RSpec.describe BoardsController do
 
     it "sets correct variables on failure" do
       login
-      other_users = 3.times.collect do create(:user) end
+      other_users = Array.new(3) { create(:user) }
 
       post :create
 

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe CharactersController do
 
       it "should set correct variables" do
         character = create(:character)
-        posts = 26.times.collect do create(:post, character: character, user: character.user) end
+        26.times do create(:post, character: character, user: character.user) end
         get :show, id: character.id
         expect(response.status).to eq(200)
         expect(assigns(:page_title)).to eq(character.name)
@@ -168,7 +168,7 @@ RSpec.describe CharactersController do
 
       it "should only show visible posts" do
         character = create(:character)
-        post = create(:post, character: character, user: character.user, privacy: Post::PRIVACY_PRIVATE)
+        create(:post, character: character, user: character.user, privacy: Post::PRIVACY_PRIVATE)
         get :show, id: character.id
         expect(assigns(:posts)).to be_blank
       end
@@ -427,9 +427,9 @@ RSpec.describe CharactersController do
       other_char.save
       calias = create(:alias, character: other_char)
       char_post = create(:post, user: user, character: character)
-      char_reply1 = create(:reply, user: user, post: char_post, character: character)
-      other_post = create(:post)
-      char_reply2 = create(:reply, user: user, character: character)
+      create(:reply, user: user, post: char_post, character: character) # reply
+      create(:post) # other post
+      char_reply2 = create(:reply, user: user, character: character) # other reply
 
       login_as(user)
       get :replace, id: character.id
@@ -447,7 +447,7 @@ RSpec.describe CharactersController do
         template = create(:template, user: user)
         character = create(:character, user: user, template: template)
         alts = 5.times.collect do create(:character, user: user, template: template) end
-        other_character = create(:character, user: user)
+        create(:character, user: user) # other character
 
         login_as(user)
         get :replace, id: character.id
@@ -461,7 +461,7 @@ RSpec.describe CharactersController do
         user = create(:user)
         template = create(:template, user: user)
         character = create(:character, user: user, template: template)
-        other_character = create(:character, user: user)
+        create(:character, user: user) # other character
 
         login_as(user)
         get :replace, id: character.id
@@ -476,7 +476,7 @@ RSpec.describe CharactersController do
         character = create(:character, user: user)
         alts = 5.times.collect do create(:character, user: user) end
         template = create(:template, user: user)
-        other_char = create(:character, user: user, template: template)
+        create(:character, user: user, template: template) # other character
 
         login_as(user)
         get :replace, id: character.id
@@ -490,7 +490,7 @@ RSpec.describe CharactersController do
         user = create(:user)
         template = create(:template, user: user)
         character = create(:character, user: user)
-        other_character = create(:character, user: user, template: template)
+        create(:character, user: user, template: template) # other character
 
         login_as(user)
         get :replace, id: character.id

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe CharactersController do
       chars = 3.times.collect do create(:template_character, pb: SecureRandom.urlsafe_base64) end
       chars += 3.times.collect do create(:character, pb: SecureRandom.urlsafe_base64) end
       get :facecasts, sort: 'writer'
-      expect(assigns(:pbs).keys).to match_array(chars.map { |c| c.user })
+      expect(assigns(:pbs).keys).to match_array(chars.map(&:user))
     end
   end
 

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe CharactersController do
 
     it "sets correct variables" do
       user = create(:user)
-      templates = 2.times.collect do create(:template, user: user) end
+      templates = Array.new(2) { create(:template, user: user) }
       names = ['— Create New Template —'] + templates.map(&:name)
       create(:template)
 
@@ -123,7 +123,7 @@ RSpec.describe CharactersController do
 
     it "sets correct variables when invalid" do
       user = create(:user)
-      templates = 2.times.collect do create(:template, user: user) end
+      templates = Array.new(2) { create(:template, user: user) }
       names = ['— Create New Template —'] + templates.map(&:name)
       create(:template)
 
@@ -158,7 +158,7 @@ RSpec.describe CharactersController do
 
       it "should set correct variables" do
         character = create(:character)
-        26.times do create(:post, character: character, user: character.user) end
+        Array.new(26) { create(:post, character: character, user: character.user) }
         get :show, id: character.id
         expect(response.status).to eq(200)
         expect(assigns(:page_title)).to eq(character.name)
@@ -206,7 +206,7 @@ RSpec.describe CharactersController do
     it "sets correct variables" do
       user = create(:user)
       character = create(:character, user: user)
-      templates = 2.times.collect do create(:template, user: user) end
+      templates = Array.new(2) { create(:template, user: user) }
       names = ['— Create New Template —'] + templates.map(&:name)
       create(:template)
 
@@ -292,7 +292,7 @@ RSpec.describe CharactersController do
 
     it "sets correct variables when invalid" do
       character = create(:character)
-      templates = 2.times.collect do create(:template, user: character.user) end
+      templates = Array.new(2) { create(:template, user: character.user) }
       names = ['— Create New Template —'] + templates.map(&:name)
       create(:template)
 
@@ -330,33 +330,33 @@ RSpec.describe CharactersController do
     end
 
     it "sets correct variables for facecast name sort" do
-      chars = 3.times.collect do create(:character, pb: SecureRandom.urlsafe_base64) end
+      chars = Array.new(3) { create(:character, pb: SecureRandom.urlsafe_base64) }
       get :facecasts
       expect(assigns(:pbs).keys).to match_array(chars.map(&:pb))
     end
 
     it "sets correct variables for character name sort: character only" do
-      chars = 3.times.collect do create(:character, pb: SecureRandom.urlsafe_base64) end
+      chars = Array.new(3) { create(:character, pb: SecureRandom.urlsafe_base64) }
       get :facecasts, sort: 'name'
       expect(assigns(:pbs).keys).to match_array(chars)
     end
 
     it "sets correct variables for character name sort: template only" do
-      chars = 3.times.collect do create(:template_character, pb: SecureRandom.urlsafe_base64) end
+      chars = Array.new(3) { create(:template_character, pb: SecureRandom.urlsafe_base64) }
       get :facecasts, sort: 'name'
       expect(assigns(:pbs).keys).to match_array(chars.map(&:template))
     end
 
     it "sets correct variables for character name sort: character and template mixed" do
-      chars = 3.times.collect do create(:template_character, pb: SecureRandom.urlsafe_base64) end
-      chars += 3.times.collect do create(:character, pb: SecureRandom.urlsafe_base64) end
+      chars = Array.new(3) { create(:template_character, pb: SecureRandom.urlsafe_base64) }
+      chars += Array.new(3) { create(:character, pb: SecureRandom.urlsafe_base64) }
       get :facecasts, sort: 'name'
       expect(assigns(:pbs).keys).to match_array(chars.map { |c| c.template || c })
     end
 
     it "sets correct variables for writer sort" do
-      chars = 3.times.collect do create(:template_character, pb: SecureRandom.urlsafe_base64) end
-      chars += 3.times.collect do create(:character, pb: SecureRandom.urlsafe_base64) end
+      chars = Array.new(3) { create(:template_character, pb: SecureRandom.urlsafe_base64) }
+      chars += Array.new(3) { create(:character, pb: SecureRandom.urlsafe_base64) }
       get :facecasts, sort: 'writer'
       expect(assigns(:pbs).keys).to match_array(chars.map(&:user))
     end
@@ -446,7 +446,7 @@ RSpec.describe CharactersController do
         user = create(:user)
         template = create(:template, user: user)
         character = create(:character, user: user, template: template)
-        alts = 5.times.collect do create(:character, user: user, template: template) end
+        alts = Array.new(5) { create(:character, user: user, template: template) }
         create(:character, user: user) # other character
 
         login_as(user)
@@ -474,7 +474,7 @@ RSpec.describe CharactersController do
       it "sets alts correctly" do
         user = create(:user)
         character = create(:character, user: user)
-        alts = 5.times.collect do create(:character, user: user) end
+        alts = Array.new(5) { create(:character, user: user) }
         template = create(:template, user: user)
         create(:character, user: user, template: template) # other character
 

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe GalleriesController do
       # compensates for developers not having S3 buckets set up locally
       return unless S3_BUCKET.nil?
       struct = Struct.new(:url) do
-        def presigned_post(args)
+        def presigned_post(_args)
           1
         end
       end

--- a/spec/controllers/icons_controller_spec.rb
+++ b/spec/controllers/icons_controller_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe IconsController do
       it "sets variables correctly" do
         user = create(:user)
         icon = create(:icon, user_id: user.id)
-        alts = 5.times.collect { |i| create(:icon, user_id: user.id) }
+        alts = Array.new(5) { create(:icon, user_id: user.id) }
         post = create(:post, user_id: user.id, icon_id: icon.id)
         create(:reply, post_id: post.id, user_id: user.id, icon_id: icon.id) # post reply
         reply = create(:reply, user_id: user.id, icon_id: icon.id)
@@ -370,7 +370,7 @@ RSpec.describe IconsController do
       it "sets variables correctly" do
         user = create(:user)
         icon = create(:icon, user_id: user.id)
-        alts = 5.times.collect { |i| create(:icon, user: user) }
+        alts = Array.new(5) { create(:icon, user: user) }
         gallery = create(:gallery, user: user, icon_ids: [icon.id] + alts.map(&:id))
         other_icon = create(:icon, user: user)
 

--- a/spec/controllers/icons_controller_spec.rb
+++ b/spec/controllers/icons_controller_spec.rb
@@ -348,14 +348,14 @@ RSpec.describe IconsController do
         icon = create(:icon, user_id: user.id)
         alts = 5.times.collect { |i| create(:icon, user_id: user.id) }
         post = create(:post, user_id: user.id, icon_id: icon.id)
-        post_reply = create(:reply, post_id: post.id, user_id: user.id, icon_id: icon.id)
+        create(:reply, post_id: post.id, user_id: user.id, icon_id: icon.id) # post reply
         reply = create(:reply, user_id: user.id, icon_id: icon.id)
 
         other_icon = create(:icon, user_id: user.id)
         gallery = create(:gallery, user_id: user.id, icon_ids: [other_icon.id])
         expect(gallery.icons).to match_array([other_icon])
-        other_post = create(:post, user_id: user.id, icon_id: other_icon.id)
-        other_reply = create(:reply, user_id: user.id, icon_id: other_icon.id)
+        create(:post, user_id: user.id, icon_id: other_icon.id) # other post
+        create(:reply, user_id: user.id, icon_id: other_icon.id) # other reply
 
         login_as(icon.user)
         get :replace, id: icon.id
@@ -377,11 +377,11 @@ RSpec.describe IconsController do
         expect(gallery.icons).to match_array([icon] + alts)
 
         post = create(:post, user: user, icon: icon)
-        post_reply = create(:reply, post: post, user: user, icon: icon)
+        create(:reply, post: post, user: user, icon: icon) # post reply
         reply = create(:reply, user: user, icon: icon)
 
-        other_post = create(:post, user: user, icon: other_icon)
-        other_reply = create(:reply, user: user, icon: other_icon)
+        create(:post, user: user, icon: other_icon) # other post
+        create(:reply, user: user, icon: other_icon) # other reply
 
         login_as(icon.user)
         get :replace, id: icon.id

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MessagesController do
     it "assigns correct inbox variables" do
       user = create(:user)
       login_as(user)
-      messages = 4.times.collect do create(:message, recipient: user) end
+      messages = Array.new(4) { create(:message, recipient: user) }
       get :index
       expect(response).to have_http_status(200)
       expect(assigns(:view)).to eq('inbox')
@@ -22,7 +22,7 @@ RSpec.describe MessagesController do
     it "assigns correct outbox variables" do
       user = create(:user)
       login_as(user)
-      messages = 4.times.collect do create(:message, sender: user) end
+      messages = Array.new(4) { create(:message, sender: user) }
       get :index, view: 'outbox'
       expect(response).to have_http_status(200)
       expect(assigns(:view)).to eq('outbox')

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe MessagesController do
 
     it "works for unread in thread" do
       message = create(:message, unread: true)
-      sender = create(:message, sender: message.recipient, recipient: message.sender, parent: message, thread_id: message.id, unread: false)
+      create(:message, sender: message.recipient, recipient: message.sender, parent: message, thread_id: message.id, unread: false) # sender
       subsequent = create(:message, sender: message.recipient, recipient: message.sender, parent: message, thread_id: message.id, unread: false)
       login_as(message.recipient)
       get :show, id: subsequent.id

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -568,8 +568,8 @@ RSpec.describe PostsController do
       it "goes to post page if you're behind" do
         post = create(:post)
         reply1 = create(:reply, post: post, user: post.user)
-        reply2 = Timecop.freeze(reply1.created_at + 1.second) do create(:reply, post: post, user: post.user) end
-        reply3 = Timecop.freeze(reply1.created_at + 2.seconds) do create(:reply, post: post, user: post.user) end
+        Timecop.freeze(reply1.created_at + 1.second) do create(:reply, post: post, user: post.user) end # second reply
+        Timecop.freeze(reply1.created_at + 2.seconds) do create(:reply, post: post, user: post.user) end # third reply
         user = create(:user)
         post.mark_read(user, reply1.created_at)
         login_as(user)
@@ -772,7 +772,7 @@ RSpec.describe PostsController do
         post = create(:post)
         post.mark_read(post.user, post.created_at)
         unread_reply = create(:reply, post: post)
-        reply = create(:reply, post: post)
+        create(:reply, post: post)
         time = Time.now
         post.board.mark_read(post.user, time)
 
@@ -790,7 +790,7 @@ RSpec.describe PostsController do
       it "works with at_id" do
         post = create(:post)
         unread_reply = create(:reply, post: post)
-        reply = create(:reply, post: post)
+        create(:reply, post: post)
         time = Time.now
         post.mark_read(post.user, time)
         expect(post.last_read(post.user)).to be_the_same_time_as(time)
@@ -902,7 +902,7 @@ RSpec.describe PostsController do
       end
 
       context "with an old thread" do
-        {hiatus: 'on_hiatus', active: 'active'}.each do |status, method|
+        [:hiatus, :active].each do |status|
           context "to #{status}" do
             time = 2.months.ago
             let(:post) { create(:post, created_at: time, updated_at: time) }
@@ -1040,7 +1040,6 @@ RSpec.describe PostsController do
 
       it "requires valid update" do
         post = create(:post)
-        newcontent = post.content + 'new'
         login_as(post.user)
         put :update, id: post.id, post: {subject: ''}
         expect(response).to render_template(:edit)

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe PostsController do
       end
 
       it "filters by authors" do
-        posts = 4.times.collect do create(:post) end
+        posts = Array.new(4) { create(:post) }
         filtered_post = posts.last
         first_post = posts.first
         create(:reply, post: first_post, user: filtered_post.user)

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -552,7 +552,7 @@ RSpec.describe RepliesController do
 
       it "filters by continuity" do
         continuity_post = create(:post, num_replies: 1)
-        wrong_post = create(:post, num_replies: 1)
+        create(:post, num_replies: 1) # wrong post
         filtered_reply = continuity_post.replies.last
         get :search, commit: true, board_id: continuity_post.board_id
         expect(assigns(:search_results)).to match_array([filtered_reply])

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -483,7 +483,7 @@ RSpec.describe RepliesController do
       end
 
       it "filters by author" do
-        replies = 4.times.collect do create(:reply) end
+        replies = Array.new(4) { create(:reply) }
         filtered_reply = replies.last
         get :search, commit: true, author_id: filtered_reply.user_id
         expect(assigns(:search_results)).to match_array([filtered_reply])
@@ -535,7 +535,7 @@ RSpec.describe RepliesController do
       end
 
       it "filters by post" do
-        replies = 4.times.collect do create(:reply) end
+        replies = Array.new(4) { create(:reply) }
         filtered_reply = replies.last
         get :search, commit: true, post_id: filtered_reply.post_id
         expect(assigns(:search_results)).to match_array([filtered_reply])

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -402,21 +402,21 @@ RSpec.describe RepliesController do
     end
 
     it "respects per_page when redirecting" do
-      reply = create(:reply) #p1
-      reply = create(:reply, post: reply.post, user: reply.user) #p1
-      reply = create(:reply, post: reply.post, user: reply.user) #p2
-      reply = create(:reply, post: reply.post, user: reply.user) #p2
+      reply = create(:reply) # p1
+      reply = create(:reply, post: reply.post, user: reply.user) # p1
+      reply = create(:reply, post: reply.post, user: reply.user) # p2
+      reply = create(:reply, post: reply.post, user: reply.user) # p2
       login_as(reply.user)
       delete :destroy, id: reply.id, per_page: 2
       expect(response).to redirect_to(post_url(reply.post, page: 2))
     end
 
     it "respects per_page when redirecting first on page" do
-      reply = create(:reply) #p1
-      reply = create(:reply, post: reply.post, user: reply.user) #p1
-      reply = create(:reply, post: reply.post, user: reply.user) #p2
-      reply = create(:reply, post: reply.post, user: reply.user) #p2
-      reply = create(:reply, post: reply.post, user: reply.user) #p3
+      reply = create(:reply) # p1
+      reply = create(:reply, post: reply.post, user: reply.user) # p1
+      reply = create(:reply, post: reply.post, user: reply.user) # p2
+      reply = create(:reply, post: reply.post, user: reply.user) # p2
+      reply = create(:reply, post: reply.post, user: reply.user) # p3
       login_as(reply.user)
       delete :destroy, id: reply.id, per_page: 2
       expect(response).to redirect_to(post_url(reply.post, page: 2))

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe ReportsController do
       it "works with logged in" do
         user = create(:user)
         DailyReport.mark_read(user, 3.day.ago.to_date)
-        view = PostView.create(user: user, post: create(:post))
+        PostView.create(user: user, post: create(:post))
         login_as(user)
         get :show, id: 'daily'
       end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe SessionsController do
 
     it "disallows logins with old passwords when reset is pending" do
       user = create(:user)
-      reset = create(:password_reset, user: user)
+      create(:password_reset, user: user)
       expect(user.password_resets.active.unused).not_to be_empty
       post :create, username: user.username
       expect(flash[:error]).to eq("The password for this account has been reset. Please check your email.")

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe UsersController do
       render_views
 
       it "displays the name" do
-        user = create(:user, moiety: 'fed123', moiety_name: 'moietycolor')
+        create(:user, moiety: 'fed123', moiety_name: 'moietycolor')
         get :index
         expect(response.body).to include('moietycolor')
         expect(response.body).to include('fed123')

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe UsersController do
 
     it "sets the correct variables" do
       user = create(:user)
-      posts = 3.times.collect do create(:post, user: user) end
+      posts = Array.new(3) { create(:post, user: user) }
       create(:post)
       get :show, id: user.id
       expect(assigns(:page_title)).to eq(user.username)

--- a/spec/lib/post_scraper_spec.rb
+++ b/spec/lib/post_scraper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PostScraper do
     url = 'http://wild-pegasus-appeared.dreamwidth.org/403.html?view=flat'
     scraper = PostScraper.new(url)
     expect(scraper.url.sub('view=flat', '')).not_to include('view=flat')
-    expect(scraper.url.gsub("&style=site","").length).to eq(url.length)
+    expect(scraper.url.gsub("&style=site", "").length).to eq(url.length)
   end
 
   it "should add site style to the url" do

--- a/spec/lib/presentable_spec.rb
+++ b/spec/lib/presentable_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe Presentable do
   class ExampleWithPresenter
     def initialize(obj) end
-    def as_json(options={})
+    def as_json(_options={})
       4
     end
   end
@@ -13,7 +13,7 @@ RSpec.describe Presentable do
   end
 
   class ExampleWithout
-    def as_json(options={})
+    def as_json(_options={})
       3
     end
     include Presentable

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Board do
     board = create(:board)
     board2 = create(:board)
     coauthor = create(:user)
-    cameo = create(:user)
+    cameo = create(:user) # FIXME: unused
     board.board_authors.create(user: coauthor)
     board.board_authors.create(user: coauthor)
     board2.board_authors.create(user: coauthor)

--- a/spec/models/daily_report_spec.rb
+++ b/spec/models/daily_report_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe DailyReport do
     default_zone = Time.zone
     {
       # 2017-11-05 10:00, clock goes back in Eastern
-      "without timezone" => [default_zone, [2017, 11, 05, 10, 00]],
+      "without timezone" => [default_zone, [2017, 11, 5, 10, 0]],
       # 2017-10-29 10:00, clock goes back in GMT/BST
-      "with timezone" => ["Europe/London", [2017, 10, 29, 10, 00]]
+      "with timezone" => ["Europe/London", [2017, 10, 29, 10, 0]]
     }.each do |name, data|
       zone = data.first
       dst_day_params = data.last
@@ -15,7 +15,7 @@ RSpec.describe DailyReport do
         before(:each) { Time.zone = zone }
         after(:each) { Time.zone = default_zone }
         it "should work on a regular day" do
-          time = Time.zone.local(2017, 01, 02, 10, 00) # 2017-01-02 10:00
+          time = Time.zone.local(2017, 1, 2, 10, 0) # 2017-01-02 10:00
           day = time.beginning_of_day
           shown_posts = Array.new(24) do |i| # 0 .. 23
             step = day + i.hours

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -360,8 +360,8 @@ RSpec.describe Post do
   describe "#word_count" do
     it "guesses correctly with replies" do
       post = create(:post, content: 'one two three four five')
-      reply = create(:reply, post: post, content: 'six seven')
-      reply = create(:reply, post: post, content: 'eight')
+      create(:reply, post: post, content: 'six seven')
+      create(:reply, post: post, content: 'eight')
       expect(post.word_count).to eq(5)
       expect(post.total_word_count).to eq(8)
     end

--- a/spec/support/spec_test_helper.rb
+++ b/spec/support/spec_test_helper.rb
@@ -1,4 +1,4 @@
-module SpecTestHelper  
+module SpecTestHelper
   def login_as(user)
     request.session[:user_id] = user.id
   end


### PR DESCRIPTION
I went through the whole of the rubocop configuration and tried to set it up to be in line with the project style, and then did commits (that were mostly bulk things) to fix the project style to match it (this gets it in line with the standard Ruby style guide and also fixes some small performance things, including ones that showed up in Codeclimate).

It is humongous. I apologize. It does not break any tests, and it only touches the Ruby code, and most of the things I changed would be glaringly horribly wrong if I did them incorrectly (such as mistyping a method name) or would not be able to cause an issue (such as whitespace changes). Almost everything should act exactly the same, and the few places I changed (such as removing unused variables, or converting `num.times.collect { thing }` to `Array.new(num) { thing }`) are recommended to be changed and should not impact functionality at all (just improve performance / readability).

Looking back at this I don't actually know if you'll accept it, because it's huge. I don't think it does anything bad, though.