### PR TITLE
Test ReportsController#posts_for with EST and GMT timezones

### DIFF
--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -61,4 +61,59 @@ RSpec.describe ReportsController do
       end
     end
   end
+
+  describe "#posts_for" do
+    default_zone = Time.zone
+    {
+      # 2017-11-05 10:00, clock goes back in Eastern
+      "without timezone" => [default_zone, [2017, 11, 05, 10, 00]],
+      # 2017-10-29 10:00, clock goes back in GMT/BST
+      "with timezone" => ["Europe/London", [2017, 10, 29, 10, 00]]
+    }.each do |name, data|
+      zone = data.first
+      dst_day_params = data.last
+      context name do
+        before(:each) { Time.zone = zone }
+        after(:each) { Time.zone = default_zone }
+        it "should work on a regular day" do
+          time = Time.zone.local(2017, 01, 02, 10, 00) # 2017-01-02 10:00
+          day = time.beginning_of_day
+          shown_posts = Array.new(24) do |i| # 0 .. 23
+            step = day + i.hours
+            Timecop.freeze(step) { create(:post) }
+          end
+          shown_posts.each do |post|
+            expect(post.tagged_at).to be_between(day, day.end_of_day).inclusive
+          end
+
+          hidden_post1 = Timecop.freeze(day - 1.hour) { create(:post) }
+          hidden_post2 = Timecop.freeze(day.end_of_day + 1.hour) { create(:post) }
+          expect(hidden_post1.tagged_at).not_to be_between(day, day.end_of_day).inclusive
+          expect(hidden_post2.tagged_at).not_to be_between(day, day.end_of_day).inclusive
+
+          expect(controller.send(:posts_for, time)).to match_array(shown_posts)
+        end
+
+        it "should work on a daylight change day" do
+          time = Time.zone.local(*dst_day_params)
+          # clock goes back; 25 hours in the day
+          day = time.beginning_of_day
+          shown_posts = Array.new(25) do |i| # 0 .. 24
+            step = day + i.hours
+            Timecop.freeze(step) { create(:post) }
+          end
+          shown_posts.each do |post|
+            expect(post.tagged_at).to be_between(day, day.end_of_day).inclusive
+          end
+
+          hidden_post1 = Timecop.freeze(day - 1.hour) { create(:post) }
+          hidden_post2 = Timecop.freeze(day.end_of_day + 1.hour) { create(:post) }
+          expect(hidden_post1.tagged_at).not_to be_between(day, day.end_of_day).inclusive
+          expect(hidden_post2.tagged_at).not_to be_between(day, day.end_of_day).inclusive
+
+          expect(controller.send(:posts_for, time)).to match_array(shown_posts)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
As it says. It tests both on a standard day (2017-01-02, which does not exhibit daylight saving time changes in either EST or GMT) and on a daylight saving time change day (the one where there are overlapping hours, yet to happen sometime this fall/winter). It makes 24 (matched) posts on the regular day and 25 on the daylight day, in addition to two outside the day's bounds, to check it matches just the appropriate replies.

I was going to go fixing this up further, so it would show posts on multiple days, but that sounds like a reasonable quantity of effort and you might find it easier to do.