### PR TITLE
Make character#replace use char.default_icon not char.icon

### DIFF
--- a/app/views/characters/replace.haml
+++ b/app/views/characters/replace.haml
@@ -26,7 +26,7 @@
         - if @character.aliases.exists?
           = select_tag :orig_alias, options_for_select({'— Any Alias —': 'all'}, 'all') + options_from_collection_for_select(@character.aliases, :id, :name), prompt: '— No alias —'
       %td.green.width-150.centered
-        - if @alts.first.try(:icon)
+        - if @alts.first.try(:default_icon)
           = icon_tag @alts.first.default_icon, id: 'new_icon'
         - else
           = no_icon_tag id: 'new_icon'


### PR DESCRIPTION
Fixes a crash after a7710dcb12085df147cce0ad8e8008a1161b67fd.

When I checked for uses of `.icon`, I only checked with the regex `\.icon\b` – this particular instance was `.try(:icon)` and was accordingly not matched.

I now checked through all instances of `:icon`, all others of which look unrelated. There are no other instances of `.try(:icon)` that I can find.