### PR TITLE
Implement a new quicker character switcher below the info box

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -93,6 +93,8 @@ $(document).ready(function() {
     }
   }
 
+  setCharacterListSelected(selectedCharID);
+
   if (String($("#post_privacy").val()) !== String(PRIVACY_ACCESS)){
     $("#access_list").hide();
   }
@@ -160,6 +162,12 @@ $(document).ready(function() {
   $("#active_character").change(function() {
     // Set the ID
     var id = $(this).val();
+    $("#reply_character_id").val(id);
+    getAndSetCharacterData(id);
+  });
+
+  $(".char-access-icon").click(function() {
+    var id = $(this).data('character-id');
     $("#reply_character_id").val(id);
     getAndSetCharacterData(id);
   });
@@ -289,6 +297,8 @@ getAndSetCharacterData = function(characterId, options) {
   $("#character-selector").hide();
   $("#current-icon-holder").unbind();
   $("#icon_dropdown").empty().append('<option value="">No Icon</option>');
+
+  setCharacterListSelected(characterId);
 
   // Handle special case where just setting to your base account
   if (characterId === '') {
@@ -465,3 +475,10 @@ createTagSelect = function(tagType) {
     width: '300px'
   });
 };
+
+function setCharacterListSelected(characterId) {
+  $(".char-access-icon.semiopaque").removeClass('semiopaque').addClass('pointer');
+  $(".char-access-icon").each(function(){
+    if (String($(this).data('character-id')) === String(characterId)) $(this).addClass('semiopaque').removeClass('pointer');
+  });
+}

--- a/app/assets/stylesheets/global.css
+++ b/app/assets/stylesheets/global.css
@@ -63,6 +63,7 @@ button, .button {
 .vmid { vertical-align: middle; }
 .bold { font-weight: bold; }
 .auto { overflow: auto; }
+.semiopaque { opacity: 0.5; }
 
 /* Displaying forum threads */
 #content .bg { background-color: #e5dfd1; }

--- a/app/assets/stylesheets/replies.css
+++ b/app/assets/stylesheets/replies.css
@@ -96,12 +96,28 @@ select.per-page { margin-top: 5px; margin-bottom: 5px; }
 #post-editor { position: relative; }
 .details { display: inline; font-size: 12px; font-style: italic; }
 
+/* Small icons for selecting characters in post-editor */
+.char-access-icon {
+  height: 30px;
+  width: 30px;
+  float: left;
+  box-sizing: border-box;
+}
+div.char-access-icon {
+  padding: 5px 0 5px 0;
+  font-size: 80%;
+  background-color: #aaa;
+  background-color: rgba(128,128,128,0.3);
+}
+
+/* Blockquotes */
 .post-post blockquote, .post-reply:nth-child(even) blockquote { background-color: #D8D8D8; }
 .post-reply:nth-child(odd) blockquote { background-color: #E3E3E3; }
 .post-content blockquote { margin: 0.5em 5.5em; padding: 0.5em; }
 .post-content blockquote > p:first-child { margin-top: 0; }
 .post-content blockquote > p:last-child { margin-bottom: 0; }
 
+/* Narrow window display */
 @media (max-width: 600px) {
     .post-info-box { float: none; width: 100%; display: inline-block; }
     .post-icon { float: left; margin-right: 0; margin-bottom: 5px; }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,7 @@ module ApplicationHelper
   NO_ICON = 'No Icon'.freeze
   NO_ICON_URL = '/images/no-icon.png'.freeze
   TIME_FORMAT = '%b %d, %Y %l:%M %p'.freeze
+  CHAR_ICON = 'char-access-icon pointer'.freeze
 
   def icon_tag(icon, **args)
     return '' if icon.nil?
@@ -22,6 +23,21 @@ module ApplicationHelper
 
   def no_icon_tag(**args)
     icon_mem_tag(NO_ICON_URL, NO_ICON, **args)
+  end
+
+  def quick_switch_tag(image_url, short_text, hover_name, char_id)
+    if image_url.nil?
+      return content_tag :div, short_text, class: CHAR_ICON, title: hover_name, data: { character_id: char_id }
+    end
+    image_tag image_url, class: CHAR_ICON, alt: hover_name, title: hover_name, data: { character_id: char_id }
+  end
+
+  def user_icon_tag(user)
+    quick_switch_tag(user.avatar.try(:url), user.username[0..1], user.username, '')
+  end
+
+  def character_icon_tag(character)
+    quick_switch_tag(character.icon.try(:url), character.name[0..1], character.selector_name, character.id)
   end
 
   def swap_icon_url

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -111,6 +111,21 @@ class Post < ActiveRecord::Base
     @first_unread ||= reply
   end
 
+  def recent_characters_for(user, count=4)
+    # fetch the 4 (count) most recent non-nil character_ids for user in post
+    recent_ids = replies.where(user_id: user.id).where('character_id IS NOT NULL').limit(count).group('character_id').select('DISTINCT character_id, MAX(id)').order('MAX(id) desc').pluck(:character_id)
+
+    # add the post's character_id to the last one if it's not over the limit
+    if character_id.present? && user_id == user.id && recent_ids.length < count && !recent_ids.include?(character_id)
+      recent_ids << character_id
+    end
+
+    # fetch the relevant characters and sort by their index in the recent list
+    Character.where(id: recent_ids).includes(:default_icon).sort_by do |x|
+      recent_ids.index(x.id)
+    end
+  end
+
   def hide_warnings_for(user)
     view_for(user).update_attributes(warnings_hidden: true)
   end

--- a/app/views/posts/_editor.haml
+++ b/app/views/posts/_editor.haml
@@ -40,6 +40,13 @@
             option_groups_from_collection_for_select(@templates, :characters, :name, :id, :selector_name, item.character_id),
             { prompt: current_user.username, class: 'chosen-select' }
             %br
+      - if item.is_a?(Reply)
+        .post-char-access
+          - recent_characters = item.post.try(:recent_characters_for, current_user)
+          = user_icon_tag(current_user)
+          - if recent_characters.present?
+            - recent_characters.each do |character|
+              = character_icon_tag character
   #gallery.green
     - if item.character.nil?
       - if current_user.avatar


### PR DESCRIPTION
## Description of issue
As the character switcher is slightly unwieldy to use, for a variety of reasons including (but not limited to), in my opinion:
- The floating box
- The forced scrolling of the browser
- The dropdown (unexpected closing, unexpected selection, generally ugly)
- The lack of ordering of characters for utility, generally (excepting "Thread characters")

I aired opinions about this a while back and came up with a concept idea, for this quick-switcher, but didn't get around to implementing it. I now have.

## Description of the feature

- It shows the user's avatar and their four most recently used characters in the relevant post
- It includes the post's character if the user owns the post
- If there is no avatar or the character does not have an icon, it falls back to the first two letters of the username or the character (could act weirdly around spaces except for how HTML handles spaces; ie it mostly ignores them)
- These icons are clickable to switch to the relevant character (or lack of)
- It does not show on `post#new` or `post#edit`. It *does* show on `reply#edit` in case people would like to change characters swiftly, and it's not liable to be too annoying; this can be changed if popular opinion would like it hidden there too. It does show on `writable#show` (ie where the `reply#new` box appears)
- It greys out when the relevant character has been selected; this also triggers when the conventional dropdown is used, and it will not grey out any character if a character is selected that is not in the list
- It displays the username (for a user) or `selector_name` (for a character) on hover

## Screenshots
With a character in the list selected (characters taken from previous reply and post, sorted with more recent characters earlier in the list except the author first):
![image](https://cloud.githubusercontent.com/assets/577128/25548427/3c82429e-2c64-11e7-8035-00a1b57192c4.png)

With a character selected that does not have a default icon:
![image](https://cloud.githubusercontent.com/assets/577128/25548448/533ba886-2c64-11e7-9bc6-716c23274531.png)

With a character selected that is not in the list:
![image](https://cloud.githubusercontent.com/assets/577128/25548454/5ab6b600-2c64-11e7-935a-94d45182291a.png)

With a character selected who is in the list and then another icon selected:
![image](https://cloud.githubusercontent.com/assets/577128/25548467/698cd376-2c64-11e7-9590-b95aa3935012.png)

In Starry Dark:
![image](https://cloud.githubusercontent.com/assets/577128/25548472/6f05f774-2c64-11e7-9fe4-5cbb0aa56106.png)

In Starry Dark with the user account selected:
![image](https://cloud.githubusercontent.com/assets/577128/25548478/784be370-2c64-11e7-99f4-bf636d2e0054.png)

In Starry Light:
![image](https://cloud.githubusercontent.com/assets/577128/25548482/7daa550e-2c64-11e7-8c72-71b33ae307cf.png)

On mobile (not perfect, but people have suggested it is probably an improvement and it can be easily hidden if consensus is changed):
![image](https://cloud.githubusercontent.com/assets/577128/25548496/93753eee-2c64-11e7-871b-21a742c05462.png)

![image](https://cloud.githubusercontent.com/assets/577128/25548498/96beb166-2c64-11e7-97dc-7c474085f7c8.png)

If the user does not have an avatar:
![image](https://cloud.githubusercontent.com/assets/577128/25548509/9e1bba3a-2c64-11e7-9dcd-7cf2390bb5e7.png)

Using a character with a space as the second character of the name (HTML ignores the space):
![image](https://cloud.githubusercontent.com/assets/577128/25548512/aa6968b4-2c64-11e7-9a34-e151881df520.png)
