### PR TITLE
Fix posts javascript wrt characters with no default icon but galleries

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -368,18 +368,22 @@ getAndSetCharacterData = function(characterId, options) {
       $("#reply_character_alias_id").val('');
     }
 
+    $("#gallery").html('');
+
     // Display no icon if no default set
     if (!resp.default) {
-      $("#current-icon").removeClass('pointer');
       setIcon('');
-      return;
+      // Remove pointer and skip galleries if no galleries attached to character
+      if (resp.galleries.length == 0) {
+        $("#current-icon").removeClass('pointer');
+        return;
+      }
     }
 
     // Display default icon
     $("#current-icon").addClass('pointer');
 
     // Calculate new galleries
-    $("#gallery").html("");
     var multiGallery = resp.galleries.length > 1;
     for(var j = 0; j < resp.galleries.length; j++) {
       $("#gallery").append(galleryString(resp.galleries[j], multiGallery));


### PR DESCRIPTION
If switching to a character that has no default icon but that does have galleries, at present it will make the `current-icon` not clickable (as it guesses no icons based on the lack of a default); this fixes that logic to only occur if the character has no galleries.

It also moves the `$("#gallery").html('');` call earlier, so the `#gallery` widget should be cleared if there are no icons for the character (simply so the HTML matches the current state more neatly; this should not modify visible behavior).