### PR TITLE
Mark posts read even if the board is ignored

### DIFF
--- a/app/concerns/viewable.rb
+++ b/app/concerns/viewable.rb
@@ -6,7 +6,6 @@ module Viewable
 
     def mark_read(user, at_time=nil, force=false)
       view = view_for(user)
-      return true if view.ignored
 
       if view.new_record?
         view.read_at = at_time || Time.now
@@ -36,6 +35,7 @@ module Viewable
 
     def reload
       @view = nil
+      @first_unread = nil
       super
     end
 

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -102,7 +102,7 @@ class WritableController < ApplicationController
         @reply = @post.build_new_reply_for(current_user)
       end
 
-      @post.mark_read(current_user, @post.read_time_for(@replies)) unless @post.board.ignored_by?(current_user)
+      @post.mark_read(current_user, @post.read_time_for(@replies))
     end
 
     @warnings = @post.content_warnings if display_warnings?


### PR DESCRIPTION
I'm not sure why it's special-cased so this isn't done – people would like the arrows to keep track of where they've read up to even if they hide the board for reasons such as 'it was cluttering that page and I didn't want to typically be reminded of this board'. (If there is no reason *against* this change, I'd say there's good reason to bring it through, even if it seems weird / unaesthetic.)

Pedro is one specific person who would like this behavior, I think.