### PR TITLE
Collapse authors list on a post when more than 3 authors

### DIFF
--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -40,7 +40,14 @@
               = link_to (index), post_path(post, page: index)
   - unless local_assigns[:hide_continuity]
     %td.post-board{class: klass}= link_to post.board_name, board_path(post.board_id)
-  %td.post-authors{class: klass}= post.authors.sort_by { |author| author.username.downcase }.map { |author| link_to author.username, user_path(author) }.join(', ').html_safe
+  %td.post-authors{class: klass}
+    - authors = post.authors.sort_by { |author| author.username.downcase }
+    - if authors.length < 4
+      = authors.map { |author| link_to author.username, user_path(author) }.join(', ').html_safe
+    - else
+      = link_to post.user.username, user_path(post.user)
+      and
+      = link_to "#{authors.length-1} others", stats_post_path(post)
   %td.width-70.post-replies{class: klass}= replies_count
   - if logged_in? && local_assigns[:show_unread_count]
     %td.width-70{class: klass}

--- a/features/boards/view_board.feature
+++ b/features/boards/view_board.feature
@@ -8,3 +8,13 @@ Given there is a board "Test board" with 5 posts
 When I view the board "Test board"
 Then I should see "Test board"
 And I should see 5 posts
+
+Scenario: Viewing a board with various authors
+Given there is a board "Author board"
+And there is a post "post 1" in "Author board" with 2 authors
+And there is a post "post 2" in "Author board" with 5 authors
+When I view the board "Author board"
+Then I should see 2 posts
+And I should see "post 1"
+And I should see "and 4 others"
+And I should see "post 2"

--- a/features/step_definitions/board_steps.rb
+++ b/features/step_definitions/board_steps.rb
@@ -1,4 +1,14 @@
+Given(/^there is a board "(.*)"$/) do |name|
+  board = create(:board, name: name)
+end
+
 Given(/^there is a board "(.*)" with (\d+) posts?$/) do |name, count|
   board = create(:board, name: name)
   count.to_i.times { create(:post, board: board, user: board.creator) }
+end
+
+Given(/^there is a post "(.*)" in "(.*)" with (\d+) authors?$/) do |post_name, board_name, author_count|
+  board = Board.where(name: board_name).first
+  post = create(:post, subject: post_name, board: board)
+  (author_count.to_i - 1).times { create(:reply, post: post) }
 end


### PR DESCRIPTION
Solves #181 by replacing e.g. "temp0, temp1, temp2, temp3, temp4" with "temp0 and 4 others" (where "4 others" is a link to the post's stats page, so people can see the other authors).