### PR TITLE
Allow dir and lang attributes in posts, also various HTML tags

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,11 +14,11 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module Glowfic
-  ALLOWED_TAGS = ["b", "i", "u", "sub", "sup", "del", "hr", "p", "br", "div", "span", "pre", "code", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "dl", "dt", "dd", "a", "img", "blockquote", "table", "td", "th", "tr", "strike", "s", "strong", "em", "big", "small", "font"]
+  ALLOWED_TAGS = ["b", "i", "u", "sub", "sup", "del", "hr", "p", "br", "div", "span", "pre", "code", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "dl", "dt", "dd", "a", "img", "blockquote", "q", "table", "td", "th", "tr", "strike", "s", "strong", "em", "big", "small", "font",  "cite", "abbr"]
   POST_CONTENT_SANITIZER = Sanitize::Config.merge(Sanitize::Config::RELAXED,
     :elements => ALLOWED_TAGS,
     :attributes => {
-      :all => ["xml:lang", "class", "style", "title"],
+      :all => ["xml:lang", "class", "style", "title", "lang", "dir"],
       "hr" => ["width"],
       "li" => ["value"],
       "ol" => ["reversed", "start", "type"],
@@ -27,13 +27,14 @@ module Glowfic
       "table" => ["width"],
       "td" => ["abbr", "width"],
       "th" => ["abbr", "width"],
-      "blockquote" => ["cite"]
+      "blockquote" => ["cite"],
+      "cite" => ["href"]
     }
   )
 
   class Application < Rails::Application
     config.assets.enabled = true
-    
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module Glowfic
-  ALLOWED_TAGS = ["b", "i", "u", "sub", "sup", "del", "hr", "p", "br", "div", "span", "pre", "code", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "dl", "dt", "dd", "a", "img", "blockquote", "q", "table", "td", "th", "tr", "strike", "s", "strong", "em", "big", "small", "font",  "cite", "abbr"]
+  ALLOWED_TAGS = ["b", "i", "u", "sub", "sup", "del", "hr", "p", "br", "div", "span", "pre", "code", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "dl", "dt", "dd", "a", "img", "blockquote", "q", "table", "td", "th", "tr", "strike", "s", "strong", "em", "big", "small", "font",  "cite", "abbr", "var", "samp", "kbd", "mark", "ruby", "rp", "rt", "bdo", "wbr"]
   POST_CONTENT_SANITIZER = Sanitize::Config.merge(Sanitize::Config::RELAXED,
     :elements => ALLOWED_TAGS,
     :attributes => {


### PR DESCRIPTION
This should fix [Moriwen's latest problem](http://alicorn.elcenia.com/board/viewtopic.php?f=12&t=459&p=32809#p32803) as it seems the `dir` and `lang` attributes are being stripped from the HTML of her reply when it's rendered (due to Sanitize) – these should be non-harmful and so I think we can safely let them through.

Relatedly, we're missing various HTML tags from our list, especially HTML5 ones. I don't have a complete list, but there are (or were) at least: `cite`, `q` and `abbr` in addition to other "elements conveying text-level semantics". (See [cite](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite), [q](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q), [abbr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr).) `abbr` led me to the rest of the "elements conveying text-level semantics", which I added (except `dfn` and `time` as these seem to have use-cases that are not found within the context of writing glowfic replies, I think).

They're mostly unlikely to be used, except `q`, `cite`, `abbr`, but oh well.