### PR TITLE
Clear icon and alias IDs from ReplyDrafts on destroy

### DIFF
--- a/app/models/character_alias.rb
+++ b/app/models/character_alias.rb
@@ -12,5 +12,6 @@ class CharacterAlias < ActiveRecord::Base
   def clear_alias_ids
     Reply.where(character_alias_id: id).update_all(character_alias_id: nil)
     Post.where(character_alias_id: id).update_all(character_alias_id: nil)
+    ReplyDraft.where(character_alias_id: id).update_all(character_alias_id: nil)
   end
 end

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -48,6 +48,7 @@ class Icon < ActiveRecord::Base
   def clear_icon_ids
     Reply.where(icon_id: id).update_all(icon_id: nil)
     Post.where(icon_id: id).update_all(icon_id: nil)
+    ReplyDraft.where(icon_id: id).update_all(icon_id: nil)
   end
 
   class UploadError < Exception


### PR DESCRIPTION
Solves a bug Kel encountered where a reply draft had been saved with an alias and then the alias was deleted (this made the post page crash each time it was loaded as `return character_name unless character_alias_id.present?` at [writable.rb#L43](https://github.com/Marri/glowfic/blob/195b28136563f8fc23778c91693328a148abf90c/app/concerns/writable.rb#L43) was skipped, the ID existing but the associated object not).