### PR TITLE
Fix report zone issues

### DIFF
--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -65,49 +65,52 @@ RSpec.describe ReportsController do
     end
 
     context "reading" do
-      it "does not mark read for today's unfinished report" do
-        user = create(:user)
-        expect(user.report_view).to be_nil
-        login_as(user)
-        get :show, id: 'daily'
-        expect(user.reload.report_view).to be_nil
-      end
+      ["Hawaii", "UTC", "Auckland", nil].each do |place|
+        context "in #{place}" do
+          let(:user) { create(:user, timezone: place) }
 
-      it "marks read for previous days" do
-        user = create(:user)
-        expect(user.report_view).to be_nil
-        login_as(user)
-        get :show, id: 'daily', day: 2.days.ago.to_date.to_s
-        expect(user.reload.report_view).not_to be_nil
-        expect(user.report_view.read_at.to_date).to eq(2.days.ago.to_date)
-      end
+          it "does not mark read for today's unfinished report" do
+            expect(user.report_view).to be_nil
+            login_as(user)
+            get :show, id: 'daily'
+            expect(user.reload.report_view).to be_nil
+          end
 
-      it "does not mark read for ignoring users" do
-        user = create(:user, ignore_unread_daily_report: true)
-        expect(user.report_view).to be_nil
-        login_as(user)
-        get :show, id: 'daily', day: 2.days.ago.to_date.to_s
-        expect(user.report_view).to be_nil
-      end
+          it "marks read for previous days" do
+            expect(user.report_view).to be_nil
+            login_as(user)
+            get :show, id: 'daily', day: 2.days.ago.to_date.to_s
+            expect(user.reload.report_view).not_to be_nil
+            expect(user.report_view.read_at.in_time_zone(place).to_date).to eq(2.days.ago.to_date)
+          end
 
-      it "marks read for previous days when already read once" do
-        user = create(:user)
-        expect(user.report_view).to be_nil
-        DailyReport.mark_read(user, 3.day.ago.to_date)
-        login_as(user)
-        get :show, id: 'daily', day: 2.days.ago.to_date.to_s
-        expect(user.reload.report_view).not_to be_nil
-        expect(user.report_view.read_at.to_date).to eq(2.days.ago.to_date)
-      end
+          it "does not mark read for ignoring users" do
+            user.update_attributes(ignore_unread_daily_report: true)
+            expect(user.report_view).to be_nil
+            login_as(user)
+            get :show, id: 'daily', day: 2.days.ago.to_date.to_s
+            expect(user.report_view).to be_nil
+          end
 
-      it "does not mark read if you've read more recently" do
-        user = create(:user)
-        expect(user.report_view).to be_nil
-        DailyReport.mark_read(user, 2.day.ago.to_date)
-        login_as(user)
-        get :show, id: 'daily', day: 3.days.ago.to_date.to_s
-        expect(user.reload.report_view).not_to be_nil
-        expect(user.report_view.read_at.to_date).to eq(2.days.ago.to_date)
+          it "marks read for previous days when already read once" do
+            expect(user.report_view).to be_nil
+            DailyReport.mark_read(user, 3.days.ago.to_date)
+            login_as(user)
+            get :show, id: 'daily', day: 2.days.ago.to_date.to_s
+            expect(user.reload.report_view).not_to be_nil
+            expect(user.report_view.read_at.to_date).to eq(2.days.ago.to_date)
+          end
+
+          it "does not mark read if you've read more recently" do
+            user = create(:user)
+            expect(user.report_view).to be_nil
+            DailyReport.mark_read(user, 2.days.ago.to_date)
+            login_as(user)
+            get :show, id: 'daily', day: 3.days.ago.to_date.to_s
+            expect(user.reload.report_view).not_to be_nil
+            expect(user.report_view.read_at.to_date).to eq(2.days.ago.to_date)
+          end
+        end
       end
     end
   end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -65,10 +65,6 @@ RSpec.describe ReportsController do
     end
 
     context "reading" do
-      before(:each) do
-        Time.zone = "UTC"
-      end
-
       it "does not mark read for today's unfinished report" do
         user = create(:user)
         expect(user.report_view).to be_nil

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -69,6 +69,9 @@ RSpec.describe ReportsController do
         context "in #{place}" do
           let(:user) { create(:user, timezone: place) }
 
+          # the user's report_view.read_at should be set in their relevant timezone, since that's what will occur in the application
+          # the user's report_view.read_at should be read as a date *in their timezone*, since again, that's what happens in the application
+
           it "does not mark read for today's unfinished report" do
             expect(user.report_view).to be_nil
             login_as(user)


### PR DESCRIPTION
This should fix the tests to work in any timezone without forcing the server timezone pre-tests, and also tests reading things across the world (Hawaii, UTC, Auckland, which should test the full day-or-two at any moment in time).