### PR TITLE
Update .eslintrc and then fix a ton of JS lint things

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 **/*{.,-}min.js
+**/jquery.ui.widget.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,6 @@ env:
 # http://eslint.org/docs/rules/
 rules:
   # Possible Errors
-  comma-dangle: [2, never]
   no-cond-assign: 2
   no-console: 0
   no-constant-condition: 2
@@ -43,61 +42,73 @@ rules:
 
   # Best Practices
   accessor-pairs: 2
-  block-scoped-var: 0
+  block-scoped-var: 2
   complexity: [2, 6]
-  consistent-return: 0
+  consistent-return: 1
   curly: 0
   default-case: 0
-  dot-location: 0
-  dot-notation: 0
+  dot-location: [2, property]
+  dot-notation: 1
   eqeqeq: 2
   guard-for-in: 2
-  no-alert: 2
-  no-caller: 2
+  no-alert: 0
+  no-caller: 1
   no-case-declarations: 2
   no-div-regex: 2
-  no-else-return: 0
-  no-empty-label: 2
+  no-else-return: 2
+  no-empty-function: 2
   no-empty-pattern: 2
   no-eq-null: 2
   no-eval: 2
   no-extend-native: 2
   no-extra-bind: 2
+  no-extra-label: 2
   no-fallthrough: 2
-  no-floating-decimal: 0
-  no-implicit-coercion: 0
+  no-floating-decimal: 2
+  no-global-assign: 2
+  no-implicit-coercion: 2
+  no-implicit-globals: 2
   no-implied-eval: 2
-  no-invalid-this: 0
+  no-invalid-this: 2
   no-iterator: 2
-  no-labels: 0
+  no-labels: 2
   no-lone-blocks: 2
   no-loop-func: 2
-  no-magic-number: 0
-  no-multi-spaces: 0
-  no-multi-str: 0
-  no-native-reassign: 2
+  no-magic-numbers: 0
+  no-multi-spaces: 2
+  no-multi-str: 2
+  no-new: 2
   no-new-func: 2
   no-new-wrappers: 2
-  no-new: 2
-  no-octal-escape: 2
   no-octal: 2
+  no-octal-escape: 2
+  no-param-reassign: 0
   no-proto: 2
   no-redeclare: 2
+  no-restricted-properties: 2
   no-return-assign: 2
+  no-return-await: 2
   no-script-url: 2
+  no-self-assign: 2
   no-self-compare: 2
-  no-sequences: 0
-  no-throw-literal: 0
+  no-sequences: 2
+  no-throw-literal: 2
+  no-unmodified-loop-condition: 2
   no-unused-expressions: 2
+  no-unused-labels: 2
   no-useless-call: 2
   no-useless-concat: 2
+  no-useless-escape: 2
+  no-useless-return: 2
   no-void: 2
-  no-warning-comments: 0
+  no-warning-comments: 1
   no-with: 2
-  radix: 2
+  prefer-promise-reject-errors: 2
+  radix: 0
+  require-await: 1
   vars-on-top: 0
   wrap-iife: 2
-  yoda: 0
+  yoda: 1
 
   # Strict
   strict: 0
@@ -107,89 +118,121 @@ rules:
   no-catch-shadow: 2
   no-delete-var: 2
   no-label-var: 2
+  no-restricted-globals: 2
+  no-shadow: 2
   no-shadow-restricted-names: 2
-  no-shadow: 0
+  no-undef: 1
   no-undef-init: 2
-  no-undef: 0
-  no-undefined: 0
-  no-unused-vars: 0
+  no-undefined: 2
+  no-unused-vars: 1
+  # TODO: consider using below
   no-use-before-define: 0
 
   # Node.js and CommonJS
   callback-return: 2
   global-require: 2
   handle-callback-err: 2
-  no-mixed-requires: 0
-  no-new-require: 0
+  no-mixed-requires: 1
+  no-new-require: 1
   no-path-concat: 2
+  no-process-env: 1
   no-process-exit: 2
-  no-restricted-modules: 0
-  no-sync: 0
+  no-restricted-modules: 2
+  no-sync: 1
 
   # Stylistic Issues
-  array-bracket-spacing: 0
-  block-spacing: 0
-  brace-style: 0
-  camelcase: 0
-  comma-spacing: 0
-  comma-style: 0
-  computed-property-spacing: 0
+  array-bracket-spacing: 1
+  block-spacing: 1
+  brace-style:
+    - 1
+    - 1tbs
+    - allowSingleLine: true
+  camelcase: 1
+  capitalized-comments: 0
+  comma-dangle: 0
+  comma-spacing: 1
+  comma-style: 1
+  computed-property-spacing: 1
   consistent-this: 0
-  eol-last: 0
+  eol-last: 1
+  func-call-spacing: 1
+  func-name-matching: 0
   func-names: 0
   func-style: 0
+  id-blacklist: 0
   id-length: 0
   id-match: 0
-  indent: 0
-  jsx-quotes: 0
-  key-spacing: 0
-  linebreak-style: 0
+  indent: [2, 2]
+  jsx-quotes: [1, prefer-single]
+  key-spacing: 1
+  keyword-spacing: 2
+  line-comment-position: 0
+  linebreak-style: 1
   lines-around-comment: 0
+  lines-around-directive: 0
   max-depth: 0
   max-len: 0
+  max-lines: 0
   max-nested-callbacks: 0
   max-params: 0
-  max-statements: [2, 30]
+  max-statements: [1, 30]
+  max-statements-per-line: 0
+  multiline-ternary: 0
   new-cap: 0
-  new-parens: 0
+  new-parens: 1
   newline-after-var: 0
-  no-array-constructor: 0
-  no-bitwise: 0
+  newline-before-return: 0
+  newline-per-chained-call: 0
+  no-array-constructor: 1
+  no-bitwise: 1
   no-continue: 0
   no-inline-comments: 0
-  no-lonely-if: 0
-  no-mixed-spaces-and-tabs: 0
+  no-lonely-if: 1
+  no-mixed-operators: 2
+  no-mixed-spaces-and-tabs: 2
+  no-multi-assign: 1
   no-multiple-empty-lines: 0
-  no-negated-condition: 0
-  no-nested-ternary: 0
-  no-new-object: 0
-  no-plusplus: 0
+  no-negated-condition: 1
+  no-nested-ternary: 1
+  no-new-object: 2
+  no-plusplus:
+    - 2
+    - allowForLoopAfterthoughts: true
   no-restricted-syntax: 0
-  no-spaced-func: 0
+  no-tabs: 0
   no-ternary: 0
-  no-trailing-spaces: 0
+  no-trailing-spaces: 2
   no-underscore-dangle: 0
-  no-unneeded-ternary: 0
-  object-curly-spacing: 0
+  no-unneeded-ternary: 2
+  no-whitespace-before-property: 2
+  nonblock-statement-body-position: 0
+  object-curly-newline: 0
+  object-curly-spacing: 1
+  object-property-newline: 0
   one-var: 0
-  operator-assignment: 0
+  one-var-declaration-per-line: 0
+  operator-assignment: 1
   operator-linebreak: 0
   padded-blocks: 0
   quote-props: 0
   quotes: 0
   require-jsdoc: 0
-  semi-spacing: 0
-  semi: 0
+  semi: 2
+  semi-spacing: 2
+  sort-keys: 0
   sort-vars: 0
-  space-after-keywords: 0
-  space-before-blocks: 0
-  space-before-function-paren: 0
-  space-before-keywords: 0
-  space-in-parens: 0
+  space-before-blocks: 2
+  space-before-function-paren: [2, never]
+  space-in-parens: 1
   space-infix-ops: 0
-  space-return-throw-case: 0
-  space-unary-ops: 0
-  spaced-comment: 0
+  space-unary-ops: 1
+  spaced-comment:
+    - 2
+    - always
+    - markers:
+      - "= require"
+  template-tag-spacing: 0
+  unicode-bom: 0
   wrap-regex: 0
 
   # ECMAScript 6

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -55,29 +55,29 @@ $(document).ready(function() {
   });
 });
 
