### PR TITLE
Refactor the character editor

### DIFF
--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -1,5 +1,5 @@
 /* global gon, createTagSelect */
-var galleryIds;
+var galleryIds, oldTemplate;
 var galleryGroupIds = [];
 var galleryGroups = {};
 
@@ -25,11 +25,17 @@ $(document).ready(function() {
 
   bindIcons();
 
-  $("#character_template_id").change(function() {
-    if ($(this).val() === "0") {
+  oldTemplate = $("#character_template_id").val();
+  $("#new_template").change(function() {
+    if ($("#new_template").is(":checked")) {
+      $("#character_template_attributes_name").val('');
       $("#create_template").show();
+      oldTemplate = $("#character_template_id").val();
+      $("#character_template_id").attr("disabled", true).val('').trigger("change.select2");;
     } else {
       $("#create_template").hide();
+      $("#character_template_id").attr("disabled", false).val(oldTemplate).trigger("change.select2");
+      $("#character_template_attributes_name").val($("#character_template_id option:selected").text());
     }
   });
 

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -2,7 +2,7 @@ class Template < ActiveRecord::Base
   include Presentable
 
   belongs_to :user, inverse_of: :templates
-  has_many :characters, -> { order('LOWER(name) ASC') }
+  has_many :characters, -> { order('LOWER(name) ASC') }, inverse_of: :template
 
   validates_presence_of :name, :user
 

--- a/app/views/characters/_editor.haml
+++ b/app/views/characters/_editor.haml
@@ -14,11 +14,16 @@
   /  Setting.all, :id, :name, {selected: @character.settings.pluck(:id)}, {multiple: true})
 %tr
   - klass = cycle('even', 'odd')
-  %th.sub Template
-  %td{class: klass}= f.collection_select :template_id, @templates, :id, :name, {include_blank: '— Choose Template —'}, {class: 'text chosen-select'}
-%tr#create_template{class: ('hidden' unless params[:character].try(:[], :template_id) == "0")}
+  %th.sub.vtop Template
+  %td{class: klass}
+    = f.collection_select :template_id, @templates, :id, :name, {include_blank: '— Choose Template —'}, {class: 'text chosen-select', disabled: params[:new_template].present?}
+    %br
+    = check_box_tag :new_template, '1', params[:new_template].present?
+    = label_tag :new_template, 'Create New Template'
+%tr#create_template{class: ('hidden' unless params[:new_template])}
   %th.sub &#8627; Name
-  %td{class: klass}= f.text_field :new_template_name, placeholder: "Template Name", class: 'text'
+  = f.fields_for :template do |ff|
+    %td{class: klass}= ff.text_field :name, placeholder: "Template Name", class: 'text'
 - if current_user.galleries.present?
   %tr
     %th.sub Galleries

--- a/app/views/characters/edit.haml
+++ b/app/views/characters/edit.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
   = link_to "Characters", characters_path
   &raquo;
-  - if @character.template
+  - if @character.template.persisted?
     = link_to @character.template.name, template_path(@character.template)
     &raquo;
   = link_to @character.name, character_path(@character)


### PR DESCRIPTION
Uses nested_attributes_for for templates instead of hacking it together myself. TBD: can I get it to only allow them if the user is creating a new one?