### PR TITLE
[WIP] Add gallery groups to characters

### DIFF
--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -91,6 +91,7 @@ $(document).ready(function() {
 
     var newId = $(newGalleryGroupIds).not(galleryGroupIds).get(0);
     galleryGroupIds = newGalleryGroupIds;
+    if (typeof newId === 'undefined') return;
     if (newId.substring(0, 1) === '_') return; // skip uncreated tags
 
     // fetch galleryGroup galleryIds

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -1,4 +1,4 @@
-/* global gon */
+/* global gon, createTagSelect */
 var galleryIds;
 
 $(document).ready(function() {
@@ -49,8 +49,11 @@ $(document).ready(function() {
     galleryIds = newGalleryIds;
     $(".gallery #gallery0").remove();
 
+    // display only if not visible (for gallery groups)
     if ($(".gallery #gallery" + newId).length === 0) displayGallery(newId);
   });
+
+  createTagSelect("GalleryGroup", "gallery_group", "character", {user_id: gon.user_id});
 });
 
 function displayGallery(newId) {

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -78,9 +78,8 @@ $(document).ready(function() {
       group.gallery_ids.forEach(function(galleryId) {
         if (findGalleryInGroups(galleryId) || galleryIds.indexOf(galleryId.toString()) >= 0) return;
         $(".gallery #gallery" + galleryId).remove();
-        galleryIds = $(galleryIds).not([galleryId.toString()]);
+        galleryIds = $.makeArray($(galleryIds).not([galleryId.toString()]));
       });
-      galleryIds = $.makeArray(galleryIds);
 
       // if no more galleries remain, display galleryless icons
       if ($(".gallery [id^='gallery']").length === 0) {

--- a/app/concerns/taggable.rb
+++ b/app/concerns/taggable.rb
@@ -37,7 +37,7 @@ module Taggable
           # set tag list to: [old tags] + [existing new tags] + [new tags]
           final_tags = (old_tags + existing_tags + new_tags).uniq
           self.public_send(tag_method_assign, final_tags)
-          self.instance_variable_set('@' + tag_ids_method + '_tags_todo', final_tags.map(&:id))
+          self.instance_variable_set('@' + tag_ids_method, final_tags.map(&:id_for_select))
         end
       end
     end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -304,6 +304,6 @@ class CharactersController < ApplicationController
   end
 
   def character_params
-    params.fetch(:character, {}).permit(:default_icon_id, :name, :template_name, :screenname, :setting, :template_id, :new_template_name, :pb, :description, gallery_ids: [], gallery_group_ids: [])
+    params.fetch(:character, {}).permit(:default_icon_id, :name, :template_name, :screenname, :setting, :template_id, :new_template_name, :pb, :description, ungrouped_gallery_ids: [], gallery_group_ids: [])
   end
 end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -32,6 +32,7 @@ class CharactersController < ApplicationController
 
     @character = Character.new(character_params)
     @character.user = current_user
+    @character.build_new_tags_with(current_user)
 
     if @character.valid?
       save_character_with_extras
@@ -57,6 +58,7 @@ class CharactersController < ApplicationController
 
   def update
     @character.assign_attributes(character_params)
+    @character.build_new_tags_with(current_user)
 
     if @character.valid?
       save_character_with_extras
@@ -264,8 +266,15 @@ class CharactersController < ApplicationController
     new_group = faked.new('— Create New Group —', 0)
     @groups = current_user.character_groups.order('name asc') + [new_group]
     use_javascript('characters/editor')
+    build_tags
     gon.character_id = @character.try(:id) || ''
+    gon.user_id = current_user.id
     @aliases = @character.aliases.order('name asc') if @character
+    gon.gallery_groups = @gallery_groups.map {|group| group.as_json(include: [:gallery_ids], user_id: current_user.id) }
+  end
+
+  def build_tags
+    @gallery_groups = @character.try(:gallery_groups) || []
   end
 
   def save_character_with_extras
@@ -295,6 +304,6 @@ class CharactersController < ApplicationController
   end
 
   def character_params
-    params.fetch(:character, {}).permit(:default_icon_id, :name, :template_name, :screenname, :setting, :template_id, :new_template_name, :pb, :description, gallery_ids: [])
+    params.fetch(:character, {}).permit(:default_icon_id, :name, :template_name, :screenname, :setting, :template_id, :new_template_name, :pb, :description, gallery_ids: [], gallery_group_ids: [])
   end
 end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -75,7 +75,8 @@ class CharactersController < ApplicationController
   def duplicate
     Character.transaction do
       @dup = @character.dup
-      @dup.galleries = @character.galleries
+      @dup.gallery_groups = @character.gallery_groups
+      @dup.ungrouped_gallery_ids = @character.ungrouped_gallery_ids
       @character.aliases.find_each do |calias|
         dupalias = calias.dup
         @dup.aliases << dupalias

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -11,6 +11,7 @@ class TagsController < ApplicationController
 
   def show
     @posts = posts_from_relation(@tag.posts)
+    @characters = @tag.characters
     @galleries = @tag.galleries
     @page_title = @tag.name.to_s
   end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -55,7 +55,7 @@ class Character < ActiveRecord::Base
   end
 
   def ungrouped_gallery_ids
-    characters_galleries.where(added_by_group: false).pluck(:gallery_id)
+    characters_galleries.reject(&:added_by_group?).map(&:gallery_id)
   end
 
   def ungrouped_gallery_ids=(new_ids)

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -1,5 +1,6 @@
 class Character < ActiveRecord::Base
   include Presentable
+  include Taggable
 
   belongs_to :user
   belongs_to :template
@@ -16,6 +17,7 @@ class Character < ActiveRecord::Base
   has_many :character_tags, inverse_of: :character, dependent: :destroy
   has_many :labels, through: :character_tags, source: :label
   has_many :settings, through: :character_tags, source: :setting
+  has_many :gallery_groups, through: :character_tags, source: :gallery_group
 
   validates_presence_of :name, :user
   validate :valid_template, :valid_group, :valid_galleries, :valid_default_icon
@@ -23,6 +25,8 @@ class Character < ActiveRecord::Base
   attr_accessor :new_template_name, :group_name
 
   after_destroy :clear_char_ids
+
+  acts_as_tag :label, :setting, :gallery_group
 
   nilify_blanks
 

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -10,14 +10,15 @@ class Character < ActiveRecord::Base
   has_many :posts
   has_many :aliases, class_name: CharacterAlias
 
-  has_many :characters_galleries
+  has_many :characters_galleries, inverse_of: :character
+  accepts_nested_attributes_for :characters_galleries, allow_destroy: true
   has_many :galleries, through: :characters_galleries, after_remove: :reorder_galleries
   has_many :icons, -> { group('icons.id').order('LOWER(keyword)') }, through: :galleries
 
   has_many :character_tags, inverse_of: :character, dependent: :destroy
   has_many :labels, through: :character_tags, source: :label
   has_many :settings, through: :character_tags, source: :setting
-  has_many :gallery_groups, through: :character_tags, source: :gallery_group
+  has_many :gallery_groups, through: :character_tags, source: :gallery_group, after_remove: :remove_galleries_from_character
 
   validates_presence_of :name, :user
   validate :valid_template, :valid_group, :valid_galleries, :valid_default_icon
@@ -51,6 +52,47 @@ class Character < ActiveRecord::Base
       other.section_order = index
       other.save
     end
+  end
+
+  def ungrouped_gallery_ids
+    characters_galleries.where(added_by_group: false).pluck(:gallery_id)
+  end
+
+  def ungrouped_gallery_ids=(new_ids)
+    new_ids -= ['']
+    new_ids = new_ids.map(&:to_i)
+    old_ids = ungrouped_gallery_ids
+    rem_ids = old_ids - new_ids
+    group_gallery_ids = gallery_groups.joins(:gallery_tags).reorder('gallery_tags.gallery_id').pluck('distinct gallery_tags.gallery_id')
+    new_chargals = []
+    characters_galleries.each do |char_gal|
+      gallery_id = char_gal.gallery_id
+      if new_ids.include?(gallery_id)
+        # add relevant old galleries, making sure added_by_group is false
+        char_gal.added_by_group = false
+        new_chargals << char_gal.attributes
+        new_ids.delete(gallery_id)
+      elsif group_gallery_ids.include?(gallery_id)
+        # add relevant old group galleries, added_by_group being true
+        char_gal.added_by_group = true
+        new_chargals << char_gal.attributes
+        group_gallery_ids.delete(gallery_id)
+      else
+        # destroy joins that are not in the new set of IDs
+        new_chargals << char_gal.attributes.merge(_destroy: true)
+      end
+    end
+    new_ids.each do |gallery_id|
+      # add any leftover new galleries
+      new_chargals << {gallery_id: gallery_id, character_id: id, added_by_group: false}
+    end
+    # leftover galleries from gallery groups will be added by that model
+    self.characters_galleries_attributes = new_chargals
+  end
+
+  def remove_galleries_from_character(gallery_group)
+    galleries = gallery_group.galleries.where(user_id: user_id)
+    CharactersGallery.where(character: self, gallery: galleries, added_by_group: true).destroy_all
   end
 
   private

--- a/app/models/character_tag.rb
+++ b/app/models/character_tag.rb
@@ -11,10 +11,10 @@ class CharacterTag < ActiveRecord::Base
 
   def add_galleries_to_character
     return if gallery_group.nil? # skip non-gallery_groups
-    joined_galleries = gallery_group.galleries.joins(:characters_galleries).where(characters_galleries: {character_id: character.id})
+    joined_galleries = gallery_group.galleries.where(id: character.characters_galleries.map(&:gallery_id))
     galleries = gallery_group.galleries.where(user_id: character.user_id).where.not(id: joined_galleries.pluck(:id))
     galleries.each do |gallery|
-      CharactersGallery.create(character_id: character.id, gallery_id: gallery.id, added_by_group: true)
+      character.characters_galleries.create(gallery_id: gallery.id, added_by_group: true)
     end
   end
 

--- a/app/models/character_tag.rb
+++ b/app/models/character_tag.rb
@@ -3,4 +3,6 @@ class CharacterTag < ActiveRecord::Base
   belongs_to :tag
   belongs_to :label, foreign_key: :tag_id
   belongs_to :setting, foreign_key: :tag_id
+  belongs_to :gallery_group, foreign_key: :tag_id
+  validates_presence_of :character
 end

--- a/app/models/characters_gallery.rb
+++ b/app/models/characters_gallery.rb
@@ -1,6 +1,7 @@
 class CharactersGallery < ActiveRecord::Base
-  belongs_to :character
-  belongs_to :gallery
+  belongs_to :character, inverse_of: :characters_galleries
+  belongs_to :gallery, inverse_of: :characters_galleries
+  validates_presence_of :character, :gallery
 
   before_create :autofill_order
   after_destroy :reorder_others

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -10,7 +10,7 @@ class Gallery < ActiveRecord::Base
   has_many :characters, through: :characters_galleries
 
   has_many :gallery_tags, inverse_of: :gallery, dependent: :destroy
-  has_many :gallery_groups, through: :gallery_tags, source: :gallery_group
+  has_many :gallery_groups, through: :gallery_tags, source: :gallery_group, after_remove: :remove_gallery_from_characters
 
   validates_presence_of :user, :name
 
@@ -47,5 +47,10 @@ class Gallery < ActiveRecord::Base
 
   def character_gallery_for(character)
     characters_galleries.where(character_id: character).first
+  end
+
+  def remove_gallery_from_characters(gallery_group)
+    characters = gallery_group.characters.where(user_id: user_id)
+    CharactersGallery.where(character: characters, gallery: self, added_by_group: true).destroy_all
   end
 end

--- a/app/models/gallery_tag.rb
+++ b/app/models/gallery_tag.rb
@@ -8,10 +8,10 @@ class GalleryTag < ActiveRecord::Base
 
   def add_gallery_to_characters
     return if gallery_group.nil? # skip non-gallery_groups
-    joined_characters = gallery_group.characters.joins(:characters_galleries).where(characters_galleries: {gallery_id: gallery.id})
+    joined_characters = gallery_group.characters.where(id: gallery.characters_galleries.map(&:character_id))
     characters = gallery_group.characters.where(user_id: gallery.user_id).where.not(id: joined_characters.pluck(:id))
     characters.each do |character|
-      CharactersGallery.create(character_id: character.id, gallery_id: gallery.id, added_by_group: true)
+      gallery.characters_galleries.create(character_id: character.id, added_by_group: true)
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,8 +19,15 @@ class Tag < ActiveRecord::Base
     user.try(:admin?)
   end
 
-  def as_json(*)
-    {id: self.id, text: self.name}
+  def as_json(options={})
+    tag_json = {id: self.id, text: self.name}
+    return tag_json unless options[:include].present?
+    if options[:include].include?(:gallery_ids)
+      g_tags = gallery_tags.joins(:gallery)
+      g_tags = g_tags.where(galleries: {user_id: options[:user_id]}) if options[:user_id].present?
+      tag_json[:gallery_ids] = g_tags.pluck(:gallery_id)
+    end
+    tag_json
   end
 
   def id_for_select

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -12,6 +12,7 @@ class Tag < ActiveRecord::Base
 
   scope :with_item_counts, -> {
     select('(SELECT COUNT(DISTINCT post_tags.post_id) FROM post_tags WHERE post_tags.tag_id = tags.id) AS post_count,
+    (SELECT COUNT(DISTINCT character_tags.character_id) FROM character_tags WHERE character_tags.tag_id = tags.id) AS character_count,
     (SELECT COUNT(DISTINCT gallery_tags.gallery_id) FROM gallery_tags WHERE gallery_tags.tag_id = tags.id) AS gallery_count')
   }
 
@@ -37,6 +38,11 @@ class Tag < ActiveRecord::Base
   def post_count
     return read_attribute(:post_count) if has_attribute?(:post_count)
     posts.count
+  end
+
+  def character_count
+    return read_attribute(:character_count) if has_attribute?(:character_count)
+    characters.count
   end
 
   def gallery_count

--- a/app/views/characters/_editor.haml
+++ b/app/views/characters/_editor.haml
@@ -23,9 +23,9 @@
   %tr
     %th.sub Galleries
     %td{class: cycle('even', 'odd')}
-      = f.collection_select(:gallery_ids,
+      = f.collection_select(:ungrouped_gallery_ids,
       current_user.galleries.order('name asc'),
-      :id, :name, {selected: @character.galleries.pluck(:id)}, {multiple: true})
+      :id, :name, {selected: @character.ungrouped_gallery_ids}, {multiple: true})
   %tr
     %th.sub Gallery Groups
     %td{class: cycle('even', 'odd')}

--- a/app/views/characters/_editor.haml
+++ b/app/views/characters/_editor.haml
@@ -26,6 +26,10 @@
       = f.collection_select(:gallery_ids,
       current_user.galleries.order('name asc'),
       :id, :name, {selected: @character.galleries.pluck(:id)}, {multiple: true})
+  %tr
+    %th.sub Gallery Groups
+    %td{class: cycle('even', 'odd')}
+      = f.select :gallery_group_ids, options_from_collection_for_select(@gallery_groups, :id_for_select, :name, @character.gallery_group_ids || @character.gallery_groups.map(&:id)), {}, {multiple: true}
 %tr
   %th.sub Facecast
   %td{class: cycle('even', 'odd')}= f.text_field :pb, placeholder: "Facecast", class: 'text'

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -47,9 +47,10 @@
       %td.padding-5{class: klass, style:'width:15%'}= character.setting
 
       %td.width-70.right-align{class: klass}
-        - if @user.id == current_user.try(:id)
-          = link_to edit_character_path(character) do
-            = image_tag "/images/pencil.png"
-          = link_to character_path(character), :method => :delete, data: { confirm: 'Are you sure you want to delete '+character.name+'?' } do
-            = image_tag "/images/cross.png"
-          &nbsp;
+        - unless local_assigns[:hide_buttons]
+          - if @user.id == current_user.try(:id)
+            = link_to edit_character_path(character) do
+              = image_tag "/images/pencil.png"
+            = link_to character_path(character), :method => :delete, data: { confirm: 'Are you sure you want to delete '+character.name+'?' } do
+              = image_tag "/images/cross.png"
+            &nbsp;

--- a/app/views/tags/index.haml
+++ b/app/views/tags/index.haml
@@ -1,13 +1,14 @@
 %table
   %thead
     %tr
-      %th{colspan: 5}
+      %th{colspan: 6}
         Tags
   %tbody
     %tr
       %th.sub Tag
       %th.sub Type
       %th.sub Posts
+      %th.sub Characters
       %th.sub Galleries
       %th.sub
     - @tags.each do |tag|
@@ -16,6 +17,7 @@
         %td{class: klass}= link_to tag.name, tag_path(tag)
         %td{class: klass}= (tag.type || 'Tag').titlecase
         %td{class: klass}= tag.post_count
+        %td{class: klass}= tag.character_count
         %td{class: klass}= tag.gallery_count
         %td.width-70.right-align{class: klass}
           - if tag.editable_by?(current_user)
@@ -27,4 +29,4 @@
   - if @tags.total_pages > 1
     %tfoot
       %tr
-        %td{colspan: 5}= render partial: 'posts/paginator', locals: { paginated: @tags }
+        %td{colspan: 6}= render partial: 'posts/paginator', locals: { paginated: @tags }

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -37,3 +37,15 @@
           - klass = cycle('even', 'odd')
           %td.gallery-name{class: klass}= link_to gallery.name, gallery_path(gallery)
           %td.width-150.centered.gallery-icon-count{class: klass}= gallery.icon_count
+  %br
+
+- if @characters.present?
+  - reset_cycle
+  %table
+    %thead
+      %tr
+        %th{colspan: 6}
+          Characters Tagged: #{@tag.name}
+          - content_for :edit_box
+    %tbody
+      = render partial: 'characters/list_section', locals: {name: nil, characters: @characters.order('name asc'), hide_buttons: true}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,7 +102,7 @@ Rails.application.routes.draw do
         resources :replies, only: :index
         collection { post :reorder }
       end
-      resources :tags, only: :index
+      resources :tags, only: [:index, :show]
       resources :templates, only: :index
       resources :users, only: :index
     end

--- a/db/migrate/20170828144608_add_added_by_group_to_characters_galleries.rb
+++ b/db/migrate/20170828144608_add_added_by_group_to_characters_galleries.rb
@@ -1,0 +1,5 @@
+class AddAddedByGroupToCharactersGalleries < ActiveRecord::Migration
+  def change
+    add_column :characters_galleries, :added_by_group, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -350,7 +350,8 @@ CREATE TABLE characters_galleries (
     id integer NOT NULL,
     character_id integer NOT NULL,
     gallery_id integer NOT NULL,
-    section_order integer DEFAULT 0 NOT NULL
+    section_order integer DEFAULT 0 NOT NULL,
+    added_by_group boolean DEFAULT false
 );
 
 
@@ -2030,4 +2031,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170819222420');
 INSERT INTO schema_migrations (version) VALUES ('20170821210336');
 
 INSERT INTO schema_migrations (version) VALUES ('20170826211901');
+
+INSERT INTO schema_migrations (version) VALUES ('20170828144608');
 

--- a/spec/controllers/api/v1/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/tags_controller_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe Api::V1::TagsController do
           expect(response.json).to have_key('results')
           expect(response.json['results']).to contain_exactly(gal_grouped_tag.as_json.stringify_keys)
         end
+
+        it "should display tags used on characters" do
+          char_grouped_tag = create(:gallery_group)
+          create(:character, user: user, gallery_groups: [char_grouped_tag])
+          get :index, q: char_grouped_tag.name, t: 'GalleryGroup', user_id: user.id
+          expect(response).to have_http_status(200)
+          expect(response.json).to have_key('results')
+          expect(response.json['results']).to contain_exactly(char_grouped_tag.as_json.stringify_keys)
+        end
       end
     end
 

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -95,12 +95,12 @@ RSpec.describe CharactersController do
       gallery = create(:gallery, user: user)
 
       login_as(user)
-      post :create, character: {name: test_name, template_name: 'TempName', screenname: 'just-a-test', setting: 'A World', template_id: template.id, pb: 'Facecast', description: 'Desc', gallery_ids: [gallery.id]}
+      post :create, character: {name: test_name, template_name: 'TempName', screenname: 'just-a-test', setting: 'A World', template_id: template.id, pb: 'Facecast', description: 'Desc', ungrouped_gallery_ids: [gallery.id]}
 
       expect(response).to redirect_to(assigns(:character))
       expect(flash[:success]).to eq("Character saved successfully.")
       expect(Character.count).to eq(1)
-      character = assigns(:character)
+      character = assigns(:character).reload
       expect(character.name).to eq(test_name)
       expect(character.user_id).to eq(user.id)
       expect(character.template_name).to eq('TempName')
@@ -265,7 +265,7 @@ RSpec.describe CharactersController do
       new_name = character.name + 'aaa'
       template = create(:template, user: user)
       gallery = create(:gallery, user: user)
-      put :update, id: character.id, character: {name: new_name, template_name: 'TemplateName', screenname: 'a-new-test', setting: 'Another World', template_id: template.id, pb: 'Actor', description: 'Description', gallery_ids: [gallery.id]}
+      put :update, id: character.id, character: {name: new_name, template_name: 'TemplateName', screenname: 'a-new-test', setting: 'Another World', template_id: template.id, pb: 'Actor', description: 'Description', ungrouped_gallery_ids: [gallery.id]}
 
       expect(response).to redirect_to(assigns(:character))
       expect(flash[:success]).to eq("Character saved successfully.")
@@ -316,7 +316,7 @@ RSpec.describe CharactersController do
       expect(g2_cg.section_order).to eq(1)
 
       login_as(character.user)
-      put :update, id: character.id, character: {gallery_ids: [g2.id.to_s]}
+      put :update, id: character.id, character: {ungrouped_gallery_ids: [g2.id.to_s]}
 
       expect(character.reload.galleries.pluck(:id)).to eq([g2.id])
       expect(g2_cg.reload.section_order).to eq(0)

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -51,18 +51,24 @@ RSpec.describe CharactersController do
       expect(response.status).to eq(200)
     end
 
-    it "sets correct variables" do
-      user = create(:user)
-      templates = Array.new(2) { create(:template, user: user) }
-      names = ['— Create New Template —'] + templates.map(&:name)
-      create(:template)
+    context "with views" do
+      render_views
+      it "sets correct variables" do
+        user = create(:user)
+        templates = Array.new(2) { create(:template, user: user) }
+        names = ['— Create New Template —'] + templates.map(&:name)
+        create(:template)
 
-      login_as(user)
-      get :new
+        login_as(user)
+        get :new
 
-      expect(assigns(:page_title)).to eq("New Character")
-      expect(controller.gon.character_id).to eq('')
-      expect(assigns(:templates).map(&:name)).to match_array(names)
+        expect(assigns(:page_title)).to eq("New Character")
+        expect(assigns(:templates).map(&:name)).to match_array(names)
+        expect(controller.gon.character_id).to eq('')
+        expect(controller.gon.user_id).to eq(user.id)
+        expect(controller.gon.gallery_groups).to eq([])
+        expect(assigns(:aliases)).to be_blank
+      end
     end
   end
 
@@ -121,57 +127,64 @@ RSpec.describe CharactersController do
       expect(assigns(:character).template_id).to eq(Template.first.id)
     end
 
-    it "sets correct variables when invalid" do
-      user = create(:user)
-      templates = Array.new(2) { create(:template, user: user) }
-      names = ['— Create New Template —'] + templates.map(&:name)
-      create(:template)
+    context "with views" do
+      render_views
+      it "sets correct variables when invalid" do
+        user = create(:user)
+        gallery = create(:gallery, user: user)
+        group = create(:gallery_group)
+        group_gallery = create(:gallery, user: user, gallery_groups: [group])
+        templates = Array.new(2) { create(:template, user: user) }
+        names = ['— Create New Template —'] + templates.map(&:name)
+        create(:template)
 
-      login_as(user)
-      post :create, character: {}
+        login_as(user)
+        post :create, character: {ungrouped_gallery_ids: [gallery.id, group_gallery.id], gallery_group_ids: [group.id]}
 
-      expect(controller.gon.character_id).to eq('')
-      expect(assigns(:templates).map(&:name)).to match_array(names)
+        expect(response).to render_template(:new)
+        expect(controller.gon.character_id).to eq('')
+        expect(assigns(:templates).map(&:name)).to match_array(names)
+        expect(assigns(:character).ungrouped_gallery_ids).to match_array([gallery.id, group_gallery.id])
+        expect(assigns(:character).gallery_group_ids).to eq([group.id])
+      end
     end
   end
 
   describe "GET show" do
-    context "html" do
-      it "requires valid character" do
-        get :show, id: -1
-        expect(response).to redirect_to(characters_url)
-        expect(flash[:error]).to eq("Character could not be found.")
-      end
+    it "requires valid character" do
+      get :show, id: -1
+      expect(response).to redirect_to(characters_url)
+      expect(flash[:error]).to eq("Character could not be found.")
+    end
 
-      it "should succeed when logged out" do
-        character = create(:character)
-        get :show, id: character.id
-        expect(response.status).to eq(200)
-      end
+    it "should succeed when logged out" do
+      character = create(:character)
+      get :show, id: character.id
+      expect(response.status).to eq(200)
+    end
 
-      it "should succeed when logged in" do
-        character = create(:character)
-        login
-        get :show, id: character.id
-        expect(response.status).to eq(200)
-      end
+    it "should succeed when logged in" do
+      character = create(:character)
+      login
+      get :show, id: character.id
+      expect(response.status).to eq(200)
+    end
 
-      it "should set correct variables" do
-        character = create(:character)
-        Array.new(26) { create(:post, character: character, user: character.user) }
-        get :show, id: character.id
-        expect(response.status).to eq(200)
-        expect(assigns(:page_title)).to eq(character.name)
-        expect(assigns(:posts).size).to eq(25)
-        expect(assigns(:posts)).to match_array(Post.where(character_id: character.id).order('tagged_at desc').limit(25))
-      end
+    it "should set correct variables" do
+      character = create(:character)
+      Array.new(26) { create(:post, character: character, user: character.user) }
+      get :show, id: character.id
+      expect(response.status).to eq(200)
+      expect(assigns(:page_title)).to eq(character.name)
+      expect(assigns(:posts).size).to eq(25)
+      expect(assigns(:posts)).to match_array(Post.where(character_id: character.id).order('tagged_at desc').limit(25))
+    end
 
-      it "should only show visible posts" do
-        character = create(:character)
-        create(:post, character: character, user: character.user, privacy: Post::PRIVACY_PRIVATE)
-        get :show, id: character.id
-        expect(assigns(:posts)).to be_blank
-      end
+    it "should only show visible posts" do
+      character = create(:character)
+      create(:post, character: character, user: character.user, privacy: Post::PRIVACY_PRIVATE)
+      get :show, id: character.id
+      expect(assigns(:posts)).to be_blank
     end
   end
 
@@ -203,19 +216,30 @@ RSpec.describe CharactersController do
       expect(response.status).to eq(200)
     end
 
-    it "sets correct variables" do
-      user = create(:user)
-      character = create(:character, user: user)
-      templates = Array.new(2) { create(:template, user: user) }
-      names = ['— Create New Template —'] + templates.map(&:name)
-      create(:template)
+    context "with views" do
+      render_views
+      it "sets correct variables" do
+        user = create(:user)
+        group = create(:gallery_group)
+        gallery = create(:gallery, user: user, gallery_groups: [group])
+        character = create(:character, user: user, gallery_groups: [group])
+        calias = create(:alias, character: character)
+        templates = Array.new(2) { create(:template, user: user) }
+        names = ['— Create New Template —'] + templates.map(&:name)
+        create(:template)
 
-      login_as(user)
-      get :edit, id: character.id
+        login_as(user)
+        get :edit, id: character.id
 
-      expect(assigns(:page_title)).to eq("Edit Character: #{character.name}")
-      expect(controller.gon.character_id).to eq(character.id)
-      expect(assigns(:templates).map(&:name)).to match_array(names)
+        expect(assigns(:page_title)).to eq("Edit Character: #{character.name}")
+        expect(controller.gon.character_id).to eq(character.id)
+        expect(controller.gon.user_id).to eq(user.id)
+        expect(controller.gon.gallery_groups.map{|g|g[:id]}).to eq([group.id])
+        expect(controller.gon.gallery_groups.map{|g|g[:gallery_ids]}).to eq([[gallery.id]])
+        expect(assigns(:gallery_groups)).to match_array([group])
+        expect(assigns(:templates).map(&:name)).to match_array(names)
+        expect(assigns(:aliases)).to match_array([calias])
+      end
     end
   end
 
@@ -280,6 +304,104 @@ RSpec.describe CharactersController do
       expect(character.galleries).to match_array([gallery])
     end
 
+    it "adds galleries by groups" do
+      user = create(:user)
+      group = create(:gallery_group)
+      gallery = create(:gallery, gallery_groups: [group], user: user)
+      character = create(:character, user: user)
+      login_as(user)
+      put :update, id: character.id, character: {gallery_group_ids: [group.id]}
+
+      expect(flash[:success]).to eq('Character saved successfully.')
+      character.reload
+      expect(character.gallery_groups).to match_array([group])
+      expect(character.galleries).to match_array([gallery])
+      expect(character.ungrouped_gallery_ids).to be_blank
+      expect(character.characters_galleries.first).to be_added_by_group
+    end
+
+    it "removes gallery only if not shared between groups" do
+      user = create(:user)
+      group1 = create(:gallery_group) # gallery1
+      group2 = create(:gallery_group) # -> gallery1
+      group3 = create(:gallery_group) # gallery2 ->
+      group4 = create(:gallery_group) # gallery2
+      gallery1 = create(:gallery, gallery_groups: [group1, group2], user: user)
+      gallery2 = create(:gallery, gallery_groups: [group3, group4], user: user)
+      character = create(:character, gallery_groups: [group1, group3, group4], user: user)
+      login_as(user)
+      put :update, id: character.id, character: {gallery_group_ids: [group2.id, group4.id]}
+
+      expect(flash[:success]).to eq('Character saved successfully.')
+      character.reload
+      expect(character.gallery_groups).to match_array([group2, group4])
+      expect(character.galleries).to match_array([gallery1, gallery2])
+      expect(character.ungrouped_gallery_ids).to be_blank
+      expect(character.characters_galleries.map(&:added_by_group)).to eq([true, true])
+    end
+
+    it "does not remove gallery if tethered by group" do
+      user = create(:user)
+      group = create(:gallery_group)
+      gallery = create(:gallery, gallery_groups: [group], user: user)
+      character = create(:character, gallery_groups: [group], user: user)
+      character.ungrouped_gallery_ids = [gallery.id]
+      character.save!
+      expect(character.characters_galleries.first).not_to be_added_by_group
+
+      login_as(user)
+      put :update, id: character.id, character: {ungrouped_gallery_ids: []}
+      expect(flash[:success]).to eq('Character saved successfully.')
+      character.reload
+      expect(character.gallery_groups).to match_array([group])
+      expect(character.galleries).to match_array([gallery])
+      expect(character.ungrouped_gallery_ids).to be_blank
+      expect(character.characters_galleries.first).to be_added_by_group
+    end
+
+    it "works when adding both group and gallery" do
+      user = create(:user)
+      group = create(:gallery_group)
+      gallery = create(:gallery, gallery_groups: [group], user: user)
+      character = create(:character, user: user)
+
+      login_as(user)
+      put :update, id: character.id, character: {gallery_group_ids: [group.id], ungrouped_gallery_ids: [gallery.id]}
+      expect(flash[:success]).to eq('Character saved successfully.')
+      character.reload
+      expect(character.gallery_groups).to match_array([group])
+      expect(character.galleries).to match_array([gallery])
+      expect(character.ungrouped_gallery_ids).to eq([gallery.id])
+      expect(character.characters_galleries.first).not_to be_added_by_group
+    end
+
+    it "does not add another user's galleries" do
+      group = create(:gallery_group)
+      gallery = create(:gallery, gallery_groups: [group])
+      character = create(:character)
+
+      login_as(character.user)
+      put :update, id: character.id, character: {gallery_group_ids: [group.id]}
+      expect(flash[:success]).to eq('Character saved successfully.')
+      character.reload
+      expect(character.gallery_groups).to match_array([group])
+      expect(character.galleries).to be_blank
+    end
+
+    it "removes untethered galleries when group goes" do
+      user = create(:user)
+      group = create(:gallery_group)
+      gallery = create(:gallery, gallery_groups: [group], user: user)
+      character = create(:character, gallery_groups: [group], user: user)
+
+      login_as(user)
+      put :update, id: character.id, character: {gallery_group_ids: []}
+      expect(flash[:success]).to eq('Character saved successfully.')
+      character.reload
+      expect(character.gallery_groups).to eq([])
+      expect(character.galleries).to eq([])
+    end
+
     it "creates new templates when specified" do
       expect(Template.count).to eq(0)
       character = create(:character)
@@ -290,18 +412,28 @@ RSpec.describe CharactersController do
       expect(character.reload.template_id).to eq(Template.first.id)
     end
 
-    it "sets correct variables when invalid" do
-      character = create(:character)
-      templates = Array.new(2) { create(:template, user: character.user) }
-      names = ['— Create New Template —'] + templates.map(&:name)
-      create(:template)
+    context "with views" do
+      render_views
+      it "sets correct variables when invalid" do
+        user = create(:user)
+        group = create(:gallery_group)
+        gallery = create(:gallery, user: user, gallery_groups: [group])
+        character = create(:character, user: user, gallery_groups: [group])
+        templates = Array.new(2) { create(:template, user: user) }
+        names = ['— Create New Template —'] + templates.map(&:name)
+        create(:template)
 
-      login_as(character.user)
-      put :update, id: character.id, character: {name: ''}
+        login_as(user)
+        put :update, id: character.id, character: {name: ''}
 
-      expect(response).to render_template(:edit)
-      expect(controller.gon.character_id).to eq(character.id)
-      expect(assigns(:templates).map(&:name)).to match_array(names)
+        expect(response).to render_template(:edit)
+        expect(controller.gon.character_id).to eq(character.id)
+        expect(controller.gon.user_id).to eq(user.id)
+        expect(controller.gon.gallery_groups.map{|g|g[:id]}).to eq([group.id])
+        expect(controller.gon.gallery_groups.map{|g|g[:gallery_ids]}).to eq([[gallery.id]])
+        expect(assigns(:gallery_groups)).to match_array([group])
+        expect(assigns(:templates).map(&:name)).to match_array(names)
+      end
     end
 
     it "reorders galleries as necessary" do

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -11,9 +11,16 @@ RSpec.describe TagsController do
         create(:post, labels: [tag])
 
         empty_group = create(:gallery_group)
-        group = create(:gallery_group)
-        create(:gallery, gallery_groups: [group])
-        [empty_tag, tag, empty_group, group]
+        group1 = create(:gallery_group)
+        create(:gallery, gallery_groups: [group1])
+
+        group2 = create(:gallery_group)
+        create(:gallery, gallery_groups: [group2])
+        create(:character, gallery_groups: [group2])
+
+        group3 = create(:gallery_group)
+        create(:character, gallery_groups: [group3])
+        [empty_tag, tag, empty_group, group1, group2, group3]
       end
 
       it "succeeds when logged out" do
@@ -74,6 +81,23 @@ RSpec.describe TagsController do
         get :show, id: group.id
         expect(response.status).to eq(200)
         expect(assigns(:galleries)).to match_array([gallery])
+      end
+
+      it "succeeds with valid character tag" do
+        group = create(:gallery_group)
+        character = create(:character, gallery_groups: [group])
+        get :show, id: group.id
+        expect(response.status).to eq(200)
+        expect(assigns(:characters)).to match_array([character])
+      end
+
+      it "succeeds for logged in users with valid character tag" do
+        group = create(:gallery_group)
+        character = create(:character, gallery_groups: [group])
+        login
+        get :show, id: group.id
+        expect(response.status).to eq(200)
+        expect(assigns(:characters)).to match_array([character])
       end
     end
   end

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -161,6 +161,7 @@ RSpec.describe Character do
     end
   end
 
+  # from Taggable concern; duplicated between PostSpec, CharacterSpec, GallerySpec
   context "tags" do
     let(:taggable) { create(:character) }
     ['gallery_group'].each do |type|

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -40,4 +40,77 @@ RSpec.describe Character do
     expect(character.galleries.size).to eq(2)
     expect(character.icons.map(&:id)).to eq([icon.id])
   end
+
+  context "tags" do
+    let(:taggable) { create(:character) }
+    ['gallery_group'].each do |type|
+      it "creates new #{type} tags if they don't exist" do
+        taggable.send(type + '_ids=', ['_tag'])
+        expect(taggable.send(type + 's').map(&:name)).to match_array(['tag'])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags.map(&:name)).to match_array(['tag'])
+        expect(tags.map(&:user)).to match_array([taggable.user])
+      end
+
+      it "uses extant tags with same name and type for #{type}" do
+        tag = create(type)
+        old_user = tag.user
+        taggable.send(type + '_ids=', ['_' + tag.name])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+
+      it "does not use extant tags of a different type with same name for #{type}" do
+        name = "Example Tag"
+        tag = create(:tag, type: 'NonexistentTag', name: name)
+        taggable.send(type + '_ids=', ['_' + name])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags.map(&:name)).to match_array([name])
+        expect(tags.map(&:user)).to match_array([taggable.user])
+        expect(tags).not_to include(tag)
+      end
+
+      it "uses extant #{type} tags by id" do
+        tag = create(type)
+        old_user = tag.user
+        taggable.send(type + '_ids=', [tag.id.to_s])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+
+      it "removes #{type} tags when not in list given" do
+        tag = create(type)
+        taggable.send(type + 's=', [tag])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to match_array([tag])
+        taggable.send(type + '_ids=', [])
+        taggable.save
+        taggable.reload
+        expect(taggable.send(type + 's')).to eq([])
+      end
+
+      it "only adds #{type} tags once if given multiple times" do
+        name = 'Example Tag'
+        tag = create(type, name: name)
+        old_user = tag.user
+        taggable.send(type + '_ids=', ['_' + name, '_' + name, tag.id.to_s, tag.id.to_s])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags).to match_array([tag])
+        expect(tags.map(&:user)).to match_array([old_user])
+      end
+    end
+  end
 end

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -41,6 +41,126 @@ RSpec.describe Character do
     expect(character.icons.map(&:id)).to eq([icon.id])
   end
 
+  describe "#ungrouped_gallery_ids" do
+    it "returns only galleries not added by groups" do
+      user = create(:user)
+      character = create(:character, user: user)
+      gallery1 = create(:gallery, user: user)
+      gallery2 = create(:gallery, user: user)
+
+      CharactersGallery.create(character: character, gallery: gallery1)
+      CharactersGallery.create(character: character, gallery: gallery2, added_by_group: true)
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery1.id, gallery2.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery1.id])
+    end
+  end
+
+  describe "#ungrouped_gallery_ids=" do
+    it "adds unattached galleries" do
+      user = create(:user)
+      character = create(:character, user: user)
+      gallery = create(:gallery, user: user)
+
+      expect(character.gallery_ids).to eq([])
+      expect(character.ungrouped_gallery_ids).to eq([])
+      character.ungrouped_gallery_ids = [gallery.id]
+      character.save!
+
+      character.reload
+      expect(character.characters_galleries.map(&:added_by_group?)).to match_array([false])
+      expect(character.gallery_ids).to match_array([gallery.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery.id])
+    end
+
+    it "sets already-attached galleries to not be added_by_group" do
+      # does not add a new attachment
+      user = create(:user)
+      group = create(:gallery_group)
+      character = create(:character, gallery_groups: [group], user: user)
+      gallery = create(:gallery, gallery_groups: [group], user: user)
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery.id])
+      expect(character.ungrouped_gallery_ids).to match_array([])
+
+      character.ungrouped_gallery_ids = [gallery.id]
+      character.save!
+      character.reload
+
+      expect(character.gallery_ids).to match_array([gallery.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery.id])
+      expect(character.characters_galleries.map(&:added_by_group)).to match_array([false])
+    end
+
+    it "removes associated galleries when not present only if not also present in groups, otherwise sets flag" do
+      # does not remove gallery_manual when not told to
+      # sets flag on gallery_both to be added_by_group
+      # does not remove gallery_auto despite not being present
+      user = create(:user)
+      group = create(:gallery_group)
+      character = create(:character, gallery_groups: [group], user: user)
+      gallery_manual = create(:gallery, user: user)
+      gallery_both = create(:gallery, gallery_groups: [group], user: user)
+      gallery_automatic = create(:gallery, gallery_groups: [group], user: user)
+
+      CharactersGallery.create(character: character, gallery: gallery_manual)
+      character.characters_galleries.where(gallery_id: gallery_both.id).update_all(added_by_group: false)
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery_manual.id, gallery_both.id, gallery_automatic.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery_manual.id, gallery_both.id])
+
+      character.ungrouped_gallery_ids = [gallery_manual.id]
+      character.save!
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery_manual.id, gallery_both.id, gallery_automatic.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery_manual.id])
+      expect(character.characters_galleries.find_by(gallery_id: gallery_both.id)).to be_added_by_group
+    end
+
+    it "deletes manually-added galleries when not present" do
+      user = create(:user)
+      gallery = create(:gallery, user: user)
+      character = create(:character, user: user, galleries: [gallery])
+
+      character.reload
+      expect(character.gallery_ids).to eq([gallery.id])
+      expect(character.ungrouped_gallery_ids).to eq([gallery.id])
+      character.ungrouped_gallery_ids = []
+      character.save!
+
+      character.reload
+      expect(character.gallery_ids).to eq([])
+    end
+
+    it "does nothing if unchanged" do
+      # does not remove or change the status of any of: gallery_manual, gallery_both, gallery_auto
+      user = create(:user)
+      group = create(:gallery_group)
+      character = create(:character, gallery_groups: [group], user: user)
+      gallery_manual = create(:gallery, user: user)
+      gallery_both = create(:gallery, gallery_groups: [group], user: user)
+      gallery_automatic = create(:gallery, gallery_groups: [group], user: user)
+
+      CharactersGallery.create(character: character, gallery: gallery_manual)
+      character.characters_galleries.where(gallery_id: gallery_both.id).update_all(added_by_group: false)
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery_manual.id, gallery_both.id, gallery_automatic.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery_manual.id, gallery_both.id])
+
+      character.ungrouped_gallery_ids = [gallery_manual.id, gallery_both.id]
+      character.save!
+
+      character.reload
+      expect(character.gallery_ids).to match_array([gallery_manual.id, gallery_both.id, gallery_automatic.id])
+      expect(character.ungrouped_gallery_ids).to match_array([gallery_manual.id, gallery_both.id])
+    end
+  end
+
   context "tags" do
     let(:taggable) { create(:character) }
     ['gallery_group'].each do |type|

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -171,6 +171,7 @@ RSpec.describe Character do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags.map(&:name)).to match_array(['tag'])
         expect(tags.map(&:user)).to match_array([taggable.user])
       end
