### PR TITLE
Revert 8bba13fe partially, undoing post tag order

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -28,9 +28,9 @@ class Post < ActiveRecord::Base
   has_many :viewers, through: :post_viewers, source: :user
   has_many :reply_drafts, dependent: :destroy
   has_many :post_tags, inverse_of: :post, dependent: :destroy
-  has_many :labels, -> { order('name') }, through: :post_tags, source: :label
-  has_many :settings, -> { order('name') }, through: :post_tags, source: :setting
-  has_many :content_warnings, -> { order('name') }, through: :post_tags, source: :content_warning, after_add: :reset_warnings
+  has_many :labels, through: :post_tags, source: :label
+  has_many :settings, through: :post_tags, source: :setting
+  has_many :content_warnings, through: :post_tags, source: :content_warning, after_add: :reset_warnings
   has_many :favorites, as: :favorite, dependent: :destroy
 
   attr_accessible :board, :board_id, :subject, :privacy, :viewer_ids, :description, :section_id, :label_ids, :content_warning_ids, :setting_ids, :section_order, :status, :authors_locked


### PR DESCRIPTION
Some people use the specific order of the tags for a narrative, so don't order them by name, as that could cause this to break.