### PR TITLE
Prevent ScrapePostJobSpec from outputting during tests

### DIFF
--- a/spec/jobs/scrape_post_job_spec.rb
+++ b/spec/jobs/scrape_post_job_spec.rb
@@ -1,7 +1,10 @@
 require "spec_helper"
 
 RSpec.describe ScrapePostJob do
-  before(:each) do ResqueSpec.reset! end
+  before(:each) do
+    ResqueSpec.reset!
+    allow(STDOUT).to receive(:puts)
+  end
 
   it "creates the correct objects" do
     url = 'http://wild-pegasus-appeared.dreamwidth.org/403.html?style=site&view=flat'


### PR DESCRIPTION
Really minor thing, but it keeps outputting during tests and messing up the display of the dots. This stubs STDOUT.puts so it doesn't actually output for the relevant tests.