### PR TITLE
Add Taggable concern to handle tag-creation logic

### DIFF
--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
 
   createTagSelect("Label", "label");
   createTagSelect("Setting", "setting");
-  createTagSelect("ContentWarning", "warning");
+  createTagSelect("ContentWarning", "content_warning");
 
   if (String($("#post_privacy").val()) !== String(PRIVACY_ACCESS)) {
     $("#access_list").hide();
@@ -444,7 +444,7 @@ function createTagSelect(tagType, selector) {
   $("#post_"+selector+"_ids").select2({
     tags: true,
     tokenSeparators: [','],
-    placeholder: 'Enter ' + selector + '(s) separated by commas',
+    placeholder: 'Enter ' + selector.replace('_', ' ') + '(s) separated by commas',
     ajax: {
       delay: 200,
       url: '/api/v1/tags',
@@ -468,6 +468,15 @@ function createTagSelect(tagType, selector) {
         };
       },
       cache: true
+    },
+    createTag: function(params) {
+      var term = $.trim(params.term);
+      if (term === '') return null;
+
+      return {
+        id: '_' + term,
+        text: term
+      };
     },
     width: '300px'
   });

--- a/app/concerns/taggable.rb
+++ b/app/concerns/taggable.rb
@@ -17,6 +17,7 @@ module Taggable
         attr_reader tag_ids_method
         # on assignment of tag IDs, find relevant tag objects and new-ify unfound ones, then set local variable:
         define_method(tag_ids_method_assign) do |tag_ids|
+          tag_ids = tag_ids.uniq
           # fake tag IDs start with initial underscore
           fakes = tag_ids.select { |id| id.to_s.start_with?('_') }.uniq
           tag_ids -= fakes # remove them from proper list
@@ -34,7 +35,7 @@ module Taggable
           new_tags = fakes.map { |name| klass.new(user: user, name: name) }
 
           # set tag list to: [old tags] + [existing new tags] + [new tags]
-          final_tags = old_tags + existing_tags + new_tags
+          final_tags = (old_tags + existing_tags + new_tags).uniq
           self.public_send(tag_method_assign, final_tags)
           self.instance_variable_set('@' + tag_ids_method + '_tags_todo', final_tags.map(&:id))
         end

--- a/app/concerns/taggable.rb
+++ b/app/concerns/taggable.rb
@@ -1,0 +1,55 @@
+module Taggable
+  extend ActiveSupport::Concern
+
+  included do
+    def self.acts_as_tag(*tag_names)
+      # for each tag name, create a getter and a custom setter for tag_name_ids, so that it updates the relevant association and stays up to date
+      # will be outdated if you set the IDs then update the tag list directly without setting the IDs again
+      # defaults to building new tags with `user`, but can be modified before saving with `build_new_tags_with`
+      @acts_as_tags = tag_names
+      tag_names.each do |tag_name|
+        base = tag_name.to_s # setting, content_warning
+        klass = base.camelize.constantize # Setting, ContentWarning
+        tag_method = base + 's' # settings, content_warnings
+        tag_method_assign = tag_method + '='
+        tag_ids_method = base + '_ids' # setting_ids, content_warning_ids
+        tag_ids_method_assign = tag_ids_method + '='
+        attr_reader tag_ids_method
+        # on assignment of tag IDs, find relevant tag objects and new-ify unfound ones, then set local variable:
+        define_method(tag_ids_method_assign) do |tag_ids|
+          # fake tag IDs start with initial underscore
+          fakes = tag_ids.select { |id| id.to_s.start_with?('_') }.uniq
+          tag_ids -= fakes # remove them from proper list
+          old_tags = klass.where(id: tag_ids)
+
+          fakes.map! { |name| name[1..-1] } # trim names
+
+          # find existing tags by same name
+          existing_tags = klass.where(name: fakes)
+          # remove fakes with same name, case-insensitively
+          existing_names = (old_tags + existing_tags).map(&:name).map(&:upcase)
+          fakes.reject! { |name| existing_names.include?(name.upcase) }
+
+          # create real tags for remaining fakes, must be added user separately
+          new_tags = fakes.map { |name| klass.new(user: user, name: name) }
+
+          # set tag list to: [old tags] + [existing new tags] + [new tags]
+          final_tags = old_tags + existing_tags + new_tags
+          self.public_send(tag_method_assign, final_tags)
+          self.instance_variable_set('@' + tag_ids_method + '_tags_todo', final_tags.map(&:id))
+        end
+      end
+    end
+
+    def build_new_tags_with(user)
+      self.class.instance_variable_get(:@acts_as_tags).each do |tag_name|
+        base = tag_name.to_s
+        tag_method = base + 's'
+        self.public_send(tag_method).each do |tag|
+          next if tag.persisted?
+          tag.user = user
+        end
+      end
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,8 +32,8 @@ class Post < ActiveRecord::Base
   has_many :content_warnings, through: :post_tags, source: :content_warning, after_add: :reset_warnings
   has_many :favorites, as: :favorite, dependent: :destroy
 
-  attr_accessible :board, :board_id, :subject, :privacy, :viewer_ids, :description, :section_id, :label_ids, :warning_ids, :setting_ids, :section_order, :status, :authors_locked
-  attr_accessor :label_ids, :warning_ids, :setting_ids, :is_import
+  attr_accessible :board, :board_id, :subject, :privacy, :viewer_ids, :description, :section_id, :label_ids, :content_warning_ids, :setting_ids, :section_order, :status, :authors_locked
+  attr_accessor :is_import, :label_ids, :content_warning_ids, :setting_ids
   attr_writer :skip_edited
 
   validates_presence_of :board, :subject
@@ -246,9 +246,9 @@ class Post < ActiveRecord::Base
   end
 
   def update_tag_list
-    return unless label_ids.present? || setting_ids.present? || warning_ids.present?
+    return unless label_ids.present? || setting_ids.present? || content_warning_ids.present?
 
-    updated_ids = ((label_ids || []) + (setting_ids || []) + (warning_ids || []) - ['']).map(&:to_i).reject(&:zero?).uniq.compact
+    updated_ids = ((label_ids || []) + (setting_ids || []) + (content_warning_ids || []) - ['']).map(&:to_i).reject(&:zero?).uniq.compact
     existing_ids = post_tags.map(&:tag_id)
 
     PostTag.where(post_id: id, tag_id: (existing_ids - updated_ids)).destroy_all

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -43,7 +43,6 @@ class Post < ActiveRecord::Base
   before_create :build_initial_flat_post
   before_create :set_last_user
   after_commit :notify_followers, on: :create
-  after_save :update_tag_list
 
   acts_as_tag :label, :content_warning, :setting
 
@@ -245,18 +244,6 @@ class Post < ActiveRecord::Base
   def valid_board_section
     if section.present? && section.board_id != board_id
       errors.add(:section, "must be in the post's board")
-    end
-  end
-
-  def update_tag_list
-    return unless label_ids.present? || setting_ids.present? || content_warning_ids.present?
-
-    updated_ids = ((label_ids || []) + (setting_ids || []) + (content_warning_ids || []) - ['']).map(&:to_i).reject(&:zero?).uniq.compact
-    existing_ids = post_tags.map(&:tag_id)
-
-    PostTag.where(post_id: id, tag_id: (existing_ids - updated_ids)).destroy_all
-    (updated_ids - existing_ids).each do |new_id|
-      PostTag.create(post_id: id, tag_id: new_id)
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,6 +16,10 @@ class Tag < ActiveRecord::Base
     {id: self.id, text: self.name}
   end
 
+  def id_for_select
+    id || "_#{name}"
+  end
+
   def merge_with(other_tag)
     transaction do
       PostTag.where(tag_id: other_tag.id).where(post_id: post_tags.pluck('distinct post_id')).delete_all

--- a/app/views/posts/_write_post.haml
+++ b/app/views/posts/_write_post.haml
@@ -14,13 +14,13 @@
       :id, :username, {selected: post.viewer_ids}, {multiple: true})
     %br
     = f.label :setting_ids, 'Setting:'
