### PR TITLE
Select search results by visibility

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -231,6 +231,9 @@ class PostsController < WritableController
       @search_results = @search_results.where(where)
     end
     @search_results = @search_results.paginate(page: page, per_page: 25)
+    if @search_results.total_pages <= 1
+      @search_results = @search_results.select {|post| post.visible_to?(current_user)}.paginate(page: page, per_page: 25)
+    end
   end
 
   def warnings

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -61,6 +61,9 @@ class RepliesController < WritableController
       .joins(:user, :post)
       .joins("LEFT OUTER JOIN characters ON characters.id = replies.character_id")
       .paginate(page: page, per_page: 25)
+    if @search_results.total_pages <= 1
+      @search_results = @search_results.select {|reply| reply.post.visible_to?(current_user)}.paginate(page: page, per_page: 25)
+    end
   end
 
   def create

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -55,6 +55,7 @@
                   %th.sub Last Updated
               %tbody
                 - @search_results.each do |post|
+                  - next unless post.visible_to?(current_user)
                   %tr
                     - klass = cycle('even', 'odd')
                     %td.padding-10.post-subject{class: klass}= link_to post.subject, post_path(post)

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -53,6 +53,7 @@
             %table
               %tbody
                 - @search_results.each do |reply|
+                  - next unless reply.post.visible_to?(current_user)
                   - klass = cycle('even'.freeze, 'odd'.freeze)
                   %tr
                     %td{class: klass}


### PR DESCRIPTION
Previously, people could search for posts that they couldn't see and search for replies that they also couldn't see.

This both:

- skips in the post list (so it skips even if there is more than one page or weird things occur)
- selects the whole list if there are ≤ 1 pages (so the 'count:' value doesn't show '1' when there are no replies, and so 'no search results' shows if applicable)