### PR TITLE
Fix report showing posts unopened when read_at nil

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -14,7 +14,7 @@ class ReportsController < ApplicationController
     @day = (page.to_i - 1).days.ago
 
     if logged_in?
-      @opened_posts = PostView.where(user_id: current_user.id).select([:post_id, :read_at, :ignored])
+      @opened_posts = PostView.where(user_id: current_user.id).where('read_at IS NOT NULL').select([:post_id, :read_at, :ignored])
       @board_views = BoardView.where(user_id: current_user.id).select([:board_id, :ignored])
       @opened_ids = @opened_posts.map(&:post_id)
     end


### PR DESCRIPTION
This is to fix [the issue Pedro mentioned on the forum](http://alicorn.elcenia.com/board/viewtopic.php?f=12&t=459&start=2180#p33256) – it happened due to how the reports page was figuring out opened posts (by checking for the existence of post views), which doesn't match with the new logic added in #186.