-    = f.select :setting_ids, options_from_collection_for_select(@settings, :id, :name, post.setting_ids || post.settings.map(&:id)), {}, {multiple: true}
+    = f.select :setting_ids, options_from_collection_for_select(@settings, :id_for_select, :name, post.setting_ids || post.settings.map(&:id)), {}, {multiple: true}
     %br
     = f.label :content_warning_ids, 'Content Warnings:'
-    = f.select :content_warning_ids, options_from_collection_for_select(@warnings, :id, :name, post.content_warning_ids || post.content_warnings.map(&:id)), {}, {multiple: true}
+    = f.select :content_warning_ids, options_from_collection_for_select(@warnings, :id_for_select, :name, post.content_warning_ids || post.content_warnings.map(&:id)), {}, {multiple: true}
     %br
     = f.label :label_ids, 'Labels:'
-    = f.select :label_ids, options_from_collection_for_select(@tags, :id, :name, post.label_ids || post.labels.map(&:id)), {}, {multiple: true}
+    = f.select :label_ids, options_from_collection_for_select(@tags, :id_for_select, :name, post.label_ids || post.labels.map(&:id)), {}, {multiple: true}
     %hr
     - unless post.id.present? && !post.editable_by?(current_user)
       .view-button#rtf{class: ('selected' if current_user.default_editor == 'rtf')} Rich Text

