### PR TITLE
DEV: Fix wordcount handling wrt nil contents

### DIFF
--- a/app/concerns/writable.rb
+++ b/app/concerns/writable.rb
@@ -25,6 +25,7 @@ module Writable
     end
 
     def word_count
+      return 0 if content.nil?
       content.split.size
     end
 


### PR DESCRIPTION
Related to how I fixed `reply#single` displaying a post with nil content (as generated in the dev console), fix the `word_count` property with nil content, otherwise `post#stats` crashed when there's a writable with nil content in the post.