### PR TITLE
Display 'Daily Report' instead of 'Report' for clarity

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -86,7 +86,7 @@
             %li= link_to 'Unread', unread_posts_path
             %li= link_to 'Tags Owed', owed_posts_path
           %li= link_to 'Contribute', contribute_path
-          %li= link_to 'Report', report_path(id: :daily)
+          %li= link_to 'Daily Report', report_path(id: :daily)
     - if content_for?(:breadcrumbs)
       .flash.subber= content_for :breadcrumbs
     - if flash[:error].is_a?(Hash)


### PR DESCRIPTION
Someone mentioned it was potentially misleading, and might make someone think of the moderation-type "report" (i.e. "click here to report a post"). I felt that was a sensible complaint, and "Daily Report" sounded like the best alternative.