### PR TITLE
Delete GalleriesIcon when Gallery deleted, for association callbacks

### DIFF
--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -2,7 +2,7 @@ class Gallery < ActiveRecord::Base
   belongs_to :user
   belongs_to :cover_icon, class_name: Icon
 
-  has_many :galleries_icons
+  has_many :galleries_icons, dependent: :destroy
   has_many :icons, -> { order('LOWER(keyword)') }, through: :galleries_icons
 
   has_many :characters_galleries

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -313,6 +313,19 @@ RSpec.describe GalleriesController do
       expect(flash[:success]).to eq("Gallery deleted successfully.")
       expect(Gallery.find_by_id(gallery.id)).to be_nil
     end
+
+    it "modifies associations relevantly" do
+      user_id = login
+      gallery = create(:gallery, user_id: user_id)
+      icon = create(:icon, user_id: user_id)
+      gallery.icons << icon
+      gallery.save
+      expect(icon.reload.has_gallery).to be_true
+      delete :destroy, id: gallery.id
+      expect(response).to redirect_to(galleries_url)
+      expect(flash[:success]).to eq("Gallery deleted successfully.")
+      expect(icon.reload.has_gallery).not_to be_true
+    end
   end
 
   describe "GET add" do


### PR DESCRIPTION
So icons will have "has_gallery" set appropriately, and so GalleriesIcon will not exist for non-extant galleries.

This was meaning, previously, that if you deleted galleries the icons from them wouldn't be placed in galleryless.

Possibly fixes #259, but we might be missing other cases around setting `has_gallery`; it seems like this needs some sort of audit.