### PR TITLE
Add gallery groups

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,8 @@
 //= require select2
 /* global gon */
 
+var foundTags = {};
+
 $(document).ready(function() {
   $(".chosen-select").select2({
     width: '100%',
@@ -95,4 +97,66 @@ function resizeScreenname(screenameBox) {
 
   if (screenameBox.height() <= 20) return;
   screenameBox.css('font-size', "75%");
+}
+
+function saveExistingTags(selector, newTags) {
+  var newList = foundTags[selector].concat(newTags);
+  var ids = [];
+  foundTags[selector] = [];
+  // add tags, uniquely by ID
+  newList.forEach(function(tag) {
+    if (ids.indexOf(tag.id) >= 0) return;
+    ids.push(tag.id);
+    foundTags[selector].push(tag);
+  });
+}
+
+function createTagSelect(tagType, selector, formType, scope) {
+  foundTags[selector] = [];
+  $("#"+formType+"_"+selector+"_ids").select2({
+    tags: true,
+    tokenSeparators: [','],
+    placeholder: 'Enter ' + selector.replace('_', ' ') + '(s) separated by commas',
+    ajax: {
+      delay: 200,
+      url: '/api/v1/tags',
+      dataType: 'json',
+      data: function(params) {
+        var data = {
+          q: params.term,
+          t: tagType,
+          page: params.page
+        };
+        if (scope) Object.assign(data, scope);
+        return data;
+      },
+      processResults: function(data, params) {
+        params.page = params.page || 1;
+        var total = this._request.getResponseHeader('Total');
+        saveExistingTags(selector, data.results);
+        return {
+          results: data.results,
+          pagination: {
+            more: (params.page * 25) < total
+          }
+        };
+      },
+      cache: true
+    },
+    createTag: function(params) {
+      var term = $.trim(params.term);
+      if (term === '') return null;
+      var extantTag;
+      foundTags[selector].forEach(function(tag) {
+        if (tag.text.toUpperCase() === term.toUpperCase()) extantTag = tag;
+      });
+      if (extantTag) return extantTag;
+
+      return {
+        id: '_' + term,
+        text: term
+      };
+    },
+    width: '300px'
+  });
 }

--- a/app/assets/javascripts/galleries/editor.js
+++ b/app/assets/javascripts/galleries/editor.js
@@ -1,0 +1,4 @@
+/* global createTagSelect */
+$(document).ready(function() {
+  createTagSelect("GalleryGroup", "gallery_group", "gallery", {user_id: gon.user_id});
+});

--- a/app/assets/javascripts/galleries/expander.js
+++ b/app/assets/javascripts/galleries/expander.js
@@ -33,4 +33,32 @@ $(document).ready(function() {
       });
     });
   });
+
+  $(".tag-item").hover(function mouseIn() {
+    $(this).removeClass('semiplusopaque');
+  }, function mouseOut() {
+    $(this).addClass('semiplusopaque');
+  });
+
+  // add ellipsis box for many (> 5) tags
+  $(".tag-box").each(function() {
+    var tagBox = $(this);
+    var tagBoxItems = $(".tag-item", tagBox);
+    if (tagBoxItems.length <= 5) return;
+    var hiddenTags = tagBoxItems.slice(4);
+    hiddenTags.hide();
+    var ellipsisBox = $("<span>").attr({class: 'tag-item semiopaque pointer', title: 'Click to show more tags…'}).append("...");
+    var recollapseBox = $("<span>").attr({class: 'tag-item semiopaque pointer', title: 'Click to hide extra tags…'}).append("←").hide();
+    tagBox.append(ellipsisBox).append(' ').append(recollapseBox); // inline-block cares about spaces for formatting
+    ellipsisBox.click(function() {
+      hiddenTags.show();
+      ellipsisBox.hide();
+      recollapseBox.show();
+    });
+    recollapseBox.click(function() {
+      hiddenTags.hide();
+      recollapseBox.hide();
+      ellipsisBox.show();
+    });
+  });
 });

