### PR TITLE
Rewrite character.icon calls to character.default_icon

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -111,8 +111,8 @@ class CharactersController < ApplicationController
     use_javascript('icons')
 
     icons = @alts.map do |alt|
-      if alt.icon.present?
-        [alt.id, {url: alt.icon.url, keyword: alt.icon.keyword, aliases: alt.aliases.as_json}]
+      if alt.default_icon.present?
+        [alt.id, {url: alt.default_icon.url, keyword: alt.default_icon.keyword, aliases: alt.aliases.as_json}]
       else
         [alt.id, {url: '/images/no-icon.png', keyword: 'No Icon', aliases: alt.aliases.as_json}]
       end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -81,7 +81,7 @@ class PostsController < WritableController
     @post = Post.new(character: current_user.active_character, user: current_user)
     @post.board_id = params[:board_id]
     @post.section_id = params[:section_id]
-    @post.icon_id = (current_user.active_character ? current_user.active_character.icon.try(:id) : current_user.avatar_id)
+    @post.icon_id = (current_user.active_character ? current_user.active_character.default_icon.try(:id) : current_user.avatar_id)
     @page_title = 'New Post'
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,7 +37,7 @@ module ApplicationHelper
   end
 
   def character_icon_tag(character)
-    quick_switch_tag(character.icon.try(:url), character.name[0..1], character.selector_name, character.id)
+    quick_switch_tag(character.default_icon.try(:url), character.name[0..1], character.selector_name, character.id)
   end
 
   def swap_icon_url

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -25,10 +25,6 @@ class Character < ActiveRecord::Base
 
   nilify_blanks
 
-  def icon
-    default_icon
-  end
-
   def recent_posts
     return @recent unless @recent.nil?
     reply_ids = replies.group(:post_id).pluck(:post_id)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -96,7 +96,7 @@ class Post < ActiveRecord::Base
     if reply.character_id.nil?
       reply.icon_id = user.avatar_id
     else
-      reply.icon_id = reply.character.icon.try(:id)
+      reply.icon_id = reply.character.default_icon.try(:id)
     end
 
     return reply

--- a/app/presenters/character_presenter.rb
+++ b/app/presenters/character_presenter.rb
@@ -19,7 +19,7 @@ class CharacterPresenter
       return char_json unless options[:include].present?
     end
 
-    char_json.merge!(default: character.icon.try(:as_json)) if options[:include].include?(:default)
+    char_json.merge!(default: character.default_icon.try(:as_json)) if options[:include].include?(:default)
     char_json.merge!(aliases: character.aliases) if options[:include].include?(:aliases)
     return char_json unless options[:include].include?(:galleries)
 
@@ -44,8 +44,8 @@ class CharacterPresenter
   def single_gallery_json
     if character.galleries.present?
       [{icons: character.icons}]
-    elsif character.icon.present?
-      [{icons: [character.icon]}]
+    elsif character.default_icon.present?
+      [{icons: [character.default_icon]}]
     else
       []
     end

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -7,8 +7,8 @@
       - characters.each do |character|
         .gallery-icon
           = link_to character_path(character) do
-            - if character.icon
-              = icon_tag character.icon
+            - if character.default_icon
+              = icon_tag character.default_icon
               %br
             - else
               <div class='icon gallery-no-icon'>&nbsp;</div>

--- a/app/views/characters/replace.haml
+++ b/app/views/characters/replace.haml
@@ -20,14 +20,14 @@
       %th.sub New
     %tr
       %td.green.width-150.centered.vtop
-        = icon_tag @character.icon
+        = icon_tag @character.default_icon
         %br
         = @character.name
         - if @character.aliases.exists?
           = select_tag :orig_alias, options_for_select({'— Any Alias —': 'all'}, 'all') + options_from_collection_for_select(@character.aliases, :id, :name), prompt: '— No alias —'
       %td.green.width-150.centered
         - if @alts.first.try(:icon)
-          = icon_tag @alts.first.icon, id: 'new_icon'
+          = icon_tag @alts.first.default_icon, id: 'new_icon'
         - else
           = no_icon_tag id: 'new_icon'
         %br

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -27,11 +27,11 @@
           %br
           %span.character-screenname= @character.screenname
   %tbody
-    - if @character.icon
+    - if @character.default_icon
       %tr
         %td.green.centered.character-icon
-          = link_to icon_path(@character.icon) do
-            = icon_tag @character.icon
+          = link_to icon_path(@character.default_icon) do
+            = icon_tag @character.default_icon
     %tr
       %td.centered{class: cycle('even', 'odd')}
         = link_to character_path(@character) do

--- a/app/views/posts/_editor.haml
+++ b/app/views/posts/_editor.haml
@@ -16,7 +16,7 @@
         - else
           - icons = item.character.icons.map{|i| [i.keyword, i.id]}
         - unless icons.present?
-          - icon = item.character.icon
+          - icon = item.character.default_icon
           - icons = [[icon.keyword, icon.id]] unless icon.nil?
         = select_tag :icon_dropdown, options_for_select(icons, item.icon_id), prompt: "No Icon"
       - elsif current_user.avatar


### PR DESCRIPTION
As suggested [here](https://github.com/Marri/glowfic/pull/223#pullrequestreview-36652149), replace calls to `character.icon` with calls to `character.default_icon` now the extra unnecessary logic has been removed.