### PR TITLE
Make board#delete delete sections too, test move to sandboxes

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -5,7 +5,7 @@ class Board < ActiveRecord::Base
   ID_SITETESTING = 4
 
   has_many :posts
-  has_many :board_sections
+  has_many :board_sections, dependent: :destroy
   has_many :favorites, as: :favorite, dependent: :destroy
   belongs_to :creator, class_name: User
 

--- a/spec/controllers/boards_controller_spec.rb
+++ b/spec/controllers/boards_controller_spec.rb
@@ -316,6 +316,20 @@ RSpec.describe BoardsController do
       expect(response).to redirect_to(boards_url)
       expect(flash[:success]).to eq("Continuity deleted.")
     end
+
+    it "moves posts to sandboxes" do
+      board = create(:board)
+      section = create(:board_section, board: board)
+      post = create(:post, board: board, section: section)
+      login_as(board.creator)
+      delete :destroy, id: board.id
+      expect(response).to redirect_to(boards_url)
+      expect(flash[:success]).to eq('Continuity deleted.')
+      post.reload
+      expect(post.board_id).to eq(3)
+      expect(post.section).to be_nil
+      expect(BoardSection.find_by_id(section.id)).to be_nil
+    end
   end
 
   describe "POST mark" do


### PR DESCRIPTION
Previously board sections still existed after destroying a board, meaning you could visit the section page without a board (causing a crash) and the breadcrumbs on the post would then erroneously display `Continuities » Sandboxes » Section » Post` (despite `Section` not being in `Sandboxes`).

This should fix that, and adds a test that the sections are destroyed at the same time.