### PR TITLE
Unlink object name in new profiles if view is blank

### DIFF
--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -9,7 +9,7 @@
     &raquo;
     = link_to @character.template.name, template_path(@character.template)
   &raquo;
-  = link_to @character.name, character_path(@character)
+  = link_to_if params[:view].present?, @character.name, character_path(@character)
   &raquo;
   - if params[:view] == 'galleries'
     %b Galleries

--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -6,7 +6,7 @@
     &raquo;
     = link_to "#{@icon.user.username}'s Galleries", user_galleries_path(@icon.user)
   &raquo;
-  = link_to @icon.keyword, icon_path(@icon)
+  = link_to_if params[:view].present?, @icon.keyword, icon_path(@icon)
   &raquo;
   - if params[:view] == 'galleries'
     %b Galleries


### PR DESCRIPTION
In the new icon and character profiles, with the breadcrumbs that show "Info" (`Characters » Template » Character » Info`), the "Character" (or "Icon") part should not be a link as it just links to the current page.