@@ -193,9 +194,11 @@ RSpec.describe Character do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags.map(&:name)).to match_array([name])
         expect(tags.map(&:user)).to match_array([taggable.user])
         expect(tags).not_to include(tag)
+        expect(tag_ids).to match_array(tags.map(&:id))
       end
 
       it "uses extant #{type} tags by id" do
@@ -205,8 +208,10 @@ RSpec.describe Character do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags).to match_array([tag])
         expect(tags.map(&:user)).to match_array([old_user])
+        expect(tag_ids).to match_array([tag.id])
       end
 
       it "removes #{type} tags when not in list given" do
@@ -219,6 +224,7 @@ RSpec.describe Character do
         taggable.save
         taggable.reload
         expect(taggable.send(type + 's')).to eq([])
+        expect(taggable.send(type + '_ids')).to eq([])
       end
 
       it "only adds #{type} tags once if given multiple times" do
@@ -229,8 +235,10 @@ RSpec.describe Character do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags).to match_array([tag])
         expect(tags.map(&:user)).to match_array([old_user])
+        expect(tag_ids).to match_array([tag.id])
       end
     end
   end

--- a/spec/models/character_tag_spec.rb
+++ b/spec/models/character_tag_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+
+RSpec.describe CharacterTag do
+  describe "callbacks" do
+    context "when gallery group added" do
+      it "does not add other users' galleries" do
+        group = create(:gallery_group)
+        gallery = create(:gallery, gallery_groups: [group])
+
+        character = create(:character)
+        character.gallery_groups << group
+        character.save
+        expect(character.reload.galleries).to match_array([])
+      end
+
+      it "does not add a gallery twice" do
+        # tests a manually-attached gallery1
+        # and a double-grouped gallery2
+        group = create(:gallery_group)
+        group2 = create(:gallery_group)
+        user = create(:user)
+        gallery1 = create(:gallery, user: user, gallery_groups: [group])
+        gallery2 = create(:gallery, user: user, gallery_groups: [group, group2])
+
+        character = create(:character, user: user, galleries: [gallery1])
+        character.gallery_groups << group
+        character.save
+        character.reload
+        expect(character.galleries).to match_array([gallery1, gallery2])
+        expect(character.characters_galleries.find_by(gallery_id: gallery1.id)).not_to be_added_by_group
+        expect(character.characters_galleries.find_by(gallery_id: gallery2.id)).to be_added_by_group
+
+        character.gallery_groups << group2
+        character.save
+        character.reload
+        expect(character.galleries).to match_array([gallery1, gallery2])
+        expect(character.characters_galleries.find_by(gallery_id: gallery1.id)).not_to be_added_by_group
+        expect(character.characters_galleries.find_by(gallery_id: gallery2.id)).to be_added_by_group
+      end
+
+      it "adds galleries from given group" do
+        group = create(:gallery_group)
+        user = create(:user)
+        gallery1 = create(:gallery, user: user, gallery_groups: [group])
+        gallery2 = create(:gallery, user: user, gallery_groups: [group])
+
+        character = create(:character, user: user)
+        character.gallery_groups << group
+        character.save
+        character.reload
+        expect(character.galleries).to match_array([gallery1, gallery2])
+        expect(character.characters_galleries.map(&:added_by_group?)).to eq([true, true])
+      end
+
+      it "does right things when gallery group removed" do
+        # does not touch unrelated galleries
+        # does not touch galleries that have been otherwise tethered
+        # removes galleries that are not otherwise tethered
+        group = create(:gallery_group)
+        user = create(:user)
+        other_gallery = create(:gallery, user: user)
+        character = create(:character, user: user, gallery_groups: [group], galleries: [other_gallery])
+        gallery_auto = create(:gallery, user: user, gallery_groups: [group])
+        gallery_both = create(:gallery, user: user, gallery_groups: [group])
+        character.reload
+        character.characters_galleries.find_by(gallery_id: gallery_both.id).update_attributes(added_by_group: false)
+        expect(character.galleries).to match_array([other_gallery, gallery_auto, gallery_both])
+        expect(character.characters_galleries.find_by(gallery_id: gallery_auto.id)).to be_added_by_group
+
+        character.update_attributes(gallery_groups: [])
+        character.reload
+        expect(character.galleries).to match_array([other_gallery, gallery_both])
+        expect(character.characters_galleries.find_by(gallery_id: gallery_both.id)).not_to be_added_by_group
+      end
+    end
+  end
+end

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Gallery do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags.map(&:name)).to match_array(['tag'])
         expect(tags.map(&:user)).to match_array([taggable.user])
       end
