### PR TITLE
Notify users of new posts before doing flat mode generation

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-worker: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=7 QUEUES=mailer,high,* bundle exec rake resque:work
+worker: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=7 QUEUES=mailer,notifier,high,* bundle exec rake resque:work

--- a/app/jobs/notify_followers_of_new_post_job.rb
+++ b/app/jobs/notify_followers_of_new_post_job.rb
@@ -1,5 +1,5 @@
 class NotifyFollowersOfNewPostJob < BaseJob
-  @queue = :high
+  @queue = :notifier
   @retry_limit = 5
   @expire_retry_key_after = 3600
 


### PR DESCRIPTION
Fixes #308. Flat posts take relatively long to generate, whereas notifications don't take much time at all. Notifications should go first to get the queue gone faster.