### PR TITLE
Fix some styling – th.header, groupheader color

### DIFF
--- a/app/assets/stylesheets/layouts/starry.css
+++ b/app/assets/stylesheets/layouts/starry.css
@@ -8,7 +8,7 @@ body { background-color: #6C697C; }
 #content th, .post-header { background-color: #13132F; }
 #content .sub { color: #F3F3F3; }
 #content .sub, .post-navheader, .subber { background-color: #182152; }
-#content .subber { background-color: #13132F; }
+#content .subber, #content th.subber { background-color: #13132F; }
 #content .beige { background-color: #484357; color: #DADADA; }
 #content .beige a, #content th a, .post-header a { color: #B5AFCB; }
 #content .beige a:visited, #content th a:visited, .post-header a:visited { color: #9C9AA4; }

--- a/app/assets/stylesheets/layouts/starrydark.css
+++ b/app/assets/stylesheets/layouts/starrydark.css
@@ -7,7 +7,7 @@ body { background-color: #211E2F; color: #DADADA; }
 #content th, .post-header { background-color: #0D0B1E; }
 #content .sub { color: #F3F3F3; }
 #content .sub, .post-navheader, .subber { background-color: #131937; }
-#content .subber { background-color: #0D0B1E; color: #DADADA; }
+#content .subber, #content th.subber { background-color: #0D0B1E; color: #DADADA; }
 #content .beige { background-color: #484357; color: #DADADA; }
 #content .beige a, #content th a, .post-header a { color: #B5AFCB; }
 #content .beige a:visited, #content th a:visited, .post-header a:visited { color: #9C9AA4; }

--- a/app/assets/stylesheets/layouts/starrylight.css
+++ b/app/assets/stylesheets/layouts/starrylight.css
@@ -7,7 +7,7 @@ body { background-color: #B0AFB7; }
 #content th, .post-header { background-color: #42416E; }
 #content .sub { color: #F3F3F3; }
 #content .sub, .post-navheader, .flash.subber { background-color: #8287A2; }
-#content .beige, #content .subber, .subber { background-color: #6F658D; color: #DADADA; }
+#content .beige, #content .subber, #content th.subber, .subber { background-color: #6F658D; color: #DADADA; }
 #content .beige a, #content th a, .post-header a { color: #F3F3F3; }
 #content .beige a:visited, #content th a:visited { color: #C6C6E5; }
 

--- a/app/views/characters/_list_view.haml
+++ b/app/views/characters/_list_view.haml
@@ -8,7 +8,7 @@
 - elsif @user.character_groups.exists?
   - @user.character_groups.order('id asc').each do |group|
     %tr
-      %th.subber{colspan: 6}
+      %th.sub{colspan: 6}
         Group:
         = group.name
     - group.characters.map(&:template).uniq.compact.sort_by(&:name).each do |template|
@@ -17,14 +17,14 @@
       = render partial: 'characters/list_section', locals: {name: "No Template", characters: group.characters.where(template_id: nil).order('name asc')}
   - if @user.characters.where(character_group_id: nil).exists?
     %tr
-      %th{colspan: 6} Ungrouped Characters
+      %th.sub{colspan: 6} Ungrouped Characters
     - @user.characters.where(character_group_id: nil).includes(:template).map(&:template).uniq.compact.sort_by(&:name).each do |template|
       - next if template.characters.where('character_group_id is not null').exists?
       = render partial: 'characters/list_section', locals: {name: template, characters: template.characters}
     = render partial: 'characters/list_section', locals: {name: "No Template", characters: @user.characters.where(character_group_id: nil).where(template_id: nil).order('name asc')}
 
 - elsif @user.characters.exists?
-  - @user.templates.order('name asc').each do |template|  
+  - @user.templates.order('name asc').each do |template|
     = render partial: 'characters/list_section', locals: {name: template, characters: template.characters}
 
   - unless @user.characters.where(template_id: nil).count.zero?


### PR DESCRIPTION
The first change was originally done to fix the character group header font color in `starry{,light,dark}`, but also affects other locations (such as the "Edit Icons" text when editing a gallery). The second change makes CharacterGroups headers consistently into `th.sub`s, so they're the header color between plain `th` and `th.subber` (since they appear as the second-level header).

In Starry Light and Starry, some headers are unreadable without this change.