### PR TITLE
Fix deprecation notices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ services:
   - redis-server
   - postgresql
 cache: bundler
+before_install:
+  - gem install bundler
 before_script:
   - psql -c 'create database glowfic_test;' -U postgres
 script:

--- a/db/migrate/20150413062555_create_users.rb
+++ b/db/migrate/20150413062555_create_users.rb
@@ -6,7 +6,7 @@ class CreateUsers < ActiveRecord::Migration
       t.integer :avatar_id
       t.integer :active_character_id
       t.integer :per_page, :default => 25
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :users, :username, unique: true
   end

--- a/db/migrate/20150413233206_create_icons.rb
+++ b/db/migrate/20150413233206_create_icons.rb
@@ -4,7 +4,7 @@ class CreateIcons < ActiveRecord::Migration
       t.integer :user_id, :null => false
       t.string :url, :null => false
       t.string :keyword, :null => false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :icons, :user_id
     add_index :icons, :keyword

--- a/db/migrate/20150414195302_create_templates.rb
+++ b/db/migrate/20150414195302_create_templates.rb
@@ -3,7 +3,7 @@ class CreateTemplates < ActiveRecord::Migration
     create_table :templates do |t|
       t.integer :user_id, :null => false
       t.string :name
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :templates, :user_id
   end

--- a/db/migrate/20150414195307_create_characters.rb
+++ b/db/migrate/20150414195307_create_characters.rb
@@ -8,7 +8,7 @@ class CreateCharacters < ActiveRecord::Migration
       t.integer :gallery_id
       t.integer :template_id
       t.integer :default_icon_id
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :characters, :screenname, unique: true
     add_index :characters, :user_id

--- a/db/migrate/20150414200044_create_galleries.rb
+++ b/db/migrate/20150414200044_create_galleries.rb
@@ -4,7 +4,7 @@ class CreateGalleries < ActiveRecord::Migration
       t.integer :user_id, :null => false
       t.string :name, :null => false
       t.integer :cover_icon_id
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :galleries, :user_id
   end

--- a/db/migrate/20150415221435_create_boards.rb
+++ b/db/migrate/20150415221435_create_boards.rb
@@ -4,7 +4,7 @@ class CreateBoards < ActiveRecord::Migration
       t.string :name, :null => false
       t.integer :creator_id, :null => false
       t.integer :coauthor_id
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150415221456_create_posts.rb
+++ b/db/migrate/20150415221456_create_posts.rb
@@ -8,7 +8,7 @@ class CreatePosts < ActiveRecord::Migration
       t.integer :character_id
       t.integer :icon_id
       t.integer :privacy, :null => false, :default => 0
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :posts, :board_id
     add_index :posts, :user_id

--- a/db/migrate/20150417214406_create_replies.rb
+++ b/db/migrate/20150417214406_create_replies.rb
@@ -7,7 +7,7 @@ class CreateReplies < ActiveRecord::Migration
       t.integer :character_id
       t.integer :icon_id
       t.integer :thread_id
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :replies, :post_id
     add_index :replies, :user_id

--- a/db/migrate/20150704060600_create_post_viewers.rb
+++ b/db/migrate/20150704060600_create_post_viewers.rb
@@ -3,7 +3,7 @@ class CreatePostViewers < ActiveRecord::Migration
     create_table :post_viewers do |t|
       t.integer :post_id, :null => false
       t.integer :user_id, :null => false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :post_viewers, :post_id
   end

--- a/db/migrate/20151125201254_create_messages.rb
+++ b/db/migrate/20151125201254_create_messages.rb
@@ -13,7 +13,7 @@ class CreateMessages < ActiveRecord::Migration
       t.boolean :marked_inbox, :default => false
       t.boolean :marked_outbox, :default => false
       t.datetime :read_at
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :messages, :sender_id
     add_index :messages, [:recipient_id, :unread]

--- a/db/migrate/20151127210938_create_board_sections.rb
+++ b/db/migrate/20151127210938_create_board_sections.rb
@@ -5,7 +5,7 @@ class CreateBoardSections < ActiveRecord::Migration
       t.string :name, :null => false
       t.integer :status, :null => false, :default => 0
       t.integer :section_order, :null => false
-      t.timestamps
+      t.timestamps null: true
     end
     add_column :posts, :section_id, :integer
     add_column :posts, :section_order, :integer

--- a/db/migrate/20160218041741_create_board_view.rb
+++ b/db/migrate/20160218041741_create_board_view.rb
@@ -6,7 +6,7 @@ class CreateBoardView < ActiveRecord::Migration
       t.boolean :ignored, :default => false
       t.boolean :notify_message, :default => false
       t.boolean :notify_email, :default => false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :board_views, [:user_id, :board_id]
   end

