### PR TITLE
Use timezone for date in report

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -12,9 +12,9 @@ class ReportsController < ApplicationController
     @page_title = params[:id].capitalize + " Report"
     @hide_quicklinks = true
     if params[:day].present?
-      @day = Date.parse(params[:day]) rescue Date.today
+      @day = Date.parse(params[:day]) rescue Time.zone.now.to_date
     else
-      @day = Date.today
+      @day = Time.zone.now.to_date
     end
 
     if logged_in?

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -12,7 +12,7 @@ class ReportsController < ApplicationController
     @page_title = params[:id].capitalize + " Report"
     @hide_quicklinks = true
     if params[:day].present?
-      @day = Date.parse(params[:day]) rescue Time.zone.now.to_date
+      @day = params[:day].in_time_zone(Time.zone).to_date rescue Time.zone.now.to_date
     else
       @day = Time.zone.now.to_date
     end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -64,49 +64,55 @@ RSpec.describe ReportsController do
       end
     end
 
-    it "does not mark read for today's unfinished report" do
-      user = create(:user)
-      expect(user.report_view).to be_nil
-      login_as(user)
-      get :show, id: 'daily'
-      expect(user.reload.report_view).to be_nil
-    end
+    context "reading" do
+      before(:each) do
+        Time.zone = "UTC"
+      end
 
-    it "marks read for previous days" do
-      user = create(:user)
-      expect(user.report_view).to be_nil
-      login_as(user)
-      get :show, id: 'daily', day: 2.days.ago.to_date.to_s
-      expect(user.reload.report_view).not_to be_nil
-      expect(user.report_view.read_at.to_date).to eq(2.days.ago.to_date)
-    end
+      it "does not mark read for today's unfinished report" do
+        user = create(:user)
+        expect(user.report_view).to be_nil
+        login_as(user)
+        get :show, id: 'daily'
+        expect(user.reload.report_view).to be_nil
+      end
 
-    it "does not mark read for ignoring users" do
-      user = create(:user, ignore_unread_daily_report: true)
-      expect(user.report_view).to be_nil
-      login_as(user)
-      get :show, id: 'daily', day: 2.days.ago.to_date.to_s
-      expect(user.report_view).to be_nil
-    end
+      it "marks read for previous days" do
+        user = create(:user)
+        expect(user.report_view).to be_nil
+        login_as(user)
+        get :show, id: 'daily', day: 2.days.ago.to_date.to_s
+        expect(user.reload.report_view).not_to be_nil
+        expect(user.report_view.read_at.to_date).to eq(2.days.ago.to_date)
+      end
 
-    it "marks read for previous days when already read once" do
-      user = create(:user)
-      expect(user.report_view).to be_nil
-      DailyReport.mark_read(user, 3.day.ago.to_date)
-      login_as(user)
-      get :show, id: 'daily', day: 2.days.ago.to_date.to_s
-      expect(user.reload.report_view).not_to be_nil
-      expect(user.report_view.read_at.to_date).to eq(2.days.ago.to_date)
-    end
+      it "does not mark read for ignoring users" do
+        user = create(:user, ignore_unread_daily_report: true)
+        expect(user.report_view).to be_nil
+        login_as(user)
+        get :show, id: 'daily', day: 2.days.ago.to_date.to_s
+        expect(user.report_view).to be_nil
+      end
 
-    it "does not mark read if you've read more recently" do
-      user = create(:user)
-      expect(user.report_view).to be_nil
-      DailyReport.mark_read(user, 2.day.ago.to_date)
-      login_as(user)
-      get :show, id: 'daily', day: 3.days.ago.to_date.to_s
-      expect(user.reload.report_view).not_to be_nil
-      expect(user.report_view.read_at.to_date).to eq(2.days.ago.to_date)
+      it "marks read for previous days when already read once" do
+        user = create(:user)
+        expect(user.report_view).to be_nil
+        DailyReport.mark_read(user, 3.day.ago.to_date)
+        login_as(user)
+        get :show, id: 'daily', day: 2.days.ago.to_date.to_s
+        expect(user.reload.report_view).not_to be_nil
+        expect(user.report_view.read_at.to_date).to eq(2.days.ago.to_date)
+      end
+
+      it "does not mark read if you've read more recently" do
+        user = create(:user)
+        expect(user.report_view).to be_nil
+        DailyReport.mark_read(user, 2.day.ago.to_date)
+        login_as(user)
+        get :show, id: 'daily', day: 3.days.ago.to_date.to_s
+        expect(user.reload.report_view).not_to be_nil
+        expect(user.report_view.read_at.to_date).to eq(2.days.ago.to_date)
+      end
     end
   end
 end


### PR DESCRIPTION
I'm not really sure what to do to test this but you can see the issue if you look in a console in a timezone that's far enough out:

```
2.3.3 :002 > Time.zone = "Hawaii"
 => "Hawaii" 
2.3.3 :003 > Date.today
 => Sun, 18 Jun 2017 
2.3.3 :004 > Time.zone.now.to_date
 => Sat, 17 Jun 2017 
2.3.3 :005 > Time.zone = "Tokyo"
 => "Tokyo" 
2.3.3 :006 > Date.today
 => Sun, 18 Jun 2017 
2.3.3 :007 > Time.zone.now.to_date
 => Sun, 18 Jun 2017 
```

Note how with 'Hawaii', `Date.today` does not match up with `Time.zone.now.to_date`, since it's using my GMT+1 timezone for `Date.today`.

This is causing a bug where Pedro looked at the report and found an empty page, despite it being approximately 11pm his time.

This should probably have tests somewhere but I'm a bit too tired to add them now and thought I'd try to bring this to your attention rather than halt it on that.