### PR TITLE
Throw in a sanity check for Viewable's view_for caching

### DIFF
--- a/app/concerns/viewable.rb
+++ b/app/concerns/viewable.rb
@@ -42,6 +42,7 @@ module Viewable
     private
 
     def view_for(user)
+      raise("view_for(#{user.id}) but @view.user_id is #{@view.user_id}") if @view && user.id != @view.user_id
       @view ||= views.where(user_id: user.id).first_or_initialize
     end
   end


### PR DESCRIPTION
So that if a problem might be encountered whereby the cached view doesn't actually correspond to the user given, an explicit error will be thrown instead of just returning a different user's view.

(In case we ever want to use this concern in bulk instead of directly using `PostView.where(user_id: xx, post_id: yy).…`. I did this in dev mode. I don't think it hurts to add a sanity check?)