@@ -63,9 +64,11 @@ RSpec.describe Gallery do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags.map(&:name)).to match_array([name])
         expect(tags.map(&:user)).to match_array([taggable.user])
         expect(tags).not_to include(tag)
+        expect(tag_ids).to match_array(tags.map(&:id))
       end
 
       it "uses extant #{type} tags by id" do
@@ -75,8 +78,10 @@ RSpec.describe Gallery do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags).to match_array([tag])
         expect(tags.map(&:user)).to match_array([old_user])
+        expect(tag_ids).to match_array([tag.id])
       end
 
       it "removes #{type} tags when not in list given" do
@@ -89,6 +94,7 @@ RSpec.describe Gallery do
         taggable.save
         taggable.reload
         expect(taggable.send(type + 's')).to eq([])
+        expect(taggable.send(type + '_ids')).to eq([])
       end
 
       it "only adds #{type} tags once if given multiple times" do
@@ -99,8 +105,10 @@ RSpec.describe Gallery do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags).to match_array([tag])
         expect(tags.map(&:user)).to match_array([old_user])
+        expect(tag_ids).to match_array([tag.id])
       end
     end
   end

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Gallery do
     expect(gallery.icons.pluck(:keyword)).to eq(['xxx', 'yyy', 'zzz'])
   end
 
