### PR TITLE
Display description on boards without sections if given

### DIFF
--- a/app/views/boards/show.haml
+++ b/app/views/boards/show.haml
@@ -56,4 +56,7 @@
         - next unless post.visible_to?(current_user)
         = render partial: 'posts/list_item', locals: {post: post, hide_continuity: true}
 - else
+  - if @board.description.present?
+    - content_for :post_list_description do
+      = sanitize_written_content(@board.description).html_safe
   = render partial: 'posts/list', locals: {posts: @posts, hide_continuity: true, path: :board_path}

--- a/app/views/posts/_list.haml
+++ b/app/views/posts/_list.haml
@@ -10,6 +10,11 @@
   %thead
     %tr
       %th{colspan: col_count}= content_for :posts_title
+    - if content_for? :post_list_description
+      %tr
+        %td.odd{colspan: col_count}= content_for :post_list_description
+      %tr
+        %td.continuity-spacer{colspan: col_count}
     %tr
       %th.sub.width-15
       %th.sub Thread


### PR DESCRIPTION
Previously, such descriptions were not exposed to the user anywhere.

New screenshot with description:

![](https://cdn.discordapp.com/attachments/294586535049953281/351102627762798594/unknown.png)

New screenshot without description:

![](https://cdn.discordapp.com/attachments/294586535049953281/351102836051804171/unknown.png)

Fixes #324.