### PR TITLE
Migrate database times to UTC

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,7 +61,6 @@ module Glowfic
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     config.time_zone = 'Eastern Time (US & Canada)'
-    config.active_record.default_timezone = :local
 
     config.action_view.sanitized_allowed_tags = Glowfic::ALLOWED_TAGS
     config.after_initialize do

--- a/db/migrate/20170914191425_change_timestamps_to_utc.rb
+++ b/db/migrate/20170914191425_change_timestamps_to_utc.rb
@@ -1,0 +1,77 @@
+class ChangeTimestampsToUtc < ActiveRecord::Migration
+  TABLES = {
+    audits: [:created_at],
+    board_authors: [:created_at, :updated_at],
+    board_sections: [:created_at, :updated_at],
+    board_views: [:created_at, :updated_at, :read_at],
+    boards: [:created_at, :updated_at],
+    character_aliases: [:created_at, :updated_at],
+    character_tags: [:created_at, :updated_at],
+    characters: [:created_at, :updated_at],
+    favorites: [:created_at, :updated_at],
+    flat_posts: [:created_at, :updated_at],
+    galleries: [:created_at, :updated_at],
+    gallery_tags: [:created_at, :updated_at],
+    icons: [:created_at, :updated_at],
+    messages: [:read_at, :created_at, :updated_at],
+    password_resets: [:created_at, :updated_at],
+    post_tags: [:created_at, :updated_at],
+    post_viewers: [:created_at, :updated_at],
+    post_views: [:created_at, :updated_at, :read_at],
+    posts: [:created_at, :updated_at, :edited_at, :tagged_at],
+    replies: [:created_at, :updated_at],
+    reply_drafts: [:created_at, :updated_at],
+    report_views: [:read_at, :created_at, :updated_at],
+    tags: [:created_at, :updated_at],
+    templates: [:created_at, :updated_at],
+    users: [:created_at, :updated_at]
+  }
+
+  def fetch_zone
+    zone_name = Time.now.zone # GMT, BST, etc.
+    # this list is likely overkill
+    zone_maps = {
+      "UTC" => ["UTC"],
+      "Europe/London" => ["GMT", "BST"],
+      "America/New_York" => ["EST", "EDT"],
+      "America/Chicago" => ["CST", "CDT"],
+      "America/Denver" => ["MST", "MDT"], # sorry Phoenix
+      "America/Los_Angeles" => ["PST", "PDT"],
+      "Europe/Paris" => ["CET", "CEST"], # there is no general Europe one?
+      "Europe/Lisbon" => ["WET", "WEST"],
+      "America/Sao_Paulo" => ["-02", "-03"] # may get false positives, but we don't have many Brazilians
+      # no Australians etc probably?
+      # none who are actively developing at least and
+      # this migration will become outdated but unnecessary
+    }
+    zone_maps.each do |olson, zones|
+      return olson if zones.include?(zone_name)
+    end
+    raise("Failed to map timezone to region.")
+  end
+
+  def sql_for_migrate(table_name, cols, from_zone, to_zone)
+    sql = "UPDATE #{table_name} SET "
+    sql += cols.map do |col|
+      "#{col}=((#{col} AT TIME ZONE '#{from_zone}') AT TIME ZONE '#{to_zone}')"
+    end.join(', ')
+    sql += ';'
+    sql
+  end
+
+  def up
+    local_zone = fetch_zone
+    utc_zone = 'UTC'
+    TABLES.each do |table_name, cols|
+      execute sql_for_migrate(table_name, cols, local_zone, utc_zone)
+    end
+  end
+
+  def down
+    local_zone = fetch_zone
+    utc_zone = 'UTC'
+    TABLES.reverse_each do |table_name, cols|
+      execute sql_for_migrate(table_name, cols, utc_zone, local_zone)
+    end
+  end
+end

--- a/db/migrate/20170914191425_change_timestamps_to_utc.rb
+++ b/db/migrate/20170914191425_change_timestamps_to_utc.rb
@@ -61,17 +61,25 @@ class ChangeTimestampsToUtc < ActiveRecord::Migration
 
   def up
     local_zone = fetch_zone
-    utc_zone = 'UTC'
+    target_zone = 'UTC'
+    if local_zone == target_zone
+      say "Skipping migration as local_zone (#{local_zone}) matches target_zone (#{target_zone})"
+      return
+    end
     TABLES.each do |table_name, cols|
-      execute sql_for_migrate(table_name, cols, local_zone, utc_zone)
+      execute sql_for_migrate(table_name, cols, local_zone, target_zone)
     end
   end
 
   def down
     local_zone = fetch_zone
-    utc_zone = 'UTC'
+    target_zone = 'UTC'
+    if local_zone == target_zone
+      say "Skipping migration as local_zone (#{local_zone}) matches target_zone (#{target_zone})"
+      return
+    end
     TABLES.reverse_each do |table_name, cols|
-      execute sql_for_migrate(table_name, cols, utc_zone, local_zone)
+      execute sql_for_migrate(table_name, cols, target_zone, local_zone)
     end
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2039,3 +2039,5 @@ INSERT INTO schema_migrations (version) VALUES ('20170907180029');
 
 INSERT INTO schema_migrations (version) VALUES ('20170911235423');
 
+INSERT INTO schema_migrations (version) VALUES ('20170914191425');
+


### PR DESCRIPTION
Instead of storing timestamps in the database in the local time (e.g. EDT, or if you're in Britain, BST) without an associated timezone, instead save them in UTC without an associated timezone. Migrate pre-existing columns that reference timestamps.

This feels quite risky. I ran it, it seemed to work fine, no timestamps appeared different. Rolling back also seemed to work fine. Unfortunately there doesn't seem to be a way to get the "Olson timezone" (i.e. `America/New_York` instead of EDT) directly using Ruby, so I had to hardcode a map – `Time.now.zone` returns e.g. EDT or EST depending on what time of the year it is, which would then mean the change is off by an hour during half the year. (Or, in my case, it returns BST or GMT depending on what time of the year it is.) `fetch_zone` maps this backwards (lossily and through half-guesswork, but this only needs to run on the production server and possibly our local databases).

It seems to keep times constant for me, with `Europe/London`. Performing the migration and removing `config.active_record.default_timezone = :local` gives the same times as rolling back / not having performed the migration and having that line.

It's kinda blegh. We may have lost data when the server changed timezone (back in like October) for winter, as there would have been an hour where timestamps overlapped, and this isn't going to fix that. (Then again, if you currently load those timestamps they'll probably display the wrong timezone; it has no way to distinguish them. We could plausibly distinguish them by looking at sequential IDs, but I don't think Rails does.)