### PR TITLE
Refactor the unread warning

### DIFF
--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -109,7 +109,8 @@ class RepliesController < WritableController
       if most_recent_unseen_reply.present?
         reply.post.mark_read(current_user, reply.post.read_time_for(@unseen_replies))
         num = @unseen_replies.count
-        flash[:error] = "There have been #{num} new #{'reply'.pluralize(num)} since you last viewed this post."
+        pluraled = num > 1 ? "have been #{num} new replies" : "has been 1 new reply"
+        flash[:error] = "There #{pluraled} since you last viewed this post."
         @last_seen_id = most_recent_unseen_reply.id
         preview(reply) and return
       end

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -101,11 +101,16 @@ class RepliesController < WritableController
     reply = Reply.new(params[:reply])
     reply.user = current_user
 
-    if reply.post.try(:first_unread_for, current_user) && !params[:unread_warned]
-      # There are unreads and the user has not been warned.
-      params[:unread_warned] = true
-      flash[:error] = "There are unread replies not shown here. (Click 'post' again if you wish to ignore this warning.)"
-      preview(reply) and return
+    if reply.post.present?
+      last_seen_reply_id = params[:last_seen]
+      @unseen_replies = reply.post.replies.order('id asc').paginate(page: 1, per_page: 5)
+      @unseen_replies = @unseen_replies.where('id > ?', last_seen_reply_id) if last_seen_reply_id.present?
+      most_recent_unseen_reply = @unseen_replies.last
+      if most_recent_unseen_reply.present?
+        flash[:error] = "There have been #{@unseen_replies.count} new replies since you last viewed this post."
+        @last_seen_id = most_recent_unseen_reply.id
+        preview(reply) and return
+      end
     end
 
     if reply.save

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -103,11 +103,13 @@ class RepliesController < WritableController
 
     if reply.post.present?
       last_seen_reply_id = params[:last_seen]
-      @unseen_replies = reply.post.replies.order('id asc').paginate(page: 1, per_page: 5)
+      @unseen_replies = reply.post.replies.order('id asc').paginate(page: 1, per_page: 10)
       @unseen_replies = @unseen_replies.where('id > ?', last_seen_reply_id) if last_seen_reply_id.present?
       most_recent_unseen_reply = @unseen_replies.last
       if most_recent_unseen_reply.present?
-        flash[:error] = "There have been #{@unseen_replies.count} new replies since you last viewed this post."
+        reply.post.mark_read(current_user, reply.post.read_time_for(@unseen_replies))
+        num = @unseen_replies.count
+        flash[:error] = "There have been #{num} new #{'reply'.pluralize(num)} since you last viewed this post."
         @last_seen_id = most_recent_unseen_reply.id
         preview(reply) and return
       end

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -103,6 +103,12 @@ class WritableController < ApplicationController
       end
 
       @post.mark_read(current_user, @post.read_time_for(@replies))
+
+      if @replies.total_pages == cur_page
+        @last_seen_id = @replies.last.try(:id)
+      else
+        @last_seen_id = @post.last_seen_reply_for(current_user).try(:id)
+      end
     end
 
     @warnings = @post.content_warnings if display_warnings?

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -1,14 +1,13 @@
 module WritableHelper
   def unread_warning
-    return @unread_warning unless @unread_warning.nil?
-    # Get unread_reply separately from @post.first_unread_for because that caches (and sometimes does "halfway down the page you just loaded" when we want 'first unread after the whole page has loaded')
-    viewed_at = @post.last_read(current_user) || @post.board.last_read(current_user)
-    unread_reply = if viewed_at
-      @post.replies.where('created_at > ?', viewed_at).order('id asc').first
-    else
-      @post
-    end
-    return (@unread_warning = false) unless unread_reply
-    @unread_warning = content_tag :a, 'Post has unread replies', href: post_or_reply_link(unread_reply), class: 'unread-warning', target: '_blank'
+    return unless @replies.present?
+    return if @replies.total_pages == page
+    'Post has unread replies ' + \
+    content_tag(:a, '(View)', href: unread_path(@post, warn_id: @last_seen_id.to_i), class: 'unread-warning') + ' ' + \
+    content_tag(:a, '(New Tab)', href: unread_path(@post), class: 'unread-warning', target: '_blank')
+  end
+
+  def unread_path(post, **kwargs)
+    post_path(post, page: 'unread', anchor: 'unread', **kwargs)
   end
 end

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -2,9 +2,9 @@ module WritableHelper
   def unread_warning
     return unless @replies.present?
     return if @replies.total_pages == page
