### PR TITLE
Allow users to toggle the pinned user character in the quick switcher

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -114,6 +114,28 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.fetch(:user, {}).permit(:username, :email, :password, :password_confirmation, :email_notifications, :per_page, :timezone, :icon_picker_grouping, :default_view, :default_editor, :moiety, :moiety_name, :layout, :time_display, :unread_opened, :hide_warnings, :hide_hiatused_tags_owed, :ignore_unread_daily_report, :visible_unread, :favorite_notifications)
+    params.fetch(:user, {}).permit(
+      :username,
+      :email,
+      :password,
+      :password_confirmation,
+      :email_notifications,
+      :per_page,
+      :timezone,
+      :icon_picker_grouping,
+      :default_view,
+      :default_editor,
+      :moiety,
+      :moiety_name,
+      :layout,
+      :time_display,
+      :unread_opened,
+      :hide_warnings,
+      :hide_hiatused_tags_owed,
+      :ignore_unread_daily_report,
+      :visible_unread,
+      :favorite_notifications,
+      :show_user_in_switcher
+    )
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -137,7 +137,7 @@ class Post < ActiveRecord::Base
     @last_seen = reply
   end
 
-  def recent_characters_for(user, count=4)
+  def recent_characters_for(user, count)
     # fetch the 4 (count) most recent non-nil character_ids for user in post
     recent_ids = replies.where(user_id: user.id).where('character_id IS NOT NULL').limit(count).group('character_id').select('DISTINCT character_id, MAX(id)').order('MAX(id) desc').pluck(:character_id)
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -138,7 +138,7 @@ class Post < ActiveRecord::Base
   end
 
   def recent_characters_for(user, count)
-    # fetch the 4 (count) most recent non-nil character_ids for user in post
+    # fetch the (count) most recent non-nil character_ids for user in post
     recent_ids = replies.where(user_id: user.id).where('character_id IS NOT NULL').limit(count).group('character_id').select('DISTINCT character_id, MAX(id)').order('MAX(id) desc').pluck(:character_id)
 
     # add the post's character_id to the last one if it's not over the limit

--- a/app/views/posts/_editor.haml
+++ b/app/views/posts/_editor.haml
@@ -42,8 +42,11 @@
             %br
       - if item.is_a?(Reply)
         .post-char-access
-          - recent_characters = item.post.try(:recent_characters_for, current_user)
-          = user_icon_tag(current_user)
+          - char_count = 5
+          - char_count -= 1 if current_user.show_user_in_switcher?
+          - recent_characters = item.post.try(:recent_characters_for, current_user, char_count)
+          - if current_user.show_user_in_switcher?
+            = user_icon_tag(current_user)
           - if recent_characters.present?
             - recent_characters.each do |character|
               = character_icon_tag character

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -76,6 +76,11 @@
         = f.check_box :hide_hiatused_tags_owed, class: 'width-15 vmid'
         = f.label :hide_hiatused_tags_owed, "Hide hiatused threads"
     %tr
+      %th.sub Character Quick Switcher
+      %td{class: cycle('even', 'odd')}
+        = f.check_box :show_user_in_switcher, class: 'width-15 vmid'
+        = f.label :show_user_in_switcher, "Show user character"
+    %tr
       %th.centered.subber{colspan: 2}= submit_tag "Save", class: 'button'
 
 %br

--- a/db/migrate/20170501214439_add_show_user_in_switcher_to_user.rb
+++ b/db/migrate/20170501214439_add_show_user_in_switcher_to_user.rb
@@ -1,0 +1,5 @@
+class AddShowUserInSwitcherToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :show_user_in_switcher, :boolean, default: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -984,6 +984,7 @@ CREATE TABLE users (
     visible_unread boolean DEFAULT false,
     ignore_unread_daily_report boolean DEFAULT false,
     favorite_notifications boolean DEFAULT true
+    show_user_in_switcher boolean DEFAULT true
 );
 
 
@@ -1940,6 +1941,8 @@ INSERT INTO schema_migrations (version) VALUES ('20170221171959');
 INSERT INTO schema_migrations (version) VALUES ('20170331133925');
 
 INSERT INTO schema_migrations (version) VALUES ('20170413195840');
+
+INSERT INTO schema_migrations (version) VALUES ('20170501214439');
 
 INSERT INTO schema_migrations (version) VALUES ('20170505173455');
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -213,7 +213,8 @@ RSpec.describe UsersController do
         email_notifications: true,
         moiety_name: 'Testmoiety',
         moiety: 'AAAAAA',
-        favorite_notifications: false
+        favorite_notifications: false,
+        show_user_in_switcher: false
       }
 
       # ensure new values are different, so test tests correct things

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -520,13 +520,13 @@ RSpec.describe Post do
       create(:reply, post: post)
       user = create(:user)
       expect(post.authors).not_to include(user)
-      expect(post.recent_characters_for(user)).to be_blank
+      expect(post.recent_characters_for(user, 4)).to be_blank
     end
 
     it "includes the post character if relevant" do
       char = create(:character)
       post = create(:post, user: char.user, character: char)
-      expect(post.recent_characters_for(char.user)).to match_array([char])
+      expect(post.recent_characters_for(char.user, 4)).to match_array([char])
     end
 
     it "only includes characters for specified author" do
@@ -535,7 +535,7 @@ RSpec.describe Post do
       post = create(:post, user: other_char1.user, character: other_char1)
       create(:reply, post: post, user: other_char2.user, character: other_char2)
       reply = create(:reply, character_id: nil)
-      expect(post.recent_characters_for(reply.user)).to be_blank
+      expect(post.recent_characters_for(reply.user, 4)).to be_blank
     end
 
     it "returns correctly ordered information without duplicates" do
@@ -557,7 +557,19 @@ RSpec.describe Post do
       create(:reply, post: other_post, user: user, character: other_char)
       create(:reply, post: post, user: coauthor, character: cochar)
 
-      expect(post.recent_characters_for(user)).to eq([reply_char2, char, reply_char])
+      expect(post.recent_characters_for(user, 4)).to eq([reply_char2, char, reply_char])
+    end
+
+    it "limits the amount of returned data" do
+      user = create(:user)
+      characters = Array.new(5) { create(:character, user: user) }
+      post_char = create(:character, user: user)
+      post = create(:post, user: user, character: post_char)
+      characters.each do |char|
+        create(:reply, user: user, post: post, character: char)
+      end
+
+      expect(post.recent_characters_for(user, 4)).to eq(characters[-4..-1].reverse)
     end
   end
 


### PR DESCRIPTION
Some people don't use their user accounts ever, and would prefer that the user account accordingly not display in this list.

Fixes part of #219.

With user checkbox toggled on (default):
![image](https://cloud.githubusercontent.com/assets/577128/25596813/191ff81c-2ec3-11e7-8fdf-17c91422149b.png)

With user checkbox toggled off:
![image](https://cloud.githubusercontent.com/assets/577128/25596818/1e4946a4-2ec3-11e7-8192-d01d65febbd7.png)