### PR TITLE
Add Travis caching for bundler to speed builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
 services:
   - redis-server
   - postgresql
+cache: bundler
 before_script:
   - psql -c 'create database glowfic_test;' -U postgres
 script:


### PR DESCRIPTION
As per https://docs.travis-ci.com/user/caching/#Bundler. It also says:

> **To use the caching feature**, in your repository settings, set *Build branch updates* to *ON*.

We currently don't have that enabled because there were a lot of commits and so a lot of builds, I think. There wasn't a strong reason behind it except – maybe we had emails enabled for it? This is no longer a problem, as far as I know.

Builds take a few minutes at present which is kinda annoying. This should reduce that by quite a lot.

(Note https://docs.travis-ci.com/user/caching/#Clearing-Caches in the case we need to clear a bogus cache.)