### PR TITLE
Improve the formatting of HTML-input written content by formatting with 'simple_format'

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -127,7 +127,7 @@ module ApplicationHelper
   end
 
   def sanitize_written_content(content)
-    content = (content.include?("<p>".freeze) || content[/<br ?\/?>/]) ? content : content.gsub("\n".freeze, "<br/>".freeze)
+    content = content.gsub("\n".freeze, "<br/>".freeze) unless content.include?("<p>".freeze) || content[/<br *\/?>/]
     Sanitize.fragment(content, Glowfic::POST_CONTENT_SANITIZER)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,8 +126,11 @@ module ApplicationHelper
     Sanitize.fragment(desc, elements: ['a'], attributes: {'a' => ['href']})
   end
 
+  P_TAG = "<p>".freeze
+  BR_TAG = /<br *\/?>/
+
   def sanitize_written_content(content)
-    content = content.gsub("\n".freeze, "<br/>".freeze) unless content.include?("<p>".freeze) || content[/<br *\/?>/]
+    content = simple_format(content, sanitize: false) unless content[P_TAG] || content[BR_TAG]
     Sanitize.fragment(content, Glowfic::POST_CONTENT_SANITIZER)
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+
+RSpec.describe ApplicationHelper do
+  describe "#sanitize_post_description" do
+    it "remains blank if given blank" do
+      text = ''
+      expect(helper.sanitize_post_description(text)).to eq(text)
+    end
+
+    it "does not malform plain text" do
+      text = 'sample text'
+      expect(helper.sanitize_post_description(text)).to eq(text)
+    end
+
+    it "permits links" do
+      text = 'here is <a href="http://example.com">a link</a>'
+      expect(helper.sanitize_post_description(text)).to eq(text)
+    end
+
+    it "removes unpermitted attributes" do
+      text = '<a onclick="function(){ alert("bad!");}">test</a>'
+      expect(helper.sanitize_post_description(text)).to eq('<a>test</a>')
+    end
+
+    it "removes unpermitted elements" do
+      text = '<b>test</b> <script type="text/javascript">alert("bad!");</script> <p>text</p>'
+      expect(helper.sanitize_post_description(text)).to eq('test alert("bad!");  text ')
+    end
+
+    it "fixes unending tags" do
+      text = '<a>test'
+      expect(helper.sanitize_post_description(text)).to eq('<a>test</a>')
+    end
+  end
+
+  describe "#sanitize_written_content" do
+    it "remains blank if given blank" do
+      text = ''
+      expect(helper.sanitize_written_content(text)).to eq(text)
+    end
+
+    it "does not malform plain text" do
+      text = 'sample text'
+      expect(helper.sanitize_written_content(text)).to eq(text)
+    end
+
+    it "permits links" do
+      text = 'here is <a href="http://example.com">a link</a>'
+      expect(helper.sanitize_written_content(text)).to eq(text)
+    end
+
+    it "removes unpermitted attributes" do
+      text = '<a onclick="function(){ alert("bad!");}">test</a>'
+      expect(helper.sanitize_written_content(text)).to eq('<a>test</a>')
+    end
+
+    it "removes unpermitted elements" do
+      text = '<b>test</b> <script type="text/javascript">alert("bad!");</script> <p>text</p>'
+      expect(helper.sanitize_written_content(text)).to eq('<b>test</b> alert("bad!"); <p>text</p>')
+    end
+
+    it "fixes unending tags" do
+      text = '<a>test'
+      expect(helper.sanitize_written_content(text)).to eq('<a>test</a>')
+    end
+
+    it "automatically converts linebreaks in text without manual linebreaking" do
+      text = "line1\nline2\n\nline3"
+      expect(helper.sanitize_written_content(text)).to eq('line1<br>line2<br><br>line3')
+    end
+
+    it "does not convert linebreaks in text with <br> tags" do
+      text = "line1<br>line2\nline3"
+      display = text
+      expect(helper.sanitize_written_content(text)).to eq(display)
+
+      text = "line1<br/>line2\nline3"
+      expect(helper.sanitize_written_content(text)).to eq(display)
+
+      text = "line1<br />line2\nline3"
+      expect(helper.sanitize_written_content(text)).to eq(display)
+    end
+
+    it "does not convert linebreaks in text with <p> tags" do
+      text = "<p>line1</p><p>line2\nline3</p>"
+      expect(helper.sanitize_written_content(text)).to eq(text)
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -34,24 +34,24 @@ RSpec.describe ApplicationHelper do
   end
 
   describe "#sanitize_written_content" do
-    it "remains blank if given blank" do
+    it "is blank if given blank" do
       text = ''
-      expect(helper.sanitize_written_content(text)).to eq(text)
+      expect(helper.sanitize_written_content(text)).to eq("<p>#{text}</p>")
     end
 
     it "does not malform plain text" do
       text = 'sample text'
-      expect(helper.sanitize_written_content(text)).to eq(text)
+      expect(helper.sanitize_written_content(text)).to eq("<p>#{text}</p>")
     end
 
     it "permits links" do
       text = 'here is <a href="http://example.com">a link</a>'
-      expect(helper.sanitize_written_content(text)).to eq(text)
+      expect(helper.sanitize_written_content(text)).to eq("<p>#{text}</p>")
     end
 
     it "removes unpermitted attributes" do
       text = '<a onclick="function(){ alert("bad!");}">test</a>'
-      expect(helper.sanitize_written_content(text)).to eq('<a>test</a>')
+      expect(helper.sanitize_written_content(text)).to eq('<p><a>test</a></p>')
     end
 
     it "removes unpermitted elements" do
@@ -61,12 +61,12 @@ RSpec.describe ApplicationHelper do
 
     it "fixes unending tags" do
       text = '<a>test'
-      expect(helper.sanitize_written_content(text)).to eq('<a>test</a>')
+      expect(helper.sanitize_written_content(text)).to eq('<p><a>test</a></p>')
     end
 
     it "automatically converts linebreaks in text without manual linebreaking" do
       text = "line1\nline2\n\nline3"
-      expect(helper.sanitize_written_content(text)).to eq('line1<br>line2<br><br>line3')
+      expect(helper.sanitize_written_content(text)).to eq("<p>line1\n<br>line2</p>\n\n<p>line3</p>")
     end
 
     it "does not convert linebreaks in text with <br> tags" do


### PR DESCRIPTION
Also adds tests to ApplicationHelper for `#sanitize_post_description` and `#sanitize_written_content`.