### PR TITLE
Minor changes to hopefully make the report page more understandable

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -87,7 +87,10 @@
             %li= link_to 'Tags Owed', owed_posts_path
           %li= link_to 'Contribute', contribute_path
           - if (day = DailyReport.unread_date_for(current_user)).present?
-            %li= link_to 'Daily Report', report_path(id: :daily, day: day), style: 'text-shadow: 0 0 0.8em #F87, 0 0 0.8em #F87'
+            %li
+              = link_to report_path(id: :daily, day: day), style: 'text-shadow: 0 0 0.8em #F87, 0 0 0.8em #F87' do
+                Daily Report
+                %em= '(' + Date.parse(day).strftime("%b %d, %Y") + ')'
           - else
             %li= link_to 'Daily Report', report_path(id: :daily)
     - if content_for?(:breadcrumbs)

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -6,11 +6,14 @@
       %th{colspan: 7}
         Daily Report -
         = @day.strftime("%b %d, %Y")
+        - if @day == Date.today
+          %em (Incomplete)
     %tr
       %th.sub{colspan: 7}
         - if @day < Date.today
           = link_to url_for(params.except(:page).merge(day: @day + 1.day)) do
-            .view-button &raquo; Next Day
+            - style = 'font-style: italic;' if @day + 1.day >= Date.today
+            .view-button{style: style} &raquo; Next Day
         = link_to url_for(params.except(:page).merge(day: @day - 1.day)) do
           .view-button.float-none &laquo; Previous Day
   - posts = DailyReport.new(@day).posts(sort, page, per_page)


### PR DESCRIPTION
Part of #63, this seems like a good way to reduce the confusion over not going to the latest report day?

1. Indicates the report day in the header
2. Italicize today and mark as incomplete to make that clearer