### PR TITLE
DOC: Add note for how to resolve citext extension issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ More specific details may be found on the GitHub site.
 
 #### Language dependencies
 
-Ruby is required for this project. [RVM](https://rvm.io/rvm/install) and [rbenv](https://github.com/rbenv/rbenv) allow you to have multiple versions of Ruby installed at a time, so it's recommended you get one of those if you plan on doing much Ruby work.
+Ruby is required for this project.
+[RVM](https://rvm.io/rvm/install) and [rbenv](https://github.com/rbenv/rbenv) allow you to have multiple versions of Ruby installed at a time, so it's recommended you get one of those if you plan on doing much Ruby work.
 
 Once you've done so, you need to install the necessary dependencies.
 This can be done with:
@@ -81,10 +82,23 @@ Once you've taken these steps, you should be able to go into the 'glowfic' folde
 
 This will set up the database and add some sample information, though no posts will be created.
 
+If you encounter an error when creating the 'citext' extension:
+
+*   Execute `sudo -u postgres psql`, and then in the prompt that appears:
+*   `CREATE EXTENSION IF NOT EXISTS citext;`
+
+You will need to re-run `rake db:migrate`.
+If the error persists, you might consider making your user a superuser with the following:
+
+*   Execute `sudo -u postgres psql` again, and in the prompt:
+*   `ALTER USER "<USERNAME>" WITH superuser;`
+
 #### Executing the server
 
-You should now be able to run `script/rails s` in the glowfic directory. When it's started, go to [http://localhost:3000/](http://localhost:3000/), where you should see a local copy of the Constellation.
+You should now be able to run `script/rails s` in the glowfic directory.
+When it's started, go to [http://localhost:3000/](http://localhost:3000/), where you should see a local copy of the Constellation.
 
 #### Running tests
 
-To run tests, go to the root of the directory (the 'glowfic' folder) and execute the command `rake spec`. This will go through the [rspec](http://rspec.info/) tests.
+To run tests, go to the root of the directory (the 'glowfic' folder) and execute the command `rake spec`.
+This will go through the [rspec](http://rspec.info/) tests.


### PR DESCRIPTION
I had an issue after upgrading to Ubuntu 17.04, removing my Postgres 9.5 cluster, and then re-creating the  database – I received an error when trying to create the citext extension. The superuser thing fixed it but I'm wary of suggesting that first, hence the first thing. (Which didn't fix it for me since it then complained I still wasn't allowed to create the extension, but that sounds like something that might not be an absolute rule, due to the 'IF NOT EXISTS'.)

The rest of the changes are just linebreaks on periods. It's a good way to format markdown documentation so future diffs only +/- the sentences that are changed.