### PR TITLE
Use the Location response in S3 uploads to properly escape URIs

### DIFF
--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -86,8 +86,8 @@ function bindFileInput(fileInput) {
       submitButton.prop('disabled', false);
 
       // extract key and generate URL from response
-      var key = $(data.jqXHR.responseXML).find("Key").text();
-      var url = 'https://d1anwqy6ci9o1i.cloudfront.net/' + key;
+      // replace https://glowfic-constellation.s3.amazonaws.com with Cloudfront URL
+      var url = $(data.jqXHR.responseXML).find("Location").text().replace(form.data('url'), 'https://d1anwqy6ci9o1i.cloudfront.net');
 
       // create hidden field
       var iconIndex = addNewRow();


### PR DESCRIPTION
As per #140 (see [comment about this](https://github.com/Marri/glowfic/issues/140#issuecomment-294027307)), use the `Location` response to get the image's URI instead of generating it from the `Key` value, so it escapes things properly. (Replace `https://glowfic-constellation.s3.amazonaws.com` with `https://d1anwqy6ci9o1i.cloudfront.net` so it still uses Cloudfront, though.)

I would appreciate it if you could test this, as I don't think I have a way to do so. Specific things you'd be looking for:
- It uses the Cloudfront URL instead of the S3 URL
- It actually works with any icons (and it doesn't just mysteriously fail)
- It works with an icon where the filename of the icon includes a `+` (which I think fails at present – the icon won't display on the site, as the URL will be broken)

**This is mostly untested.**