### PR TITLE
Improve flat mode with new div classes and add update times

### DIFF
--- a/app/views/posts/_generate_flat.haml
+++ b/app/views/posts/_generate_flat.haml
@@ -1,7 +1,6 @@
 - 1.upto((replies.count(:all) / 250.0).ceil).each do |index|
   - replies.paginate(per_page: 250, page: index).each do |reply|
-    - klass = cycle('even'.freeze, 'odd'.freeze)
-    .post-container{class: klass}
+    .post-container{class: 'post-reply'}
       <a id="reply-#{reply.id}" class="noheight"> </a>
       .padding-10
         .post-info-box
@@ -20,7 +19,12 @@
             = image_tag "/images/link.png".freeze, title: 'Permalink'.freeze, alt: 'Permalink'.freeze
           = link_to Rails.application.routes.url_helpers.post_path(reply.post_id, unread: true, at_id: reply.id), method: :put do
             = image_tag '/images/eye.png'.freeze, title: 'Mark Unread Here'.freeze, alt: 'Eye'.freeze
-        .post-content= sanitize_written_content(reply.content).html_safe
+        .post-content= sanitize_written_content(reply.content.to_s).html_safe
       .post-footer
         .right-align>
-          .padding-5> Posted #{pretty_time(reply.created_at, ApplicationHelper::TIME_FORMAT)}
+          .padding-5>
+            = precede 'Posted '.freeze do
+              %span.post-posted=pretty_time(reply.created_at, ApplicationHelper::TIME_FORMAT)
+            - if reply.created_at.to_i != reply.last_updated.to_i
+              = precede ' | Updated '.freeze do
+                %span.post-updated=pretty_time(reply.last_updated, ApplicationHelper::TIME_FORMAT)

--- a/app/views/posts/flat.haml
+++ b/app/views/posts/flat.haml
@@ -22,7 +22,7 @@
         %span#post-title= @post.subject
       - if @post.description.present?
         .post-subheader= sanitize_post_description(@post.description).html_safe
-      .post-container{class: 'odd'}
+      .post-container{class: 'post-post'}
         .padding-10
           .post-info-box
             - if @post.icon
@@ -40,8 +40,14 @@
               = image_tag "/images/link.png", title: 'Permalink', alt: 'Permalink'
             = link_to post_path(@post, unread: true), method: :put do
               = image_tag '/images/eye.png', title: 'Mark Unread Here', alt: 'Eye'
-          .post-content= sanitize_written_content(@post.content).html_safe
+          .post-content= sanitize_written_content(@post.content.to_s).html_safe
         .post-footer
           .right-align>
-            .padding-5> Posted #{pretty_time(@post.created_at, ApplicationHelper::TIME_FORMAT)}
+            .padding-5>
+              - if @post.created_at
+                = precede 'Posted ' do
+                  %span.post-posted=pretty_time(@post.created_at, ApplicationHelper::TIME_FORMAT)
+              - if @post.created_at.to_i != @post.last_updated.to_i
+                = precede ' | Updated ' do
+                  %span.post-updated=pretty_time(@post.last_updated, ApplicationHelper::TIME_FORMAT)
       = @post.flat_post.content.try(:html_safe)


### PR DESCRIPTION
Some flat mode styling was broken as the posts and replies used to use even/odd instead of post-reply and post-post (see, e.g., blockquotes), and they also didn't include edit times. This should fix that (but might need old posts to have their flat modes regenerated at some point).