### PR TITLE
Fix icon matching in PostScraper with accessibility descriptions

### DIFF
--- a/lib/post_scraper.rb
+++ b/lib/post_scraper.rb
@@ -217,11 +217,28 @@ class PostScraper < Object
       icon = tag.character.icons.where(keyword: keyword).first
       tag.icon = icon and return if icon
 
+      # split out the last " (...)" from the keyword (which should be at the very end), if applicable, for without_desc
+      without_desc = nil
+      if keyword.end_with?(')')
+        lbracket = keyword.rindex(' (')
+        if lbracket && lbracket > 0 # without_desc must be non-empty
+          without_desc = keyword[0...lbracket]
+          icon = tag.character.icons.where(keyword: without_desc).first
+          tag.icon = icon and return if icon
+        end
+      end
+
       # kappa icon handling - icons are prefixed
       if tag.user_id == 3 && (spaceindex = keyword.index(" "))
         unprefixed = keyword.slice(spaceindex, keyword.length)
         icon = tag.character.icons.detect { |i| i.keyword.ends_with?(unprefixed) }
         tag.icon = icon and return if icon
+
+        if without_desc
+          unprefixed = without_desc.slice(spaceindex, without_desc.length)
+          icon = tag.character.icons.detect { |i| i.keyword.ends_with?(unprefixed) }
+          tag.icon = icon and return if icon
+        end
       end
     end
 

--- a/spec/lib/post_scraper_spec.rb
+++ b/spec/lib/post_scraper_spec.rb
@@ -235,4 +235,34 @@ RSpec.describe PostScraper do
     expect(Icon.count).to eq(1)
     expect(tag.icon_id).to eq(icon.id)
   end
+
+  it "handles icons with descriptions" do
+    user = create(:user)
+    char = create(:character, user: user)
+    gallery = create(:gallery, user: user)
+    char.galleries << gallery
+    icon = create(:icon, user: user, keyword: 'keyword blah')
+    gallery.icons << icon
+    tag = build(:reply, user: user, character: char)
+    expect(tag.icon_id).to be_nil
+    scraper = PostScraper.new('')
+    scraper.send(:set_from_icon, tag, 'http://irrelevanturl.com', 'keyword blah (Accessbility description.)')
+    expect(Icon.count).to eq(1)
+    expect(tag.icon_id).to eq(icon.id)
+  end
+
+  it "handles kappa icons with descriptions" do
+    kappa = create(:user, id: 3)
+    char = create(:character, user: kappa)
+    gallery = create(:gallery, user: kappa)
+    char.galleries << gallery
+    icon = create(:icon, user: kappa, keyword: '⑮ keyword blah')
+    gallery.icons << icon
+    tag = build(:reply, user: kappa, character: char)
+    expect(tag.icon_id).to be_nil
+    scraper = PostScraper.new('')
+    scraper.send(:set_from_icon, tag, 'http://irrelevanturl.com', 'f.1 keyword blah (Accessbility description.)')
+    expect(Icon.count).to eq(1)
+    expect(tag.icon_id).to eq(icon.id)
+  end
 end


### PR DESCRIPTION
Kappa has various icons with accessibility descriptions, which Dreamwidth places into icon `title` attributes in parentheses next to the keyword. These should be stripped when matching for duplicates, as this does.

Otherwise we get a lot of parenthesized version of keywords in galleries:

![image](https://user-images.githubusercontent.com/577128/29240498-b5dc8f76-7f5e-11e7-9d34-0738722719fc.png)

- https://www.glowfic.com/galleries/609