### PR TITLE
Fix the arrow on Tags Owed with fully unread posts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,7 +117,13 @@ class ApplicationController < ActionController::Base
   helper_method :posts_from_relation
 
   def unread_ids
+    # does not necessarily include fully unread posts
     @unread_ids
   end
   helper_method :unread_ids
+
+  def opened_ids
+    @opened_ids
+  end
+  helper_method :opened_ids
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -143,4 +143,10 @@ module ApplicationHelper
     return false unless unread_ids
     unread_ids.include?(post.id)
   end
+
+  def opened_post?(post, opened_ids)
+    return false unless post
+    return false unless opened_ids
+    opened_ids.include?(post.id)
+  end
 end

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -12,7 +12,7 @@
       = image_tag "/images/exclamation.png", class: 'vmid', title: "Content Warning: " + post.content_warnings.pluck(:name).join(', '), alt: '!'
   %td.post-subject{class: klass}
     - if logged_in?
-      - if unread_post?(post, unread_ids)
+      - if unread_post?(post, unread_ids) || (@show_unread && !opened_post?(post, opened_ids))
         = link_to post_path(post, page: 'unread', anchor: 'unread') do
           = image_tag unread_img, class: 'vmid', title: 'First Unread'
       - elsif @show_unread


### PR DESCRIPTION
Previously, if a post was fully unread, it wouldn't count in the `unread_post?` method (as that's designed to know whether to display a link arrow). As a result, the arrow would display as though you had fully read a post if you had marked it completely unread. This checks through `opened_ids` (via `opened_post?`) if the `@show_unread` parameter is true, so it will show the arrow green on fully unread posts too.

This only produces a small change to the UI.