--- a/app/assets/javascripts/galleries/expander_old.js
+++ b/app/assets/javascripts/galleries/expander_old.js
@@ -4,9 +4,11 @@ $(document).ready(function() {
     var id = elem.data('id');
     if (elem.html().trim() === '-') {
       $('#gallery' + id).hide();
+      $('#gallery-tags-' + id).hide();
       elem.html('+');
     } else {
       $('#gallery' + id).show();
+      $('#gallery-tags-' + id).show();
       elem.html('-');
     }
   });

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -1,6 +1,5 @@
-/* global gon, tinymce, tinyMCE, resizeScreenname */
+/* global gon, tinymce, tinyMCE, resizeScreenname, createTagSelect */
 var tinyMCEInit = false;
-var foundTags = {};
 
 $(document).ready(function() {
   // SET UP POST METADATA EDITOR:
@@ -29,9 +28,9 @@ $(document).ready(function() {
     placeholder: 'Choose user(s) to view this post'
   });
 
-  createTagSelect("Label", "label");
-  createTagSelect("Setting", "setting");
-  createTagSelect("ContentWarning", "content_warning");
+  createTagSelect("Label", "label", "post");
+  createTagSelect("Setting", "setting", "post");
+  createTagSelect("ContentWarning", "content_warning", "post");
 
   if (String($("#post_privacy").val()) !== String(PRIVACY_ACCESS)) {
     $("#access_list").hide();
@@ -439,67 +438,6 @@ function setSections() {
       $("#section").hide();
     }
   }, 'json');
-}
-
-function saveExistingTags(selector, newTags) {
-  var newList = foundTags[selector].concat(newTags);
-  var ids = [];
-  foundTags[selector] = [];
-  // add tags, uniquely by ID
-  newList.forEach(function(tag) {
-    if (ids.indexOf(tag.id) >= 0) return;
-    ids.push(tag.id);
-    foundTags[selector].push(tag);
-  });
-}
-
-function createTagSelect(tagType, selector) {
-  foundTags[selector] = [];
-  $("#post_"+selector+"_ids").select2({
-    tags: true,
-    tokenSeparators: [','],
-    placeholder: 'Enter ' + selector.replace('_', ' ') + '(s) separated by commas',
-    ajax: {
-      delay: 200,
-      url: '/api/v1/tags',
-      dataType: 'json',
-      data: function(params) {
-        var data = {
-          q: params.term,
-          t: tagType,
-          page: params.page
-        };
-        return data;
-      },
-      processResults: function(data, params) {
-        params.page = params.page || 1;
-        var total = this._request.getResponseHeader('Total');
-        saveExistingTags(selector, data.results);
-        return {
-          results: data.results,
-          pagination: {
-            more: (params.page * 25) < total
-          }
-        };
-      },
-      cache: true
-    },
-    createTag: function(params) {
-      var term = $.trim(params.term);
-      if (term === '') return null;
-      var extantTag;
-      foundTags[selector].forEach(function(tag) {
-        if (tag.text.toUpperCase() === term.toUpperCase()) extantTag = tag;
-      });
-      if (extantTag) return extantTag;
-
-      return {
-        id: '_' + term,
-        text: term
-      };
-    },
-    width: '300px'
-  });
 }
 
 function setCharacterListSelected(characterId) {

--- a/app/assets/stylesheets/global.css
+++ b/app/assets/stylesheets/global.css
@@ -64,6 +64,7 @@ button, .button {
 .bold { font-weight: bold; }
 .auto { overflow: auto; }
 .semiopaque { opacity: 0.5; }
+.semiplusopaque { opacity: 0.6; }
 
 /* For UI elements involving reordering */
 .disabled-arrow {

--- a/app/assets/stylesheets/layout.css
+++ b/app/assets/stylesheets/layout.css
@@ -114,6 +114,25 @@
 .view-button .list-view { width: 20px; height: 17px; display: inline; margin: 0; padding: 0; top: 2px; position: relative; }
 .view-button .icon-view { width: 15px; height: 15px; display: inline; margin: 0; padding: 0; top: 2px; position: relative; }
 
+/* Tag label buttons, like seen on the gallery page */
+.tag-box {
+  display: inline;
+  margin-left: 5px;
+}
+.tag-item-link:hover {
+  color: unset;
+}
+.tag-item {
+  display: inline-block;
+  background-color: #B9B6AD;
+  color: #3F7055;
+  margin: 2px 0;
+  padding: 2px 8px;
+  border-radius: 5px;
+  font-size: 90%;
+  font-weight: normal;
+}
+
 /* The new object layout with the floating left info box and the right content area */
 #content .left-info-box { float: left; }
 #content .right-content-box { float: left; }

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -10,6 +10,13 @@ class Api::V1::TagsController < Api::ApiController
   error 422, "Invalid parameters provided"
   def index
     queryset = params[:t].constantize.where("name LIKE ?", params[:q].to_s + '%').order('name')
+
+    # gallery groups only searches groups the specified user has used
+    if (user_id = params[:user_id]) && params[:t] == 'GalleryGroup'
+      user_gal_tags = GalleryGroup.joins(gallery_tags: [:gallery]).where(galleries: {user_id: user_id}).pluck(:id)
+      queryset = queryset.where(id: user_gal_tags)
+    end
+
     tags = paginate queryset, per_page: 25
     render json: {results: tags}
   end

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::TagsController < Api::ApiController
   api :GET, '/tags', 'Load all the tags of the specified type that match the given query, results ordered by name'
   param :q, String, required: false, desc: "Query string"
   param :page, :number, required: false, desc: 'Page in results (25 per page)'
-  param :t, ['Setting', 'Label', 'ContentWarning'], required: true, desc: 'Whether to search Settings, Content Warnings or Labels'
+  param :t, ['Setting', 'Label', 'ContentWarning', 'GalleryGroup'], required: true, desc: 'Whether to search Settings, Content Warnings, Labels or Gallery Groups'
   error 422, "Invalid parameters provided"
   def index
     queryset = params[:t].constantize.where("name LIKE ?", params[:q].to_s + '%').order('name')

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -4,6 +4,7 @@ class GalleriesController < ApplicationController
   before_filter :find_gallery, only: [:destroy, :edit, :update]
   before_filter :setup_new_icons, only: [:add, :icon]
   before_filter :set_s3_url, only: [:add, :icon]
+  before_filter :setup_editor, only: [:new, :edit]
 
   def index
     if params[:user_id].present?
@@ -33,10 +34,12 @@ class GalleriesController < ApplicationController
   def create
     @gallery = Gallery.new(gallery_params)
     @gallery.user = current_user
+    @gallery.build_new_tags_with(current_user)
 
     unless @gallery.save
       flash.now[:error] = "Your gallery could not be saved."
       @page_title = 'New Gallery'
+      setup_editor
       render :action => :new and return
     end
 
@@ -74,11 +77,15 @@ class GalleriesController < ApplicationController
   end
 
   def update
-    unless @gallery.update_attributes(gallery_params)
+    @gallery.assign_attributes(gallery_params)
+    @gallery.build_new_tags_with(current_user)
+
+    unless @gallery.save
       flash.now[:error] = {}
       flash.now[:error][:message] = "Gallery could not be saved."
       flash.now[:error][:array] = @gallery.errors.full_messages
       @page_title = 'Edit Gallery: ' + @gallery.name_was
+      setup_editor
       render action: :edit and return
     end
 
@@ -198,8 +205,18 @@ class GalleriesController < ApplicationController
       cache_control: 'public, max-age=31536000')
   end
 
+  def setup_editor
+    use_javascript('galleries/editor')
+    build_tags
+    gon.user_id = current_user.id
+  end
+
+  def build_tags
+    @gallery_groups = @gallery.try(:gallery_groups) || []
+  end
+
   def gallery_params
-    params.fetch(:gallery, {}).permit(:name, galleries_icons_attributes: [:id, :_destroy, icon_attributes: [:url, :keyword, :credit, :id, :_destroy]], icon_ids: [])
+    params.fetch(:gallery, {}).permit(:name, galleries_icons_attributes: [:id, :_destroy, icon_attributes: [:url, :keyword, :credit, :id, :_destroy]], icon_ids: [], gallery_group_ids: [])
   end
 
   def icon_params(paramset)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -6,11 +6,12 @@ class TagsController < ApplicationController
 
   def index
     @page_title = "Tags"
-    @tags = Tag.order('type desc, LOWER(name) asc').paginate(per_page: 25, page: page)
+    @tags = Tag.order('type desc, LOWER(name) asc').select('tags.*').with_item_counts.paginate(per_page: 25, page: page)
   end
 
   def show
     @posts = posts_from_relation(@tag.posts)
+    @galleries = @tag.galleries
     @page_title = @tag.name.to_s
   end
 

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -1,15 +1,20 @@
 class Gallery < ActiveRecord::Base
+  include Taggable
   belongs_to :user
 
   has_many :galleries_icons, dependent: :destroy
+  accepts_nested_attributes_for :galleries_icons, allow_destroy: true
   has_many :icons, -> { order('LOWER(keyword)') }, through: :galleries_icons
 
-  has_many :characters_galleries
+  has_many :characters_galleries, inverse_of: :gallery
   has_many :characters, through: :characters_galleries
 
-  accepts_nested_attributes_for :galleries_icons, allow_destroy: true
+  has_many :gallery_tags, inverse_of: :gallery, dependent: :destroy
+  has_many :gallery_groups, through: :gallery_tags, source: :gallery_group
 
   validates_presence_of :user, :name
+
+  acts_as_tag :gallery_group
 
   scope :ordered, -> { order('characters_galleries.section_order ASC') }
   scope :with_icon_count, -> {

--- a/app/models/gallery_group.rb
+++ b/app/models/gallery_group.rb
@@ -1,0 +1,2 @@
+class GalleryGroup < Tag
+end

--- a/app/models/gallery_tag.rb
+++ b/app/models/gallery_tag.rb
@@ -1,0 +1,22 @@
+class GalleryTag < ActiveRecord::Base
+  belongs_to :gallery, inverse_of: :gallery_tags
+  belongs_to :tag
+  belongs_to :gallery_group, foreign_key: :tag_id
+
+  after_create :add_gallery_to_characters
+  after_destroy :remove_gallery_from_characters
+
+  def add_gallery_to_characters
+    return if gallery_group.nil? # skip non-gallery_groups
+    joined_characters = gallery_group.characters.joins(:characters_galleries).where(characters_galleries: {gallery_id: gallery.id})
+    characters = gallery_group.characters.where(user_id: gallery.user_id).where.not(id: joined_characters.pluck(:id))
+    characters.each do |character|
+      CharactersGallery.create(character_id: character.id, gallery_id: gallery.id, added_by_group: true)
+    end
+  end
+
+  def remove_gallery_from_characters
+    return if gallery_group.nil? # skip non-gallery_groups
+    gallery.remove_gallery_from_characters(gallery_group)
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,6 +10,11 @@ class Tag < ActiveRecord::Base
   validates_presence_of :user, :name, :type
   validates :name, uniqueness: { scope: :type }
 
+  scope :with_item_counts, -> {
+    select('(SELECT COUNT(DISTINCT post_tags.post_id) FROM post_tags WHERE post_tags.tag_id = tags.id) AS post_count,
+    (SELECT COUNT(DISTINCT gallery_tags.gallery_id) FROM gallery_tags WHERE gallery_tags.tag_id = tags.id) AS gallery_count')
+  }
+
   def editable_by?(user)
     user.try(:admin?)
   end
@@ -20,6 +25,16 @@ class Tag < ActiveRecord::Base
 
   def id_for_select
     id || "_#{name}"
+  end
+
+  def post_count
+    return read_attribute(:post_count) if has_attribute?(:post_count)
+    posts.count
+  end
+
+  def gallery_count
+    return read_attribute(:gallery_count) if has_attribute?(:gallery_count)
+    galleries.count
   end
 
   def merge_with(other_tag)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,6 +4,8 @@ class Tag < ActiveRecord::Base
   has_many :posts, through: :post_tags
   has_many :character_tags, dependent: :destroy
   has_many :characters, through: :character_tags
+  has_many :gallery_tags, dependent: :destroy
+  has_many :galleries, through: :gallery_tags
 
   validates_presence_of :user, :name, :type
   validates :name, uniqueness: { scope: :type }
@@ -26,6 +28,8 @@ class Tag < ActiveRecord::Base
       PostTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
       CharacterTag.where(tag_id: other_tag.id).where(character_id: character_tags.pluck('distinct character_id')).delete_all
       CharacterTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
+      GalleryTag.where(tag_id: other_tag.id).where(gallery_id: gallery_tags.pluck('distinct gallery_id')).delete_all
+      GalleryTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
       other_tag.destroy
     end
   end

--- a/app/views/galleries/_list_view.haml
+++ b/app/views/galleries/_list_view.haml
@@ -24,10 +24,16 @@
       - if @user.id == current_user.try(:id)
         .clear.centered.icons-remove
           = submit_tag "x Delete selected icons permanently", data: { confirm: "Are you sure? These icons will be gone from the site!" }
-- @user.galleries.with_icon_count.order('name asc').each do |gallery|
+- @user.galleries.with_icon_count.with_gallery_groups.order('name asc').each do |gallery|
   %tr
     - klass = cycle('even', 'odd')
-    %td.gallery-name{class: klass}= link_to gallery.name, gallery_path(gallery)
+    %td.gallery-name{class: klass}
+      = link_to gallery.name, gallery_path(gallery)
+      .tag-box
+        - gallery.gallery_groups_data.each do |group|
+          = link_to tag_path(group.id), class: 'tag-item-link' do
+            %span.tag-item.semiplusopaque
+              = group.name
     %td.width-150.centered.gallery-icon-count{class: klass}= gallery.icon_count
     %td.width-70.gallery-buttons{class: klass}
       - if @user.id == current_user.try(:id)

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -17,6 +17,16 @@
       .float-right
         = image_tag "/images/arrow_up.png", class: "section-up disabled-arrow", data: {order: section.section_order}
         = image_tag "/images/arrow_down.png", class: "section-down disabled-arrow", data: {order: section.section_order}
+- groups = gallery.gallery_groups_data
+  - if groups.present?
+  %tr.gallery-tags
+    %th.subber{id: "gallery-tags-#{gallery.id}"}
+      Groups:
+      .tag-box
+        - gallery.gallery_groups_data.each do |group|
+          = link_to tag_path(group.id), class: 'tag-item-link' do
+            %span.tag-item
+              = group.name
 - attrs = {id: "section-gallery-#{section.section_order}"} if attrs[:id]
 %tr.gallery-icons{**attrs}
   %td.green

--- a/app/views/galleries/edit.haml
+++ b/app/views/galleries/edit.haml
@@ -12,7 +12,11 @@
         Edit Gallery
     %tr
       %th.sub Name
-      %td.even{colspan: 2}= f.text_field :name, placeholder: "Gallery Name", class: 'text'
+      %td{class: cycle('even', 'odd'), colspan: 2}= f.text_field :name, placeholder: "Gallery Name", class: 'text'
+    %tr
+      %th.vtop.sub Groups
+      %td{class: cycle('even', 'odd'), colspan: 2}
+        = f.select :gallery_group_ids, options_from_collection_for_select(@gallery_groups, :id_for_select, :name, @gallery.gallery_group_ids || @gallery.gallery_groups.map(&:id)), {}, {multiple: true}
     %tr
       %th.subber{colspan: 3} Edit Icons
     = f.fields_for :galleries_icons, @gallery.galleries_icons.joins(:icon).order('LOWER(keyword)') do |gif|

--- a/app/views/galleries/new.haml
+++ b/app/views/galleries/new.haml
@@ -5,11 +5,15 @@
       %th.centered{colspan: 2}New Gallery
     %tr
       %th.vtop.sub Name
-      %td.even= f.text_field :name, placeholder: "Gallery Name", class: 'text'
+      %td{class: cycle('even', 'odd')}= f.text_field :name, placeholder: "Gallery Name", class: 'text'
+    %tr
+      %th.vtop.sub Groups
+      %td{class: cycle('even', 'odd')}
+        = f.select :gallery_group_ids, options_from_collection_for_select(@gallery_groups, :id_for_select, :name, @gallery.gallery_group_ids || @gallery.gallery_groups.map(&:id)), {}, {multiple: true}
     - if icons_present
       %tr
         %th.vtop.sub Icons
-        %td.odd
+        %td{class: cycle('even', 'odd')}
           - current_user.galleryless_icons.each do |icon|
             = label_tag "gallery_icon_ids_#{icon.id}" do
               .gallery-icon

--- a/app/views/tags/index.haml
+++ b/app/views/tags/index.haml
@@ -1,20 +1,22 @@
 %table
   %thead
     %tr
-      %th{colspan: 4}
+      %th{colspan: 5}
         Tags
   %tbody
     %tr
       %th.sub Tag
       %th.sub Type
       %th.sub Posts
+      %th.sub Galleries
       %th.sub
     - @tags.each do |tag|
       - klass = cycle('even', 'odd')
       %tr
         %td{class: klass}= link_to tag.name, tag_path(tag)
         %td{class: klass}= (tag.type || 'Tag').titlecase
-        %td{class: klass}= tag.posts.count
+        %td{class: klass}= tag.post_count
+        %td{class: klass}= tag.gallery_count
         %td.width-70.right-align{class: klass}
           - if tag.editable_by?(current_user)
             = link_to edit_tag_path(tag) do

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -3,8 +3,7 @@
   &raquo;
   %b= @tag.name
 
-- content_for :posts_title do
-  Posts Tagged: #{@tag.name}
+- content_for :edit_box do
   - if @tag.editable_by?(current_user)
     = link_to edit_tag_path(@tag) do
       .link-box.blue
@@ -13,4 +12,28 @@
     = link_to tag_path(@tag), method: :delete, data: { confirm: 'Are you sure you want to delete this tag?' } do
       .link-box.red x Delete
 
-= render partial: 'posts/list', locals: {posts: @posts}
+- if @posts.present?
+  - content_for :posts_title do
+    Posts Tagged: #{@tag.name}
+    - content_for :edit_box
+
+  = render partial: 'posts/list', locals: {posts: @posts}
+  %br
+
+- if @galleries.present?
+  - reset_cycle
+  %table
+    %thead
+      %tr
+        %th.padding-10{colspan: 2}
+          Galleries Tagged: #{@tag.name}
+          - content_for :edit_box
+    %tbody
+      %tr
+        %th.sub Name
+        %th.sub # of Icons
+      - @galleries.with_icon_count.order('name asc').each do |gallery|
+        %tr
+          - klass = cycle('even', 'odd')
+          %td.gallery-name{class: klass}= link_to gallery.name, gallery_path(gallery)
+          %td.width-150.centered.gallery-icon-count{class: klass}= gallery.icon_count

--- a/db/migrate/20170826211901_add_gallery_tags.rb
+++ b/db/migrate/20170826211901_add_gallery_tags.rb
@@ -1,0 +1,12 @@
+class AddGalleryTags < ActiveRecord::Migration
+  def change
+    create_table :gallery_tags do |t|
+      t.integer :gallery_id, null: false
+      t.integer :tag_id, null: false
+      t.timestamps null: true
+
+      t.index :gallery_id
+      t.index :tag_id
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -520,6 +520,38 @@ ALTER SEQUENCE galleries_id_seq OWNED BY galleries.id;
 
 
 --
+-- Name: gallery_tags; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE gallery_tags (
+    id integer NOT NULL,
+    gallery_id integer NOT NULL,
+    tag_id integer NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: gallery_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE gallery_tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: gallery_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE gallery_tags_id_seq OWNED BY gallery_tags.id;
+
+
+--
 -- Name: icons; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1112,6 +1144,13 @@ ALTER TABLE ONLY galleries_icons ALTER COLUMN id SET DEFAULT nextval('galleries_
 
 
 --
+-- Name: gallery_tags id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY gallery_tags ALTER COLUMN id SET DEFAULT nextval('gallery_tags_id_seq'::regclass);
+
+
+--
 -- Name: icons id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1312,6 +1351,14 @@ ALTER TABLE ONLY galleries_icons
 
 ALTER TABLE ONLY galleries
     ADD CONSTRAINT galleries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: gallery_tags gallery_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY gallery_tags
+    ADD CONSTRAINT gallery_tags_pkey PRIMARY KEY (id);
 
 
 --
@@ -1584,6 +1631,20 @@ CREATE INDEX index_galleries_icons_on_icon_id ON galleries_icons USING btree (ic
 --
 
 CREATE INDEX index_galleries_on_user_id ON galleries USING btree (user_id);
+
+
+--
+-- Name: index_gallery_tags_on_gallery_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_gallery_tags_on_gallery_id ON gallery_tags USING btree (gallery_id);
+
+
+--
+-- Name: index_gallery_tags_on_tag_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_gallery_tags_on_tag_id ON gallery_tags USING btree (tag_id);
 
 
 --
@@ -1967,4 +2028,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170814042150');
 INSERT INTO schema_migrations (version) VALUES ('20170819222420');
 
 INSERT INTO schema_migrations (version) VALUES ('20170821210336');
+
+INSERT INTO schema_migrations (version) VALUES ('20170826211901');
 

--- a/spec/controllers/api/v1/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/tags_controller_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe Api::V1::TagsController do
         expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
       end
 
+      it "should support gallery group search" do
+        tag = create(:gallery_group)
+        get :index, q: tag.name, t: 'GalleryGroup'
+        expect(response).to have_http_status(200)
+        expect(response.json).to have_key('results')
+        expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
+      end
+
       it "should handle invalid input", show_in_doc: in_doc do
         get :index, t: 'b'
         expect(response).to have_http_status(422)

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe PostsController do
       end
     end
 
-    it "creates new tags" do
+    it "creates new labels" do
       existing_name = create(:label)
       existing_case = create(:label)
       tags = ['_atag', '_atag', create(:label).id, '', '_' + existing_name.name, '_' + existing_case.name.upcase]

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -2,15 +2,34 @@ require "spec_helper"
 
 RSpec.describe TagsController do
   describe "GET index" do
-    it "succeeds when logged out" do
-      get :index
-      expect(response.status).to eq(200)
-    end
+    context "with views" do
+      render_views
+      def create_tags
+        # set up sample tags, empty and not
+        empty_tag = create(:label)
+        tag = create(:label)
+        create(:post, labels: [tag])
 
-    it "succeeds when logged in" do
-      login
-      get :index
-      expect(response.status).to eq(200)
+        empty_group = create(:gallery_group)
+        group = create(:gallery_group)
+        create(:gallery, gallery_groups: [group])
+        [empty_tag, tag, empty_group, group]
+      end
+
+      it "succeeds when logged out" do
+        tags = create_tags
+        get :index
+        expect(response.status).to eq(200)
+        expect(assigns(:tags)).to match_array(tags)
+      end
+
+      it "succeeds when logged in" do
+        tags = create_tags
+        login
+        get :index
+        expect(response.status).to eq(200)
+        expect(assigns(:tags)).to match_array(tags)
+      end
     end
   end
 
@@ -21,17 +40,41 @@ RSpec.describe TagsController do
       expect(flash[:error]).to eq("Tag could not be found.")
     end
 
-    it "succeeds with valid tag" do
-      tag = create(:label)
-      get :show, id: tag.id
-      expect(response.status).to eq(200)
-    end
+    context "with views" do
+      render_views
+      it "succeeds with valid post tag" do
+        tag = create(:label)
+        post = create(:post, labels: [tag])
+        get :show, id: tag.id
+        expect(response.status).to eq(200)
+        expect(assigns(:posts)).to match_array([post])
+      end
 
-    it "succeeds for logged in users with valid tag" do
-      tag = create(:label)
-      login
-      get :show, id: tag.id
-      expect(response.status).to eq(200)
+      it "succeeds for logged in users with valid post tag" do
+        tag = create(:label)
+        post = create(:post, labels: [tag])
+        login
+        get :show, id: tag.id
+        expect(response.status).to eq(200)
+        expect(assigns(:posts)).to match_array([post])
+      end
+
+      it "succeeds with valid gallery tag" do
+        group = create(:gallery_group)
+        gallery = create(:gallery, gallery_groups: [group])
+        get :show, id: group.id
+        expect(response.status).to eq(200)
+        expect(assigns(:galleries)).to match_array([gallery])
+      end
+
+      it "succeeds for logged in users with valid gallery tag" do
+        group = create(:gallery_group)
+        gallery = create(:gallery, gallery_groups: [group])
+        login
+        get :show, id: group.id
+        expect(response.status).to eq(200)
+        expect(assigns(:galleries)).to match_array([gallery])
+      end
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -138,6 +138,10 @@ FactoryGirl.define do
     factory :content_warning, class: ContentWarning do
       type 'ContentWarning'
     end
+
+    factory :gallery_group, class: GalleryGroup do
+      type 'GalleryGroup'
+    end
   end
 
   factory :message do

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -30,4 +30,77 @@ RSpec.describe Gallery do
     gallery.icons << create(:icon, keyword: 'xxx', user: gallery.user)
     expect(gallery.icons.pluck(:keyword)).to eq(['xxx', 'yyy', 'zzz'])
   end
+
+  context "tags" do
+    let(:taggable) { create(:gallery) }
+    ['gallery_group'].each do |type|
+      it "creates new #{type} tags if they don't exist" do
+        taggable.send(type + '_ids=', ['_tag'])
+        expect(taggable.send(type + 's').map(&:name)).to match_array(['tag'])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags.map(&:name)).to match_array(['tag'])
+        expect(tags.map(&:user)).to match_array([taggable.user])
+      end
+
+      it "uses extant tags with same name and type for #{type}" do
+        tag = create(type)
+        old_user = tag.user
+        taggable.send(type + '_ids=', ['_' + tag.name])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+
+      it "does not use extant tags of a different type with same name for #{type}" do
+        name = "Example Tag"
+        tag = create(:tag, type: 'NonexistentTag', name: name)
+        taggable.send(type + '_ids=', ['_' + name])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags.map(&:name)).to match_array([name])
+        expect(tags.map(&:user)).to match_array([taggable.user])
+        expect(tags).not_to include(tag)
+      end
+
+      it "uses extant #{type} tags by id" do
+        tag = create(type)
+        old_user = tag.user
+        taggable.send(type + '_ids=', [tag.id.to_s])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+
+      it "removes #{type} tags when not in list given" do
+        tag = create(type)
+        taggable.send(type + 's=', [tag])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to match_array([tag])
+        taggable.send(type + '_ids=', [])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to eq([])
+      end
+
+      it "only adds #{type} tags once if given multiple times" do
+        name = 'Example Tag'
+        tag = create(type, name: name)
+        old_user = tag.user
+        taggable.send(type + '_ids=', ['_' + name, '_' + name, tag.id.to_s, tag.id.to_s])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+    end
+  end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -49,4 +49,54 @@ RSpec.describe Tag do
       expect(tag.id_for_select).to eq('_tag')
     end
   end
+
+  describe "#post_count" do
+    def create_tags
+      tag1 = create(:label)
+      tag2 = create(:label)
+      create(:post, labels: [tag2])
+      tag3 = create(:label)
+      2.times { create(:post, labels: [tag3]) }
+      [tag1, tag2, tag3]
+    end
+
+    it "works with with_item_counts scope" do
+      tags = create_tags
+      fetched = Label.where(id: tags.map(&:id)).select(:id).with_item_counts
+      expect(fetched).to eq(tags)
+      expect(fetched.map(&:post_count)).to eq([0, 1, 2])
+    end
+
+    it "works without with_item_counts scope" do
+      tags = create_tags
+      fetched = Label.where(id: tags.map(&:id))
+      expect(fetched).to eq(tags)
+      expect(fetched.map(&:post_count)).to eq([0, 1, 2])
+    end
+  end
+
+  describe "#gallery_count" do
+    def create_tags
+      tag1 = create(:gallery_group)
+      tag2 = create(:gallery_group)
+      create(:gallery, gallery_groups: [tag2])
+      tag3 = create(:gallery_group)
+      2.times { create(:gallery, gallery_groups: [tag3]) }
+      [tag1, tag2, tag3]
+    end
+
+    it "works with with_item_counts scope" do
+      tags = create_tags
+      fetched = GalleryGroup.where(id: tags.map(&:id)).select(:id).with_item_counts
+      expect(fetched).to eq(tags)
+      expect(fetched.map(&:gallery_count)).to eq([0, 1, 2])
+    end
+
+    it "works without with_item_counts scope" do
+      tags = create_tags
+      fetched = GalleryGroup.where(id: tags.map(&:id))
+      expect(fetched).to eq(tags)
+      expect(fetched.map(&:gallery_count)).to eq([0, 1, 2])
+    end
+  end
 end


### PR DESCRIPTION
Does part of #330. This is only the gallery side of the tag.

TODO:

- [X] Test *everything*, all the things
- [X] Expose the tags somewhere on gallery pages
- [X] Expose galleries on the relevant tag pages?
- [X] Rebase onto #336 once tested fully and then remove `update_tag_list` from `character` and `gallery`
- [X] Update character and gallery tag tests to use newer post tag tests

Tests:

- [x] TagsController limits to user's used GalleryGroups if `user_id` given
- Model tags:
  - [x] Creates tags if they don't exist
  - [x] Uses extant tags with same name and type (**only** if same type)
  - [x] Uses extant IDs
  - [x] Removes things not in the list
- Other controller tag-related things (for GalleriesController)
  - [X] Persists if saving fails
  - [X] Sets relevant @-variable (new, failed create, edit, failed update)
  - [X] Successfully submits the tags
- Tag controller handles it well
  - [X] Shown galleries in tags#show
  - [X] Count galleries in tags#index
- [X] `merge_with`
- [X] editor loads? try doing `render_views` for galleries#edit and galleries#new