### PR TITLE
Improve javascript screenname resizing

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -81,3 +81,17 @@ function add_parameter(url, param, value) {
   parser.search = '?' + list.join('&');
   return parser.href;
 }
+
+function resizeScreenname(screenameBox) {
+  screenameBox = $(screenameBox);
+
+  // reset previous CSS for post-editor screenname updates
+  screenameBox.css('font-size', '');
+
+  // shrink font-size to decrease box size
+  if (screenameBox.height() <= 20) return;
+  screenameBox.css('font-size', "87.5%");
+
+  if (screenameBox.height() <= 20) return;
+  screenameBox.css('font-size', "75%");
+}

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -1,4 +1,4 @@
-/* global gon, tinymce, tinyMCE */
+/* global gon, tinymce, tinyMCE, resizeScreenname */
 var tinyMCEInit = false;
 
 $(document).ready(function() {
@@ -294,7 +294,7 @@ function getAndSetCharacterData(characterId, options) {
   // Handle special case where just setting to your base account
   if (characterId === '') {
     $("#post-editor .post-character").hide().data('character-id', '').data('alias-id', '');
-    $("#post-editor .post-screenname").hide();
+    $("#post-editor .post-screenname").hide().html('');
 
     var avatar = gon.current_user.avatar;
     if (avatar && avatar.url !== null) {
@@ -325,10 +325,12 @@ function getAndSetCharacterData(characterId, options) {
     $("#post-editor #post-author-spacer").hide();
     $("#post-editor .post-character").show().data('character-id', characterId);
     $("#post-editor .post-character #name").html(resp.name);
+    var screennameBox = $("#post-editor .post-screenname")
     if (!resp.screenname) {
-      $("#post-editor .post-screenname").hide();
+      screennameBox.hide().html('');
     } else {
-      $("#post-editor .post-screenname").show().html(resp.screenname);
+      screennameBox.show().html(resp.screenname);
+      resizeScreenname(screennameBox);
     }
 
     // Display alias selector if relevant

--- a/app/assets/javascripts/posts/show.js
+++ b/app/assets/javascripts/posts/show.js
@@ -1,3 +1,4 @@
+/* global resizeScreenname */
 $(document).ready(function() {
   // Checks if the user is on the unread page but also started near the unread element,
   // since e.g. on a refresh some browsers will retain your spot on the page
@@ -44,10 +45,7 @@ $(document).ready(function() {
   // TODO fix hack
   // Resizes screennames to be slightly smaller if they're long for UI reasons
   $(".post-screenname").each(function() {
-    if ($(this).height() > 20) {
-      $(this).css('font-size', "14px");
-      if ($(this).height() > 20) $(this).css('font-size', "12px");
-    }
+    resizeScreenname(this);
   });
 
   // Now that we've finished the scripts that change page locations, scroll to #unread


### PR DESCRIPTION
Builds on #174. Improves how screennames are handled, slightly, by using % sizes in the CSS and also applying when the character is changed in the post editor.