### PR TITLE
Make the 'unread replies' link of the reply editor have target=_blank

### DIFF
--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -9,6 +9,6 @@ module WritableHelper
       @post
     end
     return (@unread_warning = false) unless unread_reply
-    @unread_warning = content_tag :a, 'Post has unread replies', href: post_or_reply_link(unread_reply), class: 'unread-warning'
+    @unread_warning = content_tag :a, 'Post has unread replies', href: post_or_reply_link(unread_reply), class: 'unread-warning', target: '_blank'
   end
 end


### PR DESCRIPTION
Previously if you clicked the link you'd be taken to the unread replies, potentially losing your editor. This adds `target="_blank"` so it'll open it in a new tab/window instead.