### PR TITLE
Display a warning when the user logs in/out in another tab

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,6 +22,38 @@ $(document).ready(function() {
     width: '100%',
     minimumResultsForSearch: 10,
   });
+
+  // Set localStorage if login status has changed
+  // storage values are usually strings, cast to be sure
+  var loggedInKey = 'loggedIn';
+  if (window.gon) {
+    var wasLoggedIn = gon.logged_in.toString();
+    if (localStorage.getItem(loggedInKey) !== wasLoggedIn) {
+      localStorage.setItem(loggedInKey, wasLoggedIn);
+    }
+  }
+
+  // Watch for login status change
+  // Display warning prompting user to reload when it occurs
+  window.addEventListener('storage', function(e) {
+    // skip non-login-status changes
+    if (e.key !== loggedInKey) return;
+    console.log(e.key, '–', e.oldValue, '→', e.newValue);
+    // skip creation and deletion of storage key (when someone loads the site for the first time or clears cache)
+    if (e.oldValue === null || e.newValue === null) return;
+
+    // find or create the warning box
+    var warningBox = $('#login_status_warning');
+    if (warningBox.length === 0) {
+      warningBox = $('<div class="flash inbox pointer" id="login_status_warning">');
+      warningBox.click(function() { $(this).remove(); });
+      $('#header').after(warningBox);
+    }
+
+    // set the relevant warning text
+    var msgText = 'logged ' + (e.newValue === 'true' ? 'in' : 'out');
+    warningBox.html('You have <strong>' + msgText + '</strong> in another tab. Please reload before submitting any forms.');
+  });
 });
 
 function add_parameter(url, param, value){

--- a/app/assets/stylesheets/layout.css
+++ b/app/assets/stylesheets/layout.css
@@ -63,6 +63,9 @@
 .flash.success { background-color: #DDEEDD; }
 .flash.inbox { background-color: #DDDDEE; }
 
+/* Login / logout warning */
+#login_status_warning { position: absolute; top: 0; width: 100%; box-sizing: border-box; }
+
 /* List Tables */
 #content table { width: 100%; }
 #content th { background-color: #8B8687; color: #EEEEEE; padding: 15px; font-size: 18px; font-weight: normal; }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   before_filter :check_permanent_user
   before_filter :show_password_warning
   before_filter :require_glowfic_domain
+  before_filter :set_login_gon
   around_filter :set_timezone
   after_filter :store_location
 
@@ -95,6 +96,10 @@ class ApplicationController < ActionController::Base
     return if request.host.include?('glowfic.com')
     glowfic_url = root_url(host: ENV['DOMAIN_NAME'], protocol: 'https')[0...-1] + request.fullpath # strip double slash
     redirect_to glowfic_url, status: :moved_permanently
+  end
+
+  def set_login_gon
+    gon.logged_in = logged_in?
   end
 
   def post_or_reply_link(reply)

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe SessionsController do
     it "works when logged out" do
       get :index
       expect(response.status).to eq(200)
+      expect(controller.gon.logged_in).not_to be_true
     end
 
     it "works when logged in" do
       login
       get :index
       expect(response).to have_http_status(200)
+      expect(controller.gon.logged_in).to be_true
     end
   end
 


### PR DESCRIPTION
Uses `gon` to be notified of login status. This is in an attempt to reduce the prevalence of InvalidAuthenticityToken errors (see issue #282), by notifying users when their forms become invalid due to a change in login status.