### PR TITLE
Except draft attributes properly

### DIFF
--- a/app/models/reply_draft.rb
+++ b/app/models/reply_draft.rb
@@ -15,6 +15,6 @@ class ReplyDraft < ActiveRecord::Base
   end
 
   def self.reply_from_draft(draft)
-    Reply.new(draft.attributes.except(:id, :created_at, :updated_at))
+    Reply.new(draft.attributes.except('id', 'created_at', 'updated_at'))
   end
 end


### PR DESCRIPTION
`draft.attributes` returns a hash with keys of strings, so using `.except(:id, …)` didn't actually remove them from the assignment (at least in Rails 4). This fixes that.