+  # from Taggable concern; duplicated between PostSpec, CharacterSpec, GallerySpec
   context "tags" do
     let(:taggable) { create(:gallery) }
     ['gallery_group'].each do |type|

--- a/spec/models/gallery_tag_spec.rb
+++ b/spec/models/gallery_tag_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+
+RSpec.describe GalleryTag do
+  describe "callbacks" do
+    context "when gallery group added" do
+      it "does not add to other users' characters" do
+        group = create(:gallery_group)
+        character = create(:character, gallery_groups: [group])
+
+        gallery = create(:gallery)
+        gallery.gallery_groups << group
+        gallery.save
+        expect(character.reload.galleries).to match_array([])
+      end
+
+      it "does not add to a character twice" do
+        # tests a manually-attached character1
+        # and a double-grouped character2
+        group = create(:gallery_group)
+        group2 = create(:gallery_group)
+        user = create(:user)
+        character1 = create(:character, user: user, gallery_groups: [group])
+        character2 = create(:character, user: user, gallery_groups: [group, group2])
+
+        gallery = create(:gallery, user: user, characters: [character1])
+        gallery.gallery_groups << group
+        gallery.save
+        gallery.reload
+        expect(gallery.characters).to match_array([character1, character2])
+        expect(gallery.characters_galleries.find_by(character_id: character1.id)).not_to be_added_by_group
+        expect(gallery.characters_galleries.find_by(character_id: character2.id)).to be_added_by_group
+
+        gallery.gallery_groups << group2
+        gallery.save
+        gallery.reload
+        expect(gallery.characters).to match_array([character1, character2])
+        expect(gallery.characters_galleries.find_by(character_id: character1.id)).not_to be_added_by_group
+        expect(gallery.characters_galleries.find_by(character_id: character2.id)).to be_added_by_group
+      end
+
+      it "adds galleries to given group" do
+        group = create(:gallery_group)
+        user = create(:user)
+        character1 = create(:character, user: user, gallery_groups: [group])
+        character2 = create(:character, user: user, gallery_groups: [group])
+
+        gallery = create(:gallery, user: user)
+        gallery.gallery_groups << group
+        gallery.save
+        gallery.reload
+        expect(gallery.characters).to match_array([character1, character2])
+        expect(gallery.characters_galleries.map(&:added_by_group?)).to eq([true, true])
+      end
+
+      it "does right things when gallery group removed" do
+        # does not touch unrelated characters
+        # does not touch characters that have been otherwise tethered
+        # removes from characters that are not otherwise tethered
+        group = create(:gallery_group)
+        user = create(:user)
+        other_character = create(:character, user: user)
+        gallery = create(:gallery, user: user, gallery_groups: [group], characters: [other_character])
+        character_auto = create(:character, user: user, gallery_groups: [group])
+        character_both = create(:character, user: user, gallery_groups: [group])
+        gallery.reload
+        gallery.characters_galleries.find_by(character_id: character_both.id).update_attributes(added_by_group: false)
+        expect(gallery.characters).to match_array([other_character, character_auto, character_both])
+        expect(gallery.characters_galleries.find_by(character_id: character_auto.id)).to be_added_by_group
+
+        gallery.update_attributes(gallery_groups: [])
+        gallery.reload
+        expect(gallery.characters).to match_array([other_character, character_both])
+        expect(gallery.characters_galleries.find_by(character_id: character_both.id)).not_to be_added_by_group
+      end
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -704,6 +704,7 @@ RSpec.describe Post do
     expect(NotifyFollowersOfNewPostJob).to have_queued(post.id)
   end
 
