### PR TITLE
Fix unread timestamps changing when hiding a post

### DIFF
--- a/app/concerns/viewable.rb
+++ b/app/concerns/viewable.rb
@@ -9,12 +9,12 @@ module Viewable
       return true if view.ignored
 
       if view.new_record?
-        view.read_at = at_time
+        view.read_at = at_time || Time.now
         return view.save
       end
 
       return view.update_attributes(read_at: Time.now) unless at_time.present?
-      return true if at_time <= view.read_at && !force
+      return true if view.read_at && at_time <= view.read_at && !force
       view.update_attributes(read_at: at_time)
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -118,7 +118,7 @@ class ApplicationController < ActionController::Base
       @unread_ids ||= []
       @unread_ids += opened_posts.select do |view|
         post = posts.detect { |p| p.id == view.post_id }
-        post && view.read_at < post.tagged_at
+        post && (view.read_at.nil? || view.read_at < post.tagged_at)
       end.map(&:post_id)
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -112,13 +112,13 @@ class ApplicationController < ActionController::Base
     end
 
     if logged_in?
-      @opened_ids ||= PostView.where(user_id: current_user.id).pluck(:post_id)
+      @opened_ids ||= PostView.where(user_id: current_user.id).where('read_at IS NOT NULL').pluck(:post_id)
 
-      opened_posts = PostView.where(user_id: current_user.id).where(post_id: posts.map(&:id)).select([:post_id, :read_at])
+      opened_posts = PostView.where(user_id: current_user.id).where('read_at IS NOT NULL').where(post_id: posts.map(&:id)).select([:post_id, :read_at])
       @unread_ids ||= []
       @unread_ids += opened_posts.select do |view|
         post = posts.detect { |p| p.id == view.post_id }
-        post && (view.read_at.nil? || view.read_at < post.tagged_at)
+        post && view.read_at < post.tagged_at
       end.map(&:post_id)
     end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -29,8 +29,8 @@ class PostsController < WritableController
     @started = (params[:started] == 'true') || (params[:started].nil? && current_user.unread_opened)
     @posts = Post.joins("LEFT JOIN post_views ON post_views.post_id = posts.id AND post_views.user_id = #{current_user.id}")
     @posts = @posts.joins("LEFT JOIN board_views on board_views.board_id = posts.board_id AND board_views.user_id = #{current_user.id}")
-    @posts = @posts.where("post_views.user_id IS NULL OR (date_trunc('second', post_views.read_at) < date_trunc('second', posts.tagged_at) AND post_views.ignored = '0')")
-    @posts = @posts.where("board_views.user_id IS NULL OR (date_trunc('second', board_views.read_at) < date_trunc('second', posts.tagged_at) AND board_views.ignored = '0')")
+    @posts = @posts.where("post_views.user_id IS NULL OR  ((post_views.read_at IS NULL OR (date_trunc('second', post_views.read_at) < date_trunc('second', posts.tagged_at))) AND post_views.ignored = '0')")
+    @posts = @posts.where("board_views.user_id IS NULL OR ((board_views.read_at IS NULL OR (date_trunc('second', board_views.read_at) < date_trunc('second', posts.tagged_at))) AND board_views.ignored = '0')")
     @posts = posts_from_relation(@posts.order('tagged_at desc'), true, false)
     @posts = @posts.select { |p| p.visible_to?(current_user) }
     @posts = @posts.select { |p|  @opened_ids.include?(p.id) } if @started

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -173,7 +173,7 @@ class PostsController < WritableController
       return redirect_to unread_posts_path
     end
 
-    @post.views.where(user_id: current_user.id).destroy_all
+    @post.views.where(user_id: current_user.id).first.try(:update_attributes, read_at: nil)
     flash[:success] = "Post has been marked as unread"
     redirect_to unread_posts_path
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -26,7 +26,7 @@ class ReportsController < ApplicationController
     view = @opened_posts.detect { |v| v.post_id == post.id }
     return false unless view
     return false if view.ignored?
-    view.read_at < post.tagged_at
+    view.read_at.nil? || view.read_at < post.tagged_at
   end
   helper_method :has_unread?
 

