### PR TITLE
[WIP] Add gallery groups

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -111,7 +111,7 @@ function saveExistingTags(selector, newTags) {
   });
 }
 
-function createTagSelect(tagType, selector, formType) {
+function createTagSelect(tagType, selector, formType, scope) {
   foundTags[selector] = [];
   $("#"+formType+"_"+selector+"_ids").select2({
     tags: true,
@@ -127,6 +127,7 @@ function createTagSelect(tagType, selector, formType) {
           t: tagType,
           page: params.page
         };
+        if (scope) Object.assign(data, scope);
         return data;
       },
       processResults: function(data, params) {

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -1,8 +1,14 @@
 /* global gon, createTagSelect */
 var galleryIds;
+var galleryGroupIds = [];
+var galleryGroups = {};
 
 $(document).ready(function() {
-  galleryIds = $("#character_gallery_ids").val() || [];
+  gon.gallery_groups.forEach(function(galleryGroup) {
+    galleryGroups[galleryGroup.id] = galleryGroup;
+  });
+  galleryIds = $("#character_ungrouped_gallery_ids").val() || [];
+  galleryGroupIds = $("#character_gallery_group_ids").val() || [];
 
   $("#character_setting_ids").select2({
     width: '100%',
@@ -27,7 +33,7 @@ $(document).ready(function() {
     }
   });
 
-  $("#character_gallery_ids").change(function() {
+  $("#character_ungrouped_gallery_ids").change(function() {
     $("#character_default_icon_id").val('');
 
     var newGalleryIds = $(this).val() || [];
@@ -36,6 +42,7 @@ $(document).ready(function() {
     if (galleryIds.length > newGalleryIds.length) {
       var removedGallery = $(galleryIds).not(newGalleryIds).get(0);
       galleryIds = newGalleryIds;
+      if (findGalleryInGroups(removedGallery)) return;
       $(".gallery #gallery"+removedGallery).remove();
 
       // if no more galleries are left, display galleryless icons
@@ -49,11 +56,70 @@ $(document).ready(function() {
     galleryIds = newGalleryIds;
     $(".gallery #gallery0").remove();
 
+    // display only if not visible (for gallery groups)
     if ($(".gallery #gallery" + newId).length === 0) displayGallery(newId);
+  });
+
+  $("#character_gallery_group_ids").change(function() {
+    $("#character_default_icon_id").val('');
+
+    var newGalleryGroupIds = $(this).val() || [];
+
+    // a gallery group was removed
+    if (galleryGroupIds.length > newGalleryGroupIds.length) {
+      var removedGroup = $(galleryGroupIds).not(newGalleryGroupIds).get(0);
+      galleryGroupIds = newGalleryGroupIds;
+      if (removedGroup.substring(0, 1) === '_') return; // skip uncreated tags
+
+      var group = galleryGroups[parseInt(removedGroup)];
+      delete galleryGroups[parseInt(removedGroup)];
+
+      // delete unfound galleries from icons list
+      group.gallery_ids.forEach(function(galleryId) {
+        if (findGalleryInGroups(galleryId) || galleryIds.indexOf(galleryId.toString()) >= 0) return;
+        $(".gallery #gallery" + galleryId).remove();
+        galleryIds = $(galleryIds).not([galleryId.toString()]);
+      });
+      galleryIds = $.makeArray(galleryIds);
+
+      // if no more galleries remain, display galleryless icons
+      if ($(".gallery [id^='gallery']").length === 0) {
+        displayGallery('0');
+      }
+      return;
+    }
+
+    var newId = $(newGalleryGroupIds).not(galleryGroupIds).get(0);
+    galleryGroupIds = newGalleryGroupIds;
+    if (newId.substring(0, 1) === '_') return; // skip uncreated tags
+
+    // fetch galleryGroup galleryIds
+    $.get('/api/v1/tags/'+newId, {user_id: gon.user_id}, function(resp) {
+      var ids = resp.gallery_ids;
+      galleryGroups[resp.id] = {gallery_ids: ids};
+
+      if (ids.length === 0) return; // return if empty
+
+      $(".gallery #gallery0").remove();
+      ids.forEach(function(id) {
+        if ($(".gallery #gallery" + id).length === 0) {
+          displayGallery(id);
+        }
+      });
+    });
   });
 
   createTagSelect("GalleryGroup", "gallery_group", "character", {user_id: gon.user_id});
 });
+
+function findGalleryInGroups(galleryId) {
+  galleryId = parseInt(galleryId);
+  var found = false;
+  Object.keys(galleryGroups).forEach(function(groupId) {
+    if (galleryGroups[groupId].gallery_ids.indexOf(galleryId) >= 0) found = true;
+  });
+  return found;
+}
 
 function displayGallery(newId) {
   $.get('/api/v1/galleries/'+newId, function(resp) {

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -1,4 +1,4 @@
-/* global gon */
+/* global gon, createTagSelect */
 var galleryIds;
 
 $(document).ready(function() {
@@ -11,7 +11,7 @@ $(document).ready(function() {
     tags: true
   });
 
-  $("#character_gallery_ids").select2({
+  $("#character_ungrouped_gallery_ids").select2({
     width: '100%',
     minimumResultsForSearch: 10,
     placeholder: 'Default Gallery'
@@ -51,6 +51,8 @@ $(document).ready(function() {
 
     if ($(".gallery #gallery" + newId).length === 0) displayGallery(newId);
   });
+
+  createTagSelect("GalleryGroup", "gallery_group", "character");
 });
 
 function displayGallery(newId) {

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -52,7 +52,7 @@ $(document).ready(function() {
     if ($(".gallery #gallery" + newId).length === 0) displayGallery(newId);
   });
 
-  createTagSelect("GalleryGroup", "gallery_group", "character");
+  createTagSelect("GalleryGroup", "gallery_group", "character", {user_id: gon.user_id});
 });
 
 function displayGallery(newId) {

--- a/app/assets/javascripts/galleries/editor.js
+++ b/app/assets/javascripts/galleries/editor.js
@@ -1,4 +1,4 @@
 /* global createTagSelect */
 $(document).ready(function() {
-  createTagSelect("GalleryGroup", "gallery_group", "gallery");
+  createTagSelect("GalleryGroup", "gallery_group", "gallery", {user_id: gon.user_id});
 });

--- a/app/assets/javascripts/galleries/editor.js
+++ b/app/assets/javascripts/galleries/editor.js
@@ -1,0 +1,4 @@
+/* global createTagSelect */
+$(document).ready(function() {
+  createTagSelect("GalleryGroup", "gallery_group", "gallery");
+});

--- a/app/assets/javascripts/galleries/expander.js
+++ b/app/assets/javascripts/galleries/expander.js
@@ -33,4 +33,32 @@ $(document).ready(function() {
       });
     });
   });
+
+  $(".tag-item").hover(function mouseIn() {
+    $(this).removeClass('semiplusopaque');
+  }, function mouseOut() {
+    $(this).addClass('semiplusopaque');
+  });
+
+  // add ellipsis box for many (> 5) tags
+  $(".tag-box").each(function() {
+    var tagBox = $(this);
+    var tagBoxItems = $(".tag-item", tagBox);
+    if (tagBoxItems.length <= 5) return;
+    var hiddenTags = tagBoxItems.slice(4);
+    hiddenTags.hide();
+    var ellipsisBox = $("<span>").attr({class: 'tag-item semiopaque pointer', title: 'Click to show more tags…'}).append("...");
+    var recollapseBox = $("<span>").attr({class: 'tag-item semiopaque pointer', title: 'Click to hide extra tags…'}).append("←").hide();
+    tagBox.append(ellipsisBox).append(' ').append(recollapseBox); // inline-block cares about spaces for formatting
+    ellipsisBox.click(function() {
+      hiddenTags.show();
+      ellipsisBox.hide();
+      recollapseBox.show();
+    });
+    recollapseBox.click(function() {
+      hiddenTags.hide();
+      recollapseBox.hide();
+      ellipsisBox.show();
+    });
+  });
 });

--- a/app/assets/javascripts/galleries/expander_old.js
+++ b/app/assets/javascripts/galleries/expander_old.js
@@ -4,9 +4,11 @@ $(document).ready(function() {
     var id = elem.data('id');
     if (elem.html().trim() === '-') {
       $('#gallery' + id).hide();
+      $('#gallery-tags-' + id).hide();
       elem.html('+');
     } else {
       $('#gallery' + id).show();
+      $('#gallery-tags-' + id).show();
       elem.html('-');
     }
   });

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -1,6 +1,5 @@
-/* global gon, tinymce, tinyMCE, resizeScreenname */
+/* global gon, tinymce, tinyMCE, resizeScreenname, createTagSelect */
 var tinyMCEInit = false;
-var foundTags = {};
 
 $(document).ready(function() {
   // SET UP POST METADATA EDITOR:
@@ -29,9 +28,9 @@ $(document).ready(function() {
     placeholder: 'Choose user(s) to view this post'
   });
 
-  createTagSelect("Label", "label");
-  createTagSelect("Setting", "setting");
-  createTagSelect("ContentWarning", "content_warning");
+  createTagSelect("Label", "label", "post");
+  createTagSelect("Setting", "setting", "post");
+  createTagSelect("ContentWarning", "content_warning", "post");
 
   if (String($("#post_privacy").val()) !== String(PRIVACY_ACCESS)) {
     $("#access_list").hide();
@@ -439,67 +438,6 @@ function setSections() {
       $("#section").hide();
     }
   }, 'json');
-}
-
-function saveExistingTags(selector, newTags) {
-  var newList = foundTags[selector].concat(newTags);
-  var ids = [];
-  foundTags[selector] = [];
-  // add tags, uniquely by ID
-  newList.forEach(function(tag) {
-    if (ids.indexOf(tag.id) >= 0) return;
-    ids.push(tag.id);
-    foundTags[selector].push(tag);
-  });
-}
-
-function createTagSelect(tagType, selector) {
-  foundTags[selector] = [];
-  $("#post_"+selector+"_ids").select2({
-    tags: true,
-    tokenSeparators: [','],
-    placeholder: 'Enter ' + selector.replace('_', ' ') + '(s) separated by commas',
-    ajax: {
-      delay: 200,
-      url: '/api/v1/tags',
-      dataType: 'json',
-      data: function(params) {
-        var data = {
-          q: params.term,
-          t: tagType,
-          page: params.page
-        };
-        return data;
-      },
-      processResults: function(data, params) {
-        params.page = params.page || 1;
-        var total = this._request.getResponseHeader('Total');
-        saveExistingTags(selector, data.results);
-        return {
-          results: data.results,
-          pagination: {
-            more: (params.page * 25) < total
-          }
-        };
-      },
-      cache: true
-    },
-    createTag: function(params) {
-      var term = $.trim(params.term);
-      if (term === '') return null;
-      var extantTag;
-      foundTags[selector].forEach(function(tag) {
-        if (tag.text.toUpperCase() === term.toUpperCase()) extantTag = tag;
-      });
-      if (extantTag) return extantTag;
-
-      return {
-        id: '_' + term,
-        text: term
-      };
-    },
-    width: '300px'
-  });
 }
 
 function setCharacterListSelected(characterId) {

--- a/app/assets/stylesheets/global.css
+++ b/app/assets/stylesheets/global.css
@@ -64,6 +64,7 @@ button, .button {
 .bold { font-weight: bold; }
 .auto { overflow: auto; }
 .semiopaque { opacity: 0.5; }
+.semiplusopaque { opacity: 0.6; }
 
 /* For UI elements involving reordering */
 .disabled-arrow {

--- a/app/assets/stylesheets/layout.css
+++ b/app/assets/stylesheets/layout.css
@@ -114,6 +114,25 @@
 .view-button .list-view { width: 20px; height: 17px; display: inline; margin: 0; padding: 0; top: 2px; position: relative; }
 .view-button .icon-view { width: 15px; height: 15px; display: inline; margin: 0; padding: 0; top: 2px; position: relative; }
 
+/* Tag label buttons, like seen on the gallery page */
+.tag-box {
+  display: inline;
+  margin-left: 5px;
+}
+.tag-item-link:hover {
+  color: unset;
+}
+.tag-item {
+  display: inline-block;
+  background-color: #B9B6AD;
+  color: #3F7055;
+  margin: 2px 0;
+  padding: 2px 8px;
+  border-radius: 5px;
+  font-size: 90%;
+  font-weight: normal;
+}
+
 /* The new object layout with the floating left info box and the right content area */
 #content .left-info-box { float: left; }
 #content .right-content-box { float: left; }

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -13,7 +13,9 @@ class Api::V1::TagsController < Api::ApiController
 
     # gallery groups only searches groups the current user has used
     if (user_id = params[:user_id]) && params[:t] == 'GalleryGroup'
-      queryset = queryset.where('(SELECT 1 FROM gallery_tags LEFT JOIN galleries ON gallery_tags.gallery_id = galleries.id WHERE galleries.user_id = ? LIMIT 1) IS NOT NULL', current_user.id)
+      user_char_tags = GalleryGroup.joins(character_tags: [:character]).where(characters: {user_id: user_id}).pluck(:id)
+      user_gal_tags = GalleryGroup.joins(gallery_tags: [:gallery]).where(galleries: {user_id: user_id}).pluck(:id)
+      queryset = queryset.where(id: user_char_tags + user_gal_tags)
     end
 
     tags = paginate queryset, per_page: 25

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -3,13 +3,19 @@ class Api::V1::TagsController < Api::ApiController
     description 'Viewing tags'
   end
 
-  api :GET, '/tags', 'Load all the tags of the specified type that match the given query, results ordered by name'
+  api :GET, '/tags', 'Load all the tags of the specified type that match the given query, results ordered by name. GalleryGroup tags are filtered to tags the current user has used.'
   param :q, String, required: false, desc: "Query string"
   param :page, :number, required: false, desc: 'Page in results (25 per page)'
-  param :t, ['Setting', 'Label', 'ContentWarning'], required: true, desc: 'Whether to search Settings, Content Warnings or Labels'
+  param :t, ['Setting', 'Label', 'ContentWarning', 'GalleryGroup'], required: true, desc: 'Whether to search Settings, Content Warnings or Labels'
   error 422, "Invalid parameters provided"
   def index
     queryset = params[:t].constantize.where("name LIKE ?", params[:q].to_s + '%').order('name')
+
+    # gallery groups only searches groups the current user has used
+    if (user_id = params[:user_id]) && params[:t] == 'GalleryGroup'
+      queryset = queryset.where('(SELECT 1 FROM gallery_tags LEFT JOIN galleries ON gallery_tags.gallery_id = galleries.id WHERE galleries.user_id = ? LIMIT 1) IS NOT NULL', current_user.id)
+    end
+
     tags = paginate queryset, per_page: 25
     render json: {results: tags}
   end

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::TagsController < Api::ApiController
+  before_filter :find_tag, except: :index
+
   resource_description do
     description 'Viewing tags'
   end
@@ -6,7 +8,7 @@ class Api::V1::TagsController < Api::ApiController
   api :GET, '/tags', 'Load all the tags of the specified type that match the given query, results ordered by name. GalleryGroup tags are filtered to tags the current user has used.'
   param :q, String, required: false, desc: "Query string"
   param :page, :number, required: false, desc: 'Page in results (25 per page)'
-  param :t, ['Setting', 'Label', 'ContentWarning', 'GalleryGroup'], required: true, desc: 'Whether to search Settings, Content Warnings or Labels'
+  param :t, ['Setting', 'Label', 'ContentWarning', 'GalleryGroup'], required: true, desc: 'Whether to search Settings, Content Warnings, Labels or Gallery Groups'
   error 422, "Invalid parameters provided"
   def index
     queryset = params[:t].constantize.where("name LIKE ?", params[:q].to_s + '%').order('name')
@@ -20,5 +22,21 @@ class Api::V1::TagsController < Api::ApiController
 
     tags = paginate queryset, per_page: 25
     render json: {results: tags}
+  end
+
+  api! 'Load a single tag as a JSON resource'
+  param :id, :number, required: true, desc: 'Tag ID'
+  def show
+    render json: @tag.as_json(include: [:gallery_ids], user_id: params[:user_id])
+  end
+
+  private
+
+  def find_tag
+    unless (@tag = Tag.find_by(id: params[:id]))
+      error = {message: 'Tag could not be found'}
+      render json: {errors: [error]}, status: :not_found and return
+    end
+    @tag = @tag.type.constantize.find_by(id: params[:id])
   end
 end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -270,6 +270,7 @@ class CharactersController < ApplicationController
     gon.character_id = @character.try(:id) || ''
     gon.user_id = current_user.id
     @aliases = @character.aliases.order('name asc') if @character
+    gon.gallery_groups = @gallery_groups.map {|group| group.as_json(include: [:gallery_ids], user_id: current_user.id) }
   end
 
   def build_tags

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -32,6 +32,7 @@ class CharactersController < ApplicationController
 
     @character = Character.new(character_params)
     @character.user = current_user
+    @character.build_new_tags_with(current_user)
 
     if @character.valid?
       save_character_with_extras
@@ -57,6 +58,7 @@ class CharactersController < ApplicationController
 
   def update
     @character.assign_attributes(character_params)
+    @character.build_new_tags_with(current_user)
 
     if @character.valid?
       save_character_with_extras
@@ -264,8 +266,14 @@ class CharactersController < ApplicationController
     new_group = faked.new('— Create New Group —', 0)
     @groups = current_user.character_groups.order('name asc') + [new_group]
     use_javascript('characters/editor')
+    build_tags
     gon.character_id = @character.try(:id) || ''
+    gon.user_id = current_user.id
     @aliases = @character.aliases.order('name asc') if @character
+  end
+
+  def build_tags
+    @gallery_groups = @character.try(:gallery_groups) || []
   end
 
   def save_character_with_extras
@@ -295,6 +303,6 @@ class CharactersController < ApplicationController
   end
 
   def character_params
-    params.fetch(:character, {}).permit(:default_icon_id, :name, :template_name, :screenname, :setting, :template_id, :new_template_name, :pb, :description, gallery_ids: [])
+    params.fetch(:character, {}).permit(:default_icon_id, :name, :template_name, :screenname, :setting, :template_id, :new_template_name, :pb, :description, ungrouped_gallery_ids: [], gallery_group_ids: [])
   end
 end

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -208,6 +208,7 @@ class GalleriesController < ApplicationController
   def setup_editor
     use_javascript('galleries/editor')
     build_tags
+    gon.user_id = current_user.id
   end
 
   def build_tags

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -18,7 +18,7 @@ class Character < ActiveRecord::Base
   has_many :character_tags, inverse_of: :character, dependent: :destroy
   has_many :labels, -> { order('name') }, through: :character_tags, source: :label
   has_many :settings, -> { order('name') }, through: :character_tags, source: :setting
-  has_many :gallery_groups, -> { order('name') }, through: :character_tags, source: :gallery_group
+  has_many :gallery_groups, -> { order('name') }, through: :character_tags, source: :gallery_group, after_remove: :remove_galleries_from_character
 
   validates_presence_of :name, :user
   validate :valid_template, :valid_group, :valid_galleries, :valid_default_icon
@@ -89,6 +89,11 @@ class Character < ActiveRecord::Base
     end
     # leftover galleries from gallery groups will be added by that model
     self.characters_galleries_attributes = new_chargals
+  end
+
+  def remove_galleries_from_character(gallery_group)
+    galleries = gallery_group.galleries.where(user_id: user_id)
+    CharactersGallery.where(character: self, gallery: galleries, added_by_group: true).destroy_all
   end
 
   private

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -16,9 +16,9 @@ class Character < ActiveRecord::Base
   has_many :icons, -> { group('icons.id').order('LOWER(keyword)') }, through: :galleries
 
   has_many :character_tags, inverse_of: :character, dependent: :destroy
-  has_many :labels, -> { order('name') }, through: :character_tags, source: :label
-  has_many :settings, -> { order('name') }, through: :character_tags, source: :setting
-  has_many :gallery_groups, -> { order('name') }, through: :character_tags, source: :gallery_group, after_remove: :remove_galleries_from_character
+  has_many :labels, through: :character_tags, source: :label
+  has_many :settings, through: :character_tags, source: :setting
+  has_many :gallery_groups, through: :character_tags, source: :gallery_group, after_remove: :remove_galleries_from_character
 
   validates_presence_of :name, :user
   validate :valid_template, :valid_group, :valid_galleries, :valid_default_icon

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -1,5 +1,6 @@
 class Character < ActiveRecord::Base
   include Presentable
+  include Taggable
 
   belongs_to :user
   belongs_to :template
@@ -9,13 +10,15 @@ class Character < ActiveRecord::Base
   has_many :posts
   has_many :aliases, class_name: CharacterAlias
 
-  has_many :characters_galleries
+  has_many :characters_galleries, inverse_of: :character
+  accepts_nested_attributes_for :characters_galleries, allow_destroy: true
   has_many :galleries, through: :characters_galleries, after_remove: :reorder_galleries
   has_many :icons, -> { group('icons.id').order('LOWER(keyword)') }, through: :galleries
 
   has_many :character_tags, inverse_of: :character, dependent: :destroy
-  has_many :labels, through: :character_tags, source: :label
-  has_many :settings, through: :character_tags, source: :setting
+  has_many :labels, -> { order('name') }, through: :character_tags, source: :label
+  has_many :settings, -> { order('name') }, through: :character_tags, source: :setting
+  has_many :gallery_groups, -> { order('name') }, through: :character_tags, source: :gallery_group
 
   validates_presence_of :name, :user
   validate :valid_template, :valid_group, :valid_galleries, :valid_default_icon
@@ -23,6 +26,9 @@ class Character < ActiveRecord::Base
   attr_accessor :new_template_name, :group_name
 
   after_destroy :clear_char_ids
+  after_save :update_tag_list
+
+  acts_as_tag :label, :setting, :gallery_group
 
   nilify_blanks
 
@@ -47,6 +53,42 @@ class Character < ActiveRecord::Base
       other.section_order = index
       other.save
     end
+  end
+
+  def ungrouped_gallery_ids
+    characters_galleries.where(added_by_group: false).pluck(:gallery_id)
+  end
+
+  def ungrouped_gallery_ids=(new_ids)
+    new_ids -= ['']
+    new_ids = new_ids.map(&:to_i)
+    old_ids = ungrouped_gallery_ids
+    rem_ids = old_ids - new_ids
+    group_gallery_ids = gallery_groups.joins(:gallery_tags).reorder('gallery_tags.gallery_id').pluck('distinct gallery_tags.gallery_id')
+    new_chargals = []
+    characters_galleries.each do |char_gal|
+      gallery_id = char_gal.gallery_id
+      if new_ids.include?(gallery_id)
+        # add relevant old galleries, making sure added_by_group is false
+        char_gal.added_by_group = false
+        new_chargals << char_gal.attributes
+        new_ids.delete(gallery_id)
+      elsif group_gallery_ids.include?(gallery_id)
+        # add relevant old group galleries, added_by_group being true
+        char_gal.added_by_group = true
+        new_chargals << char_gal.attributes
+        group_gallery_ids.delete(gallery_id)
+      else
+        # destroy joins that are not in the new set of IDs
+        new_chargals << char_gal.attributes.merge(_destroy: true)
+      end
+    end
+    new_ids.each do |gallery_id|
+      # add any leftover new galleries
+      new_chargals << {gallery_id: gallery_id, character_id: id, added_by_group: false}
+    end
+    # leftover galleries from gallery groups will be added by that model
+    self.characters_galleries_attributes = new_chargals
   end
 
   private
@@ -87,5 +129,17 @@ class Character < ActiveRecord::Base
   def clear_char_ids
     Reply.where(character_id: id).update_all(character_id: nil)
     Post.where(character_id: id).update_all(character_id: nil)
+  end
+
+  def update_tag_list
+    return unless label_ids.present? || setting_ids.present? || gallery_group_ids.present?
+
+    updated_ids = ((label_ids || []) + (setting_ids || []) + (gallery_group_ids || []) - ['']).map(&:to_i).reject(&:zero?).uniq.compact
+    existing_ids = character_tags.map(&:tag_id)
+
+    CharacterTag.where(character_id: id, tag_id: (existing_ids - updated_ids)).destroy_all
+    (updated_ids - existing_ids).each do |new_id|
+      CharacterTag.create(character_id: id, tag_id: new_id)
+    end
   end
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -26,7 +26,6 @@ class Character < ActiveRecord::Base
   attr_accessor :new_template_name, :group_name
 
   after_destroy :clear_char_ids
-  after_save :update_tag_list
 
   acts_as_tag :label, :setting, :gallery_group
 
@@ -134,17 +133,5 @@ class Character < ActiveRecord::Base
   def clear_char_ids
     Reply.where(character_id: id).update_all(character_id: nil)
     Post.where(character_id: id).update_all(character_id: nil)
-  end
-
-  def update_tag_list
-    return unless label_ids.present? || setting_ids.present? || gallery_group_ids.present?
-
-    updated_ids = ((label_ids || []) + (setting_ids || []) + (gallery_group_ids || []) - ['']).map(&:to_i).reject(&:zero?).uniq.compact
-    existing_ids = character_tags.map(&:tag_id)
-
-    CharacterTag.where(character_id: id, tag_id: (existing_ids - updated_ids)).destroy_all
-    (updated_ids - existing_ids).each do |new_id|
-      CharacterTag.create(character_id: id, tag_id: new_id)
-    end
   end
 end

--- a/app/models/character_tag.rb
+++ b/app/models/character_tag.rb
@@ -15,14 +15,11 @@ class CharacterTag < ActiveRecord::Base
     galleries = gallery_group.galleries.where(user_id: character.user_id).where.not(id: joined_galleries.pluck(:id))
     galleries.each do |gallery|
       CharactersGallery.create(character_id: character.id, gallery_id: gallery.id, added_by_group: true)
-      puts "Adding gallery #{gallery.id} to character #{character.id}"
     end
   end
 
   def remove_galleries_from_character
-    puts "GOT REMOVED"
     return if gallery_group.nil? # skip non-gallery_groups
-    galleries = gallery_group.galleries.where(user_id: character.user_id)
-    CharactersGallery.where(character: character, gallery: galleries, added_by_group: true).destroy_all
+    character.remove_galleries_from_character(gallery_group)
   end
 end

--- a/app/models/character_tag.rb
+++ b/app/models/character_tag.rb
@@ -3,4 +3,26 @@ class CharacterTag < ActiveRecord::Base
   belongs_to :tag
   belongs_to :label, foreign_key: :tag_id
   belongs_to :setting, foreign_key: :tag_id
+  belongs_to :gallery_group, foreign_key: :tag_id
+  validates_presence_of :character
+
+  after_create :add_galleries_to_character
+  after_destroy :remove_galleries_from_character
+
+  def add_galleries_to_character
+    return if gallery_group.nil? # skip non-gallery_groups
+    joined_galleries = gallery_group.galleries.joins(:characters_galleries).where(characters_galleries: {character_id: character.id})
+    galleries = gallery_group.galleries.where(user_id: character.user_id).where.not(id: joined_galleries.pluck(:id))
+    galleries.each do |gallery|
+      CharactersGallery.create(character_id: character.id, gallery_id: gallery.id, added_by_group: true)
+      puts "Adding gallery #{gallery.id} to character #{character.id}"
+    end
+  end
+
+  def remove_galleries_from_character
+    puts "GOT REMOVED"
+    return if gallery_group.nil? # skip non-gallery_groups
+    galleries = gallery_group.galleries.where(user_id: character.user_id)
+    CharactersGallery.where(character: character, gallery: galleries, added_by_group: true).destroy_all
+  end
 end

--- a/app/models/characters_gallery.rb
+++ b/app/models/characters_gallery.rb
@@ -1,6 +1,7 @@
 class CharactersGallery < ActiveRecord::Base
-  belongs_to :character
-  belongs_to :gallery
+  belongs_to :character, inverse_of: :characters_galleries
+  belongs_to :gallery, inverse_of: :characters_galleries
+  validates_presence_of :character, :gallery
 
   before_create :autofill_order
   after_destroy :reorder_others

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -1,15 +1,21 @@
 class Gallery < ActiveRecord::Base
+  include Taggable
   belongs_to :user
 
   has_many :galleries_icons, dependent: :destroy
+  accepts_nested_attributes_for :galleries_icons, allow_destroy: true
   has_many :icons, -> { order('LOWER(keyword)') }, through: :galleries_icons
 
-  has_many :characters_galleries
+  has_many :characters_galleries, inverse_of: :gallery
   has_many :characters, through: :characters_galleries
 
-  accepts_nested_attributes_for :galleries_icons, allow_destroy: true
+  has_many :gallery_tags, inverse_of: :gallery, dependent: :destroy
+  has_many :gallery_groups, -> { order('name') }, through: :gallery_tags, source: :gallery_group
 
   validates_presence_of :user, :name
+  after_save :update_tag_list
+
+  acts_as_tag :gallery_group
 
   scope :ordered, -> { order('characters_galleries.section_order ASC') }
   scope :with_icon_count, -> {
@@ -20,5 +26,17 @@ class Gallery < ActiveRecord::Base
 
   def character_gallery_for(character)
     characters_galleries.where(character_id: character).first
+  end
+
+  def update_tag_list
+    return unless gallery_group_ids.present?
+
+    updated_ids = ((gallery_group_ids || []) - ['']).map(&:to_i).reject(&:zero?).uniq.compact
+    existing_ids = gallery_tags.map(&:tag_id)
+
+    GalleryTag.where(gallery_id: id, tag_id: (existing_ids - updated_ids)).destroy_all
+    (updated_ids - existing_ids).each do |new_id|
+      GalleryTag.create(gallery_id: id, tag_id: new_id)
+    end
   end
 end

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -13,7 +13,6 @@ class Gallery < ActiveRecord::Base
   has_many :gallery_groups, -> { order('name') }, through: :gallery_tags, source: :gallery_group, after_remove: :remove_gallery_from_characters
 
   validates_presence_of :user, :name
-  after_save :update_tag_list
 
   acts_as_tag :gallery_group
 
@@ -26,18 +25,6 @@ class Gallery < ActiveRecord::Base
 
   def character_gallery_for(character)
     characters_galleries.where(character_id: character).first
-  end
-
-  def update_tag_list
-    return unless gallery_group_ids.present?
-
-    updated_ids = ((gallery_group_ids || []) - ['']).map(&:to_i).reject(&:zero?).uniq.compact
-    existing_ids = gallery_tags.map(&:tag_id)
-
-    GalleryTag.where(gallery_id: id, tag_id: (existing_ids - updated_ids)).destroy_all
-    (updated_ids - existing_ids).each do |new_id|
-      GalleryTag.create(gallery_id: id, tag_id: new_id)
-    end
   end
 
   def remove_gallery_from_characters(gallery_group)

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -10,7 +10,7 @@ class Gallery < ActiveRecord::Base
   has_many :characters, through: :characters_galleries
 
   has_many :gallery_tags, inverse_of: :gallery, dependent: :destroy
-  has_many :gallery_groups, -> { order('name') }, through: :gallery_tags, source: :gallery_group, after_remove: :remove_gallery_from_characters
+  has_many :gallery_groups, through: :gallery_tags, source: :gallery_group, after_remove: :remove_gallery_from_characters
 
   validates_presence_of :user, :name
 
@@ -22,6 +22,29 @@ class Gallery < ActiveRecord::Base
       .select("galleries.*, count(galleries_icons.id) as icon_count")
       .group("galleries.id")
   }
+  scope :with_gallery_groups, -> {
+    # fetches an array of
+    # galleries.map(&:gallery_groups).map{|group| [f1: group.id, f2: group.name]}
+    # ordered by tag name
+    select("ARRAY(SELECT row_to_json(ROW(tags.id, tags.name)) FROM tags LEFT JOIN gallery_tags ON gallery_tags.tag_id = tags.id WHERE gallery_tags.gallery_id = galleries.id AND tags.type = 'GalleryGroup') AS gallery_groups_data_internal")
+  }
+
+  # Requires .with_gallery_groups scope
+  # Converts the internal [{'f1' => id, 'f2' => name}] structure of the retrieved data
+  # to [{id => id, name => name}]
+  def gallery_groups_data
+    return @gallery_groups_data unless @gallery_groups_data.nil?
+    if has_attribute?(:gallery_groups_data_internal)
+      data_internal = read_attribute(:gallery_groups_data_internal)
+      faked = Struct.new(:id, :name)
+      @gallery_groups_data = gallery_groups_data_internal.map do |old|
+        faked.new(old['f1'], old['f2'])
+      end
+    else
+      @gallery_groups_data = gallery_groups
+    end
+    @gallery_groups_data
+  end
 
   def character_gallery_for(character)
     characters_galleries.where(character_id: character).first

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -10,7 +10,7 @@ class Gallery < ActiveRecord::Base
   has_many :characters, through: :characters_galleries
 
   has_many :gallery_tags, inverse_of: :gallery, dependent: :destroy
-  has_many :gallery_groups, -> { order('name') }, through: :gallery_tags, source: :gallery_group
+  has_many :gallery_groups, -> { order('name') }, through: :gallery_tags, source: :gallery_group, after_remove: :remove_gallery_from_characters
 
   validates_presence_of :user, :name
   after_save :update_tag_list
@@ -38,5 +38,10 @@ class Gallery < ActiveRecord::Base
     (updated_ids - existing_ids).each do |new_id|
       GalleryTag.create(gallery_id: id, tag_id: new_id)
     end
+  end
+
+  def remove_gallery_from_characters(gallery_group)
+    characters = gallery_group.characters.where(user_id: user_id)
+    CharactersGallery.where(character: characters, gallery: self, added_by_group: true).destroy_all
   end
 end

--- a/app/models/gallery_group.rb
+++ b/app/models/gallery_group.rb
@@ -1,0 +1,2 @@
+class GalleryGroup < Tag
+end

--- a/app/models/gallery_tag.rb
+++ b/app/models/gallery_tag.rb
@@ -1,0 +1,24 @@
+class GalleryTag < ActiveRecord::Base
+  belongs_to :gallery, inverse_of: :gallery_tags
+  belongs_to :tag
+  belongs_to :gallery_group, foreign_key: :tag_id
+
+  after_create :add_gallery_to_characters
+  after_destroy :remove_gallery_from_characters
+
+  def add_gallery_to_characters
+    return if gallery_group.nil? # skip non-gallery_groups
+    joined_characters = gallery_group.characters.joins(:characters_galleries).where(characters_galleries: {gallery_id: gallery.id})
+    characters = gallery_group.characters.where(user_id: gallery.user_id).where.not(id: joined_characters.pluck(:id))
+    characters.each do |character|
+      CharactersGallery.create(character_id: character.id, gallery_id: gallery.id, added_by_group: true)
+      puts "Adding gallery #{gallery.id} to character #{character.id}"
+    end
+  end
+
+  def remove_gallery_from_characters
+    return if gallery_group.nil? # skip non-gallery_groups
+    characters = gallery_group.characters.where(user_id: gallery.user_id)
+    CharactersGallery.where(character: characters, gallery: gallery, added_by_group: true).destroy_all
+  end
+end

--- a/app/models/gallery_tag.rb
+++ b/app/models/gallery_tag.rb
@@ -12,13 +12,11 @@ class GalleryTag < ActiveRecord::Base
     characters = gallery_group.characters.where(user_id: gallery.user_id).where.not(id: joined_characters.pluck(:id))
     characters.each do |character|
       CharactersGallery.create(character_id: character.id, gallery_id: gallery.id, added_by_group: true)
-      puts "Adding gallery #{gallery.id} to character #{character.id}"
     end
   end
 
   def remove_gallery_from_characters
     return if gallery_group.nil? # skip non-gallery_groups
-    characters = gallery_group.characters.where(user_id: gallery.user_id)
-    CharactersGallery.where(character: characters, gallery: gallery, added_by_group: true).destroy_all
+    gallery.remove_gallery_from_characters(gallery_group)
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,6 +4,8 @@ class Tag < ActiveRecord::Base
   has_many :posts, through: :post_tags
   has_many :character_tags, dependent: :destroy
   has_many :characters, through: :character_tags
+  has_many :gallery_tags, dependent: :destroy
+  has_many :galleries, through: :gallery_tags
 
   validates_presence_of :user, :name, :type
   validates :name, uniqueness: { scope: :type }
@@ -26,6 +28,8 @@ class Tag < ActiveRecord::Base
       PostTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
       CharacterTag.where(tag_id: other_tag.id).where(character_id: character_tags.pluck('distinct character_id')).delete_all
       CharacterTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
+      GalleryTag.where(tag_id: other_tag.id).where(gallery_id: gallery_tags.pluck('distinct gallery_id')).delete_all
+      GalleryTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
       other_tag.destroy
     end
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -14,8 +14,15 @@ class Tag < ActiveRecord::Base
     user.try(:admin?)
   end
 
-  def as_json(*)
-    {id: self.id, text: self.name}
+  def as_json(options={})
+    tag_json = {id: self.id, text: self.name}
+    return tag_json unless options[:include].present?
+    if options[:include].include?(:gallery_ids)
+      g_tags = gallery_tags.joins(:gallery)
+      g_tags = g_tags.where(galleries: {user_id: options[:user_id]}) if options[:user_id].present?
+      tag_json[:gallery_ids] = g_tags.pluck(:gallery_id)
+    end
+    tag_json
   end
 
   def id_for_select

--- a/app/views/characters/_editor.haml
+++ b/app/views/characters/_editor.haml
@@ -23,9 +23,13 @@
   %tr
     %th.sub Galleries
     %td{class: cycle('even', 'odd')}
-      = f.collection_select(:gallery_ids,
+      = f.collection_select(:ungrouped_gallery_ids,
       current_user.galleries.order('name asc'),
-      :id, :name, {selected: @character.galleries.pluck(:id)}, {multiple: true})
+      :id, :name, {selected: @character.ungrouped_gallery_ids}, {multiple: true})
+  %tr
+    %th.sub Gallery Groups
+    %td{class: cycle('even', 'odd')}
+      = f.select :gallery_group_ids, options_from_collection_for_select(@gallery_groups, :id_for_select, :name, @character.gallery_group_ids || @character.gallery_groups.map(&:id)), {}, {multiple: true}
 %tr
   %th.sub Facecast
   %td{class: cycle('even', 'odd')}= f.text_field :pb, placeholder: "Facecast", class: 'text'

--- a/app/views/galleries/_list_view.haml
+++ b/app/views/galleries/_list_view.haml
@@ -24,10 +24,17 @@
       - if @user.id == current_user.try(:id)
         .clear.centered.icons-remove
           = submit_tag "x Delete selected icons permanently", data: { confirm: "Are you sure? These icons will be gone from the site!" }
-- @user.galleries.with_icon_count.order('name asc').each do |gallery|
+- @user.galleries.with_icon_count.with_gallery_groups.order('name asc').each do |gallery|
   %tr
+    - p gallery.gallery_groups_data
     - klass = cycle('even', 'odd')
-    %td.gallery-name{class: klass}= link_to gallery.name, gallery_path(gallery)
+    %td.gallery-name{class: klass}
+      = link_to gallery.name, gallery_path(gallery)
+      .tag-box
+        - gallery.gallery_groups_data.each do |group|
+          = link_to tag_path(group.id), class: 'tag-item-link' do
+            %span.tag-item.semiplusopaque
+              = group.name
     %td.width-150.centered.gallery-icon-count{class: klass}= gallery.icon_count
     %td.width-70.gallery-buttons{class: klass}
       - if @user.id == current_user.try(:id)

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -17,6 +17,16 @@
       .float-right
         = image_tag "/images/arrow_up.png", class: "section-up disabled-arrow", data: {order: section.section_order}
         = image_tag "/images/arrow_down.png", class: "section-down disabled-arrow", data: {order: section.section_order}
+- groups = gallery.gallery_groups_data
+  - if groups.present?
+  %tr.gallery-tags
+    %th.subber{id: "gallery-tags-#{gallery.id}"}
+      Groups:
+      .tag-box
+        - gallery.gallery_groups_data.each do |group|
+          = link_to tag_path(group.id), class: 'tag-item-link' do
+            %span.tag-item
+              = group.name
 - attrs = {id: "section-gallery-#{section.section_order}"} if attrs[:id]
 %tr.gallery-icons{**attrs}
   %td.green

--- a/app/views/galleries/edit.haml
+++ b/app/views/galleries/edit.haml
@@ -12,7 +12,11 @@
         Edit Gallery
     %tr
       %th.sub Name
-      %td.even{colspan: 2}= f.text_field :name, placeholder: "Gallery Name", class: 'text'
+      %td{class: cycle('even', 'odd'), colspan: 2}= f.text_field :name, placeholder: "Gallery Name", class: 'text'
+    %tr
+      %th.vtop.sub Groups
+      %td{class: cycle('even', 'odd'), colspan: 2}
+        = f.select :gallery_group_ids, options_from_collection_for_select(@gallery_groups, :id_for_select, :name, @gallery.gallery_group_ids || @gallery.gallery_groups.map(&:id)), {}, {multiple: true}
     %tr
       %th.subber{colspan: 3} Edit Icons
     = f.fields_for :galleries_icons, @gallery.galleries_icons.joins(:icon).order('LOWER(keyword)') do |gif|

--- a/app/views/galleries/new.haml
+++ b/app/views/galleries/new.haml
@@ -5,11 +5,15 @@
       %th.centered{colspan: 2}New Gallery
     %tr
       %th.vtop.sub Name
-      %td.even= f.text_field :name, placeholder: "Gallery Name", class: 'text'
+      %td{class: cycle('even', 'odd')}= f.text_field :name, placeholder: "Gallery Name", class: 'text'
+    %tr
+      %th.vtop.sub Groups
+      %td{class: cycle('even', 'odd')}
+        = f.select :gallery_group_ids, options_from_collection_for_select(@gallery_groups, :id_for_select, :name, gallery.gallery_group_ids || gallery.gallery_groups.map(&:id)), {}, {multiple: true}
     - if icons_present
       %tr
         %th.vtop.sub Icons
-        %td.odd
+        %td{class: cycle('even', 'odd')}
           - current_user.galleryless_icons.each do |icon|
             = label_tag "gallery_icon_ids_#{icon.id}" do
               .gallery-icon

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,7 +102,7 @@ Rails.application.routes.draw do
         resources :replies, only: :index
         collection { post :reorder }
       end
-      resources :tags, only: :index
+      resources :tags, only: [:index, :show]
       resources :templates, only: :index
       resources :users, only: :index
     end

--- a/db/migrate/20170826211901_add_gallery_tags.rb
+++ b/db/migrate/20170826211901_add_gallery_tags.rb
@@ -8,7 +8,5 @@ class AddGalleryTags < ActiveRecord::Migration
       t.index :gallery_id
       t.index :tag_id
     end
-
-    add_column :characters_galleries, :added_by_group, :boolean, default: false
   end
 end

--- a/db/migrate/20170826211901_add_gallery_tags.rb
+++ b/db/migrate/20170826211901_add_gallery_tags.rb
@@ -1,0 +1,14 @@
+class AddGalleryTags < ActiveRecord::Migration
+  def change
+    create_table :gallery_tags do |t|
+      t.integer :gallery_id, null: false
+      t.integer :tag_id, null: false
+      t.timestamps null: true
+
+      t.index :gallery_id
+      t.index :tag_id
+    end
+
+    add_column :characters_galleries, :added_by_group, :boolean, default: false
+  end
+end

--- a/db/migrate/20170828144608_add_added_by_group_to_characters_galleries.rb
+++ b/db/migrate/20170828144608_add_added_by_group_to_characters_galleries.rb
@@ -1,0 +1,5 @@
+class AddAddedByGroupToCharactersGalleries < ActiveRecord::Migration
+  def change
+    add_column :characters_galleries, :added_by_group, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -55,19 +55,19 @@ SET default_with_oids = false;
 CREATE TABLE audits (
     id integer NOT NULL,
     auditable_id integer,
-    auditable_type character varying,
+    auditable_type character varying(255),
     associated_id integer,
-    associated_type character varying,
+    associated_type character varying(255),
     user_id integer,
-    user_type character varying,
-    username character varying,
-    action character varying,
+    user_type character varying(255),
+    username character varying(255),
+    action character varying(255),
     audited_changes text,
     version integer DEFAULT 0,
-    comment character varying,
-    remote_address character varying,
+    comment character varying(255),
+    remote_address character varying(255),
     created_at timestamp without time zone,
-    request_uuid character varying
+    request_uuid character varying(255)
 );
 
 
@@ -130,7 +130,7 @@ ALTER SEQUENCE board_authors_id_seq OWNED BY board_authors.id;
 CREATE TABLE board_sections (
     id integer NOT NULL,
     board_id integer NOT NULL,
-    name character varying NOT NULL,
+    name character varying(255) NOT NULL,
     status integer DEFAULT 0 NOT NULL,
     section_order integer NOT NULL,
     created_at timestamp without time zone,
@@ -234,7 +234,7 @@ ALTER SEQUENCE boards_id_seq OWNED BY boards.id;
 CREATE TABLE character_aliases (
     id integer NOT NULL,
     character_id integer NOT NULL,
-    name character varying NOT NULL,
+    name character varying(255) NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -266,7 +266,7 @@ ALTER SEQUENCE character_aliases_id_seq OWNED BY character_aliases.id;
 CREATE TABLE character_groups (
     id integer NOT NULL,
     user_id integer NOT NULL,
-    name character varying NOT NULL
+    name character varying(255) NOT NULL
 );
 
 
@@ -329,15 +329,15 @@ CREATE TABLE characters (
     id integer NOT NULL,
     user_id integer NOT NULL,
     name citext NOT NULL,
-    template_name character varying,
-    screenname character varying,
+    template_name character varying(255),
+    screenname character varying(255),
     template_id integer,
     default_icon_id integer,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    pb character varying,
+    pb character varying(255),
     character_group_id integer,
-    setting character varying,
+    setting character varying(255),
     description text
 );
 
@@ -401,7 +401,7 @@ CREATE TABLE favorites (
     id integer NOT NULL,
     user_id integer NOT NULL,
     favorite_id integer NOT NULL,
-    favorite_type character varying NOT NULL,
+    favorite_type character varying(255) NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -465,7 +465,7 @@ ALTER SEQUENCE flat_posts_id_seq OWNED BY flat_posts.id;
 CREATE TABLE galleries (
     id integer NOT NULL,
     user_id integer NOT NULL,
-    name character varying NOT NULL,
+    name character varying(255) NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -559,11 +559,11 @@ ALTER SEQUENCE gallery_tags_id_seq OWNED BY gallery_tags.id;
 CREATE TABLE icons (
     id integer NOT NULL,
     user_id integer NOT NULL,
-    url character varying NOT NULL,
-    keyword character varying NOT NULL,
+    url character varying(255) NOT NULL,
+    keyword character varying(255) NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    credit character varying,
+    credit character varying(255),
     has_gallery boolean DEFAULT false
 );
 
@@ -597,7 +597,7 @@ CREATE TABLE messages (
     recipient_id integer NOT NULL,
     parent_id integer,
     thread_id integer,
-    subject character varying,
+    subject character varying(255),
     message text,
     unread boolean DEFAULT true,
     visible_inbox boolean DEFAULT true,
@@ -636,7 +636,7 @@ ALTER SEQUENCE messages_id_seq OWNED BY messages.id;
 CREATE TABLE password_resets (
     id integer NOT NULL,
     user_id integer NOT NULL,
-    auth_token character varying NOT NULL,
+    auth_token character varying(255) NOT NULL,
     used boolean DEFAULT false,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
@@ -772,7 +772,7 @@ CREATE TABLE posts (
     id integer NOT NULL,
     board_id integer NOT NULL,
     user_id integer NOT NULL,
-    subject character varying NOT NULL,
+    subject character varying(255) NOT NULL,
     content text,
     character_id integer,
     icon_id integer,
@@ -782,7 +782,7 @@ CREATE TABLE posts (
     status integer DEFAULT 0,
     section_id integer,
     section_order integer,
-    description character varying,
+    description character varying(255),
     last_user_id integer,
     last_reply_id integer,
     edited_at timestamp without time zone,
@@ -922,7 +922,7 @@ ALTER SEQUENCE report_views_id_seq OWNED BY report_views.id;
 --
 
 CREATE TABLE schema_migrations (
-    version character varying NOT NULL
+    version character varying(255) NOT NULL
 );
 
 
@@ -936,7 +936,7 @@ CREATE TABLE tags (
     name citext NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    type character varying
+    type character varying(255)
 );
 
 
@@ -999,23 +999,23 @@ ALTER SEQUENCE templates_id_seq OWNED BY templates.id;
 CREATE TABLE users (
     id integer NOT NULL,
     username citext NOT NULL,
-    crypted character varying NOT NULL,
+    crypted character varying(255) NOT NULL,
     avatar_id integer,
     active_character_id integer,
     per_page integer DEFAULT 25,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    timezone character varying,
+    timezone character varying(255),
     email citext,
     email_notifications boolean,
     icon_picker_grouping boolean DEFAULT true,
-    moiety character varying,
-    layout character varying,
-    moiety_name character varying,
-    default_view character varying,
-    default_editor character varying DEFAULT 'rtf'::character varying,
-    time_display character varying DEFAULT '%b %d, %Y %l:%M %p'::character varying,
-    salt_uuid character varying,
+    moiety character varying(255),
+    layout character varying(255),
+    moiety_name character varying(255),
+    default_view character varying(255),
+    default_editor character varying(255) DEFAULT 'rtf'::character varying,
+    time_display character varying(255) DEFAULT '%b %d, %Y %l:%M %p'::character varying,
+    salt_uuid character varying(255),
     unread_opened boolean DEFAULT false,
     hide_hiatused_tags_owed boolean DEFAULT false,
     hide_warnings boolean DEFAULT false,
@@ -1023,7 +1023,7 @@ CREATE TABLE users (
     show_user_in_switcher boolean DEFAULT true,
     ignore_unread_daily_report boolean DEFAULT false,
     favorite_notifications boolean DEFAULT true,
-    default_character_split character varying DEFAULT 'template'::character varying
+    default_character_split character varying(255) DEFAULT 'template'::character varying
 );
 
 
@@ -2031,4 +2031,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170819222420');
 INSERT INTO schema_migrations (version) VALUES ('20170821210336');
 
 INSERT INTO schema_migrations (version) VALUES ('20170826211901');
+
+INSERT INTO schema_migrations (version) VALUES ('20170828144608');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -350,7 +350,8 @@ CREATE TABLE characters_galleries (
     id integer NOT NULL,
     character_id integer NOT NULL,
     gallery_id integer NOT NULL,
-    section_order integer DEFAULT 0 NOT NULL
+    section_order integer DEFAULT 0 NOT NULL,
+    added_by_group boolean DEFAULT false
 );
 
 
@@ -517,6 +518,38 @@ CREATE SEQUENCE galleries_id_seq
 --
 
 ALTER SEQUENCE galleries_id_seq OWNED BY galleries.id;
+
+
+--
+-- Name: gallery_tags; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE gallery_tags (
+    id integer NOT NULL,
+    gallery_id integer NOT NULL,
+    tag_id integer NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: gallery_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE gallery_tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: gallery_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE gallery_tags_id_seq OWNED BY gallery_tags.id;
 
 
 --
@@ -1112,6 +1145,13 @@ ALTER TABLE ONLY galleries_icons ALTER COLUMN id SET DEFAULT nextval('galleries_
 
 
 --
+-- Name: gallery_tags id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY gallery_tags ALTER COLUMN id SET DEFAULT nextval('gallery_tags_id_seq'::regclass);
+
+
+--
 -- Name: icons id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1312,6 +1352,14 @@ ALTER TABLE ONLY galleries_icons
 
 ALTER TABLE ONLY galleries
     ADD CONSTRAINT galleries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: gallery_tags gallery_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY gallery_tags
+    ADD CONSTRAINT gallery_tags_pkey PRIMARY KEY (id);
 
 
 --
@@ -1584,6 +1632,20 @@ CREATE INDEX index_galleries_icons_on_icon_id ON galleries_icons USING btree (ic
 --
 
 CREATE INDEX index_galleries_on_user_id ON galleries USING btree (user_id);
+
+
+--
+-- Name: index_gallery_tags_on_gallery_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_gallery_tags_on_gallery_id ON gallery_tags USING btree (gallery_id);
+
+
+--
+-- Name: index_gallery_tags_on_tag_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_gallery_tags_on_tag_id ON gallery_tags USING btree (tag_id);
 
 
 --
@@ -1967,4 +2029,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170814042150');
 INSERT INTO schema_migrations (version) VALUES ('20170819222420');
 
 INSERT INTO schema_migrations (version) VALUES ('20170821210336');
+
+INSERT INTO schema_migrations (version) VALUES ('20170826211901');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -55,19 +55,19 @@ SET default_with_oids = false;
 CREATE TABLE audits (
     id integer NOT NULL,
     auditable_id integer,
-    auditable_type character varying(255),
+    auditable_type character varying,
     associated_id integer,
-    associated_type character varying(255),
+    associated_type character varying,
     user_id integer,
-    user_type character varying(255),
-    username character varying(255),
-    action character varying(255),
+    user_type character varying,
+    username character varying,
+    action character varying,
     audited_changes text,
     version integer DEFAULT 0,
-    comment character varying(255),
-    remote_address character varying(255),
+    comment character varying,
+    remote_address character varying,
     created_at timestamp without time zone,
-    request_uuid character varying(255)
+    request_uuid character varying
 );
 
 
@@ -130,7 +130,7 @@ ALTER SEQUENCE board_authors_id_seq OWNED BY board_authors.id;
 CREATE TABLE board_sections (
     id integer NOT NULL,
     board_id integer NOT NULL,
-    name character varying(255) NOT NULL,
+    name character varying NOT NULL,
     status integer DEFAULT 0 NOT NULL,
     section_order integer NOT NULL,
     created_at timestamp without time zone,
@@ -234,7 +234,7 @@ ALTER SEQUENCE boards_id_seq OWNED BY boards.id;
 CREATE TABLE character_aliases (
     id integer NOT NULL,
     character_id integer NOT NULL,
-    name character varying(255) NOT NULL,
+    name character varying NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -266,7 +266,7 @@ ALTER SEQUENCE character_aliases_id_seq OWNED BY character_aliases.id;
 CREATE TABLE character_groups (
     id integer NOT NULL,
     user_id integer NOT NULL,
-    name character varying(255) NOT NULL
+    name character varying NOT NULL
 );
 
 
@@ -329,15 +329,15 @@ CREATE TABLE characters (
     id integer NOT NULL,
     user_id integer NOT NULL,
     name citext NOT NULL,
-    template_name character varying(255),
-    screenname character varying(255),
+    template_name character varying,
+    screenname character varying,
     template_id integer,
     default_icon_id integer,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    pb character varying(255),
+    pb character varying,
     character_group_id integer,
-    setting character varying(255),
+    setting character varying,
     description text
 );
 
@@ -401,7 +401,7 @@ CREATE TABLE favorites (
     id integer NOT NULL,
     user_id integer NOT NULL,
     favorite_id integer NOT NULL,
-    favorite_type character varying(255) NOT NULL,
+    favorite_type character varying NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -465,7 +465,7 @@ ALTER SEQUENCE flat_posts_id_seq OWNED BY flat_posts.id;
 CREATE TABLE galleries (
     id integer NOT NULL,
     user_id integer NOT NULL,
-    name character varying(255) NOT NULL,
+    name character varying NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -559,11 +559,11 @@ ALTER SEQUENCE gallery_tags_id_seq OWNED BY gallery_tags.id;
 CREATE TABLE icons (
     id integer NOT NULL,
     user_id integer NOT NULL,
-    url character varying(255) NOT NULL,
-    keyword character varying(255) NOT NULL,
+    url character varying NOT NULL,
+    keyword character varying NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    credit character varying(255),
+    credit character varying,
     has_gallery boolean DEFAULT false
 );
 
@@ -597,7 +597,7 @@ CREATE TABLE messages (
     recipient_id integer NOT NULL,
     parent_id integer,
     thread_id integer,
-    subject character varying(255),
+    subject character varying,
     message text,
     unread boolean DEFAULT true,
     visible_inbox boolean DEFAULT true,
@@ -636,7 +636,7 @@ ALTER SEQUENCE messages_id_seq OWNED BY messages.id;
 CREATE TABLE password_resets (
     id integer NOT NULL,
     user_id integer NOT NULL,
-    auth_token character varying(255) NOT NULL,
+    auth_token character varying NOT NULL,
     used boolean DEFAULT false,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
@@ -772,7 +772,7 @@ CREATE TABLE posts (
     id integer NOT NULL,
     board_id integer NOT NULL,
     user_id integer NOT NULL,
-    subject character varying(255) NOT NULL,
+    subject character varying NOT NULL,
     content text,
     character_id integer,
     icon_id integer,
@@ -782,7 +782,7 @@ CREATE TABLE posts (
     status integer DEFAULT 0,
     section_id integer,
     section_order integer,
-    description character varying(255),
+    description character varying,
     last_user_id integer,
     last_reply_id integer,
     edited_at timestamp without time zone,
@@ -922,7 +922,7 @@ ALTER SEQUENCE report_views_id_seq OWNED BY report_views.id;
 --
 
 CREATE TABLE schema_migrations (
-    version character varying(255) NOT NULL
+    version character varying NOT NULL
 );
 
 
@@ -936,7 +936,7 @@ CREATE TABLE tags (
     name citext NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    type character varying(255)
+    type character varying
 );
 
 
@@ -999,23 +999,23 @@ ALTER SEQUENCE templates_id_seq OWNED BY templates.id;
 CREATE TABLE users (
     id integer NOT NULL,
     username citext NOT NULL,
-    crypted character varying(255) NOT NULL,
+    crypted character varying NOT NULL,
     avatar_id integer,
     active_character_id integer,
     per_page integer DEFAULT 25,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    timezone character varying(255),
+    timezone character varying,
     email citext,
     email_notifications boolean,
     icon_picker_grouping boolean DEFAULT true,
-    moiety character varying(255),
-    layout character varying(255),
-    moiety_name character varying(255),
-    default_view character varying(255),
-    default_editor character varying(255) DEFAULT 'rtf'::character varying,
-    time_display character varying(255) DEFAULT '%b %d, %Y %l:%M %p'::character varying,
-    salt_uuid character varying(255),
+    moiety character varying,
+    layout character varying,
+    moiety_name character varying,
+    default_view character varying,
+    default_editor character varying DEFAULT 'rtf'::character varying,
+    time_display character varying DEFAULT '%b %d, %Y %l:%M %p'::character varying,
+    salt_uuid character varying,
     unread_opened boolean DEFAULT false,
     hide_hiatused_tags_owed boolean DEFAULT false,
     hide_warnings boolean DEFAULT false,
@@ -1023,7 +1023,7 @@ CREATE TABLE users (
     show_user_in_switcher boolean DEFAULT true,
     ignore_unread_daily_report boolean DEFAULT false,
     favorite_notifications boolean DEFAULT true,
-    default_character_split character varying(255) DEFAULT 'template'::character varying
+    default_character_split character varying DEFAULT 'template'::character varying
 );
 
 

--- a/spec/controllers/api/v1/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/tags_controller_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe Api::V1::TagsController do
         expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
       end
 
+      it "should support gallery group search" do
+        tag = create(:gallery_group)
+        get :index, q: tag.name, t: 'GalleryGroup'
+        expect(response).to have_http_status(200)
+        expect(response.json).to have_key('results')
+        expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
+      end
+
       it "should handle invalid input", show_in_doc: in_doc do
         get :index, t: 'b'
         expect(response).to have_http_status(422)
@@ -36,8 +44,37 @@ RSpec.describe Api::V1::TagsController do
     end
 
     context "when logged in" do
-      before(:each) { login }
+      let(:user) { create(:user) }
+      before(:each) { login_as(user) }
       it_behaves_like "index.json", false
+
+      context "in gallery group search with user_id" do
+        it "should not display unused tags" do
+          ungrouped_tag = create(:gallery_group)
+          get :index, q: ungrouped_tag.name, t: 'GalleryGroup', user_id: user.id
+          expect(response).to have_http_status(200)
+          expect(response.json).to have_key('results')
+          expect(response.json['results']).to eq([])
+        end
+
+        it "should display tags used on characters" do
+          char_grouped_tag = create(:gallery_group)
+          create(:character, user: user, gallery_groups: [char_grouped_tag])
+          get :index, q: char_grouped_tag.name, t: 'GalleryGroup', user_id: user.id
+          expect(response).to have_http_status(200)
+          expect(response.json).to have_key('results')
+          expect(response.json['results']).to contain_exactly(char_grouped_tag.as_json.stringify_keys)
+        end
+
+        it "should display tags used on galleries" do
+          gal_grouped_tag = create(:gallery_group)
+          create(:gallery, user: user, gallery_groups: [gal_grouped_tag])
+          get :index, q: gal_grouped_tag.name, t: 'GalleryGroup', user_id: user.id
+          expect(response).to have_http_status(200)
+          expect(response.json).to have_key('results')
+          expect(response.json['results']).to contain_exactly(gal_grouped_tag.as_json.stringify_keys)
+        end
+      end
     end
 
     context "when logged out" do

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -95,12 +95,12 @@ RSpec.describe CharactersController do
       gallery = create(:gallery, user: user)
 
       login_as(user)
-      post :create, character: {name: test_name, template_name: 'TempName', screenname: 'just-a-test', setting: 'A World', template_id: template.id, pb: 'Facecast', description: 'Desc', gallery_ids: [gallery.id]}
+      post :create, character: {name: test_name, template_name: 'TempName', screenname: 'just-a-test', setting: 'A World', template_id: template.id, pb: 'Facecast', description: 'Desc', ungrouped_gallery_ids: [gallery.id]}
 
       expect(response).to redirect_to(assigns(:character))
       expect(flash[:success]).to eq("Character saved successfully.")
       expect(Character.count).to eq(1)
-      character = assigns(:character)
+      character = assigns(:character).reload
       expect(character.name).to eq(test_name)
       expect(character.user_id).to eq(user.id)
       expect(character.template_name).to eq('TempName')
@@ -265,7 +265,7 @@ RSpec.describe CharactersController do
       new_name = character.name + 'aaa'
       template = create(:template, user: user)
       gallery = create(:gallery, user: user)
-      put :update, id: character.id, character: {name: new_name, template_name: 'TemplateName', screenname: 'a-new-test', setting: 'Another World', template_id: template.id, pb: 'Actor', description: 'Description', gallery_ids: [gallery.id]}
+      put :update, id: character.id, character: {name: new_name, template_name: 'TemplateName', screenname: 'a-new-test', setting: 'Another World', template_id: template.id, pb: 'Actor', description: 'Description', ungrouped_gallery_ids: [gallery.id]}
 
       expect(response).to redirect_to(assigns(:character))
       expect(flash[:success]).to eq("Character saved successfully.")
@@ -316,7 +316,7 @@ RSpec.describe CharactersController do
       expect(g2_cg.section_order).to eq(1)
 
       login_as(character.user)
-      put :update, id: character.id, character: {gallery_ids: [g2.id.to_s]}
+      put :update, id: character.id, character: {ungrouped_gallery_ids: [g2.id.to_s]}
 
       expect(character.reload.galleries.pluck(:id)).to eq([g2.id])
       expect(g2_cg.reload.section_order).to eq(0)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -138,6 +138,10 @@ FactoryGirl.define do
     factory :content_warning, class: ContentWarning do
       type 'ContentWarning'
     end
+
+    factory :gallery_group, class: GalleryGroup do
+      type 'GalleryGroup'
+    end
   end
 
   factory :message do

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -160,4 +160,77 @@ RSpec.describe Character do
       expect(character.ungrouped_gallery_ids).to match_array([gallery_manual.id, gallery_both.id])
     end
   end
+
+  context "tags" do
+    let(:taggable) { create(:character) }
+    ['gallery_group'].each do |type|
+      it "creates new #{type} tags if they don't exist" do
+        taggable.send(type + '_ids=', ['_tag'])
+        expect(taggable.send(type + 's').map(&:name)).to match_array(['tag'])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags.map(&:name)).to match_array(['tag'])
+        expect(tags.map(&:user)).to match_array([taggable.user])
+      end
+
+      it "uses extant tags with same name and type for #{type}" do
+        tag = create(type)
+        old_user = tag.user
+        taggable.send(type + '_ids=', ['_' + tag.name])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+
+      it "does not use extant tags of a different type with same name for #{type}" do
+        name = "Example Tag"
+        tag = create(:tag, type: 'NonexistentTag', name: name)
+        taggable.send(type + '_ids=', ['_' + name])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags.map(&:name)).to match_array([name])
+        expect(tags.map(&:user)).to match_array([taggable.user])
+        expect(tags).not_to include(tag)
+      end
+
+      it "uses extant #{type} tags by id" do
+        tag = create(type)
+        old_user = tag.user
+        taggable.send(type + '_ids=', [tag.id.to_s])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+
+      it "removes #{type} tags when not in list given" do
+        tag = create(type)
+        taggable.send(type + 's=', [tag])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to match_array([tag])
+        taggable.send(type + '_ids=', [])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to eq([])
+      end
+
+      it "only adds #{type} tags once if given multiple times" do
+        name = 'Example Tag'
+        tag = create(type, name: name)
+        old_user = tag.user
+        taggable.send(type + '_ids=', ['_' + name, '_' + name, tag.id.to_s, tag.id.to_s])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+    end
+  end
 end

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -40,4 +40,124 @@ RSpec.describe Character do
     expect(character.galleries.size).to eq(2)
     expect(character.icons.map(&:id)).to eq([icon.id])
   end
+
+  describe "#ungrouped_gallery_ids" do
+    it "returns only galleries not added by groups" do
+      user = create(:user)
+      character = create(:character, user: user)
+      gallery1 = create(:gallery, user: user)
+      gallery2 = create(:gallery, user: user)
+
+      CharactersGallery.create(character: character, gallery: gallery1)
+      CharactersGallery.create(character: character, gallery: gallery2, added_by_group: true)
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery1.id, gallery2.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery1.id])
+    end
+  end
+
+  describe "#ungrouped_gallery_ids=" do
+    it "adds unattached galleries" do
+      user = create(:user)
+      character = create(:character, user: user)
+      gallery = create(:gallery, user: user)
+
+      expect(character.gallery_ids).to eq([])
+      expect(character.ungrouped_gallery_ids).to eq([])
+      character.ungrouped_gallery_ids = [gallery.id]
+      character.save!
+
+      character.reload
+      expect(character.characters_galleries.map(&:added_by_group?)).to match_array([false])
+      expect(character.gallery_ids).to match_array([gallery.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery.id])
+    end
+
+    it "sets already-attached galleries to not be added_by_group" do
+      # does not add a new attachment
+      user = create(:user)
+      group = create(:gallery_group)
+      character = create(:character, gallery_groups: [group], user: user)
+      gallery = create(:gallery, gallery_groups: [group], user: user)
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery.id])
+      expect(character.ungrouped_gallery_ids).to match_array([])
+
+      character.ungrouped_gallery_ids = [gallery.id]
+      character.save!
+      character.reload
+
+      expect(character.gallery_ids).to match_array([gallery.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery.id])
+      expect(character.characters_galleries.map(&:added_by_group)).to match_array([false])
+    end
+
+    it "removes associated galleries when not present only if not also present in groups, otherwise sets flag" do
+      # does not remove gallery_manual when not told to
+      # sets flag on gallery_both to be added_by_group
+      # does not remove gallery_auto despite not being present
+      user = create(:user)
+      group = create(:gallery_group)
+      character = create(:character, gallery_groups: [group], user: user)
+      gallery_manual = create(:gallery, user: user)
+      gallery_both = create(:gallery, gallery_groups: [group], user: user)
+      gallery_automatic = create(:gallery, gallery_groups: [group], user: user)
+
+      CharactersGallery.create(character: character, gallery: gallery_manual)
+      character.characters_galleries.where(gallery_id: gallery_both.id).update_all(added_by_group: false)
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery_manual.id, gallery_both.id, gallery_automatic.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery_manual.id, gallery_both.id])
+
+      character.ungrouped_gallery_ids = [gallery_manual.id]
+      character.save!
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery_manual.id, gallery_both.id, gallery_automatic.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery_manual.id])
+      expect(character.characters_galleries.find_by(gallery_id: gallery_both.id)).to be_added_by_group
+    end
+
+    it "deletes manually-added galleries when not present" do
+      user = create(:user)
+      gallery = create(:gallery, user: user)
+      character = create(:character, user: user, galleries: [gallery])
+
+      character.reload
+      expect(character.gallery_ids).to eq([gallery.id])
+      expect(character.ungrouped_gallery_ids).to eq([gallery.id])
+      character.ungrouped_gallery_ids = []
+      character.save!
+
+      character.reload
+      expect(character.gallery_ids).to eq([])
+    end
+
+    it "does nothing if unchanged" do
+      # does not remove or change the status of any of: gallery_manual, gallery_both, gallery_auto
+      user = create(:user)
+      group = create(:gallery_group)
+      character = create(:character, gallery_groups: [group], user: user)
+      gallery_manual = create(:gallery, user: user)
+      gallery_both = create(:gallery, gallery_groups: [group], user: user)
+      gallery_automatic = create(:gallery, gallery_groups: [group], user: user)
+
+      CharactersGallery.create(character: character, gallery: gallery_manual)
+      character.characters_galleries.where(gallery_id: gallery_both.id).update_all(added_by_group: false)
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery_manual.id, gallery_both.id, gallery_automatic.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery_manual.id, gallery_both.id])
+
+      character.ungrouped_gallery_ids = [gallery_manual.id, gallery_both.id]
+      character.save!
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery_manual.id, gallery_both.id, gallery_automatic.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery_manual.id, gallery_both.id])
+    end
+  end
 end

--- a/spec/models/character_tag_spec.rb
+++ b/spec/models/character_tag_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+
+RSpec.describe CharacterTag do
+  describe "callbacks" do
+    context "when gallery group added" do
+      it "does not add other users' galleries" do
+        group = create(:gallery_group)
+        gallery = create(:gallery, gallery_groups: [group])
+
+        character = create(:character)
+        character.gallery_groups << group
+        character.save
+        expect(character.reload.galleries).to match_array([])
+      end
+
+      it "does not add a gallery twice" do
+        # tests a manually-attached gallery1
+        # and a double-grouped gallery2
+        group = create(:gallery_group)
+        group2 = create(:gallery_group)
+        user = create(:user)
+        gallery1 = create(:gallery, user: user, gallery_groups: [group])
+        gallery2 = create(:gallery, user: user, gallery_groups: [group, group2])
+
+        character = create(:character, user: user, galleries: [gallery1])
+        character.gallery_groups << group
+        character.save
+        character.reload
+        expect(character.galleries).to match_array([gallery1, gallery2])
+        expect(character.characters_galleries.find_by(gallery_id: gallery1.id)).not_to be_added_by_group
+        expect(character.characters_galleries.find_by(gallery_id: gallery2.id)).to be_added_by_group
+
+        character.gallery_groups << group2
+        character.save
+        character.reload
+        expect(character.galleries).to match_array([gallery1, gallery2])
+        expect(character.characters_galleries.find_by(gallery_id: gallery1.id)).not_to be_added_by_group
+        expect(character.characters_galleries.find_by(gallery_id: gallery2.id)).to be_added_by_group
+      end
+
+      it "adds galleries from given group" do
+        group = create(:gallery_group)
+        user = create(:user)
+        gallery1 = create(:gallery, user: user, gallery_groups: [group])
+        gallery2 = create(:gallery, user: user, gallery_groups: [group])
+
+        character = create(:character, user: user)
+        character.gallery_groups << group
+        character.save
+        character.reload
+        expect(character.galleries).to match_array([gallery1, gallery2])
+        expect(character.characters_galleries.map(&:added_by_group?)).to eq([true, true])
+      end
+
+      it "does right things when gallery group removed" do
+        # does not touch unrelated galleries
+        # does not touch galleries that have been otherwise tethered
+        # removes galleries that are not otherwise tethered
+        group = create(:gallery_group)
+        user = create(:user)
+        other_gallery = create(:gallery, user: user)
+        character = create(:character, user: user, gallery_groups: [group], galleries: [other_gallery])
+        gallery_auto = create(:gallery, user: user, gallery_groups: [group])
+        gallery_both = create(:gallery, user: user, gallery_groups: [group])
+        character.reload
+        character.characters_galleries.find_by(gallery_id: gallery_both.id).update_attributes(added_by_group: false)
+        expect(character.galleries).to match_array([other_gallery, gallery_auto, gallery_both])
+        expect(character.characters_galleries.find_by(gallery_id: gallery_auto.id)).to be_added_by_group
+
+        character.update_attributes(gallery_groups: [])
+        character.reload
+        expect(character.galleries).to match_array([other_gallery, gallery_both])
+        expect(character.characters_galleries.find_by(gallery_id: gallery_both.id)).not_to be_added_by_group
+      end
+    end
+  end
+end

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -30,4 +30,77 @@ RSpec.describe Gallery do
     gallery.icons << create(:icon, keyword: 'xxx', user: gallery.user)
     expect(gallery.icons.pluck(:keyword)).to eq(['xxx', 'yyy', 'zzz'])
   end
+
+  context "tags" do
+    let(:taggable) { create(:gallery) }
+    ['gallery_group'].each do |type|
+      it "creates new #{type} tags if they don't exist" do
+        taggable.send(type + '_ids=', ['_tag'])
+        expect(taggable.send(type + 's').map(&:name)).to match_array(['tag'])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags.map(&:name)).to match_array(['tag'])
+        expect(tags.map(&:user)).to match_array([taggable.user])
+      end
+
+      it "uses extant tags with same name and type for #{type}" do
+        tag = create(type)
+        old_user = tag.user
+        taggable.send(type + '_ids=', ['_' + tag.name])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+
+      it "does not use extant tags of a different type with same name for #{type}" do
+        name = "Example Tag"
+        tag = create(:tag, type: 'NonexistentTag', name: name)
+        taggable.send(type + '_ids=', ['_' + name])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags.map(&:name)).to match_array([name])
+        expect(tags.map(&:user)).to match_array([taggable.user])
+        expect(tags).not_to include(tag)
+      end
+
+      it "uses extant #{type} tags by id" do
+        tag = create(type)
+        old_user = tag.user
+        taggable.send(type + '_ids=', [tag.id.to_s])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+
+      it "removes #{type} tags when not in list given" do
+        tag = create(type)
+        taggable.send(type + 's=', [tag])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to match_array([tag])
+        taggable.send(type + '_ids=', [])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to eq([])
+      end
+
+      it "only adds #{type} tags once if given multiple times" do
+        name = 'Example Tag'
+        tag = create(type, name: name)
+        old_user = tag.user
+        taggable.send(type + '_ids=', ['_' + name, '_' + name, tag.id.to_s, tag.id.to_s])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+    end
+  end
 end

--- a/spec/models/gallery_tag_spec.rb
+++ b/spec/models/gallery_tag_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+
+RSpec.describe GalleryTag do
+  describe "callbacks" do
+    context "when gallery group added" do
+      it "does not add to other users' characters" do
+        group = create(:gallery_group)
+        character = create(:character, gallery_groups: [group])
+
+        gallery = create(:gallery)
+        gallery.gallery_groups << group
+        gallery.save
+        expect(character.reload.galleries).to match_array([])
+      end
+
+      it "does not add to a character twice" do
+        # tests a manually-attached character1
+        # and a double-grouped character2
+        group = create(:gallery_group)
+        group2 = create(:gallery_group)
+        user = create(:user)
+        character1 = create(:character, user: user, gallery_groups: [group])
+        character2 = create(:character, user: user, gallery_groups: [group, group2])
+
+        gallery = create(:gallery, user: user, characters: [character1])
+        gallery.gallery_groups << group
+        gallery.save
+        gallery.reload
+        expect(gallery.characters).to match_array([character1, character2])
+        expect(gallery.characters_galleries.find_by(character_id: character1.id)).not_to be_added_by_group
+        expect(gallery.characters_galleries.find_by(character_id: character2.id)).to be_added_by_group
+
+        gallery.gallery_groups << group2
+        gallery.save
+        gallery.reload
+        expect(gallery.characters).to match_array([character1, character2])
+        expect(gallery.characters_galleries.find_by(character_id: character1.id)).not_to be_added_by_group
+        expect(gallery.characters_galleries.find_by(character_id: character2.id)).to be_added_by_group
+      end
+
+      it "adds galleries to given group" do
+        group = create(:gallery_group)
+        user = create(:user)
+        character1 = create(:character, user: user, gallery_groups: [group])
+        character2 = create(:character, user: user, gallery_groups: [group])
+
+        gallery = create(:gallery, user: user)
+        gallery.gallery_groups << group
+        gallery.save
+        gallery.reload
+        expect(gallery.characters).to match_array([character1, character2])
+        expect(gallery.characters_galleries.map(&:added_by_group?)).to eq([true, true])
+      end
+
+      it "does right things when gallery group removed" do
+        # does not touch unrelated characters
+        # does not touch characters that have been otherwise tethered
+        # removes from characters that are not otherwise tethered
+        group = create(:gallery_group)
+        user = create(:user)
+        other_character = create(:character, user: user)
+        gallery = create(:gallery, user: user, gallery_groups: [group], characters: [other_character])
+        character_auto = create(:character, user: user, gallery_groups: [group])
+        character_both = create(:character, user: user, gallery_groups: [group])
+        gallery.reload
+        gallery.characters_galleries.find_by(character_id: character_both.id).update_attributes(added_by_group: false)
+        expect(gallery.characters).to match_array([other_character, character_auto, character_both])
+        expect(gallery.characters_galleries.find_by(character_id: character_auto.id)).to be_added_by_group
+
+        gallery.update_attributes(gallery_groups: [])
+        gallery.reload
+        expect(gallery.characters).to match_array([other_character, character_both])
+        expect(gallery.characters_galleries.find_by(character_id: character_both.id)).not_to be_added_by_group
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #330.

TODO:

- [X] Convert subquery in tags API controller to something more intelligible (joins?)
- [X] ~~Display a warning if user has manually excluded galleries that were in a group, so it is not easy to miss; maybe send list of grouped IDs?~~ … no, instead, make it not exclude, make sure it does not exclude, make sure it's just the added on/off toggle.
- [x] Show galleries on character page by AJAX (see "TagsController offers correct galleries…")
  - [ ] Fix `character#new` if you add and remove a character group!!!
- [ ] Test *everything*, all the things
- [ ] Test *all the things* if the form save fails, especially all the stuff around `ungrouped_gallery_ids`
- [ ] Expose the tags somewhere on gallery pages
- [ ] Expose galleries (and characters?) on the relevant tag pages?
- [ ] Rebase onto #336 once tested fully and then remove `update_tag_list` from `character` and `gallery`
- [ ] Update character and gallery tag tests to use newer post tag tests, leave a note about where the code is duplicated

Tests:

- [ ] The "galleries" list, in the character editor, corresponds to galleries that are not added by groups
- [ ] Removing galleries from this list either flags it "added by group" (if it can be found in an attached group), or removes it from the character (if it cannot be); adding them creates the relevant tie if it doesn't already exist, and flags it "not added by group"
- [ ] Adding a gallery at the same time you remove the group should keep the gallery and not the others
- [x] Adding a character to a group: does not add another user's galleries, does not add galleries twice, adds galleries from the given group
- [x] Adding a gallery to a group: does not add to another user's characters, does not add to characters twice, adds to characters from the given group
- [x] TagsController limits to user's used GalleryGroups if `user_id` given
- Tags:
  - [x] Creates tags if they don't exist
  - [x] Uses extant tags with same name and type (**only** if same type)
  - [x] Uses extant IDs
  - [x] Removes things not in the list
- [ ] TagsController offers correct galleries for tag#show with a gallerygroup and appropriate wants
- [ ] Other relevant tag-related things, as copied from posts controller?
  - sets relevant results
  - persists if saving fails
  - lets you submit the change
- [ ] `merge_with`
- [ ] editor loads? try doing `render_views` for [characters, galleries] × [#edit, #new]

**Note**: I am also extracting the semi-unrelated bits into separate PRs, so as to reduce the size of this thing