### PR TITLE
Fix the default icon switching of characters

### DIFF
--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -30,16 +30,15 @@ $(document).ready(function() {
     $("#character_default_icon_id").val('');
 
     var new_gallery_ids = $(this).val() || [];
-    var new_gallery;
 
     // a gallery was removed
-    if(gallery_ids.length > new_gallery_ids.length) {
+    if (gallery_ids.length > new_gallery_ids.length) {
       var removed_gallery = $(gallery_ids).not(new_gallery_ids).get();
       gallery_ids = new_gallery_ids;
       $(".gallery #gallery"+removed_gallery).remove();
 
       // if no more galleries are left, display galleryless icons
-      if (gallery_ids === '') {
+      if (gallery_ids.length == 0) {
         displayGallery('0');
       }
       return;
@@ -55,22 +54,28 @@ $(document).ready(function() {
 
 function displayGallery(new_id){
   $.get('/api/v1/galleries/'+new_id, function (resp) {
-    html_string = "<div id='gallery"+new_id+"' data-id='"+new_id+"'><br /><b class='gallery-name'>"+resp.name+"</b><br /><div class='gallery-icons'>";
-    for(var i = 0; i < resp.icons.length; i++) {
+    var galleryObj = $("<div>").attr({id: 'gallery'+new_id}).data('id', new_id);
+    galleryObj.append("<br />");
+    galleryObj.append($("<b>").attr({class: 'gallery-name'}).append(resp.name));
+    galleryObj.append("<br />");
+    var galleryIcons = $("<div>").attr({class: 'gallery-icons'});
+    galleryObj.append(galleryIcons);
+    for (var i = 0; i < resp.icons.length; i++) {
       var url = resp.icons[i].url;
       var keyword = resp.icons[i].keyword;
       var id = resp.icons[i].id;
-      html_string += '<img src="'+url+'" alt="'+keyword+'" title="'+keyword+'" class="icon character-icon" id="'+id+'" />';
+      var galleryIcon = $("<img>").attr({src: url, alt: keyword, title: keyword, class: 'icon character-icon'}).data('id', id);
+      galleryIcons.append(galleryIcon);
     }
-    html_string += "</div>";
-    $("#selected-gallery .gallery").append(html_string);
-    bindIcons();
+    $("#selected-gallery .gallery").append(galleryObj);
+    bindIcons(galleryObj);
   }, 'json');
 }
 
-function bindIcons() {
-  $(".character-icon").click(function() {
-    if($(this).hasClass('selected-icon')) {
+function bindIcons(obj) {
+  obj = obj || window.body;
+  $(".character-icon", obj).click(function() {
+    if ($(this).hasClass('selected-icon')) {
       $(this).removeClass('selected-icon');
       updateIcon('');
       return;
@@ -78,19 +83,19 @@ function bindIcons() {
 
     $(".selected-icon").removeClass('selected-icon');
     $(this).addClass('selected-icon');
-    updateIcon($(this).attr('id'));
+    updateIcon($(this).data('id'));
   });
 }
 
 function updateIcon(id) {
-    if (gon.character_id) {
-      $.ajax({
-        url: '/api/v1/characters/'+gon.character_id,
-        type: 'PUT',
-        data: {'character': {'default_icon_id':id}},
-        success: function(resp) {}
-      });
-    } else {
-      $("#character_default_icon_id").val(id);
-    }
+  if (gon.character_id) {
+    $.ajax({
+      url: '/api/v1/characters/'+gon.character_id,
+      type: 'PUT',
+      data: {character: {default_icon_id: id}},
+      success: function(resp) {}
+    });
+  } else {
+    $("#character_default_icon_id").val(id);
+  }
 }

--- a/app/assets/stylesheets/galleries.css
+++ b/app/assets/stylesheets/galleries.css
@@ -1,5 +1,6 @@
 .gallery-box { cursor: pointer; width: 20px; text-align: center; } /* The + / - symbol to minimize a gallery */
 .gallery-title { height: 5px; } /* So that when a gallery is minimized there is spacing */
+.character-icon { width: 100px; height: 100px; }
 .selected-icon { border: 10px #3F7055 solid; width: 80px; height: 80px; }
 .form-table .icon { vertical-align: middle; }
 
@@ -11,7 +12,7 @@
     display: inline-block;
     text-align: center;
     line-height: 14px;
-    margin-bottom: 10px; 
+    margin-bottom: 10px;
     position: relative;
     width: 130px;
     word-wrap: break-word;

--- a/app/views/characters/_editor.haml
+++ b/app/views/characters/_editor.haml
@@ -52,4 +52,4 @@
             - gallery.icons.each do |icon|
               - klass = 'icon character-icon'
               - klass += ' selected-icon' if icon == @character.default_icon
-              = icon_tag icon, class: klass, id: icon.id
+              = icon_tag icon, class: klass, data: { id: icon.id }


### PR DESCRIPTION
- Use `data-id` instead of `id` to keep track of icon IDs
- Force icons to be 100x100 even when deselected (for consistency with forced size once selected)
- Clean up the javascript (remove unnecessary padding, put spaces before parentheses surrounding conditions, remove unused `new_gallery`)
- Fix showing galleryless icons after removing all galleries from a character
- Make the HTML using `$("<tag>").attr(...attrs).append(contents)` instead of `<tag ...attrs>contents</tag>` so as to reduce chance of bogus input
- Only bind icons once, to prevent glitches where the icon picker refuses to select the icon you provided
  (after removing/adding a gallery, all other galleries will have the event bound twice, and would trigger both a select and deselect on one click)