--- a/app/models/board_view.rb
+++ b/app/models/board_view.rb
@@ -3,8 +3,4 @@ class BoardView < ActiveRecord::Base
   belongs_to :user
 
   validates_presence_of :user, :board
-
-  def timestamp_attributes_for_create
-    super + [:read_at]
-  end
 end

--- a/app/models/post_view.rb
+++ b/app/models/post_view.rb
@@ -3,8 +3,4 @@ class PostView < ActiveRecord::Base
   belongs_to :user
 
   validates_presence_of :user, :post
-
-  def timestamp_attributes_for_create
-    super + [:read_at]
-  end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -762,7 +762,7 @@ RSpec.describe PostsController do
 
         expect(response).to redirect_to(unread_posts_url)
         expect(flash[:success]).to eq("Post has been marked as unread")
-        expect(post.reload.send(:view_for, user)).to be_a_new_record
+        expect(post.reload.first_unread_for(user)).to eq(post)
       end
     end
 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1322,6 +1322,40 @@ RSpec.describe PostsController do
         expect(post1.reload.ignored_by?(user)).to be_true
         expect(post2.reload.ignored_by?(user)).to be_true
       end
+
+      it "does not mess with read timestamps" do
+        user = create(:user)
+
+        time = Time.now - 10.minutes
+        post1 = create(:post, created_at: time, updated_at: time) # unread
+        post2 = create(:post, created_at: time, updated_at: time) # partially read
+        post3 = create(:post, created_at: time, updated_at: time) # fully read
+        replies1 = Array.new(5) { |i| create(:reply, post: post1, created_at: time + i.minutes, updated_at: time + i.minutes) }
+        replies2 = Array.new(5) { |i| create(:reply, post: post2, created_at: time + i.minutes, updated_at: time + i.minutes) }
+        replies3 = Array.new(5) { |i| create(:reply, post: post3, created_at: time + i.minutes, updated_at: time + i.minutes) }
+
+        login_as(user)
+        expect(post1).to be_visible_to(user)
+        expect(post2).to be_visible_to(user)
+        expect(post3).to be_visible_to(user)
+
+        time2 = replies2.first.updated_at
+        time3 = replies3.last.updated_at
+        post2.mark_read(user, time2)
+        post3.mark_read(user, time3)
+
+        expect(post1.reload.last_read(user)).to be_nil
+        expect(post2.reload.last_read(user)).to be_the_same_time_as(time2)
+        expect(post3.reload.last_read(user)).to be_the_same_time_as(time3)
+
+        post :mark, marked_ids: [post1, post2, post3].map(&:id).map(&:to_s)
+
+        expect(response).to redirect_to(unread_posts_url)
+        expect(flash[:success]).to eq("3 posts hidden from this page.")
+        expect(post1.reload.last_read(user)).to be_nil
+        expect(post2.reload.last_read(user)).to be_the_same_time_as(time2)
+        expect(post3.reload.last_read(user)).to be_the_same_time_as(time3)
+      end
     end
   end
 

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -28,14 +28,16 @@ RSpec.describe ReportsController do
 
     it "sets variables with logged in daily" do
       user = create(:user)
-      view = PostView.create(user: user, post: create(:post))
+      post = create(:post)
+      post.mark_read(user)
+      time = post.last_read(user)
       login_as(user)
       get :show, id: 'daily'
       expect(response).to have_http_status(200)
       expect(assigns(:board_views)).to be_empty
-      expect(assigns(:opened_ids)).to match_array([view.post_id])
+      expect(assigns(:opened_ids)).to match_array([post.id])
       expect(assigns(:opened_posts).length).to eq(1)
-      expect(assigns(:opened_posts).first.read_at).to be_the_same_time_as(view.read_at)
+      expect(assigns(:opened_posts).first.read_at).to be_the_same_time_as(time)
     end
 
     it "succeeds with monthly" do


### PR DESCRIPTION
Builds on #185. Removes `:read_at` from the timestamps to be set on create, so it will be `nil` if the person has never read the post (e.g. they hide it without opening it).

The change to the query may not be necessary, but I thought it best to hard-code it rather than assuming `date_trunc` on nil would produce nil and that `nil < date` would be true?