### PR TITLE
Improve unread highlighting

### DIFF
--- a/app/assets/stylesheets/replies.css
+++ b/app/assets/stylesheets/replies.css
@@ -197,3 +197,5 @@ div.char-access-icon {
   top: -5px;
   font-size: 70%;
 }
+
+.reply-highlighted { border: 1px red solid; }

--- a/app/assets/stylesheets/replies.css
+++ b/app/assets/stylesheets/replies.css
@@ -185,3 +185,15 @@ div.char-access-icon {
 
 /* Handle post tables */
 .post-completed { text-align: center; width: 40px; }
+
+/* Unread marker on posts */
+.unread-marker-container {
+  position: relative;
+}
+.unread-marker {
+  background-color: transparent;
+  color: transparent !important;
+  position: absolute;
+  top: -5px;
+  font-size: 70%;
+}

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -1,14 +1,11 @@
 -# Hack for Alicorn's unread bug
-- highlighted = ''
-- if reply.id.present? && logged_in? && current_user.id == 2 && @unread.present? && @unread.id == reply.id && @unread.class == reply.class
-  - highlighted = 'border: 1px red solid;'
+- highlighted = 'border: 1px red solid;' if reply == @unread && current_user.try(:visible_unread?)
 
 .post-container{class: reply.is_a?(Post) ? 'post-post'.freeze : (reply.is_a?(Reply) ? 'post-reply'.freeze : ''), style: highlighted}
   - if reply.is_a?(Reply) && reply.id.present?
     <a id="reply-#{reply.id}" class="noheight"> </a>
-  - if reply.id.present? && logged_in? && !@unread.nil?
-    - if reply.id == @unread.id && reply.class == @unread.class
-      <a id="unread" class="noheight"> </a>
+  - if reply == @unread
+    <a id="unread" class="noheight"> </a>
   .padding-10
     .post-info-box
       - if reply.icon_id

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -1,7 +1,4 @@
--# Hack for Alicorn's unread bug
-- highlighted = 'border: 1px red solid;' if reply == @unread && current_user.try(:visible_unread?)
-
-.post-container{class: reply.is_a?(Post) ? 'post-post'.freeze : (reply.is_a?(Reply) ? 'post-reply'.freeze : ''), style: highlighted}
+.post-container{class: [reply.is_a?(Post) ? 'post-post'.freeze : (reply.is_a?(Reply) ? 'post-reply'.freeze : ''), (reply == @unread && current_user.try(:visible_unread?)) ? 'reply-highlighted' : '']}
   - if reply.is_a?(Reply) && reply.id.present?
     <a id="reply-#{reply.id}" class="noheight"> </a>
   - if reply == @unread

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -5,7 +5,8 @@
   - if reply.is_a?(Reply) && reply.id.present?
     <a id="reply-#{reply.id}" class="noheight"> </a>
   - if reply == @unread
-    <a id="unread" class="noheight"> </a>
+    .unread-marker-container
+      %a#unread.unread-marker First unread marker
   .padding-10
     .post-info-box
       - if reply.icon_id

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -50,10 +50,13 @@
       %th.sub Time display
       %td{class: cycle('even', 'odd')}= f.select :time_display, time_display_options(current_user.time_display)
     %tr
-      %th.sub Unread Default
+      %th.sub Unread
       %td{class: cycle('even', 'odd')}
         = f.check_box :unread_opened, class: 'width-15 vmid'
-        = f.label :unread_opened, "Opened threads only"
+        = f.label :unread_opened, "Display opened threads only"
+        %br
+        = f.check_box :visible_unread, class: 'width-15 vmid'
+        = f.label :visible_unread, "Outline when jumping to unread"
     %tr
       %th.sub Daily Report
       %td{class: cycle('even', 'odd')}

--- a/db/migrate/20170413195840_add_visible_unread_to_users.rb
+++ b/db/migrate/20170413195840_add_visible_unread_to_users.rb
@@ -1,0 +1,5 @@
+class AddVisibleUnreadToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :visible_unread, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -981,6 +981,7 @@ CREATE TABLE users (
     unread_opened boolean DEFAULT false,
     hide_hiatused_tags_owed boolean DEFAULT false,
     hide_warnings boolean DEFAULT false,
+    visible_unread boolean DEFAULT false,
     ignore_unread_daily_report boolean DEFAULT false
 );
 
@@ -1936,6 +1937,8 @@ INSERT INTO schema_migrations (version) VALUES ('20170210013443');
 INSERT INTO schema_migrations (version) VALUES ('20170221171959');
 
 INSERT INTO schema_migrations (version) VALUES ('20170331133925');
+
+INSERT INTO schema_migrations (version) VALUES ('20170413195840');
 
 INSERT INTO schema_migrations (version) VALUES ('20170505173455');
 


### PR DESCRIPTION
Fixes #179.

- Make the unread highlighting a toggleable account option

Displays as before:
![image](https://cloud.githubusercontent.com/assets/577128/25023553/2e42df6e-2092-11e7-9742-62aa573861f0.png)
Account option:
![image](https://cloud.githubusercontent.com/assets/577128/25023562/3302da86-2092-11e7-948e-87337145619e.png)

- Add an invisible text 'First unread marker' to mark unread reply

Looks the same as before:
![image](https://cloud.githubusercontent.com/assets/577128/25023575/437a3bc0-2092-11e7-835a-3efbee1eb331.png)
Partially selected:
![image](https://cloud.githubusercontent.com/assets/577128/25023578/47bf9888-2092-11e7-80b8-441f240ba95c.png)
Fully selected:
![image](https://cloud.githubusercontent.com/assets/577128/25023590/4c1dcef4-2092-11e7-9cd3-32f52f3bffab.png)
With border:
![image](https://cloud.githubusercontent.com/assets/577128/25023593/51921138-2092-11e7-9e8d-726853207a97.png)

I could make the text unselectable, but unfortunately either way it ends up appearing if you select the replies around it and copy and paste (i.e. the text will interrupt if people copy and paste; they shouldn't be doing this anyway but still :P). Making it unselectable still makes it show up when you hover over it (cursor changes to be the selection cursor) but it'd mean double-clicking to select wouldn't not show anything. Giving it a negative z-index (so it shows behind another element and you don't get the cursor) means it's not visible when people do Ctrl+F. I'm not sure how to resolve this, but it works pretty well at present.

The reason it's given a container with `position: relative` is so the `position: absolute` adjustments are made relative to its location; if I gave *it* `position: relative`, it wouldn't be out of the flow of the page (and accordingly it'd mess with local things like the post info box).