### PR TITLE
Make posts#search not case sensitive on subjects

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -222,7 +222,7 @@ class PostsController < WritableController
     @search_results = Post.order('tagged_at desc').includes(:board)
     @search_results = @search_results.where(board_id: params[:board_id]) if params[:board_id].present?
     @search_results = @search_results.where(id: Setting.find(params[:setting_id]).post_tags.pluck(:post_id)) if params[:setting_id].present?
-    @search_results = @search_results.search(params[:subject]).where('subject LIKE ?', "%#{params[:subject]}%") if params[:subject].present?
+    @search_results = @search_results.search(params[:subject]).where('LOWER(subject) LIKE ?', "%#{params[:subject].downcase}%") if params[:subject].present?
     @search_results = @search_results.where(status: Post::STATUS_COMPLETE) if params[:completed].present?
     if params[:author_id].present?
       post_ids = Reply.where(user_id: params[:author_id]).pluck('distinct post_id')

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -76,10 +76,11 @@ RSpec.describe PostsController do
       end
 
       it "filters by subject" do
-        post = create(:post, subject: 'contains stars')
+        post1 = create(:post, subject: 'contains stars')
+        post2 = create(:post, subject: 'contains Stars cased')
         create(:post, subject: 'unrelated')
         get :search, commit: true, subject: 'stars'
-        expect(assigns(:search_results)).to match_array([post])
+        expect(assigns(:search_results)).to match_array([post1, post2])
       end
 
       it "does not mix up subject with content" do


### PR DESCRIPTION
Previously, with a title such as "blue like I'd never known", searching "Blue like" or "Blue Like" would fail to match. This should fix that.