-function add_parameter(url, param, value){
-    var hash       = {};
-    var parser     = document.createElement('a');
+function add_parameter(url, param, value) {
+  var hash = {};
+  var parser = document.createElement('a');
 
-    parser.href    = url;
+  parser.href = url;
 
-    var parameters = parser.search.split(/\?|&/);
+  var parameters = parser.search.split(/\?|&/);
 
-    for(var i=0; i < parameters.length; i++) {
-        if(!parameters[i])
-            continue;
+  for (var i=0; i < parameters.length; i++) {
+    if (!parameters[i])
+      continue;
 
-        var ary      = parameters[i].split('=');
-        hash[ary[0]] = ary[1];
-    }
+    var ary = parameters[i].split('=');
+    hash[ary[0]] = ary[1];
+  }
 
-    hash[param] = value;
+  hash[param] = value;
 
-    var list = [];
-    Object.keys(hash).forEach(function (key) {
-        list.push(key + '=' + hash[key]);
-    });
+  var list = [];
+  Object.keys(hash).forEach(function(key) {
+    list.push(key + '=' + hash[key]);
+  });
 
-    parser.search = '?' + list.join('&');
-    return parser.href;
+  parser.search = '?' + list.join('&');
+  return parser.href;
 }

--- a/app/assets/javascripts/board_sections.js
+++ b/app/assets/javascripts/board_sections.js
@@ -1,4 +1,4 @@
-$(document).ready( function() {
+$(document).ready(function() {
   bindArrows();
 });
 
@@ -36,7 +36,7 @@ function switchRows(old_order, new_order) {
   this_row.attr('id', "section-"+new_order);
   that_row.attr('id', "section-"+old_order);
 
-  if(old_order > new_order) {
+  if (old_order > new_order) {
     this_row.insertBefore(that_row);
   } else {
     this_row.insertAfter(that_row);
@@ -53,7 +53,7 @@ function switchRows(old_order, new_order) {
     type: that_row.attr('data-type'),
     order: old_order
   };
-  $.post('/api/v1/board_sections/reorder', json, function (resp) {
+  $.post('/api/v1/board_sections/reorder', json, function(resp) {
     $("#loading").hide();
     $("#saveconf").show().delay(2000).fadeOut();
     bindArrows();

--- a/app/assets/javascripts/board_sections.js
+++ b/app/assets/javascripts/board_sections.js
@@ -6,7 +6,7 @@ function bindArrows() {
   $(".section-up").click(function() {
     var old_order = parseInt($(this).attr('data-order'));
     var new_order = old_order - 1;
-    if (old_order === 0) { return false; }
+    if (old_order === 0) return false;
     switchRows(old_order, new_order);
     return false;
   });
@@ -14,7 +14,7 @@ function bindArrows() {
   $(".section-down").click(function() {
     var old_order = parseInt($(this).attr('data-order'));
     var new_order = old_order + 1;
-    if (document.getElementById("section-"+new_order) === null) { return false; }
+    if (document.getElementById("section-"+new_order) === null) return false;
     switchRows(old_order, new_order);
     return false;
   });

--- a/app/assets/javascripts/board_sections.js
+++ b/app/assets/javascripts/board_sections.js
@@ -53,7 +53,7 @@ function switchRows(old_order, new_order) {
     type: that_row.attr('data-type'),
     order: old_order
   };
-  $.post('/api/v1/board_sections/reorder', json, function(resp) {
+  $.post('/api/v1/board_sections/reorder', json, function() {
     $("#loading").hide();
     $("#saveconf").show().delay(2000).fadeOut();
     bindArrows();

--- a/app/assets/javascripts/board_sections.js
+++ b/app/assets/javascripts/board_sections.js
@@ -58,4 +58,4 @@ function switchRows(old_order, new_order) {
     $("#saveconf").show().delay(2000).fadeOut();
     bindArrows();
   });
-};
+}

--- a/app/assets/javascripts/board_sections.js
+++ b/app/assets/javascripts/board_sections.js
@@ -45,11 +45,11 @@ function switchRows(old_order, new_order) {
   $("#section-table tr:even td").removeClass('odd').addClass("even");
 
   var json = {changes: {}};
-  json['changes'][this_row.attr('data-section')] = {
+  json.changes[this_row.attr('data-section')] = {
     type: this_row.attr('data-type'),
     order: new_order
   };
-  json['changes'][that_row.attr('data-section')] = {
+  json.changes[that_row.attr('data-section')] = {
     type: that_row.attr('data-type'),
     order: old_order
   };

--- a/app/assets/javascripts/boards.js
+++ b/app/assets/javascripts/boards.js
@@ -1,11 +1,11 @@
 $(document).ready(function() {
-  $("#board_coauthor_ids").select2({ 
-    width: '100%' ,
+  $("#board_coauthor_ids").select2({
+    width: '100%',
     minimumResultsForSearch: 10,
     placeholder: 'Open to Anyone'
   });
-  $("#board_cameo_ids").select2({ 
-    width: '100%' ,
+  $("#board_cameo_ids").select2({
+    width: '100%',
     minimumResultsForSearch: 10,
     placeholder: '(Optional)'
   });

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -19,10 +19,10 @@ $(document).ready(function() {
   bindIcons();
 
   $("#character_template_id").change(function() {
-    if ($(this).val() !== "0") {
-      $("#create_template").hide();
-    } else {
+    if ($(this).val() === "0") {
       $("#create_template").show();
+    } else {
+      $("#create_template").hide();
     }
   });
 

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -92,8 +92,7 @@ function updateIcon(id) {
     $.ajax({
       url: '/api/v1/characters/'+gon.character_id,
       type: 'PUT',
-      data: {character: {default_icon_id: id}},
-      success: function(resp) {}
+      data: {character: {default_icon_id: id}}
     });
   } else {
     $("#character_default_icon_id").val(id);

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -1,7 +1,7 @@
 var gallery_ids = [];
 
 $(document).ready(function() {
-  gallery_ids = jQuery.map($(".gallery div"), function(el) { return el.dataset['id']; });
+  gallery_ids = jQuery.map($(".gallery div"), function(el) { return el.dataset.id; });
 
   $("#character_setting_ids").select2({
     width: '100%',

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -18,7 +18,7 @@ $(document).ready(function() {
 
   bindIcons();
 
-  $("#character_template_id").change(function () {
+  $("#character_template_id").change(function() {
     if ($(this).val() !== "0") {
       $("#create_template").hide();
     } else {
@@ -52,8 +52,8 @@ $(document).ready(function() {
   });
 });
 
-function displayGallery(new_id){
-  $.get('/api/v1/galleries/'+new_id, function (resp) {
+function displayGallery(new_id) {
+  $.get('/api/v1/galleries/'+new_id, function(resp) {
     var galleryObj = $("<div>").attr({id: 'gallery'+new_id}).data('id', new_id);
     galleryObj.append("<br />");
     galleryObj.append($("<b>").attr({class: 'gallery-name'}).append(resp.name));

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -38,7 +38,7 @@ $(document).ready(function() {
       $(".gallery #gallery"+removed_gallery).remove();
 
       // if no more galleries are left, display galleryless icons
-      if (gallery_ids.length == 0) {
+      if (gallery_ids.length === 0) {
         displayGallery('0');
       }
       return;

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -1,3 +1,4 @@
+/* global gon */
 var gallery_ids = [];
 
 $(document).ready(function() {

--- a/app/assets/javascripts/characters/show.js
+++ b/app/assets/javascripts/characters/show.js
@@ -38,7 +38,7 @@ function switchRows(old_order, new_order) {
   }
 
   var json = {changes: {}, commit: 'reorder'};
-  json['changes'][this_row.attr('data-section')] = new_order;
-  json['changes'][that_row.attr('data-section')] = old_order;
+  json.changes[this_row.attr('data-section')] = new_order;
+  json.changes[that_row.attr('data-section')] = old_order;
   $.post('/characters', json, function(resp) {});
 }

--- a/app/assets/javascripts/characters/show.js
+++ b/app/assets/javascripts/characters/show.js
@@ -40,5 +40,5 @@ function switchRows(old_order, new_order) {
   var json = {changes: {}, commit: 'reorder'};
   json.changes[this_row.attr('data-section')] = new_order;
   json.changes[that_row.attr('data-section')] = old_order;
-  $.post('/characters', json, function(resp) {});
+  $.post('/characters', json);
 }

--- a/app/assets/javascripts/characters/show.js
+++ b/app/assets/javascripts/characters/show.js
@@ -1,4 +1,4 @@
-$(document).ready( function() {
+$(document).ready(function() {
   $(".section-up").click(function() {
     var old_order = parseInt($(this).attr('data-order'));
     var new_order = old_order - 1;
@@ -29,7 +29,7 @@ function switchRows(old_order, new_order) {
   this_gal.attr('id', "section-gallery-"+new_order);
   that_gal.attr('id', "section-gallery-"+old_order);
 
-  if(old_order > new_order) {
+  if (old_order > new_order) {
     this_row.insertBefore(that_row);
     this_gal.insertBefore(that_row);
   } else {
@@ -40,5 +40,5 @@ function switchRows(old_order, new_order) {
   var json = {changes: {}, commit: 'reorder'};
   json['changes'][this_row.attr('data-section')] = new_order;
   json['changes'][that_row.attr('data-section')] = old_order;
-  $.post('/characters', json, function (resp) {});
+  $.post('/characters', json, function(resp) {});
 }

--- a/app/assets/javascripts/characters/show.js
+++ b/app/assets/javascripts/characters/show.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
   $(".section-up").click(function() {
     var old_order = parseInt($(this).attr('data-order'));
     var new_order = old_order - 1;
-    if (old_order === 0) { return false; }
+    if (old_order === 0) return false;
     switchRows(old_order, new_order);
     return false;
   });
@@ -10,7 +10,7 @@ $(document).ready(function() {
   $(".section-down").click(function() {
     var old_order = parseInt($(this).attr('data-order'));
     var new_order = old_order + 1;
-    if (document.getElementById("section-"+new_order) === null) { return false; }
+    if (document.getElementById("section-"+new_order) === null) return false;
     switchRows(old_order, new_order);
     return false;
   });

--- a/app/assets/javascripts/galleries/add_existing.js
+++ b/app/assets/javascripts/galleries/add_existing.js
@@ -1,6 +1,6 @@
 image_ids = []
 skip_warning = false;
-$(document).ready( function() {
+$(document).ready(function() {
   bindGalleryIcons(".add-gallery-icon");
 
   $("#add-gallery-icons").submit(function() {
@@ -23,7 +23,7 @@ $(document).ready( function() {
     // Show icons if they're hidden
     $("#icons-" + gallery_id).show();
     $("#minmax-" + gallery_id).text("-");
-    if($("#icons-" + gallery_id).html().length > 0) { return true; }
+    if ($("#icons-" + gallery_id).html().length > 0) { return true; }
 
     // Load and bind icons if they have not already been loaded
     $.get("/api/v1/galleries/" + gallery_id, {}, function(resp) {
@@ -38,7 +38,7 @@ $(document).ready( function() {
   });
 });
 
-$(window).on('beforeunload', function(){
+$(window).on('beforeunload', function() {
   if (skip_warning || image_ids.length === 0) return;
   return "Are you sure you wish to navigate away? You have " + image_ids.length + " image(s) selected.";
 });

--- a/app/assets/javascripts/galleries/add_existing.js
+++ b/app/assets/javascripts/galleries/add_existing.js
@@ -1,4 +1,4 @@
-image_ids = []
+image_ids = [];
 skip_warning = false;
 $(document).ready(function() {
   bindGalleryIcons(".add-gallery-icon");

--- a/app/assets/javascripts/galleries/add_existing.js
+++ b/app/assets/javascripts/galleries/add_existing.js
@@ -1,5 +1,5 @@
-image_ids = [];
-skip_warning = false;
+var image_ids = [];
+var skip_warning = false;
 $(document).ready(function() {
   bindGalleryIcons(".add-gallery-icon");
 

--- a/app/assets/javascripts/galleries/add_existing.js
+++ b/app/assets/javascripts/galleries/add_existing.js
@@ -17,13 +17,13 @@ $(document).ready(function() {
     if ($("#icons-" + gallery_id).is(':visible')) {
       $("#icons-" + gallery_id).hide();
       $("#minmax-" + gallery_id).text("+");
-      return true;
+      return;
     }
 
     // Show icons if they're hidden
     $("#icons-" + gallery_id).show();
     $("#minmax-" + gallery_id).text("-");
-    if ($("#icons-" + gallery_id).html().length > 0) { return true; }
+    if ($("#icons-" + gallery_id).html().length > 0) { return; }
 
     // Load and bind icons if they have not already been loaded
     $.get("/api/v1/galleries/" + gallery_id, {}, function(resp) {

--- a/app/assets/javascripts/galleries/add_existing.js
+++ b/app/assets/javascripts/galleries/add_existing.js
@@ -43,7 +43,7 @@ $(window).on('beforeunload', function() {
   return "Are you sure you wish to navigate away? You have " + image_ids.length + " image(s) selected.";
 });
 
-bindGalleryIcons = function(css_selector) {
+function bindGalleryIcons(css_selector) {
   $(css_selector).click(function() {
     $(this).toggleClass('selected-icon');
     if ($(this).hasClass('selected-icon')) {

--- a/app/assets/javascripts/galleries/add_existing.js
+++ b/app/assets/javascripts/galleries/add_existing.js
@@ -4,7 +4,7 @@ $(document).ready(function() {
   bindGalleryIcons(".add-gallery-icon");
 
   $("#add-gallery-icons").submit(function() {
-    if (image_ids.length < 1) { return false; }
+    if (image_ids.length < 1) return false;
     $("#image_ids").val(image_ids);
     skip_warning = true;
     return true;

--- a/app/assets/javascripts/galleries/add_existing.js
+++ b/app/assets/javascripts/galleries/add_existing.js
@@ -47,9 +47,9 @@ function bindGalleryIcons(css_selector) {
   $(css_selector).click(function() {
     $(this).toggleClass('selected-icon');
     if ($(this).hasClass('selected-icon')) {
-      image_ids.push(this.dataset['id']);
+      image_ids.push(this.dataset.id);
     } else {
-      image_ids.pop(this.dataset['id']);
+      image_ids.pop(this.dataset.id);
     }
   });
 }

--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -110,7 +110,7 @@ function bindFileInput(fileInput) {
     fail: function(e, data) {
       var iconIndex = data.iconIndex;
       submitButton.prop('disabled', false);
-      var response = data.response().jqXHR
+      var response = data.response().jqXHR;
       var policyExpired = response.responseText.includes("Invalid according to Policy: Policy expired.");
       if (!policyExpired) { policyExpired = response.responseText.includes("Idle connections will be closed."); }
       var badFiletype = response.responseText.includes("Policy Condition failed") && response.responseText.includes('"$Content-Type", "image/"');
@@ -131,7 +131,7 @@ function bindFileInput(fileInput) {
       }
     },
   });
-};
+}
 
 function cleanUpRows() {
   $(".icon-row").each(function(index) {
@@ -150,4 +150,4 @@ function cleanUpRows() {
     $(this).find('input').first().attr('id', 'icons_'+index+'_url');
   });
   fixButtons();
-};
+}

--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -1,4 +1,4 @@
-$(document).ready( function() {
+$(document).ready(function() {
   fixButtons();
   bindFileInput($("#icon_files"));
 });
@@ -15,7 +15,7 @@ function fixButtons() {
 }
 
 function bindAdd() {
-  $(".icon-row-add").click(function () {
+  $(".icon-row-add").click(function() {
     addNewRow();
     fixButtons();
   });
@@ -42,7 +42,7 @@ function addNewRow() {
 }
 
 function bindRem() {
-  $(".icon-row-rem").click(function () {
+  $(".icon-row-rem").click(function() {
     var rem_row = $(this).parent().parent();
     rem_row.remove();
     fixButtons();
@@ -50,102 +50,102 @@ function bindRem() {
 }
 
 function bindFileInput(fileInput) {
-    var form         = $('form.icon-upload');
-    var submitButton = form.find('input[type="submit"]');
-    var formData     = form.data('form-data');
+  var form = $('form.icon-upload');
+  var submitButton = form.find('input[type="submit"]');
+  var formData = form.data('form-data');
 
-    fileInput.fileupload({
-      fileInput:       fileInput,
-      url:             form.data('url'),
-      type:            'POST',
-      autoUpload:       true,
-      formData:         formData,
-      paramName:        'file', // S3 does not like nested name fields i.e. name="user[avatar_url]"
-      dataType:         'XML',  // S3 returns XML if success_action_status is set to 201
-      replaceFileInput: false,
+  fileInput.fileupload({
+    fileInput: fileInput,
+    url: form.data('url'),
+    type: 'POST',
+    autoUpload: true,
+    formData: formData,
+    paramName: 'file', // S3 does not like nested name fields i.e. name="user[avatar_url]"
+    dataType: 'XML', // S3 returns XML if success_action_status is set to 201
+    replaceFileInput: false,
 
-      add: function (e, data) {
-        var fileType = data.files[0].type;
-        if (!fileType.startsWith('image/')) {
-          alert("You must upload files with an image filetype such as .png or .jpg - please retry with a valid file.");
-          return;
-        } else if (fileType === 'image/tiff') {
-          alert("Unfortunately, .tiff files are only supported by Safari - please retry with a valid file.");
-          return;
-        }
+    add: function(e, data) {
+      var fileType = data.files[0].type;
+      if (!fileType.startsWith('image/')) {
+        alert("You must upload files with an image filetype such as .png or .jpg - please retry with a valid file.");
+        return;
+      } else if (fileType === 'image/tiff') {
+        alert("Unfortunately, .tiff files are only supported by Safari - please retry with a valid file.");
+        return;
+      }
 
-        formData["Content-Type"] = fileType;
-        data.formData = formData;
-        data.submit();
-        fileInput.val('');
-      },
-      start: function (e) {
-        submitButton.prop('disabled', true);
-      },
-      done: function(e, data) {
-        submitButton.prop('disabled', false);
+      formData["Content-Type"] = fileType;
+      data.formData = formData;
+      data.submit();
+      fileInput.val('');
+    },
+    start: function(e) {
+      submitButton.prop('disabled', true);
+    },
+    done: function(e, data) {
+      submitButton.prop('disabled', false);
 
-        // extract key and generate URL from response
-        var key   = $(data.jqXHR.responseXML).find("Key").text();
-        var url   = 'https://d1anwqy6ci9o1i.cloudfront.net/' + key;
+      // extract key and generate URL from response
+      var key = $(data.jqXHR.responseXML).find("Key").text();
+      var url = 'https://d1anwqy6ci9o1i.cloudfront.net/' + key;
 
-        // create hidden field
-        var iconIndex = addNewRow();
-        var urlInput = $("#icons_"+iconIndex+"_url");
-        var urlCell = $(urlInput.parents('td:first'));
-        urlInput.hide().val(url);
-        urlCell.find('.conf').remove();
+      // create hidden field
+      var iconIndex = addNewRow();
+      var urlInput = $("#icons_"+iconIndex+"_url");
+      var urlCell = $(urlInput.parents('td:first'));
+      urlInput.hide().val(url);
+      urlCell.find('.conf').remove();
 
-        // update keyword box with data.files[0].name minus file extension
-        var keyword = data.files[0].name;
-        var fileExt = keyword.split('.').slice(-1)[0];
-        if (fileExt != keyword)
-          keyword = keyword.replace('.'+fileExt, '');
-        $(".icon-row[data-index='" + iconIndex + "'] input[id$='_keyword']").val(keyword);
+      // update keyword box with data.files[0].name minus file extension
+      var keyword = data.files[0].name;
+      var fileExt = keyword.split('.').slice(-1)[0];
+      if (fileExt != keyword)
+        keyword = keyword.replace('.'+fileExt, '');
+      $(".icon-row[data-index='" + iconIndex + "'] input[id$='_keyword']").val(keyword);
 
-        var uploaded = ' Uploaded ' + data.files[0].name;
-        urlCell.append("<span class='conf'><img src='/images/accept.png' alt='' title='Successfully uploaded' class='vmid' />"+uploaded+"</span>");
-        cleanUpRows();
-      },
-      fail: function(e, data) {
-        var iconIndex = data.iconIndex;
-        submitButton.prop('disabled', false);
-        var response = data.response().jqXHR
-        var policyExpired = response.responseText.includes("Invalid according to Policy: Policy expired.");
-        if (!policyExpired) { policyExpired = response.responseText.includes("Idle connections will be closed."); }
-        var badFiletype = response.responseText.includes("Policy Condition failed") && response.responseText.includes('"$Content-Type", "image/"');
-        var bugsData = {
-          'response_status': response.status,
-          'response_body': response.responseText,
-          'response_text': response.statusText,
-          'file_name': data.files[0].name,
-          'file_type': data.files[0].type,
-        };
-        if (policyExpired) {
-          alert("Your upload permissions appear to have expired. Please refresh the page and try again.");
-        } else if (badFiletype) {
-          alert("You must upload files with an image filetype such as .png or .jpg - please retry with a valid file.");
-        } else {
-          $.post('/bugs', bugsData);
-          alert("Upload of " + data.files[0].name + " failed, Marri has been notified.");
-        }
-      },
-    });
+      var uploaded = ' Uploaded ' + data.files[0].name;
+      urlCell.append("<span class='conf'><img src='/images/accept.png' alt='' title='Successfully uploaded' class='vmid' />"+uploaded+"</span>");
+      cleanUpRows();
+    },
+    fail: function(e, data) {
+      var iconIndex = data.iconIndex;
+      submitButton.prop('disabled', false);
+      var response = data.response().jqXHR
+      var policyExpired = response.responseText.includes("Invalid according to Policy: Policy expired.");
+      if (!policyExpired) { policyExpired = response.responseText.includes("Idle connections will be closed."); }
+      var badFiletype = response.responseText.includes("Policy Condition failed") && response.responseText.includes('"$Content-Type", "image/"');
+      var bugsData = {
+        'response_status': response.status,
+        'response_body': response.responseText,
+        'response_text': response.statusText,
+        'file_name': data.files[0].name,
+        'file_type': data.files[0].type,
+      };
+      if (policyExpired) {
+        alert("Your upload permissions appear to have expired. Please refresh the page and try again.");
+      } else if (badFiletype) {
+        alert("You must upload files with an image filetype such as .png or .jpg - please retry with a valid file.");
+      } else {
+        $.post('/bugs', bugsData);
+        alert("Upload of " + data.files[0].name + " failed, Marri has been notified.");
+      }
+    },
+  });
 };
 
 function cleanUpRows() {
-  $(".icon-row").each(function (index) {
+  $(".icon-row").each(function(index) {
     var anySet = false;
     if ($(this).find('.conf').length > 0) { return true; }
     $(this).find('input').each(function() {
-      if($(this).val() != '') {
+      if ($(this).val() != '') {
         anySet = true;
         return false;
       }
     });
     if (!anySet) { $(this).remove(); }
   });
-  $(".icon-row").each(function (index) {
+  $(".icon-row").each(function(index) {
     $(this).attr('data-index', index);
     $(this).find('input').first().attr('id', 'icons_'+index+'_url');
   });

--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -79,7 +79,7 @@ function bindFileInput(fileInput) {
       data.submit();
       fileInput.val('');
     },
-    start: function(e) {
+    start: function() {
       submitButton.prop('disabled', true);
     },
     done: function(e, data) {
@@ -108,7 +108,6 @@ function bindFileInput(fileInput) {
       cleanUpRows();
     },
     fail: function(e, data) {
-      var iconIndex = data.iconIndex;
       submitButton.prop('disabled', false);
       var response = data.response().jqXHR;
       var policyExpired = response.responseText.includes("Invalid according to Policy: Policy expired.");
@@ -134,7 +133,7 @@ function bindFileInput(fileInput) {
 }
 
 function cleanUpRows() {
-  $(".icon-row").each(function(index) {
+  $(".icon-row").each(function() {
     var anySet = false;
     if ($(this).find('.conf').length > 0) return true;
     $(this).find('input').each(function() {

--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -99,7 +99,7 @@ function bindFileInput(fileInput) {
       // update keyword box with data.files[0].name minus file extension
       var keyword = data.files[0].name;
       var fileExt = keyword.split('.').slice(-1)[0];
-      if (fileExt != keyword)
+      if (fileExt !== keyword)
         keyword = keyword.replace('.'+fileExt, '');
       $(".icon-row[data-index='" + iconIndex + "'] input[id$='_keyword']").val(keyword);
 
@@ -138,7 +138,7 @@ function cleanUpRows() {
     var anySet = false;
     if ($(this).find('.conf').length > 0) { return true; }
     $(this).find('input').each(function() {
-      if ($(this).val() != '') {
+      if ($(this).val() !== '') {
         anySet = true;
         return false;
       }

--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -135,7 +135,7 @@ function bindFileInput(fileInput) {
 function cleanUpRows() {
   $(".icon-row").each(function() {
     var anySet = false;
-    if ($(this).find('.conf').length > 0) return true;
+    if ($(this).find('.conf').length > 0) return;
     $(this).find('input').each(function() {
       if ($(this).val() !== '') {
         anySet = true;

--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -112,7 +112,7 @@ function bindFileInput(fileInput) {
       submitButton.prop('disabled', false);
       var response = data.response().jqXHR;
       var policyExpired = response.responseText.includes("Invalid according to Policy: Policy expired.");
-      if (!policyExpired) { policyExpired = response.responseText.includes("Idle connections will be closed."); }
+      if (!policyExpired) policyExpired = response.responseText.includes("Idle connections will be closed.");
       var badFiletype = response.responseText.includes("Policy Condition failed") && response.responseText.includes('"$Content-Type", "image/"');
       var bugsData = {
         'response_status': response.status,
@@ -136,14 +136,14 @@ function bindFileInput(fileInput) {
 function cleanUpRows() {
   $(".icon-row").each(function(index) {
     var anySet = false;
-    if ($(this).find('.conf').length > 0) { return true; }
+    if ($(this).find('.conf').length > 0) return true;
     $(this).find('input').each(function() {
       if ($(this).val() !== '') {
         anySet = true;
         return false;
       }
     });
-    if (!anySet) { $(this).remove(); }
+    if (!anySet) $(this).remove();
   });
   $(".icon-row").each(function(index) {
     $(this).attr('data-index', index);

--- a/app/assets/javascripts/galleries/expander.js
+++ b/app/assets/javascripts/galleries/expander.js
@@ -1,4 +1,4 @@
-$(document).ready( function() {
+$(document).ready(function() {
   $(".gallery-box").click(function() {
     // Update toggle +/-
     var toggleBox = $(this).children('.view-button').first().children('img').first();
@@ -11,7 +11,7 @@ $(document).ready( function() {
 
     // Nothing more necessary if collapsing or already loaded
     if (wasVisible) { return true; }
-    if($("#icons-" + galleryId + " .gallery").html().length > 0) { return true; }
+    if ($("#icons-" + galleryId + " .gallery").html().length > 0) { return true; }
 
     // Load and bind icons if they have not already been loaded
     $.get("/api/v1/galleries/" + galleryId, {user_id: gon.user_id}, function(resp) {
@@ -23,7 +23,7 @@ $(document).ready( function() {
         iconDiv.append(iconLink);
 
         // Add control buttons for the owner
-        if($("#icons-" + galleryId + " .icons-remove").length > 0) {
+        if ($("#icons-" + galleryId + " .icons-remove").length > 0) {
           var iconCheckbox = $("<input>").attr({id: 'marked_ids_'+icon.id, name: 'marked_ids[]', type: 'checkbox'}).val(icon.id)
           iconDiv.append($("<div>").attr({class: 'select-button'}).append(iconCheckbox));
         }

--- a/app/assets/javascripts/galleries/expander.js
+++ b/app/assets/javascripts/galleries/expander.js
@@ -11,8 +11,8 @@ $(document).ready(function() {
     $("#icons-" + galleryId).toggle();
 
     // Nothing more necessary if collapsing or already loaded
-    if (wasVisible) { return true; }
-    if ($("#icons-" + galleryId + " .gallery").html().length > 0) { return true; }
+    if (wasVisible) { return; }
+    if ($("#icons-" + galleryId + " .gallery").html().length > 0) { return; }
 
     // Load and bind icons if they have not already been loaded
     $.get("/api/v1/galleries/" + galleryId, {user_id: gon.user_id}, function(resp) {

--- a/app/assets/javascripts/galleries/expander.js
+++ b/app/assets/javascripts/galleries/expander.js
@@ -24,7 +24,7 @@ $(document).ready(function() {
 
         // Add control buttons for the owner
         if ($("#icons-" + galleryId + " .icons-remove").length > 0) {
-          var iconCheckbox = $("<input>").attr({id: 'marked_ids_'+icon.id, name: 'marked_ids[]', type: 'checkbox'}).val(icon.id)
+          var iconCheckbox = $("<input>").attr({id: 'marked_ids_'+icon.id, name: 'marked_ids[]', type: 'checkbox'}).val(icon.id);
           iconDiv.append($("<div>").attr({class: 'select-button'}).append(iconCheckbox));
         }
 

--- a/app/assets/javascripts/galleries/expander.js
+++ b/app/assets/javascripts/galleries/expander.js
@@ -1,3 +1,4 @@
+/* global gon */
 $(document).ready(function() {
   $(".gallery-box").click(function() {
     // Update toggle +/-

--- a/app/assets/javascripts/icons.js
+++ b/app/assets/javascripts/icons.js
@@ -10,7 +10,7 @@ function setIconFromId(id) {
   $("#new_icon").attr('src', gon.gallery[id].url);
   $("#new_icon").attr('alt', gon.gallery[id].keyword);
   $("#new_icon").attr('title', gon.gallery[id].keyword);
-  if (gon.gallery[id].aliases !== undefined) {
+  if (typeof gon.gallery[id].aliases !== "undefined") {
     var aliases = gon.gallery[id].aliases;
     if (aliases.length > 0) {
       $("#alias_dropdown").show().empty().append('<option value="">— No alias —</option>');

--- a/app/assets/javascripts/icons.js
+++ b/app/assets/javascripts/icons.js
@@ -9,11 +9,11 @@ function setIconFromId(id) {
   $("#new_icon").attr('src', gon.gallery[id].url);
   $("#new_icon").attr('alt', gon.gallery[id].keyword);
   $("#new_icon").attr('title', gon.gallery[id].keyword);
-  if(gon.gallery[id].aliases !== undefined) {
+  if (gon.gallery[id].aliases !== undefined) {
     var aliases = gon.gallery[id].aliases;
     if (aliases.length > 0) {
       $("#alias_dropdown").show().empty().append('<option value="">— No alias —</option>');
-      for(var i = 0; i < aliases.length; i++) {
+      for (var i = 0; i < aliases.length; i++) {
         $("#alias_dropdown").append($("<option>").attr({value: aliases[i].id}).append(aliases[i].name));
       }
     } else { $("#alias_dropdown").hide().val(''); }

--- a/app/assets/javascripts/icons.js
+++ b/app/assets/javascripts/icons.js
@@ -18,4 +18,4 @@ function setIconFromId(id) {
       }
     } else { $("#alias_dropdown").hide().val(''); }
   }
-};
+}

--- a/app/assets/javascripts/icons.js
+++ b/app/assets/javascripts/icons.js
@@ -16,6 +16,8 @@ function setIconFromId(id) {
       for (var i = 0; i < aliases.length; i++) {
         $("#alias_dropdown").append($("<option>").attr({value: aliases[i].id}).append(aliases[i].name));
       }
-    } else { $("#alias_dropdown").hide().val(''); }
+    } else {
+      $("#alias_dropdown").hide().val('');
+    }
   }
 }

--- a/app/assets/javascripts/icons.js
+++ b/app/assets/javascripts/icons.js
@@ -1,3 +1,4 @@
+/* global gon */
 $(document).ready(function() {
   // Bind both change() and keyup() in the icon keyword dropdown because Firefox doesn't
   // respect up/down key selections in a dropdown as a valid change() trigger

--- a/app/assets/javascripts/paginator.js
+++ b/app/assets/javascripts/paginator.js
@@ -1,3 +1,4 @@
+/* global add_parameter */
 $(document).ready(function() {
   $(".per-page").select2({width: '70px'});
   $(".per-page").change(function() {

--- a/app/assets/javascripts/paginator.js
+++ b/app/assets/javascripts/paginator.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
   $(".per-page").select2({width: '70px'});
-  $(".per-page").change(function () {
+  $(".per-page").change(function() {
     location.href = add_parameter(location.href, 'per_page', $(this).val());
   });
 });

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -1,9 +1,10 @@
+/* global gon, tinymce, tinyMCE */
 var tinyMCEInit = false;
 
 $(document).ready(function() {
   // SET UP POST METADATA EDITOR:
 
-  PRIVACY_ACCESS = 2; // TODO don't hardcode
+  var PRIVACY_ACCESS = 2; // TODO don't hardcode
 
   // Adding Select2 UI to relevant selects
   $("#post_board_id").select2({
@@ -201,7 +202,7 @@ $(document).ready(function() {
 
 function bindGallery() {
   $("#gallery img").click(function() {
-    id = $(this).attr('id');
+    var id = $(this).attr('id');
     setIconFromId(id, $(this));
   });
 }
@@ -259,7 +260,7 @@ function setupTinyMCE() {
       remove_script_host: true,
       document_base_url: "https://www.glowfic.com/",
       setup: function(ed) {
-        ed.on('init', function(args) {
+        ed.on('init', function() {
           var rawContent = tinymce.activeEditor.getContent({format: 'raw'});
           var content = tinymce.activeEditor.getContent();
           // TODO fix hack

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -197,14 +197,14 @@ $(document).ready(function() {
   });
 });
 
-bindGallery = function() {
+function bindGallery() {
   $("#gallery img").click(function() {
     id = $(this).attr('id');
     setIconFromId(id, $(this));
   });
 };
 
-bindIcon = function() {
+function bindIcon() {
   $('#current-icon-holder').click(function() {
     $('#icon-overlay').toggle();
     $('#gallery').toggle();
@@ -212,7 +212,7 @@ bindIcon = function() {
   });
 };
 
-galleryString = function(gallery, multiGallery) {
+function galleryString(gallery, multiGallery) {
   var iconsString = "";
   var icons = gallery.icons;
 
@@ -226,7 +226,7 @@ galleryString = function(gallery, multiGallery) {
   return "<div class='gallery-group'>" + nameString + iconsString + "</div>"
 };
 
-iconString = function(icon) {
+function iconString(icon) {
   var img_id = icon.id;
   var img_url = icon.url;
   var img_key = icon.keyword;
@@ -236,7 +236,7 @@ iconString = function(icon) {
   return $("<div>").attr('class', 'gallery-icon').append(icon_img).append("<br />").append(img_key)[0].outerHTML;
 };
 
-setupTinyMCE = function() {
+function setupTinyMCE() {
   if (typeof tinyMCE !== 'undefined') {
     tinyMCE.init({
       selector: "textarea.tinymce",
@@ -268,7 +268,7 @@ setupTinyMCE = function() {
   }
 };
 
-getAndSetCharacterData = function(characterId, options) {
+function getAndSetCharacterData(characterId, options) {
   var restore_icon = false;
   var restore_alias = false;
   if (typeof options !== 'undefined') {
@@ -384,14 +384,14 @@ getAndSetCharacterData = function(characterId, options) {
   });
 };
 
-setIconFromId = function(id, img) {
+function setIconFromId(id, img) {
   // Assumes the #gallery div is populated with icons with the correct values
   if (id == "") return setIcon(id);
   if (typeof(img) === 'undefined') img = $("#"+id);
   setIcon(id, img.attr('src'), img.attr('title'), img.attr('alt'));
 };
 
-setIcon = function(id, url, title, alt) {
+function setIcon(id, url, title, alt) {
   // Handle No Icon case
   if (id === "") {
     url = "/images/no-icon.png";
@@ -414,7 +414,7 @@ setIcon = function(id, url, title, alt) {
   $("#current-icon").attr('alt', alt);
 };
 
-setSections = function() {
+function setSections() {
   var board_id = $("#post_board_id").val();
   $.get("/api/v1/boards/"+board_id, {}, function(resp) {
     var sections = resp.board_sections;
@@ -432,7 +432,7 @@ setSections = function() {
   }, 'json');
 };
 
-createTagSelect = function(tagType, selector) {
+function createTagSelect(tagType, selector) {
   $("#post_"+selector+"_ids").select2({
     tags: true,
     tokenSeparators: [','],

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -39,7 +39,7 @@ $(document).ready(function() {
   $("#post_board_id").change(function() { setSections(); });
 
   $("#post_privacy").change(function() {
-    if (String($(this).val()) == String(PRIVACY_ACCESS)) {
+    if (String($(this).val()) === String(PRIVACY_ACCESS)) {
       $("#access_list").show();
     } else {
       $("#access_list").hide();
@@ -359,7 +359,7 @@ function getAndSetCharacterData(characterId, options) {
     if (!resp.default) {
       setIcon('');
       // Remove pointer and skip galleries if no galleries attached to character
-      if (resp.galleries.length == 0) {
+      if (resp.galleries.length === 0) {
         $("#current-icon").removeClass('pointer');
         return;
       }
@@ -386,7 +386,7 @@ function getAndSetCharacterData(characterId, options) {
 
 function setIconFromId(id, img) {
   // Assumes the #gallery div is populated with icons with the correct values
-  if (id == "") return setIcon(id);
+  if (id === "") return setIcon(id);
   if (typeof(img) === 'undefined') img = $("#"+id);
   setIcon(id, img.attr('src'), img.attr('title'), img.attr('alt'));
 }

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -202,7 +202,7 @@ function bindGallery() {
     id = $(this).attr('id');
     setIconFromId(id, $(this));
   });
-};
+}
 
 function bindIcon() {
   $('#current-icon-holder').click(function() {
@@ -210,7 +210,7 @@ function bindIcon() {
     $('#gallery').toggle();
     $('html, body').scrollTop($("#post-editor").offset().top);
   });
-};
+}
 
 function galleryString(gallery, multiGallery) {
   var iconsString = "";
@@ -222,9 +222,9 @@ function galleryString(gallery, multiGallery) {
 
   if (!multiGallery) { return iconsString; }
 
-  var nameString = "<div class='gallery-name'>" + gallery.name + "</div>"
-  return "<div class='gallery-group'>" + nameString + iconsString + "</div>"
-};
+  var nameString = "<div class='gallery-name'>" + gallery.name + "</div>";
+  return "<div class='gallery-group'>" + nameString + iconsString + "</div>";
+}
 
 function iconString(icon) {
   var img_id = icon.id;
@@ -234,7 +234,7 @@ function iconString(icon) {
   if (!icon.skip_dropdown) $("#icon_dropdown").append($("<option>").attr({value: img_id}).append(img_key));
   var icon_img = $("<img>").attr({src: img_url, id: img_id, alt: img_key, title: img_key, 'class': 'icon'});
   return $("<div>").attr('class', 'gallery-icon').append(icon_img).append("<br />").append(img_key)[0].outerHTML;
-};
+}
 
 function setupTinyMCE() {
   if (typeof tinyMCE !== 'undefined') {
@@ -266,7 +266,7 @@ function setupTinyMCE() {
   } else {
     setTimeout(arguments.callee, 50);
   }
-};
+}
 
 function getAndSetCharacterData(characterId, options) {
   var restore_icon = false;
@@ -310,7 +310,7 @@ function getAndSetCharacterData(characterId, options) {
     $("#character_alias").val('').trigger("change.select2");
     $("#reply_character_alias_id").val('');
 
-    return // Don't need to load data from server (TODO combine with below?)
+    return; // Don't need to load data from server (TODO combine with below?)
   }
 
   var postID = $("#reply_post_id").val();
@@ -382,14 +382,14 @@ function getAndSetCharacterData(characterId, options) {
     else
       setIcon(resp.default.id, resp.default.url, resp.default.keyword, resp.default.keyword);
   });
-};
+}
 
 function setIconFromId(id, img) {
   // Assumes the #gallery div is populated with icons with the correct values
   if (id == "") return setIcon(id);
   if (typeof(img) === 'undefined') img = $("#"+id);
   setIcon(id, img.attr('src'), img.attr('title'), img.attr('alt'));
-};
+}
 
 function setIcon(id, url, title, alt) {
   // Handle No Icon case
@@ -412,7 +412,7 @@ function setIcon(id, url, title, alt) {
   $("#current-icon").attr('src', url);
   $("#current-icon").attr('title', title);
   $("#current-icon").attr('alt', alt);
-};
+}
 
 function setSections() {
   var board_id = $("#post_board_id").val();
@@ -430,7 +430,7 @@ function setSections() {
       $("#section").hide();
     }
   }, 'json');
-};
+}
 
 function createTagSelect(tagType, selector) {
   $("#post_"+selector+"_ids").select2({
@@ -447,7 +447,7 @@ function createTagSelect(tagType, selector) {
           t: tagType,
           page: params.page
         };
-        return data
+        return data;
       },
       processResults: function(data, params) {
         params.page = params.page || 1;
@@ -457,13 +457,13 @@ function createTagSelect(tagType, selector) {
           pagination: {
             more: (params.page * 25) < total
           }
-        }
+        };
       },
       cache: true
     },
     width: '300px'
   });
-};
+}
 
 function setCharacterListSelected(characterId) {
   $(".char-access-icon.semiopaque").removeClass('semiopaque').addClass('pointer');

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -331,11 +331,11 @@ function getAndSetCharacterData(characterId, options) {
     }
 
     // Display alias selector if relevant
-    if (resp['aliases'].length > 0) {
+    if (resp.aliases.length > 0) {
       $("#swap-alias").show();
-      $("#character_alias").empty().append('<option value="">' + resp['name'] + '</option>');
-      for (var i=0; i<resp['aliases'].length; i++) {
-        $("#character_alias").append($("<option>").attr({value: resp['aliases'][i]['id']}).append(resp['aliases'][i]['name']));
+      $("#character_alias").empty().append('<option value="">' + resp.name + '</option>');
+      for (var i=0; i<resp.aliases.length; i++) {
+        $("#character_alias").append($("<option>").attr({value: resp.aliases[i].id}).append(resp.aliases[i].name));
       }
       // Restore active alias, but only if not already restoring an alias
       if (resp.alias_id_for_post !== undefined && !restore_alias) {

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -334,7 +334,7 @@ function getAndSetCharacterData(characterId, options) {
     // Display alias selector if relevant
     if (resp.aliases.length > 0) {
       $("#swap-alias").show();
-      $("#character_alias").empty().append('<option value="">' + resp.name + '</option>');
+      $("#character_alias").empty().append($("<option>").attr({value: ''}).append(resp.name));
       for (var i=0; i<resp.aliases.length; i++) {
         $("#character_alias").append($("<option>").attr({value: resp.aliases[i].id}).append(resp.aliases[i].name));
       }
@@ -428,7 +428,7 @@ function setSections() {
       $("#section").show();
       $("#post_section_id").empty().append('<option value="">— Choose Section —</option>');
       for (var i = 0; i < sections.length; i++) {
-        $("#post_section_id").append('<option value="'+sections[i].id+'">'+sections[i].name+'</option>');
+        $("#post_section_id").append($("<option>").attr({value: sections[i].id}).append(sections[i].name));
       }
       $("#post_section_id").trigger("change.select2");
     } else {

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -239,7 +239,9 @@ function iconString(icon) {
 }
 
 function setupTinyMCE() {
-  if (typeof tinyMCE !== 'undefined') {
+  if (typeof tinyMCE === 'undefined') {
+    setTimeout(arguments.callee, 50);
+  } else {
     tinyMCE.init({
       selector: "textarea.tinymce",
       menubar: false,
@@ -268,8 +270,6 @@ function setupTinyMCE() {
       }
     });
     tinyMCEInit = true;
-  } else {
-    setTimeout(arguments.callee, 50);
   }
 }
 

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -394,7 +394,7 @@ function setIconFromId(id, img) {
   // Assumes the #gallery div is populated with icons with the correct values
   if (id === "") return setIcon(id);
   if (typeof img === 'undefined') img = $("#"+id);
-  setIcon(id, img.attr('src'), img.attr('title'), img.attr('alt'));
+  return setIcon(id, img.attr('src'), img.attr('title'), img.attr('alt'));
 }
 
 function setIcon(id, url, title, alt) {

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -35,7 +35,7 @@ $(document).ready(function() {
     $("#access_list").hide();
   }
 
-  if ($("#post_section_id").val() === '') { setSections(); }
+  if ($("#post_section_id").val() === '') setSections();
   $("#post_board_id").change(function() { setSections(); });
 
   $("#post_privacy").change(function() {
@@ -118,7 +118,9 @@ $(document).ready(function() {
       if (tinyMCEInit) {
         tinyMCE.execCommand('mceAddEditor', true, 'post_content');
         tinyMCE.execCommand('mceAddEditor', true, 'reply_content');
-      } else { setupTinyMCE(); }
+      } else {
+        setupTinyMCE();
+      }
     } else if (this.id === 'html') {
       $("#rtf").removeClass('selected');
       $("#editor_mode").val('html');
@@ -220,7 +222,7 @@ function galleryString(gallery, multiGallery) {
     iconsString += iconString(icons[i]);
   }
 
-  if (!multiGallery) { return iconsString; }
+  if (!multiGallery) return iconsString;
 
   var nameString = "<div class='gallery-name'>" + gallery.name + "</div>";
   return "<div class='gallery-group'>" + nameString + iconsString + "</div>";
@@ -258,7 +260,10 @@ function setupTinyMCE() {
         ed.on('init', function(args) {
           var rawContent = tinymce.activeEditor.getContent({format: 'raw'});
           var content = tinymce.activeEditor.getContent();
-          if (rawContent === '<p>&nbsp;<br></p>' && content === '') { tinymce.activeEditor.setContent(''); } // TODO fix hack
+          // TODO fix hack
+          if (rawContent === '<p>&nbsp;<br></p>' && content === '') {
+            tinymce.activeEditor.setContent('');
+          }
         });
       }
     });

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -31,7 +31,7 @@ $(document).ready(function() {
   createTagSelect("Setting", "setting");
   createTagSelect("ContentWarning", "warning");
 
-  if (String($("#post_privacy").val()) !== String(PRIVACY_ACCESS)){
+  if (String($("#post_privacy").val()) !== String(PRIVACY_ACCESS)) {
     $("#access_list").hide();
   }
 
@@ -39,7 +39,7 @@ $(document).ready(function() {
   $("#post_board_id").change(function() { setSections(); });
 
   $("#post_privacy").change(function() {
-    if(String($(this).val()) == String(PRIVACY_ACCESS)) {
+    if (String($(this).val()) == String(PRIVACY_ACCESS)) {
       $("#access_list").show();
     } else {
       $("#access_list").hide();
@@ -64,7 +64,7 @@ $(document).ready(function() {
   // Hack because having In Thread characters as a group in addition to Template groups
   // duplicates characters in the dropdown, and therefore multiple options are selected
   var selectd;
-  $("#active_character option[selected]").each(function(){
+  $("#active_character option[selected]").each(function() {
     if (!selectd) selectd = this;
     $(this).prop("selected", false);
   });
@@ -72,7 +72,7 @@ $(document).ready(function() {
 
   // TODO fix hack
   // Only initialize TinyMCE if it's required
-  if($("#rtf").hasClass('selected') === true) {
+  if ($("#rtf").hasClass('selected') === true) {
     setupTinyMCE();
   }
 
@@ -111,11 +111,11 @@ $(document).ready(function() {
   $("#icon_dropdown").keyup(function() { setIconFromId($(this).val()); });
 
   $('.view-button').click(function() {
-    if(this.id === 'rtf') {
+    if (this.id === 'rtf') {
       $("#html").removeClass('selected');
       $("#editor_mode").val('rtf');
       $(this).addClass('selected');
-      if(tinyMCEInit) {
+      if (tinyMCEInit) {
         tinyMCE.execCommand('mceAddEditor', true, 'post_content');
         tinyMCE.execCommand('mceAddEditor', true, 'reply_content');
       } else { setupTinyMCE(); }
@@ -128,19 +128,19 @@ $(document).ready(function() {
     }
   });
 
-  $("#swap-icon").click(function () {
+  $("#swap-icon").click(function() {
     $('#character-selector').toggle();
     $('#alias-selector').hide();
     $('html, body').scrollTop($("#post-editor").offset().top);
   });
 
-  $("#swap-alias").click(function () {
+  $("#swap-alias").click(function() {
     $('#alias-selector').toggle();
     $('#character-selector').hide();
     $('html, body').scrollTop($("#post-editor").offset().top);
   });
 
-  $("#active_character, #character_alias").on('select2:close', function () {
+  $("#active_character, #character_alias").on('select2:close', function() {
     $('html, body').scrollTop($("#post-editor").offset().top);
   });
 
@@ -167,10 +167,10 @@ $(document).ready(function() {
   });
 
   // Hides selectors when you hit the escape key
-  $(document).bind("keydown", function(e){
+  $(document).bind("keydown", function(e) {
     e = e || window.event;
     var charCode = e.which || e.keyCode;
-    if(charCode === 27) {
+    if (charCode === 27) {
       $('#icon-overlay').hide();
       $('#gallery').hide();
       $('#character-selector').hide();
@@ -182,17 +182,17 @@ $(document).ready(function() {
     var target = e.target;
 
     if (!$(target).is('#current-icon-holder') &&
-      !$(target).parents().is('#current-icon-holder') &&
-      !$(target).is('#gallery') &&
-      !$(target).parents().is('#gallery')) {
-        $('#icon-overlay').hide();
-        $('#gallery').hide();
+        !$(target).parents().is('#current-icon-holder') &&
+        !$(target).is('#gallery') &&
+        !$(target).parents().is('#gallery')) {
+      $('#icon-overlay').hide();
+      $('#gallery').hide();
     }
 
     if (!$(target).is('#character-selector') &&
-      !$(target).is('#swap-icon') &&
-      !$(target).parents().is('#character-selector')) {
-        $('#character-selector').hide();
+        !$(target).is('#swap-icon') &&
+        !$(target).parents().is('#character-selector')) {
+      $('#character-selector').hide();
     }
   });
 });
@@ -220,7 +220,7 @@ galleryString = function(gallery, multiGallery) {
     iconsString += iconString(icons[i]);
   }
 
-  if(!multiGallery) { return iconsString; }
+  if (!multiGallery) { return iconsString; }
 
   var nameString = "<div class='gallery-name'>" + gallery.name + "</div>"
   return "<div class='gallery-group'>" + nameString + iconsString + "</div>"
@@ -291,7 +291,7 @@ getAndSetCharacterData = function(characterId, options) {
     $("#post-editor .post-screenname").hide();
 
     var avatar = gon.current_user.avatar;
-    if(avatar && avatar.url !== null) {
+    if (avatar && avatar.url !== null) {
       var url = avatar.url;
       var aid = avatar.id;
       var keyword = avatar.keyword;
@@ -314,26 +314,26 @@ getAndSetCharacterData = function(characterId, options) {
   }
 
   var postID = $("#reply_post_id").val();
-  $.getJSON('/api/v1/characters/' + characterId, { post_id: postID }, function (resp) {
+  $.getJSON('/api/v1/characters/' + characterId, {post_id: postID}, function(resp) {
     // Display the correct name/screenname fields
     $("#post-editor #post-author-spacer").hide();
     $("#post-editor .post-character").show().data('character-id', characterId);
     $("#post-editor .post-character #name").html(resp.name);
-    if(!resp.screenname) {
+    if (!resp.screenname) {
       $("#post-editor .post-screenname").hide();
     } else {
       $("#post-editor .post-screenname").show().html(resp.screenname);
     }
 
     // Display alias selector if relevant
-    if(resp['aliases'].length > 0) {
+    if (resp['aliases'].length > 0) {
       $("#swap-alias").show();
       $("#character_alias").empty().append('<option value="">' + resp['name'] + '</option>');
-      for(var i=0; i<resp['aliases'].length; i++) {
+      for (var i=0; i<resp['aliases'].length; i++) {
         $("#character_alias").append($("<option>").attr({value: resp['aliases'][i]['id']}).append(resp['aliases'][i]['name']));
       }
       // Restore active alias, but only if not already restoring an alias
-      if(resp.alias_id_for_post !== undefined && !restore_alias) {
+      if (resp.alias_id_for_post !== undefined && !restore_alias) {
         restore_alias = true;
         selectedAliasID = resp.alias_id_for_post;
         $("#reply_character_alias_id").val(selectedAliasID);
@@ -370,7 +370,7 @@ getAndSetCharacterData = function(characterId, options) {
 
     // Calculate new galleries
     var multiGallery = resp.galleries.length > 1;
-    for(var j = 0; j < resp.galleries.length; j++) {
+    for (var j = 0; j < resp.galleries.length; j++) {
       $("#gallery").append(galleryString(resp.galleries[j], multiGallery));
     }
 
@@ -421,7 +421,7 @@ setSections = function() {
     if (sections.length > 0) {
       $("#section").show();
       $("#post_section_id").empty().append('<option value="">— Choose Section —</option>');
-      for(var i = 0; i < sections.length; i++) {
+      for (var i = 0; i < sections.length; i++) {
         $("#post_section_id").append('<option value="'+sections[i].id+'">'+sections[i].name+'</option>');
       }
       $("#post_section_id").trigger("change.select2");
@@ -449,7 +449,7 @@ createTagSelect = function(tagType, selector) {
         };
         return data
       },
-      processResults: function (data, params) {
+      processResults: function(data, params) {
         params.page = params.page || 1;
         var total = this._request.getResponseHeader('Total');
         return {
@@ -467,7 +467,7 @@ createTagSelect = function(tagType, selector) {
 
 function setCharacterListSelected(characterId) {
   $(".char-access-icon.semiopaque").removeClass('semiopaque').addClass('pointer');
-  $(".char-access-icon").each(function(){
+  $(".char-access-icon").each(function() {
     if (String($(this).data('character-id')) === String(characterId)) $(this).addClass('semiopaque').removeClass('pointer');
   });
 }

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -339,7 +339,7 @@ function getAndSetCharacterData(characterId, options) {
         $("#character_alias").append($("<option>").attr({value: resp.aliases[i].id}).append(resp.aliases[i].name));
       }
       // Restore active alias, but only if not already restoring an alias
-      if (resp.alias_id_for_post !== undefined && !restore_alias) {
+      if (typeof resp.alias_id_for_post !== "undefined" && !restore_alias) {
         restore_alias = true;
         selectedAliasID = resp.alias_id_for_post;
         $("#reply_character_alias_id").val(selectedAliasID);
@@ -393,7 +393,7 @@ function getAndSetCharacterData(characterId, options) {
 function setIconFromId(id, img) {
   // Assumes the #gallery div is populated with icons with the correct values
   if (id === "") return setIcon(id);
-  if (typeof(img) === 'undefined') img = $("#"+id);
+  if (typeof img === 'undefined') img = $("#"+id);
   setIcon(id, img.attr('src'), img.attr('title'), img.attr('alt'));
 }
 

--- a/app/assets/javascripts/posts/search.js
+++ b/app/assets/javascripts/posts/search.js
@@ -1,3 +1,4 @@
+/* global gon */
 $(document).ready(function() {
   $("#setting_id").select2({
     ajax: {

--- a/app/assets/javascripts/posts/search.js
+++ b/app/assets/javascripts/posts/search.js
@@ -38,7 +38,7 @@ $(document).ready(function() {
           q: params.term,
           page: params.page
         };
-        if (typeof(gon) !== 'undefined') { data.post_id = gon.post_id; }
+        if (typeof gon !== 'undefined') { data.post_id = gon.post_id; }
         return data;
       },
       processResults: function(data, params) {

--- a/app/assets/javascripts/posts/search.js
+++ b/app/assets/javascripts/posts/search.js
@@ -10,7 +10,7 @@ $(document).ready(function() {
           t: 'Setting',
           page: params.page
         };
-        return data
+        return data;
       },
       processResults: function(data, params) {
         params.page = params.page || 1;
@@ -20,7 +20,7 @@ $(document).ready(function() {
           pagination: {
             more: (params.page * 25) < total
           }
-        }
+        };
       },
       cache: true
     },
@@ -37,27 +37,27 @@ $(document).ready(function() {
           q: params.term,
           page: params.page
         };
-        if (typeof(gon) !== 'undefined') { data.post_id = gon.post_id }
-        return data
+        if (typeof(gon) !== 'undefined') { data.post_id = gon.post_id; }
+        return data;
       },
       processResults: function(data, params) {
         params.page = params.page || 1;
         var total = this._request.getResponseHeader('Total');
 
         // Reformat the response to be
-        var formattedChars = []
+        var formattedChars = [];
         for (var i = 0; i < data.results.length; i++) {
           formattedChars[i] = {
             id: data.results[i].id,
             text: data.results[i].name
-          }
+          };
         }
         return {
           results: formattedChars,
           pagination: {
             more: (params.page * 25) < total
           }
-        }
+        };
       },
       cache: true
     },
@@ -74,26 +74,26 @@ $(document).ready(function() {
           q: params.term,
           page: params.page
         };
-        return data
+        return data;
       },
       processResults: function(data, params) {
         params.page = params.page || 1;
         var total = this._request.getResponseHeader('Total');
 
         // Reformat the response to be
-        var formattedChars = []
+        var formattedChars = [];
         for (var i = 0; i < data.results.length; i++) {
           formattedChars[i] = {
             id: data.results[i].id,
             text: data.results[i].username
-          }
+          };
         }
         return {
           results: formattedChars,
           pagination: {
             more: (params.page * 25) < total
           }
-        }
+        };
       },
       cache: true
     },
@@ -110,26 +110,26 @@ $(document).ready(function() {
           q: params.term,
           page: params.page
         };
-        return data
+        return data;
       },
       processResults: function(data, params) {
         params.page = params.page || 1;
         var total = this._request.getResponseHeader('Total');
 
         // Reformat the response to be
-        var formattedChars = []
+        var formattedChars = [];
         for (var i = 0; i < data.results.length; i++) {
           formattedChars[i] = {
             id: data.results[i].id,
             text: data.results[i].name
-          }
+          };
         }
         return {
           results: formattedChars,
           pagination: {
             more: (params.page * 25) < total
           }
-        }
+        };
       },
       cache: true
     },
@@ -146,26 +146,26 @@ $(document).ready(function() {
           q: params.term,
           page: params.page
         };
-        return data
+        return data;
       },
       processResults: function(data, params) {
         params.page = params.page || 1;
         var total = this._request.getResponseHeader('Total');
 
         // Reformat the response to be
-        var formattedChars = []
+        var formattedChars = [];
         for (var i = 0; i < data.results.length; i++) {
           formattedChars[i] = {
             id: data.results[i].id,
             text: data.results[i].name
-          }
+          };
         }
         return {
           results: formattedChars,
           pagination: {
             more: (params.page * 25) < total
           }
-        }
+        };
       },
       cache: true
     },

--- a/app/assets/javascripts/posts/search.js
+++ b/app/assets/javascripts/posts/search.js
@@ -12,7 +12,7 @@ $(document).ready(function() {
         };
         return data
       },
-      processResults: function (data, params) {
+      processResults: function(data, params) {
         params.page = params.page || 1;
         var total = this._request.getResponseHeader('Total');
         return {
@@ -37,16 +37,16 @@ $(document).ready(function() {
           q: params.term,
           page: params.page
         };
-        if(typeof(gon) !== 'undefined') { data.post_id = gon.post_id }
+        if (typeof(gon) !== 'undefined') { data.post_id = gon.post_id }
         return data
       },
-      processResults: function (data, params) {
+      processResults: function(data, params) {
         params.page = params.page || 1;
         var total = this._request.getResponseHeader('Total');
 
-        // Reformat the response to be 
+        // Reformat the response to be
         var formattedChars = []
-        for(var i = 0; i < data.results.length; i++) {
+        for (var i = 0; i < data.results.length; i++) {
           formattedChars[i] = {
             id: data.results[i].id,
             text: data.results[i].name
@@ -76,13 +76,13 @@ $(document).ready(function() {
         };
         return data
       },
-      processResults: function (data, params) {
+      processResults: function(data, params) {
         params.page = params.page || 1;
         var total = this._request.getResponseHeader('Total');
 
-        // Reformat the response to be 
+        // Reformat the response to be
         var formattedChars = []
-        for(var i = 0; i < data.results.length; i++) {
+        for (var i = 0; i < data.results.length; i++) {
           formattedChars[i] = {
             id: data.results[i].id,
             text: data.results[i].username
@@ -112,13 +112,13 @@ $(document).ready(function() {
         };
         return data
       },
-      processResults: function (data, params) {
+      processResults: function(data, params) {
         params.page = params.page || 1;
         var total = this._request.getResponseHeader('Total');
 
-        // Reformat the response to be 
+        // Reformat the response to be
         var formattedChars = []
-        for(var i = 0; i < data.results.length; i++) {
+        for (var i = 0; i < data.results.length; i++) {
           formattedChars[i] = {
             id: data.results[i].id,
             text: data.results[i].name
@@ -148,13 +148,13 @@ $(document).ready(function() {
         };
         return data
       },
-      processResults: function (data, params) {
+      processResults: function(data, params) {
         params.page = params.page || 1;
         var total = this._request.getResponseHeader('Total');
 
-        // Reformat the response to be 
+        // Reformat the response to be
         var formattedChars = []
-        for(var i = 0; i < data.results.length; i++) {
+        for (var i = 0; i < data.results.length; i++) {
           formattedChars[i] = {
             id: data.results[i].id,
             text: data.results[i].name

--- a/app/assets/javascripts/posts/show.js
+++ b/app/assets/javascripts/posts/show.js
@@ -46,7 +46,7 @@ $(document).ready(function() {
   $(".post-screenname").each(function(index) {
     if ($(this).height() > 20) {
       $(this).css('font-size', "14px");
-      if ($(this).height() > 20) { $(this).css('font-size', "12px"); }
+      if ($(this).height() > 20) $(this).css('font-size', "12px");
     }
   });
 

--- a/app/assets/javascripts/posts/show.js
+++ b/app/assets/javascripts/posts/show.js
@@ -43,7 +43,7 @@ $(document).ready(function() {
 
   // TODO fix hack
   // Resizes screennames to be slightly smaller if they're long for UI reasons
-  $(".post-screenname").each(function(index) {
+  $(".post-screenname").each(function() {
     if ($(this).height() > 20) {
       $(this).css('font-size', "14px");
       if ($(this).height() > 20) $(this).css('font-size', "12px");

--- a/app/assets/javascripts/posts/show.js
+++ b/app/assets/javascripts/posts/show.js
@@ -20,10 +20,10 @@ $(document).ready(function() {
     });
 
     // Hides selectors when you hit the escape key
-    $(document).bind("keydown", function(e){
+    $(document).bind("keydown", function(e) {
       e = e || window.event;
       var charCode = e.which || e.keyCode;
-      if(charCode === 27) {
+      if (charCode === 27) {
         $('#post-menu-box').hide();
         $('#post-menu').removeClass('selected');
       }
@@ -43,10 +43,10 @@ $(document).ready(function() {
 
   // TODO fix hack
   // Resizes screennames to be slightly smaller if they're long for UI reasons
-  $(".post-screenname").each(function (index) {
-    if($(this).height() > 20) {
+  $(".post-screenname").each(function(index) {
+    if ($(this).height() > 20) {
       $(this).css('font-size', "14px");
-      if($(this).height() > 20 ) { $(this).css('font-size', "12px"); }
+      if ($(this).height() > 20) { $(this).css('font-size', "12px"); }
     }
   });
 

--- a/app/assets/javascripts/users/edit.js
+++ b/app/assets/javascripts/users/edit.js
@@ -20,7 +20,7 @@ $(document).ready(function() {
   });
 
   $("#user_timezone").select2({width: '250px'});
-  
+
   $("#user_time_display").select2({
     width: '200px',
     minimumResultsForSearch: 20

--- a/app/assets/javascripts/users/new.js
+++ b/app/assets/javascripts/users/new.js
@@ -45,8 +45,8 @@ validateUsername = function() {
     return false;
   }
 
-  $.post('/users/username', {'username':username}, function(resp) {
-    if (!resp.username_free){
+  $.post('/users/username', {'username': username}, function(resp) {
+    if (!resp.username_free) {
       addAlertAfter('user_username', 'That username has already been taken.');
       return false;
     }

--- a/app/assets/javascripts/users/new.js
+++ b/app/assets/javascripts/users/new.js
@@ -49,7 +49,7 @@ function validateUsername() {
   $.post('/users/username', {'username': username}, function(resp) {
     if (!resp.username_free) {
       addAlertAfter('user_username', 'That username has already been taken.');
-      return false;
+      return false; // TODO: actually return false from validateUsername
     }
   });
 

--- a/app/assets/javascripts/users/new.js
+++ b/app/assets/javascripts/users/new.js
@@ -53,7 +53,7 @@ function validateUsername() {
   });
 
   return true;
-};
+}
 
 function validateEmail() {
   var email = $("#user_email").val();
@@ -62,7 +62,7 @@ function validateEmail() {
     return false;
   }
   return true;
-};
+}
 
 function validatePassword() {
   var password = $("#user_password").val();
@@ -78,7 +78,7 @@ function validatePassword() {
     success = false;
   }
   return success;
-};
+}
 
 function validateConfirmation() {
   var password = $("#user_password").val();
@@ -93,9 +93,9 @@ function validateConfirmation() {
     success = false;
   }
   return success;
-};
+}
 
 function addAlertAfter(id, message) {
-  image = "<img src='/images/exclamation.png' alt='!' title='' class='vmid' /> "
+  image = "<img src='/images/exclamation.png' alt='!' title='' class='vmid' /> ";
   $("#"+id).after("<div class='alert' style='margin: 2px 0px;'>" + image + message + "</div>");
-};
+}

--- a/app/assets/javascripts/users/new.js
+++ b/app/assets/javascripts/users/new.js
@@ -35,7 +35,7 @@ $(document).ready(function() {
   });
 });
 
-validateUsername = function() {
+function validateUsername() {
   var username = $("#user_username").val();
   if (username == '') {
     addAlertAfter('user_username', 'Please choose a username.');
@@ -55,7 +55,7 @@ validateUsername = function() {
   return true;
 };
 
-validateEmail = function() {
+function validateEmail() {
   var email = $("#user_email").val();
   if (email == '') {
     addAlertAfter('user_email', 'Please enter an email address.');
@@ -64,7 +64,7 @@ validateEmail = function() {
   return true;
 };
 
-validatePassword = function() {
+function validatePassword() {
   var password = $("#user_password").val();
   var conf = $("#user_password_confirmation").val();
   var success = true;
@@ -80,7 +80,7 @@ validatePassword = function() {
   return success;
 };
 
-validateConfirmation = function() {
+function validateConfirmation() {
   var password = $("#user_password").val();
   var conf = $("#user_password_confirmation").val();
   var success = true;
@@ -95,7 +95,7 @@ validateConfirmation = function() {
   return success;
 };
 
-addAlertAfter = function(id, message) {
+function addAlertAfter(id, message) {
   image = "<img src='/images/exclamation.png' alt='!' title='' class='vmid' /> "
   $("#"+id).after("<div class='alert' style='margin: 2px 0px;'>" + image + message + "</div>");
 };

--- a/app/assets/javascripts/users/new.js
+++ b/app/assets/javascripts/users/new.js
@@ -37,7 +37,7 @@ $(document).ready(function() {
 
 function validateUsername() {
   var username = $("#user_username").val();
-  if (username == '') {
+  if (username === '') {
     addAlertAfter('user_username', 'Please choose a username.');
     return false;
   } else if (username.length < gon.min || username.length > gon.max) {
@@ -57,7 +57,7 @@ function validateUsername() {
 
 function validateEmail() {
   var email = $("#user_email").val();
-  if (email == '') {
+  if (email === '') {
     addAlertAfter('user_email', 'Please enter an email address.');
     return false;
   }
@@ -68,11 +68,11 @@ function validatePassword() {
   var password = $("#user_password").val();
   var conf = $("#user_password_confirmation").val();
   var success = true;
-  if (password == '') {
+  if (password === '') {
     addAlertAfter('user_password', 'Please choose a password.');
     success = false;
   }
-  if (conf != password) {
+  if (conf !== password) {
     $("#conf .alert").remove();
     addAlertAfter('user_password_confirmation', 'Your passwords do not match.');
     success = false;
@@ -84,11 +84,11 @@ function validateConfirmation() {
   var password = $("#user_password").val();
   var conf = $("#user_password_confirmation").val();
   var success = true;
-  if (conf == '') {
+  if (conf === '') {
     addAlertAfter('user_password_confirmation', 'Please confirm your password.');
     success = false;
   }
-  if (conf != password) {
+  if (conf !== password) {
     addAlertAfter('user_password_confirmation', 'Your passwords do not match.');
     success = false;
   }

--- a/app/assets/javascripts/users/new.js
+++ b/app/assets/javascripts/users/new.js
@@ -1,3 +1,4 @@
+/* global gon */
 $(document).ready(function() {
   $("#user_username").blur(function() {
     $("#username .alert").remove();
@@ -96,6 +97,6 @@ function validateConfirmation() {
 }
 
 function addAlertAfter(id, message) {
-  image = "<img src='/images/exclamation.png' alt='!' title='' class='vmid' /> ";
+  var image = "<img src='/images/exclamation.png' alt='!' title='' class='vmid' /> ";
   $("#"+id).after("<div class='alert' style='margin: 2px 0px;'>" + image + message + "</div>");
 }


### PR DESCRIPTION
I'm afraid this is also pretty long, but it's more predominantly:
- fixed whitespace
- fixed semicolons
- `x = function(…) {` → `function x(…) {`
- removed braces around single-statement inline `if` blocks (mostly)
- comments that `gon` and `tinyMCE` exist
- ~~camelCasing things~~ (this was a bit large so I haven't actually done it here)
- removed unused parameters (`function a(b) { console.log(b); }` will work fine given `a(1)`, `a(1, 2)` and `a(1,2,3)` – i.e. all output `1`)
- rewrote a couple of places where some ugly string addition is done to produce HTML (as it can go horribly wrong if people try to abuse it)

Sadly we don't have tests on our JS or anything.