### PR TITLE
Improve reply unread warning by using read status instead of form data

### DIFF
--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -111,7 +111,8 @@ class RepliesController < WritableController
         num = @unseen_replies.count
         pluraled = num > 1 ? "have been #{num} new replies" : "has been 1 new reply"
         flash.now[:error] = "There #{pluraled} since you last viewed this post."
-        preview(reply) and return
+        draft = make_draft
+        preview(ReplyDraft.reply_from_draft(draft)) and return
       end
     end
 

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -111,7 +111,6 @@ class RepliesController < WritableController
         num = @unseen_replies.count
         pluraled = num > 1 ? "have been #{num} new replies" : "has been 1 new reply"
         flash.now[:error] = "There #{pluraled} since you last viewed this post."
-        @last_seen_id = most_recent_unseen_reply.id
         preview(reply) and return
       end
     end

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -195,6 +195,10 @@ class RepliesController < WritableController
 
     @page_title = @post.subject
 
+    if @written.new_record?
+      @last_seen_id = @post.last_seen_reply_for(current_user).try(:id)
+    end
+
     use_javascript('posts')
     render :action => :preview
   end

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -102,7 +102,7 @@ class RepliesController < WritableController
     reply.user = current_user
 
     if reply.post.present?
-      last_seen_reply_id = params[:last_seen]
+      last_seen_reply_id = reply.post.last_seen_reply_for(current_user).try(:id)
       @unseen_replies = reply.post.replies.order('id asc').paginate(page: 1, per_page: 10)
       @unseen_replies = @unseen_replies.where('id > ?', last_seen_reply_id) if last_seen_reply_id.present?
       most_recent_unseen_reply = @unseen_replies.last
@@ -194,10 +194,6 @@ class RepliesController < WritableController
     @written.user = current_user
 
     @page_title = @post.subject
-
-    if @written.new_record?
-      @last_seen_id = @post.last_seen_reply_for(current_user).try(:id)
-    end
 
     use_javascript('posts')
     render :action => :preview

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -103,12 +103,6 @@ class WritableController < ApplicationController
       end
 
       @post.mark_read(current_user, @post.read_time_for(@replies))
-
-      if @replies.total_pages == cur_page
-        @last_seen_id = @replies.last.try(:id)
-      else
-        @last_seen_id = @post.last_seen_reply_for(current_user).try(:id)
-      end
     end
 
     @warnings = @post.content_warnings if display_warnings?

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -3,7 +3,7 @@ module WritableHelper
     return unless @replies.present?
     return if @replies.total_pages == page
     'You are not on the latest page of the thread ' + \
-    content_tag(:a, '(View unread)', href: unread_path(@post, warn_id: @last_seen_id.to_i), class: 'unread-warning') + ' ' + \
+    content_tag(:a, '(View unread)', href: unread_path(@post, warn_time: Time.now.to_i), class: 'unread-warning') + ' ' + \
     content_tag(:a, '(New tab)', href: unread_path(@post), class: 'unread-warning', target: '_blank')
   end
 

--- a/app/views/posts/_write_reply.haml
+++ b/app/views/posts/_write_reply.haml
@@ -5,7 +5,6 @@
     .view-button#html{class: ('selected' if (params[:editor_mode] || current_user.default_editor) == 'html')} HTML
     %br
     = unread_warning.try(:html_safe)
-    = hidden_field_tag :last_seen, @last_seen_id
     %br
     = f.hidden_field :post_id
     = f.hidden_field :character_id

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe RepliesController do
       expect(flash[:error][:message]).to eq("Your post could not be saved because of the following problems:")
     end
 
-    it "requires post read if no last_seen param" do
+    it "requires post read" do
       reply_post = create(:post)
       login_as(reply_post.user)
       reply_post.mark_read(reply_post.user)

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe RepliesController do
         expect(assigns(:written)).to be_a_new_record
         expect(assigns(:written).user).to eq(reply_post.user)
         expect(assigns(:post)).to eq(reply_post)