--- a/db/migrate/20160218041751_create_post_view.rb
+++ b/db/migrate/20160218041751_create_post_view.rb
@@ -6,7 +6,7 @@ class CreatePostView < ActiveRecord::Migration
       t.boolean :ignored, :default => false
       t.boolean :notify_message, :default => false
       t.boolean :notify_email, :default => false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :post_views, [:user_id, :post_id]
   end

--- a/db/migrate/20160412035353_create_reply_drafts.rb
+++ b/db/migrate/20160412035353_create_reply_drafts.rb
@@ -7,7 +7,7 @@ class CreateReplyDrafts < ActiveRecord::Migration
       t.integer :character_id
       t.integer :icon_id
       t.integer :thread_id
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :reply_drafts, [:post_id, :user_id]
     add_column :users, :default_editor, :string, default: 'rtf'

--- a/db/migrate/20160416031844_create_password_reset.rb
+++ b/db/migrate/20160416031844_create_password_reset.rb
@@ -4,7 +4,7 @@ class CreatePasswordReset < ActiveRecord::Migration
       t.integer :user_id, null: false
       t.string :auth_token, null: false
       t.boolean :used, default: false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :password_resets, :auth_token, unique: true
     add_index :password_resets, [:user_id, :created_at]

--- a/db/migrate/20160429033350_create_tags.rb
+++ b/db/migrate/20160429033350_create_tags.rb
@@ -3,7 +3,7 @@ class CreateTags < ActiveRecord::Migration
     create_table :tags do |t|
       t.integer :user_id, null: false
       t.string :name, null: false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :tags, :name
 
@@ -11,7 +11,7 @@ class CreateTags < ActiveRecord::Migration
       t.integer :post_id, null: false
       t.integer :tag_id, null: false
       t.boolean :suggested, default: false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :post_tags, :post_id
     add_index :post_tags, :tag_id

--- a/db/migrate/20160702213101_create_board_authors.rb
+++ b/db/migrate/20160702213101_create_board_authors.rb
@@ -3,7 +3,7 @@ class CreateBoardAuthors < ActiveRecord::Migration
     create_table :board_authors do |t|
       t.integer :user_id, null: false
       t.integer :board_id, null: false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :board_authors, :board_id
     add_index :board_authors, :user_id

--- a/db/migrate/20160716055457_add_tag_types.rb
+++ b/db/migrate/20160716055457_add_tag_types.rb
@@ -6,7 +6,7 @@ class AddTagTypes < ActiveRecord::Migration
     create_table :character_tags do |t|
       t.integer :character_id, null: false
       t.integer :tag_id, null: false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :character_tags, :character_id
     add_index :character_tags, :tag_id

--- a/db/migrate/20160827161416_create_favorites.rb
+++ b/db/migrate/20160827161416_create_favorites.rb
@@ -4,7 +4,7 @@ class CreateFavorites < ActiveRecord::Migration
       t.integer :user_id, null: false
       t.integer :favorite_id, null: false
       t.string :favorite_type, null: false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :favorites, :user_id
     add_index :favorites, [:favorite_id, :favorite_type]

--- a/db/migrate/20170103184309_create_flat_posts.rb
+++ b/db/migrate/20170103184309_create_flat_posts.rb
@@ -3,7 +3,7 @@ class CreateFlatPosts < ActiveRecord::Migration
     create_table :flat_posts do |t|
       t.integer :post_id, :null => false
       t.text :content
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :flat_posts, :post_id
     ids = Post.pluck(:id)

--- a/db/migrate/20170210013443_create_character_aliases.rb
+++ b/db/migrate/20170210013443_create_character_aliases.rb
@@ -3,7 +3,7 @@ class CreateCharacterAliases < ActiveRecord::Migration
     create_table :character_aliases do |t|
       t.integer :character_id, null: false
       t.string :name, null: false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :character_aliases, :character_id
 

--- a/db/migrate/20170612015922_add_report_view.rb
+++ b/db/migrate/20170612015922_add_report_view.rb
@@ -3,7 +3,7 @@ class AddReportView < ActiveRecord::Migration
     create_table :report_views do |t|
       t.integer :user_id, :null => false
       t.datetime :read_at
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :report_views, :user_id
   end


### PR DESCRIPTION
- Add `null: true` to `t.timestamps` per deprecation notice (in Rails 5 the default will become `null: false`, and DB migrations should not change behavior due to versions)
- Update `bundler` in `before_install` for Travis (per warning from `bundler` about the `Gemfile.lock` having a newer 'bundled with' message)