### PR TITLE
Handle icon edge cases

### DIFF
--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -1,5 +1,5 @@
 /* global gon, tinymce, tinyMCE, resizeScreenname, createTagSelect */
-var tinyMCEInit = false;
+var tinyMCEInit = false, shownIcons = [];
 
 $(document).ready(function() {
   // SET UP POST METADATA EDITOR:
@@ -233,6 +233,7 @@ function iconString(icon) {
   var imgId = icon.id;
   var imgUrl = icon.url;
   var imgKey = icon.keyword;
+  shownIcons.push(icon.id);
 
   if (!icon.skip_dropdown) $("#icon_dropdown").append($("<option>").attr({value: imgId}).append(imgKey));
   var iconImg = $("<img>").attr({src: imgUrl, id: imgId, alt: imgKey, title: imgKey, 'class': 'icon'});
@@ -277,6 +278,8 @@ function setupTinyMCE() {
 function getAndSetCharacterData(characterId, options) {
   var restoreIcon = false;
   var restoreAlias = false;
+  shownIcons = [];
+
   if (typeof options !== 'undefined') {
     restoreIcon = options.restore_icon;
     restoreAlias = options.restore_alias;
@@ -382,6 +385,7 @@ function getAndSetCharacterData(characterId, options) {
       $("#gallery").append(galleryString(resp.galleries[j], multiGallery));
     }
 
+    if(shownIcons.indexOf(resp.default.id) < 0) $("#gallery").append(iconString(resp.default));
     $("#gallery").append(iconString({id: '', url: '/images/no-icon.png', keyword: 'No Icon', skip_dropdown: true}));
     bindGallery();
     bindIcon();

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -385,13 +385,19 @@ function getAndSetCharacterData(characterId, options) {
       $("#gallery").append(galleryString(resp.galleries[j], multiGallery));
     }
 
-    if(shownIcons.indexOf(resp.default.id) < 0) $("#gallery").append(iconString(resp.default));
+    // If no default and no icons in any galleries, remove pointer
+    if (!resp.default && shownIcons.length === 0) {
+      $("#current-icon").removeClass('pointer');
+      return;
+    }
+
+    if(resp.default && shownIcons.indexOf(resp.default.id) < 0) $("#gallery").append(iconString(resp.default));
     $("#gallery").append(iconString({id: '', url: '/images/no-icon.png', keyword: 'No Icon', skip_dropdown: true}));
     bindGallery();
     bindIcon();
     if (restoreIcon)
       setIconFromId(selectedIconID);
-    else
+    else if (resp.default)
       setIcon(resp.default.id, resp.default.url, resp.default.keyword, resp.default.keyword);
   });
 }

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -10,4 +10,26 @@ module WritableHelper
   def unread_path(post, **kwargs)
     post_path(post, page: 'unread', anchor: 'unread', **kwargs)
   end
+
+  def dropdown_icons(item, galleries=nil)
+    icons = []
+    selected_id = nil
+
+    if item.character
+      icons = if galleries.present?
+                galleries.map(&:icons).flatten
+              else
+                item.character.icons
+              end
+      icons |= [item.character.default_icon] if item.character.default_icon
+      icons |= [item.icon] if item.icon
+      selected_id = item.icon_id
+    elsif current_user.avatar
+      icons = [current_user.avatar]
+      selected_id = current_user.avatar_id
+    end
+
+    return '' unless icons.present?
+    select_tag :icon_dropdown, options_for_select(icons.map{|i| [i.keyword, i.id]}, selected_id), prompt: "No Icon"
+  end
 end

--- a/app/presenters/character_presenter.rb
+++ b/app/presenters/character_presenter.rb
@@ -42,12 +42,9 @@ class CharacterPresenter
   end
 
   def single_gallery_json
-    if character.galleries.present?
-      [{icons: character.icons}]
-    elsif character.default_icon.present?
-      [{icons: [character.default_icon]}]
-    else
-      []
-    end
+    icons = character.icons
+    icons |= [character.default_icon] if character.default_icon.present?
+    return [] unless icons.present?
+    [{icons: icons}]
   end
 end

--- a/app/views/posts/_editor.haml
+++ b/app/views/posts/_editor.haml
@@ -9,18 +9,7 @@
       - else
         = no_icon_tag id: 'current-icon', pointer: item.has_icons?, data: {icon_id: ''}
       #icon-overlay
-    #current-icon-dropdown
-      - if item.character
-        - if current_user.icon_picker_grouping? && item.character.galleries.count > 1
-          - icons = character_galleries.map(&:icons).flatten.map{|i| [i.keyword, i.id]}
-        - else
-          - icons = item.character.icons.map{|i| [i.keyword, i.id]}
-        - unless icons.present?
-          - icon = item.character.default_icon
-          - icons = [[icon.keyword, icon.id]] unless icon.nil?
-        = select_tag :icon_dropdown, options_for_select(icons, item.icon_id), prompt: "No Icon"
-      - elsif current_user.avatar
-        = select_tag :icon_dropdown, options_for_select([[current_user.avatar.keyword, current_user.avatar.id]], current_user.avatar.id), prompt: "No Icon"
+    #current-icon-dropdown= dropdown_icons(item, character_galleries)
     .post-info-text
       .post-character{class: ('hidden' unless item.character), data: {character_id: item.character_id || '', alias_id: item.character_alias_id || ''}}
         %span#name= item.name
@@ -51,34 +40,37 @@
             - recent_characters.each do |character|
               = character_icon_tag character
   #gallery.green
-    - if item.character.nil?
-      - if current_user.avatar
+    - if character_galleries.present?
+      - character_galleries.each do |gallery|
+        .gallery-group
+          .gallery-name= gallery.name
+          - gallery.icons.each do |icon|
+            .gallery-icon
+              = icon_tag icon, id: icon.id, pointer: true
+              %br>
+              = icon.keyword
+
+      - all_ids = item.character.icons.pluck(:id) # handle edge cases
+      - if item.character.default_icon && !all_ids.include?(item.character.default_icon_id)
         .gallery-icon
-          = icon_tag current_user.avatar, id: current_user.avatar.id, pointer: true
+          = icon_tag item.character.default_icon, id: item.character.default_icon_id, pointer: true
           %br>
-          = current_user.avatar.keyword
-    - elsif item.character.galleries.present?
-      - if current_user.icon_picker_grouping && item.character.galleries.count > 1
-        - character_galleries.each do |gallery|
-          .gallery-group
-            .gallery-name= gallery.name
-            - gallery.icons.each do |icon|
-              .gallery-icon
-                = icon_tag icon, id: icon.id, pointer: true
-                %br>
-                = icon.keyword
-      - else
-        - icons = item.character.icons
-        - icons.each do |icon|
-          .gallery-icon
-            = icon_tag icon, id: icon.id, pointer: true
-            %br>
-            = icon.keyword
-    - elsif item.character.default_icon.present?
-      .gallery-icon
-        = icon_tag item.character.default_icon, id: item.character.default_icon.id, pointer: true
-        %br>
-        = item.character.default_icon.keyword
+          = item.character.default_icon.keyword
+      - if item.icon && !all_ids.include?(item.icon_id)
+        .gallery-icon
+          = icon_tag item.icon, id: item.icon_id, pointer: true
+          %br>
+          = item.icon.keyword
+    - else
+      - icons = item.character.try(:icons) || []
+      - icons |= [item.character.default_icon] if item.character.try(:default_icon)
+      - icons |= [item.icon] if item.icon
+      - icons |= [current_user.avatar] if !item.character && current_user.avatar
+      - icons.each do |icon|
+        .gallery-icon
+          = icon_tag icon, id: icon.id, pointer: true
+          %br>
+          = icon.keyword
     .gallery-icon
       = no_icon_tag id: '', pointer: true
       %br> No Icon

--- a/spec/controllers/api/v1/characters_controller_spec.rb
+++ b/spec/controllers/api/v1/characters_controller_spec.rb
@@ -128,6 +128,8 @@ RSpec.describe Api::V1::CharactersController do
       character = create(:character, user: user)
       character.galleries << create(:gallery, user: user)
       character.galleries << create(:gallery, user: user)
+      character.galleries[0].icons << create(:icon, user: user)
+      character.galleries[1].icons << create(:icon, user: user)
       get :show, id: character.id
       expect(response).to have_http_status(200)
       expect(response.json['galleries'].size).to eq(1)


### PR DESCRIPTION
This handles the following:
* If you have a character with a default icon that is not in any of their galleries, it will correctly be included in the dropdown and in the icon picker
* If you have a post or reply with an icon set that is no longer in the character's galleries and load edit, it will correctly be included in the dropdown and the icon picker (on load, but not on character switch; this is intentional, because ugh edge cases.)
* Hopefully the code is cleaner
* TBD tests

Fixes #13