--- a/app/views/posts/_write_post.haml
+++ b/app/views/posts/_write_post.haml
@@ -16,8 +16,8 @@
     = f.label :setting_ids, 'Setting:'
     = f.select :setting_ids, options_from_collection_for_select(@settings, :id, :name, post.setting_ids || post.settings.map(&:id)), {}, {multiple: true}
     %br
-    = f.label :warning_ids, 'Content Warnings:'
-    = f.select :warning_ids, options_from_collection_for_select(@warnings, :id, :name, post.warning_ids || post.content_warnings.map(&:id)), {}, {multiple: true}
+    = f.label :content_warning_ids, 'Content Warnings:'
+    = f.select :content_warning_ids, options_from_collection_for_select(@warnings, :id, :name, post.content_warning_ids || post.content_warnings.map(&:id)), {}, {multiple: true}
     %br
     = f.label :label_ids, 'Labels:'
     = f.select :label_ids, options_from_collection_for_select(@tags, :id, :name, post.label_ids || post.labels.map(&:id)), {}, {multiple: true}

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe PostsController do
     it "creates new tags" do
       existing_name = create(:label)
       existing_case = create(:label)
-      tags = ['atag', 'atag', create(:label).id, '', existing_name.name, existing_case.name.upcase]
+      tags = ['_atag', '_atag', create(:label).id, '', '_' + existing_name.name, '_' + existing_case.name.upcase]
       login
       expect {
         post :create, post: {subject: 'a', board_id: create(:board).id, label_ids: tags}
@@ -269,7 +269,7 @@ RSpec.describe PostsController do
     it "creates new settings" do
       existing_name = create(:setting)
       existing_case = create(:setting)
-      tags = ['atag', 'atag', create(:setting).id, '', existing_name.name, existing_case.name.upcase]
+      tags = ['_atag', '_atag', create(:setting).id, '', '_' + existing_name.name, '_' + existing_case.name.upcase]
       login
       expect {
         post :create, post: {subject: 'a', board_id: create(:board).id, setting_ids: tags}
@@ -281,10 +281,10 @@ RSpec.describe PostsController do
     it "creates new content warnings" do
       existing_name = create(:content_warning)
       existing_case = create(:content_warning)
-      tags = ['atag', 'atag', create(:content_warning).id, '', existing_name.name, existing_case.name.upcase]
+      tags = ['_atag', '_atag', create(:content_warning).id, '', '_' + existing_name.name, '_' + existing_case.name.upcase]
       login
       expect {
-        post :create, post: {subject: 'a', board_id: create(:board).id, warning_ids: tags}
+        post :create, post: {subject: 'a', board_id: create(:board).id, content_warning_ids: tags}
       }.to change{ContentWarning.count}.by(1)
       expect(ContentWarning.last.name).to eq('atag')
       expect(assigns(:post).content_warnings.count).to eq(4)

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -719,10 +719,13 @@ RSpec.describe Post do
 
       it "uses extant tags with same name and type for #{type}" do
         tag = create(type)
+        old_user = tag.user
         taggable.send(type + '_ids=', ['_' + tag.name])
         taggable.save
         taggable.reload
-        expect(taggable.send(type + 's')).to match_array([tag])
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
       end
 
       it "does not use extant tags of a different type with same name for #{type}" do
@@ -739,10 +742,13 @@ RSpec.describe Post do
 
       it "uses extant #{type} tags by id" do
         tag = create(type)
+        old_user = tag.user
         taggable.send(type + '_ids=', [tag.id.to_s])
         taggable.save
         taggable.reload
-        expect(taggable.send(type + 's')).to match_array([tag])
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
       end
 
       it "removes #{type} tags when not in list given" do
@@ -755,6 +761,18 @@ RSpec.describe Post do
         taggable.save
         taggable.reload
         expect(taggable.send(type + 's')).to eq([])
+      end
+
+      it "only adds #{type} tags once if given multiple times" do
+        name = 'Example Tag'
+        tag = create(type, name: name)
+        old_user = tag.user
+        taggable.send(type + '_ids=', ['_' + name, '_' + name, tag.id.to_s, tag.id.to_s])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
       end
     end
   end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -703,4 +703,59 @@ RSpec.describe Post do
     post.run_callbacks(:commit) # deal with tests running in a transaction
     expect(NotifyFollowersOfNewPostJob).to have_queued(post.id)
   end
+
+  context "tags" do
+    let(:taggable) { create(:post) }
+    ['label', 'setting', 'content_warning'].each do |type|
+      it "creates new #{type} tags if they don't exist" do
+        taggable.send(type + '_ids=', ['_tag'])
+        expect(taggable.send(type + 's').map(&:name)).to match_array(['tag'])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags.map(&:name)).to match_array(['tag'])
+        expect(tags.map(&:user)).to match_array([taggable.user])
+      end
+
+      it "uses extant tags with same name and type for #{type}" do
+        tag = create(type)
+        taggable.send(type + '_ids=', ['_' + tag.name])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to match_array([tag])
+      end
+
+      it "does not use extant tags of a different type with same name for #{type}" do
+        name = "Example Tag"
+        tag = create(:tag, type: 'NonexistentTag', name: name)
+        taggable.send(type + '_ids=', ['_' + name])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags.map(&:name)).to match_array([name])
+        expect(tags.map(&:user)).to match_array([taggable.user])
+        expect(tags).not_to include(tag)
+      end
+
+      it "uses extant #{type} tags by id" do
+        tag = create(type)
+        taggable.send(type + '_ids=', [tag.id.to_s])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to match_array([tag])
+      end
+
+      it "removes #{type} tags when not in list given" do
+        tag = create(type)
+        taggable.send(type + 's=', [tag])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to match_array([tag])
+        taggable.send(type + '_ids=', [])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to eq([])
+      end
+    end
+  end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -37,4 +37,16 @@ RSpec.describe Tag do
       expect(new_tag).not_to be_valid
     end
   end