-    'Post has unread replies ' + \
-    content_tag(:a, '(View)', href: unread_path(@post, warn_id: @last_seen_id.to_i), class: 'unread-warning') + ' ' + \
-    content_tag(:a, '(New Tab)', href: unread_path(@post), class: 'unread-warning', target: '_blank')
+    'You are not on the latest page of the thread ' + \
+    content_tag(:a, '(View unread)', href: unread_path(@post, warn_id: @last_seen_id.to_i), class: 'unread-warning') + ' ' + \
+    content_tag(:a, '(New tab)', href: unread_path(@post), class: 'unread-warning', target: '_blank')
   end
 
   def unread_path(post, **kwargs)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -111,6 +111,15 @@ class Post < ActiveRecord::Base
     @first_unread ||= reply
   end
 
+  def last_seen_reply_for(user)
+    return @last_seen if @last_seen
+    return unless replies.exists? # unlike first_unread_for we don't care about the post
+    viewed_at = last_read(user) || board.last_read(user)
+    return unless viewed_at
+    reply = replies.where('created_at <= ?', viewed_at).order('id desc').first
+    @last_seen ||= reply
+  end
+
   def recent_characters_for(user, count=4)
     # fetch the 4 (count) most recent non-nil character_ids for user in post
     recent_ids = replies.where(user_id: user.id).where('character_id IS NOT NULL').limit(count).group('character_id').select('DISTINCT character_id, MAX(id)').order('MAX(id) desc').pluck(:character_id)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -117,7 +117,7 @@ class Post < ActiveRecord::Base
     viewed_at = last_read(user) || board.last_read(user)
     return unless viewed_at
     reply = replies.where('created_at <= ?', viewed_at).order('id desc').first
-    @last_seen ||= reply
+    @last_seen = reply
   end
 
   def recent_characters_for(user, count=4)

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -13,10 +13,10 @@
   %td.post-subject{class: klass}
     - if logged_in?
       - if unread_post?(post, unread_ids) || (@show_unread && !opened_post?(post, opened_ids))
-        = link_to post_path(post, page: 'unread', anchor: 'unread') do
+        = link_to unread_path(post) do
           = image_tag unread_img, class: 'vmid', title: 'First Unread'
       - elsif @show_unread
-        = link_to post_path(post, page: 'unread', anchor: 'unread') do
+        = link_to unread_path(post) do
           = image_tag lastlink_img, class: 'vmid', title: 'First Unread'
     - if logged_in? && @opened_ids.present? && !@opened_ids.include?(post.id)
       %b= link_to post.subject, post_path(post), title: strip_tags(post.description)

--- a/app/views/posts/_write_reply.haml
+++ b/app/views/posts/_write_reply.haml
@@ -4,6 +4,7 @@
     .view-button#rtf{class: ('selected' if (params[:editor_mode] || current_user.default_editor) == 'rtf')} Rich Text
     .view-button#html{class: ('selected' if (params[:editor_mode] || current_user.default_editor) == 'html')} HTML
     %br
+    = unread_warning.try(:html_safe)
     = hidden_field_tag :last_seen, @last_seen_id
     %br
     = f.hidden_field :post_id

--- a/app/views/posts/_write_reply.haml
+++ b/app/views/posts/_write_reply.haml
@@ -4,9 +4,7 @@
     .view-button#rtf{class: ('selected' if (params[:editor_mode] || current_user.default_editor) == 'rtf')} Rich Text
     .view-button#html{class: ('selected' if (params[:editor_mode] || current_user.default_editor) == 'html')} HTML
     %br
-    - if unread_warning
-      = unread_warning
-      = hidden_field_tag :unread_warned, true
+    = hidden_field_tag :last_seen, @last_seen_id
     %br
     = f.hidden_field :post_id
     = f.hidden_field :character_id

--- a/app/views/replies/preview.haml
+++ b/app/views/replies/preview.haml
@@ -2,9 +2,7 @@
   .post-header
     .padding-15
       Unseen Replies