-        expect(assigns(:last_seen_id)).to eq(reply.id)
         expect(ReplyDraft.count).to eq(1)
         draft = ReplyDraft.last
         expect(draft.post).to eq(reply_post)
@@ -83,7 +82,7 @@ RSpec.describe RepliesController do
       expect(flash[:error]).to eq("There has been 1 new reply since you last viewed this post.")
     end
 
-    it "handles multiple creations with last_seen" do
+    it "handles multiple creations with unread warning" do
       reply_post = create(:post)
       login_as(reply_post.user)
       reply_post.mark_read(reply_post.user)
@@ -96,7 +95,7 @@ RSpec.describe RepliesController do
       create(:reply, post: reply_post)
       create(:reply, post: reply_post)
 
-      post :create, reply: {post_id: reply_post.id, user_id: reply_post.user_id}, last_seen: assigns(:last_seen_id)
+      post :create, reply: {post_id: reply_post.id, user_id: reply_post.user_id}
       expect(response.status).to eq(200)
       expect(flash[:error]).to eq("There have been 2 new replies since you last viewed this post.")
     end

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe RepliesController do
     context "preview" do
       it "takes correct actions" do
         reply_post = create(:post)
+        reply = create(:reply, post: reply_post)
+        reply_post.mark_read(reply_post.user)
         login_as(reply_post.user)
         expect(ReplyDraft.count).to eq(0)
         post :create, button_preview: true, reply: {post_id: reply_post.id}
@@ -20,6 +22,7 @@ RSpec.describe RepliesController do
         expect(assigns(:written)).to be_a_new_record
         expect(assigns(:written).user).to eq(reply_post.user)
         expect(assigns(:post)).to eq(reply_post)
+        expect(assigns(:last_seen_id)).to eq(reply.id)
         expect(ReplyDraft.count).to eq(1)
         draft = ReplyDraft.last
         expect(draft.post).to eq(reply_post)

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -114,18 +114,6 @@ RSpec.describe RepliesController do
       expect(flash[:error][:message]).to eq("Your post could not be saved because of the following problems:")
     end
 
-    it "requires valid params with an unread_warned param if not read" do
-      user = create(:user)
-      login_as(user)
-      character = create(:character)
-      reply_post = create(:post)
-
-      expect(character.user_id).not_to eq(user.id)
-      post :create, reply: {character_id: character.id, post_id: reply_post.id}, unread_warned: true
-      expect(response).to redirect_to(post_url(reply_post))
-      expect(flash[:error][:message]).to eq("Your post could not be saved because of the following problems:")
-    end
-
     it "saves a new reply successfully if read" do
       user = create(:user)
       login_as(user)
@@ -134,20 +122,6 @@ RSpec.describe RepliesController do
       expect(Reply.count).to eq(0)
 
       post :create, reply: {post_id: reply_post.id, content: 'test!' }
-
-      reply = Reply.first
-      expect(reply).not_to be_nil
-      expect(response).to redirect_to(reply_url(reply, anchor: "reply-#{reply.id}"))
-      expect(flash[:success]).to eq("Posted!")
-    end
-
-    it "saves a new reply successfully with an unread_warned param if not read" do
-      user = create(:user)
-      login_as(user)
-      reply_post = create(:post)
-      expect(Reply.count).to eq(0)
-
-      post :create, reply: {post_id: reply_post.id}, unread_warned: true, content: 'test!'
 
       reply = Reply.first
       expect(reply).not_to be_nil


### PR DESCRIPTION
I was going to fix an issue whereby going through preview meant it thought you hadn't read the post, but instead I decided to fix the whole thing where it sends `last_seen` in the form rather than just figuring it out itself.

This seems to work fine, on testing. I expect it will overall reduce more obscure edge cases.

`@last_seen_id` hasn't been totally removed (from WritableController, mostly) because it's still used as a parameter for those links warning you you're not on the last page of the post.