### PR TITLE
Improve the tags show page

### DIFF
--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -49,3 +49,14 @@
           - content_for :edit_box
     %tbody
       = render partial: 'characters/list_section', locals: {name: nil, characters: @characters.order('name asc'), hide_buttons: true}
+
+- unless [@posts, @galleries, @characters].any?(&:present?)
+  %table
+    %thead
+      %tr
+        %th
+          Items Tagged: #{@tag.name}
+          - content_for :edit_box
+    %tbody
+      %tr
+        %td.centered.padding-5{class: cycle('even', 'odd')} — No items yet —

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -1,6 +1,9 @@
 - content_for :breadcrumbs do
   = link_to "Tags", tags_path
   &raquo;
+  - if @tag.type
+    = @tag.type.pluralize.titlecase
+    &raquo;
   %b= @tag.name
 
 - content_for :edit_box do


### PR DESCRIPTION
- Show "No items yet" when relevant
- Show the tag type (Label, Content Warning, …) in breadcrumbs if extant