### PR TITLE
Show hidden status of posts in post lists

### DIFF
--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -1,5 +1,6 @@
 %tr
-  - klass = cycle('even', 'odd')
+  - klass = [cycle('even', 'odd')]
+  - klass << 'post-ignored' if current_user && post.ignored_by?(current_user)
   - replies_count = post.reply_count
   %td.post-completed{class: [klass, (post.completed? ? 'post-complete' : 'post-incomplete')]}
     - if post.completed?


### PR DESCRIPTION
By implementing the same style as on the reports page, change the opacity of the rows for hidden posts to 30%.

I don't think people are going to be *strongly* adversely affected by this and it will improve functionality for a few people. If it's controversial enough, it can be rolled back, but when I polled people in IRC they seemed generally positive about it and the opposition on the forum seemed to drop their position.