### PR TITLE
Ensure icon has_gallery is unset when removed through mass assignment

### DIFF
--- a/app/models/galleries_icon.rb
+++ b/app/models/galleries_icon.rb
@@ -2,4 +2,11 @@ class GalleriesIcon < ActiveRecord::Base
   belongs_to :icon
   belongs_to :gallery
   accepts_nested_attributes_for :icon, allow_destroy: true
+
+  after_destroy :unset_has_gallery
+
+  def unset_has_gallery
+    return if icon.galleries.present?
+    icon.update_attributes(has_gallery: false)
+  end
 end

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -246,6 +246,7 @@ RSpec.describe GalleriesController do
       gallery = create(:gallery, user: user)
       icon = create(:icon, user: user)
       gallery.icons << icon
+      expect(icon.reload.has_gallery).to be_true
       login_as(user)
 
       icon_attributes = {id: icon.id}
@@ -257,6 +258,7 @@ RSpec.describe GalleriesController do
       expect(flash[:success]).to eq('Gallery saved.')
       expect(gallery.reload.icons).to be_empty
       expect(icon.reload).not_to be_nil
+      expect(icon.has_gallery).not_to be_true
     end
 
     it "can delete a gallery icon" do


### PR DESCRIPTION
Test fails on master, because when the nested assignment is done the call in `Gallery` isn't triggered. (The icon isn't technically "removed", the `GalleriesIcon` is destroyed.) This fixes it. We might want to run a task to check icons with `has_gallery` set to `true` actually have galleries. I noticed this while upgrading to Rails 4 and testing various models did expected things manually, but it wasn't specific to the upgrade process.