### PR TITLE
Update Discord link to a non-expired permanent invite link

### DIFF
--- a/app/views/sessions/index.haml
+++ b/app/views/sessions/index.haml
@@ -9,5 +9,5 @@ Welcome to the Glowfic Constellation. Admire the tiny, tiny words.
   %ul
     %li= link_to "Alicorn's forum", 'http://alicorn.elcenia.com/board/index.php', target: '_blank'
     %li= link_to "IRC", 'https://client00.chat.mibbit.com/?channel=%23glowfic&server=irc.psigenix.net', target: '_blank'
-    %li= link_to "Discord", 'https://discord.gg/Z4acTQ', target: '_blank'
+    %li= link_to "Discord", 'https://discord.gg/6vjWdWp', target: '_blank'
     %li= link_to "Tumblr", 'http://alicorn.elcenia.com/board/viewtopic.php?f=10&t=615', target: '_blank'


### PR DESCRIPTION
The one previously on the site went mysteriously expired, for some reason. This is the permanent one Tamien has been using which is still active.