### PR TITLE
Fix wrapping of long names in `post-info-box`

### DIFF
--- a/app/assets/stylesheets/replies.css
+++ b/app/assets/stylesheets/replies.css
@@ -70,7 +70,16 @@
 .post-container { overflow: auto; }
 #content > .post-container { padding: 0; }
 .post-edit-box { float: right; margin-left: 10px; margin-bottom: 5px; padding: 5px; }
-.post-info-box { text-align: center; padding: 0; float: left; margin-right: 10px; margin-bottom: 5px; width: 150px; overflow: visible; }
+.post-info-box {
+  text-align: center;
+  padding: 0;
+  float: left;
+  margin-right: 10px;
+  margin-bottom: 5px;
+  width: 150px;
+  overflow: visible;
+  overflow-wrap: break-word;
+}
 .post-icon, #current-icon-dropdown { background-color: #B0BBA9; }
 .post-icon { padding: 0; height: 120px; }
 .post-icon img, .post-icon div { margin-top: 10px; margin-right: 10px; margin-left: 10px; }


### PR DESCRIPTION
Especially noticeable on Firefox where hyphens don't seem to be treated as linebreak opportunities. There does not seem to be an easy way to force it to recognize them as such.

See an example of bad behavior at:
https://glowfic.com/replies/592925#reply-592925

Screenshot before:

![](https://i.gyazo.com/1f5bd1d6d45a3be295f3c642e4904fd9.png)

Screenshot after:
![](https://i.gyazo.com/85fcaf8394eb53da36a8aab58e3e426d.png)

Screenshot on Chrome:
![](https://i.gyazo.com/388de15ecdd68fdc665bd97dc764f417.png)