### PR TITLE
Add a button to create a new post from section#show

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -79,6 +79,7 @@ class PostsController < WritableController
   def new
     @post = Post.new(character: current_user.active_character, user: current_user)
     @post.board_id = params[:board_id]
+    @post.section_id = params[:section_id]
     @post.icon_id = (current_user.active_character ? current_user.active_character.icon.try(:id) : current_user.avatar_id)
     @page_title = 'New Post'
   end

--- a/app/views/board_sections/show.haml
+++ b/app/views/board_sections/show.haml
@@ -7,6 +7,9 @@
 
 - content_for :posts_title do
   = @board_section.name
+  - if @board_section.board.open_to?(current_user)
+    = link_to new_post_path params: {board_id: @board_section.board.id, section_id: @board_section.id} do
+      .link-box.green + New Post
   - if @board_section.board.editable_by?(current_user)
     = link_to edit_board_section_path(@board_section) do
       .link-box.blue


### PR DESCRIPTION
Add a `+ New Post` button to the `board_sections#show` page to make it easier to add a post to a section. (So people don't have to click `+ New Post` on the overall board and then manually set the section.)