### PR TITLE
Fix hiding screennames now that the API returns null not undefined

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -324,7 +324,7 @@ getAndSetCharacterData = function(characterId, options) {
     $("#post-editor #post-author-spacer").hide();
     $("#post-editor .post-character").show().data('character-id', characterId);
     $("#post-editor .post-character #name").html(resp.name);
-    if(resp.screenname === undefined) {
+    if(!resp.screenname) {
       $("#post-editor .post-screenname").hide();
     } else {
       $("#post-editor .post-screenname").show().html(resp.screenname);


### PR DESCRIPTION
I'm not sure what introduced this issue – maybe #166 – but the screenname box doesn't get properly hidden when swapping to characters with no screenname. (In fact, it gets *shown* no matter what character you swap to, so long as you do in fact swap characters.)

This appears to fix it.