### PR TITLE
Add tests for post subquery attachments

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -58,7 +58,7 @@ class Post < ActiveRecord::Base
   scope :no_tests, -> { where('posts.board_id != ?', Board::ID_SITETESTING) }
 
   scope :with_has_content_warnings, -> {
-    select("(SELECT tags.id FROM tags LEFT JOIN post_tags ON tags.id = post_tags.tag_id WHERE tags.type = 'ContentWarning' AND post_tags.post_id = posts.id LIMIT 1) AS has_content_warnings")
+    select("(SELECT tags.id IS NOT NULL FROM tags LEFT JOIN post_tags ON tags.id = post_tags.tag_id WHERE tags.type = 'ContentWarning' AND post_tags.post_id = posts.id LIMIT 1) AS has_content_warnings")
   }
 
   scope :with_author_ids, -> {
@@ -69,7 +69,7 @@ class Post < ActiveRecord::Base
   }
 
   scope :with_reply_count, -> {
-    select('(SELECT COUNT(*) FROM replies WHERE replies.post_id = posts.id GROUP BY posts.id) AS reply_count')
+    select('(SELECT COUNT(*) FROM replies WHERE replies.post_id = posts.id) AS reply_count')
   }
 
   def visible_to?(user)
@@ -225,7 +225,7 @@ class Post < ActiveRecord::Base
   end
 
   def reply_count
-    return read_attribute(:reply_count) || 0 if has_attribute?(:reply_count)
+    return read_attribute(:reply_count) if has_attribute?(:reply_count)
     replies.count
   end
 


### PR DESCRIPTION
- Removes the `GROUP BY` clause from `with_reply_count`, making it default to 0 not nil when no replies exist (and hence reverts 954cae212d49d4199ebd2e8d469f8c3e1d3e5c47).
- Makes `has_content_warnings` a boolean (by checking that `tags.id IS NOT NULL` instead of just selecting `tags.id`)
- Adds a test with posts of varying:
  * Author counts (1, 2, 3) – checks `authors` and `author_ids` for each
  * Content warnings (0, 1, 2) – checks `has_content_warnings?` and `content_warnings` for each
  * Reply counts (0, 1, 35) – checks `reply_count` for each

This should be pretty exhaustive for post list needs, at least at present.