+  # from Taggable concern; duplicated between PostSpec, CharacterSpec, GallerySpec
   context "tags" do
     let(:taggable) { create(:post) }
     ['label', 'setting', 'content_warning'].each do |type|

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -714,6 +714,7 @@ RSpec.describe Post do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags.map(&:name)).to match_array(['tag'])
         expect(tags.map(&:user)).to match_array([taggable.user])
       end
@@ -736,9 +737,11 @@ RSpec.describe Post do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags.map(&:name)).to match_array([name])
         expect(tags.map(&:user)).to match_array([taggable.user])
         expect(tags).not_to include(tag)
+        expect(tag_ids).to match_array(tags.map(&:id))
       end
 
       it "uses extant #{type} tags by id" do
@@ -748,8 +751,10 @@ RSpec.describe Post do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags).to match_array([tag])
         expect(tags.map(&:user)).to match_array([old_user])
+        expect(tag_ids).to match_array([tag.id])
       end
 
       it "removes #{type} tags when not in list given" do
@@ -762,6 +767,7 @@ RSpec.describe Post do
         taggable.save
         taggable.reload
         expect(taggable.send(type + 's')).to eq([])
+        expect(taggable.send(type + '_ids')).to eq([])
       end
 
       it "only adds #{type} tags once if given multiple times" do