+
+  describe "#id_for_select" do
+    it "uses ID if persisted" do
+      tag = create(:label)
+      expect(tag.id_for_select).to eq(tag.id)
+    end
+
+    it "uses name with prepended underscore otherwise" do
+      tag = build(:label, name: 'tag')
+      expect(tag.id_for_select).to eq('_tag')
+    end
+  end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Tag do
       bad_tag = create(:label)
 
       # TODO handle properly with nested attributes
-      create(:post, label_ids: [good_tag.id], setting_ids: [], warning_ids: [])
-      create(:post, label_ids: [good_tag.id], setting_ids: [], warning_ids: [])
-      create(:post, label_ids: [good_tag.id], setting_ids: [], warning_ids: [])
-      create(:post, label_ids: [bad_tag.id], setting_ids: [], warning_ids: [])
-      create(:post, label_ids: [bad_tag.id], setting_ids: [], warning_ids: [])
+      create(:post, label_ids: [good_tag.id], setting_ids: [], content_warning_ids: [])
+      create(:post, label_ids: [good_tag.id], setting_ids: [], content_warning_ids: [])
+      create(:post, label_ids: [good_tag.id], setting_ids: [], content_warning_ids: [])
+      create(:post, label_ids: [bad_tag.id], setting_ids: [], content_warning_ids: [])
+      create(:post, label_ids: [bad_tag.id], setting_ids: [], content_warning_ids: [])
 
       expect(good_tag.posts.count).to eq(3)
       expect(bad_tag.posts.count).to eq(2)


### PR DESCRIPTION
This also prepends tag IDs by underscores if they're not yet created (so we can distinguish extant and non-extant tags in a more principled manner). Also order post tags by `name` by default. Also rename `warning_ids` to `content_warning_ids` for consistency.