### PR TITLE
Attempt to fix cookie domains a second time, after first was found possibly wrong

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 options = if Rails.env.production?
-  {domain: 'glowfic.com', tld_length: 2}
+  {domain: ['glowfic.com', '.glowfic-staging.herokuapp.com'], tld_length: 2}
 elsif Rails.env.development?
   {domain: 'localhost', tld_length: 2}
 else

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,9 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
 options = if Rails.env.production?
-  {domain: ['.glowfic.com', '.glowfic-staging.herokuapp.com']}
+  {domain: 'glowfic.com', tld_length: 2}
 elsif Rails.env.development?
-  {domain: '.localhost'}
+  {domain: 'localhost', tld_length: 2}
 else
   {}
 end


### PR DESCRIPTION
Test results don't make clear what's going on behind the scenes. `notlocalhost.com` seems to be treated differently from `glowfix.com`, which is treated the same as `localhost.ssl`; the former has issues with any cross-domain stuff, and the latter work perfectly on both `domain: glowfix.com` and `domain: .glowfix.com`. Localhost fails on any subdomains after various attempts, and on the root if `domain: .localhost` is used.

I thought it prudent to try to add to the array instead of modifying any current values. Maybe this will crash and burn. I'll test it tomorrow.