### PR TITLE
Remove duplicate set_has_gallery from GalleriesIcon

### DIFF
--- a/app/models/galleries_icon.rb
+++ b/app/models/galleries_icon.rb
@@ -7,10 +7,6 @@ class GalleriesIcon < ActiveRecord::Base
   after_destroy :unset_has_gallery
   validates :gallery_id, uniqueness: { scope: :icon_id }
 
-  def set_has_gallery
-    icon.update_attributes(has_gallery: true)
-  end
-
   def unset_has_gallery
     return if icon.galleries.present?
     icon.update_attributes(has_gallery: false)


### PR DESCRIPTION
Turns out we had two of these due to accidentally doing this in two separate commits, 18134a5c0268520a74c6b6d6027d837e4cd692c4 and 8bfeae7f99ee80fd7d83706f8d2193503769e207. Oops.