-      = link_to post_path(@post, page: 'unread', anchor: 'unread'), target: '_blank' do
-        .view-button Unread (new tab) &raquo;
-      = link_to post_path(@post, page: 'unread', anchor: 'unread') do
+      = link_to unread_path(@post) do
         .view-button.float-left Unread &raquo;
 
   = render partial: 'replies/single', collection: @unseen_replies, as: :reply

--- a/app/views/replies/preview.haml
+++ b/app/views/replies/preview.haml
@@ -1,3 +1,17 @@
+- if @unseen_replies.present?
+  .post-header
+    .padding-15
+      Unseen Replies
+      = link_to post_path(@post, page: 'unread', anchor: 'unread'), target: '_blank' do
+        .view-button Unread (new tab) &raquo;
+      = link_to post_path(@post, page: 'unread', anchor: 'unread') do
+        .view-button.float-left Unread &raquo;
+
+  = render partial: 'replies/single', collection: @unseen_replies, as: :reply
+  - if @unseen_replies.total_pages > 1
+    .post-ender ... and #{@unseen_replies.total_entries - @unseen_replies.per_page} more ...
+  %br
+
 .post-header
   .padding-15= @post.subject
 - if @post.description

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -37,7 +37,7 @@
                 = image_tag "/images/exclamation.png", class: 'vmid', title: "Content Warning: " + post.content_warnings.map(&:name).join(', '), alt: '!'
             %td.post-subject{class: klass}
               - if has_unread?(post)
-                = link_to post_path(post, page: 'unread', anchor: 'unread') do
+                = link_to unread_path(post) do
                   = image_tag unread_img, class: 'vmid', title: 'First Unread'
               - if @opened_ids.present? && !@opened_ids.include?(post.id)
                 %b= link_to post.subject, post_or_reply_link(linked)

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -77,10 +77,10 @@ RSpec.describe RepliesController do
 
       post :create, reply: {post_id: reply_post.id, user_id: reply_post.user_id}
       expect(response.status).to eq(200)
-      expect(flash[:error]).to eq("There have been 1 new replies since you last viewed this post.")
+      expect(flash[:error]).to eq("There have been 1 new reply since you last viewed this post.")
     end
 
-    it "handles multiple creations with " do
+    it "handles multiple creations with last_seen" do
       reply_post = create(:post)
       login_as(reply_post.user)
       reply_post.mark_read(reply_post.user)
@@ -88,7 +88,7 @@ RSpec.describe RepliesController do
 
       post :create, reply: {post_id: reply_post.id, user_id: reply_post.user_id}
       expect(response.status).to eq(200)
-      expect(flash[:error]).to eq("There have been 1 new replies since you last viewed this post.")
+      expect(flash[:error]).to eq("There have been 1 new reply since you last viewed this post.")
 
       create(:reply, post: reply_post)
       create(:reply, post: reply_post)

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe RepliesController do
       expect(flash[:error][:message]).to eq("Your post could not be saved because of the following problems:")
     end
 
-    it "requires post read if no unread_warned param" do
+    it "requires post read if no last_seen param" do
       reply_post = create(:post)
       login_as(reply_post.user)
       reply_post.mark_read(reply_post.user)
@@ -77,7 +77,7 @@ RSpec.describe RepliesController do
 
       post :create, reply: {post_id: reply_post.id, user_id: reply_post.user_id}
       expect(response.status).to eq(200)
-      expect(flash[:error]).to eq("There have been 1 new reply since you last viewed this post.")
+      expect(flash[:error]).to eq("There has been 1 new reply since you last viewed this post.")
     end
 
     it "handles multiple creations with last_seen" do
@@ -88,7 +88,7 @@ RSpec.describe RepliesController do
 
       post :create, reply: {post_id: reply_post.id, user_id: reply_post.user_id}
       expect(response.status).to eq(200)
-      expect(flash[:error]).to eq("There have been 1 new reply since you last viewed this post.")
+      expect(flash[:error]).to eq("There has been 1 new reply since you last viewed this post.")
 
       create(:reply, post: reply_post)
       create(:reply, post: reply_post)


### PR DESCRIPTION
Uses an id instead of a boolean so it'll show the warning as many times as necessary; shows the unread posts themselves; provides both a new-window and same-window jump URL option (per lintamande's request)