### PR TITLE
Add link to post#stats on reply count in post lists

### DIFF
--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -48,7 +48,7 @@
       = link_to post.user.username, user_path(post.user)
       and
       = link_to "#{authors.length-1} others", stats_post_path(post)
-  %td.width-70.post-replies{class: klass}= replies_count
+  %td.width-70.post-replies{class: klass}= link_to replies_count, stats_post_path(post)
   - if logged_in? && local_assigns[:show_unread_count]
     %td.width-70{class: klass}
       - if @opened_ids.include?(post.id) && unread_ids.include?(post.id)

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -48,6 +48,6 @@
                 %span.details= sanitize_post_description(post.description).html_safe
             %td.vtop.post-board{class: klass}= link_to post.board.name, board_path(post.board)
             %td.vtop.post-authors{class: klass}= post.authors.sort_by { |author| author.username.downcase }.map { |author| link_to fun_name(author), user_path(author) }.join(', ').html_safe
-            %td.vtop.centered.post-replies{class: klass}= post.replies.count
+            %td.vtop.centered.post-replies{class: klass}= link_to post.replies.count, stats_post_path(post)
             %td.vtop.centered.post-replies{class: klass}= replies_today.count
             %td.vtop.centered.post-time{class: klass}= post.tagged_at.strftime("%l:%M %p")


### PR DESCRIPTION
Make `post#stats` readily accessible from post lists without going through `post#show`, by adding a link on the reply count column of post lists.