@@ -772,8 +778,10 @@ RSpec.describe Post do
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
         expect(tags).to match_array([tag])
         expect(tags.map(&:user)).to match_array([old_user])
+        expect(tag_ids).to match_array([tag.id])
       end
     end
   end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -75,6 +75,31 @@ RSpec.describe Tag do
     end
   end
 
+  describe "#character_count" do
+    def create_tags
+      tag1 = create(:gallery_group)
+      tag2 = create(:gallery_group)
+      create(:character, gallery_groups: [tag2])
+      tag3 = create(:gallery_group)
+      2.times { create(:character, gallery_groups: [tag3]) }
+      [tag1, tag2, tag3]
+    end
+
+    it "works with with_item_counts scope" do
+      tags = create_tags
+      fetched = GalleryGroup.where(id: tags.map(&:id)).select(:id).with_item_counts
+      expect(fetched).to eq(tags)
+      expect(fetched.map(&:character_count)).to eq([0, 1, 2])
+    end
+
+    it "works without with_item_counts scope" do
+      tags = create_tags
+      fetched = GalleryGroup.where(id: tags.map(&:id))
+      expect(fetched).to eq(tags)
+      expect(fetched.map(&:character_count)).to eq([0, 1, 2])
+    end
+  end
+
   describe "#gallery_count" do
     def create_tags
       tag1 = create(:gallery_group)


