### PR TITLE
Fix the wide info box resulting from long content names

### DIFF
--- a/app/assets/stylesheets/layout.css
+++ b/app/assets/stylesheets/layout.css
@@ -137,7 +137,8 @@ ul.table-list { list-style: none; padding: 0; margin: 0; }
 }
 
 /* The new object layout with the floating left info box and the right content area */
-#content .left-info-box { float: left; }
+#content .left-info-box { float: left; overflow-wrap: break-word; word-wrap: break-word; }
+#content table.left-info-box { table-layout: fixed; }
 #content .right-content-box { float: left; }
 #content .user-info-box { width: 200px; }
 #content .icon-info-box { width: 150px; }


### PR DESCRIPTION
Long content names in `left-info-box`es (e.g. long character names,
screennames without spaces) can cause the table to expand and
accordingly break the display with the content on the right.

This fixes that by forcing the left table width to be fixed, instead
of adjusting to ignore the width given in the CSS.

To create a breaking scenario, name a character `CharacterWithALongNameAsABadTest`, and/or give it a screenname `hereisacharacterwithalongscreennameasatest`. Loading the character's `show` page will (prior to this commit) cause the right-side content box to be shoved below the box, since its calculated width is too wide to fit next to the info box.