### PR TITLE
Add tests to ensure model attributes are set on create and update

### DIFF
--- a/app/concerns/viewable.rb
+++ b/app/concerns/viewable.rb
@@ -36,7 +36,7 @@ module Viewable
     def reload
       @view = nil
       @first_unread = nil
-      @visible = false # for post.visible_to? in tests
+      @visible = nil # for post.visible_to? in tests
       super
     end
 

--- a/app/concerns/viewable.rb
+++ b/app/concerns/viewable.rb
@@ -36,6 +36,7 @@ module Viewable
     def reload
       @view = nil
       @first_unread = nil
+      @visible = false # for post.visible_to? in tests
       super
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -23,7 +23,7 @@ class Post < ActiveRecord::Base
   belongs_to :last_reply, class_name: Reply
   has_one :flat_post
   has_many :replies, inverse_of: :post, dependent: :destroy
-  has_many :post_viewers, dependent: :destroy
+  has_many :post_viewers, inverse_of: :post, dependent: :destroy
   has_many :viewers, through: :post_viewers, source: :user
   has_many :reply_drafts, dependent: :destroy
   has_many :post_tags, inverse_of: :post, dependent: :destroy

--- a/spec/controllers/board_sections_controller_spec.rb
+++ b/spec/controllers/board_sections_controller_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe BoardSectionsController do
       post :create, board_section: {board_id: board.id, name: section_name}
       expect(response).to redirect_to(edit_board_url(board))
       expect(flash[:success]).to eq("New #{board.name} section #{section_name} has been successfully created.")
+      expect(assigns(:board_section).name).to eq(section_name)
     end
   end
 

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -90,15 +90,26 @@ RSpec.describe CharactersController do
     it "succeeds when valid" do
       expect(Character.count).to eq(0)
       test_name = 'Test character'
+      user = create(:user)
+      template = create(:template, user: user)
+      gallery = create(:gallery, user: user)
 
-      user_id = login
-      post :create, character: {name: test_name}
+      login_as(user)
+      post :create, character: {name: test_name, template_name: 'TempName', screenname: 'just-a-test', setting: 'A World', template_id: template.id, pb: 'Facecast', description: 'Desc', gallery_ids: [gallery.id]}
 
       expect(response).to redirect_to(assigns(:character))
       expect(flash[:success]).to eq("Character saved successfully.")
       expect(Character.count).to eq(1)
-      expect(assigns(:character).name).to eq(test_name)
-      expect(assigns(:character).user_id).to eq(user_id)
+      character = assigns(:character)
+      expect(character.name).to eq(test_name)
+      expect(character.user_id).to eq(user.id)
+      expect(character.template_name).to eq('TempName')
+      expect(character.screenname).to eq('just-a-test')
+      expect(character.setting).to eq('A World')
+      expect(character.template).to eq(template)
+      expect(character.pb).to eq('Facecast')
+      expect(character.description).to eq('Desc')
+      expect(character.galleries).to match_array([gallery])
     end
 
     it "creates new templates when specified" do
@@ -249,14 +260,24 @@ RSpec.describe CharactersController do
 
     it "succeeds when valid" do
       character = create(:character)
-      login_as(character.user)
+      user = character.user
+      login_as(user)
       new_name = character.name + 'aaa'
-      put :update, id: character.id, character: {name: new_name}
+      template = create(:template, user: user)
+      gallery = create(:gallery, user: user)
+      put :update, id: character.id, character: {name: new_name, template_name: 'TemplateName', screenname: 'a-new-test', setting: 'Another World', template_id: template.id, pb: 'Actor', description: 'Description', gallery_ids: [gallery.id]}
 
       expect(response).to redirect_to(assigns(:character))
       expect(flash[:success]).to eq("Character saved successfully.")
       character.reload
       expect(character.name).to eq(new_name)
+      expect(character.template_name).to eq('TemplateName')
+      expect(character.screenname).to eq('a-new-test')
+      expect(character.setting).to eq('Another World')
+      expect(character.template).to eq(template)
+      expect(character.pb).to eq('Actor')
+      expect(character.description).to eq('Description')
+      expect(character.galleries).to match_array([gallery])
     end
 
     it "creates new templates when specified" do

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -79,8 +79,10 @@ RSpec.describe GalleriesController do
       login
       post :create, gallery: {name: 'Test Gallery'}
       expect(Gallery.count).to eq(1)
-      expect(response).to redirect_to(gallery_url(assigns(:gallery)))
+      gallery = assigns(:gallery).reload
+      expect(response).to redirect_to(gallery_url(gallery))
       expect(flash[:success]).to eq('Gallery saved successfully.')
+      expect(gallery.name).to eq('Test Gallery')
     end
   end
 

--- a/spec/controllers/icons_controller_spec.rb
+++ b/spec/controllers/icons_controller_spec.rb
@@ -216,10 +216,13 @@ RSpec.describe IconsController do
       icon = create(:icon)
       login_as(icon.user)
       new_url = icon.url + '?param'
-      put :update, id: icon.id, icon: {url: new_url}
+      put :update, id: icon.id, icon: {url: new_url, keyword: 'new keyword', credit: 'new credit'}
       expect(response).to redirect_to(icon_url(icon))
       expect(flash[:success]).to eq("Icon updated.")
-      expect(icon.reload.url).to eq(new_url)
+      icon.reload
+      expect(icon.url).to eq(new_url)
+      expect(icon.keyword).to eq('new keyword')
+      expect(icon.credit).to eq('new credit')
     end
   end
 

--- a/spec/controllers/templates_controller_spec.rb
+++ b/spec/controllers/templates_controller_spec.rb
@@ -35,11 +35,15 @@ RSpec.describe TemplatesController do
     end
 
     it "works" do
-      login
-      post :create, template: {name: 'testtest'}
+      char = create(:character)
+      login_as(char.user)
+      post :create, template: {name: 'testtest', description: 'test desc', character_ids: [char.id]}
       created = Template.last
       expect(response).to redirect_to(template_url(created))
       expect(flash[:success]).to eq("Template saved successfully.")
+      expect(created.name).to eq('testtest')
+      expect(created.description).to eq('test desc')
+      expect(created.characters).to match_array([char])
     end
   end
 
@@ -143,12 +147,18 @@ RSpec.describe TemplatesController do
 
     it "works" do
       template = create(:template)
+      char = create(:character, user: template.user)
       new_name = template.name + 'new'
       login_as(template.user)
-      put :update, id: template.id, template: {name: new_name}
+
+      put :update, id: template.id, template: {name: new_name, description: 'new desc', character_ids: [char.id]}
       expect(response).to redirect_to(template_url(template))
       expect(flash[:success]).to eq("Template saved successfully.")
-      expect(template.reload.name).to eq(new_name)
+
+      template.reload
+      expect(template.name).to eq(new_name)
+      expect(template.description).to eq('new desc')
+      expect(template.characters).to match_array([char])
     end
   end
 


### PR DESCRIPTION
This also fixes `post_viewers` being invalid on post#create in Rails 4 (by adding an `inverse_of` attribute).