### PR DESCRIPTION
Builds on #341, so requires everything there to be done first.

Fixes #330.

TODO:

- [X] Convert subquery in tags API controller to something more intelligible (joins?)
- [X] ~~Display a warning if user has manually excluded galleries that were in a group, so it is not easy to miss; maybe send list of grouped IDs?~~ … no, instead, make it not exclude, make sure it does not exclude, make sure it's just the added on/off toggle.
- [x] Show galleries on character page by AJAX (see "TagsController offers correct galleries…")
  - [x] Fix `character#new` if you add and remove a character group!!! [done? seems to have instead been a problem with adding a character group twice, maybe? not sure...]
- [x] Test *everything*, all the things
- [x] Test *all the things* if the form save fails, especially all the stuff around `ungrouped_gallery_ids`
- [x] Expose characters on the relevant tag pages
- [x] Leave a note about where the test code is duplicated (for model tags)
- [X] Rebase onto #341 once merged.
- [x] Make sure character duplicate contains correct `ungrouped_gallery_ids` and `gallery_group_ids`

Tests:

- [x] The "galleries" list, in the character editor, corresponds to galleries that are not added by groups
- [x] Removing galleries from this list either flags it "added by group" (if it can be found in an attached group), or removes it from the character (if it cannot be); adding them creates the relevant tie if it doesn't already exist, and flags it "not added by group"
- [x] Adding a gallery at the same time you remove the group should keep the gallery and not the others
- [x] Adding a character to a group: does not add another user's galleries, does not add galleries twice, adds galleries from the given group
- [x] Adding a gallery to a group: does not add to another user's characters, does not add to characters twice, adds to characters from the given group
- [x] TagsController offers correct galleries for tag#show with a GalleryGroup and appropriate wants
- Other controller tag-related things (for CharactersController)
  - [x] Persists if saving fails
  - [x] Successfully submits the tags
- Tag controller handles it well
  - [x] Shown characters in tags#show
  - [x] Count characters in tags#index
- [x] editor loads? try doing `render_views` for characters#edit and characters#new
- [x] character duplicate