### PR TITLE
Only show icon and character if relevant attachments exist

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -22,6 +22,8 @@ class Character < ActiveRecord::Base
 
   attr_accessor :new_template_name, :group_name
 
+  after_destroy :clear_char_ids
+
   nilify_blanks
 
   def recent_posts
@@ -80,5 +82,10 @@ class Character < ActiveRecord::Base
     if default_icon.present? && default_icon.user_id != user_id
       errors.add(:default_icon, "must be yours")
     end
+  end
+
+  def clear_char_ids
+    Reply.where(character_id: id).update_all(character_id: nil)
+    Post.where(character_id: id).update_all(character_id: nil)
   end
 end

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -49,6 +49,7 @@ class Icon < ActiveRecord::Base
     Reply.where(icon_id: id).update_all(icon_id: nil)
     Post.where(icon_id: id).update_all(icon_id: nil)
     ReplyDraft.where(icon_id: id).update_all(icon_id: nil)
+    User.where(avatar_id: id).update_all(avatar_id: nil)
   end
 
   class UploadError < Exception


### PR DESCRIPTION
Due to the way we handle retrieving reply and post associations, if the ID for the association exists but the relevant association no longer does (eg an icon is deleted), the code would previously expect it to exist and hence display an icon.

This ensures the actual attached data is loaded (eg icon URL, character name) and if not then it assumes the association doesn't exist and so doesn't try to show that data.