### PR TITLE
Use a helper method for unread_ids so in-view modification persists

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -115,4 +115,9 @@ class ApplicationController < ActionController::Base
     posts
   end
   helper_method :posts_from_relation
+
+  def unread_ids
+    @unread_ids
+  end
+  helper_method :unread_ids
 end

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -12,7 +12,7 @@
       = image_tag "/images/exclamation.png", class: 'vmid', title: "Content Warning: " + post.content_warnings.pluck(:name).join(', '), alt: '!'
   %td.post-subject{class: klass}
     - if logged_in?
-      - if unread_post?(post, @unread_ids)
+      - if unread_post?(post, unread_ids)
         = link_to post_path(post, page: 'unread', anchor: 'unread') do
           = image_tag unread_img, class: 'vmid', title: 'First Unread'
       - elsif @show_unread
@@ -44,7 +44,7 @@
   %td.width-70.post-replies{class: klass}= replies_count
   - if logged_in? && local_assigns[:show_unread_count]
     %td.width-70{class: klass}
-      - if @opened_ids.include?(post.id) && @unread_ids.include?(post.id)
+      - if @opened_ids.include?(post.id) && unread_ids.include?(post.id)
         = Reply.where(post_id: post.id).where('created_at > ?', post.last_read(current_user)).count
       - else
         \-


### PR DESCRIPTION
The recent problem wherein threads varyingly don't show their go-to-unread arrows despite being partially unread: is due to something weird where `@`-variables don't seem to get updated properly between the ApplicationController and the HAML document. Perhaps the way something's done behind the scenes means it's only copied once. Anyhow, this means that the view references the ApplicationController for the `unread_ids` list, instead of directly referencing it with `@unread_ids`, so it stays up to date.

I have a test case that looks (erroneously) like this on master:
![image](https://cloud.githubusercontent.com/assets/577128/24571429/fdf85e16-1668-11e7-82ee-93524f15e7ec.png)

and looks (correctly) like this on my branch:
![image](https://cloud.githubusercontent.com/assets/577128/24571422/f6799aec-1668-11e7-9718-0ceefbd61d33.png)

Note that 'test1' and 'test2' do not have the arrow icon on master, but do on my branch. I've ensured that they've been marked unread, then I viewed the first page, so they should display an arrow (as they are only partially read).

I'm not sure if there's a more permanent way to solve this? Maybe just don't use `@`-variables so much between controllers and HAML, if that's doable.