### PR TITLE
Order tags explicitly when creating them, to preserve input order

### DIFF
--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -344,20 +344,26 @@ RSpec.describe Character do
         tag1 = create(type)
         tag2 = create(type)
         tag3 = create(type)
+        tag4 = create(type)
 
-        taggable.send(type + 's=', [tag3, tag1])
+        taggable.send(type + '_ids=', [tag3.id, '_fake1', '_'+tag1.name, '_fake2', tag4.id])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags[0]).to eq(tag3)
+        expect(tags[2]).to eq(tag1)
+        expect(tags[4]).to eq(tag4)
+        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name])
+
+        taggable.send(type + '_ids=', taggable.send(type + '_ids') + ['_'+tag2.name, '_fake3', '_fake4'])
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
         tag_ids = taggable.send(type + '_ids')
-        expect(tags).to eq([tag3, tag1])
-
-        taggable.send(type + 's=', taggable.send(type + 's') + [tag2])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags).to eq([tag3, tag1, tag2])
+        expect(tags[0]).to eq(tag3)
+        expect(tags[2]).to eq(tag1)
+        expect(tags[5]).to eq(tag2)
+        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name, tag2.name, 'fake3', 'fake4'])
       end
     end
   end

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -339,6 +339,26 @@ RSpec.describe Character do
         expect(tags.map(&:user)).to match_array([old_user])
         expect(tag_ids).to match_array([tag.id])
       end
+
+      it "orders #{type} tags by order added to model" do
+        tag1 = create(type)
+        tag2 = create(type)
+        tag3 = create(type)
+
+        taggable.send(type + 's=', [tag3, tag1])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
+        expect(tags).to eq([tag3, tag1])
+
+        taggable.send(type + 's=', taggable.send(type + 's') + [tag2])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
+        expect(tags).to eq([tag3, tag1, tag2])
+      end
     end
   end
 end

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -110,6 +110,26 @@ RSpec.describe Gallery do
         expect(tags.map(&:user)).to match_array([old_user])
         expect(tag_ids).to match_array([tag.id])
       end
+
+      it "orders #{type} tags by order added to model" do
+        tag1 = create(type)
+        tag2 = create(type)
+        tag3 = create(type)
+
+        taggable.send(type + 's=', [tag3, tag1])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
+        expect(tags).to eq([tag3, tag1])
+
+        taggable.send(type + 's=', taggable.send(type + 's') + [tag2])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
+        expect(tags).to eq([tag3, tag1, tag2])
+      end
     end
   end
 

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -115,20 +115,26 @@ RSpec.describe Gallery do
         tag1 = create(type)
         tag2 = create(type)
         tag3 = create(type)
+        tag4 = create(type)
 
-        taggable.send(type + 's=', [tag3, tag1])
+        taggable.send(type + '_ids=', [tag3.id, '_fake1', '_'+tag1.name, '_fake2', tag4.id])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags[0]).to eq(tag3)
+        expect(tags[2]).to eq(tag1)
+        expect(tags[4]).to eq(tag4)
+        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name])
+
+        taggable.send(type + '_ids=', taggable.send(type + '_ids') + ['_'+tag2.name, '_fake3', '_fake4'])
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
         tag_ids = taggable.send(type + '_ids')
-        expect(tags).to eq([tag3, tag1])
-
-        taggable.send(type + 's=', taggable.send(type + 's') + [tag2])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags).to eq([tag3, tag1, tag2])
+        expect(tags[0]).to eq(tag3)
+        expect(tags[2]).to eq(tag1)
+        expect(tags[5]).to eq(tag2)
+        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name, tag2.name, 'fake3', 'fake4'])
       end
     end
   end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -788,20 +788,26 @@ RSpec.describe Post do
         tag1 = create(type)
         tag2 = create(type)
         tag3 = create(type)
+        tag4 = create(type)
 
-        taggable.send(type + 's=', [tag3, tag1])
+        taggable.send(type + '_ids=', [tag3.id, '_fake1', '_'+tag1.name, '_fake2', tag4.id])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        expect(tags[0]).to eq(tag3)
+        expect(tags[2]).to eq(tag1)
+        expect(tags[4]).to eq(tag4)
+        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name])
+
+        taggable.send(type + '_ids=', taggable.send(type + '_ids') + ['_'+tag2.name, '_fake3', '_fake4'])
         taggable.save
         taggable.reload
         tags = taggable.send(type + 's')
         tag_ids = taggable.send(type + '_ids')
-        expect(tags).to eq([tag3, tag1])
-
-        taggable.send(type + 's=', taggable.send(type + 's') + [tag2])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags).to eq([tag3, tag1, tag2])
+        expect(tags[0]).to eq(tag3)
+        expect(tags[2]).to eq(tag1)
+        expect(tags[5]).to eq(tag2)
+        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name, tag2.name, 'fake3', 'fake4'])
       end
     end
   end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -783,6 +783,26 @@ RSpec.describe Post do
         expect(tags.map(&:user)).to match_array([old_user])
         expect(tag_ids).to match_array([tag.id])
       end
+
+      it "orders #{type} tags by order added to model" do
+        tag1 = create(type)
+        tag2 = create(type)
+        tag3 = create(type)
+
+        taggable.send(type + 's=', [tag3, tag1])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
+        expect(tags).to eq([tag3, tag1])
+
+        taggable.send(type + 's=', taggable.send(type + 's') + [tag2])
+        taggable.save
+        taggable.reload
+        tags = taggable.send(type + 's')
+        tag_ids = taggable.send(type + '_ids')
+        expect(tags).to eq([tag3, tag1, tag2])
+      end
     end
   end
 end


### PR DESCRIPTION
Some people care about the order tags are created in and so on and so we should order by ID of the association where possible and make sure it's preserved etc.