### PR TITLE
Fix post container formatting

### DIFF
--- a/app/assets/javascripts/posts/show.js
+++ b/app/assets/javascripts/posts/show.js
@@ -10,7 +10,7 @@ $(document).ready(function() {
 
   $(".post-expander").click(function() {
     $(this).children(".info").remove();
-    $(this).children(".hidden").show();
+    $(this).get(0).outerHTML = $(this).children('.hidden').html();
   });
 
   // Dropdown menu code

--- a/app/assets/stylesheets/replies.css
+++ b/app/assets/stylesheets/replies.css
@@ -67,8 +67,8 @@
 .post-expander .info { padding: 5px; text-align: center; font-size: 14px; cursor: pointer; }
 .post-ender { min-height: 5px; padding: 5px; background-color: #3e384f; color: #FEFEFE; font-size: 16px; font-weight: bold; text-align: center; }
 
-.post-container { overflow: auto; }
-#content > .post-container { padding: 0; }
+/* Post content */
+#content > .post-container { padding: 0; overflow: auto; }
 .post-edit-box { float: right; margin-left: 10px; margin-bottom: 5px; padding: 5px; }
 .post-info-box {
   text-align: center;


### PR DESCRIPTION
A check for all locations that contain `.post-container` in the views produces various documents, which are then included in various locations. ("root element" means the `.post-container` appears as a direct child of the root document, or in the case of `posts#flat`, an explicit child of `#content`; numbers given are line numbers.)

- messages#single (10, 18: root elements) hence messages#preview (16, 17: root elements), messages#show (10: root element)
- posts#flat (28: root element)
- posts#new_import (4: root element)
- posts#generate_flat (4: root element)
- replies#single (1: root element) hence posts#history (18, 25: root elements), posts#preview (6: root element), posts#show (129 root, 134 **not root** but gets converted to be root on display, 137 root), replies#preview (8, 18: root elements)

As stated, in `posts#show`, line 134 is a non-root element (the expander for the main post on subsequent pages). The first commit here makes the JavaScript convert the whole expander into the HTML of the post on expansion, so it'll display identically to the first page, instead of being `#content > .post-expander > .hidden > .post-content`. (This has a side effect of fixing the previous erroneous padding found on that post when expanded.)

This is currently a WIP while I fix all the CSS and the notes above are places for me to check that everything displays properly.