### PR TITLE
Fix written content styling

### DIFF
--- a/app/assets/stylesheets/layouts/dark.css
+++ b/app/assets/stylesheets/layouts/dark.css
@@ -17,10 +17,10 @@ a, #content a, #content a:visited { color: #66997D; }
 #header #nav-bottom, #header { background-color: #56554F; }
 #header #logo { background-color: #3B4841; }
 #header a, #header li a { color: #CCCCCC; }
-#content .even, .post-post, .post-reply:nth-child(even), #post-editor, .post-reply:nth-child(odd) blockquote {
+#content .even, .post-post, .post-reply:nth-child(even), #post-editor, .odd blockquote, .post-reply:nth-child(odd) blockquote {
   background-color: #3E3E3E;
 }
-#content .odd, .post-reply:nth-child(odd), .post-post + #post-editor, .post-post + a + #post-editor, .post-post blockquote, .post-reply:nth-child(even) blockquote {
+#content .odd, .post-reply:nth-child(odd), .post-post + #post-editor, .post-post + a + #post-editor, .even blockquote, .post-post blockquote, .post-reply:nth-child(even) blockquote {
   background-color: #474747;
 }
 .green { background-color: #444D3F; }

--- a/app/assets/stylesheets/layouts/river.css
+++ b/app/assets/stylesheets/layouts/river.css
@@ -25,5 +25,5 @@ a:visited { color: #284150; }
 .post-character a, .post-character a:visited { color: #B3D3FF; }
 .post-footer { color: #717171; }
 #content .odd, #content .even, .post-post, .post-reply, #post-editor { background-color: #F3F3F3 !important; border-top: solid 1px #aaa; }
-.post-reply blockquote, .post-post blockquote { background-color: #E8E8E8 !important; }
+.post-reply blockquote, .post-post blockquote, .even blockquote, .odd blockquote { background-color: #E8E8E8 !important; }
 .tag-item { color: #3E526F; background-color: #D0CEC8; }

--- a/app/assets/stylesheets/layouts/starry.css
+++ b/app/assets/stylesheets/layouts/starry.css
@@ -17,8 +17,8 @@ body { background-color: #6C697C; }
 #post-menu-box a:hover div { background-color: #D3D3D3; }
 #post-menu-box div { border-bottom: 1px solid #808080; border-bottom: 1px solid rgba(128,128,128,0.5); }
 #post-menu-box a { color: inherit; }
-#content .even, .post-post, .post-reply:nth-child(even), #post-editor, .post-reply:nth-child(odd) blockquote { background-color: #E3E3E3; }
-#content .odd, .post-reply:nth-child(odd), .post-post + #post-editor, .post-post + a + #post-editor, .post-post blockquote, .post-reply:nth-child(even) blockquote { background-color: #D8D8D8; }
+#content .even, .post-post, .post-reply:nth-child(even), #post-editor, .odd blockquote, .post-reply:nth-child(odd) blockquote { background-color: #E3E3E3; }
+#content .odd, .post-reply:nth-child(odd), .post-post + #post-editor, .post-post + a + #post-editor, .even blockquote, .post-post blockquote, .post-reply:nth-child(even) blockquote { background-color: #D8D8D8; }
 
 .post-navheader .view-button, .view-button.selected, .view-button, .link-box.green, .link-box.blue, .link-box.red { background-color: #463C65; }
 #content .beige .link-box, #content .subber .link-box, .subber .link-box { background-color: #66608B; }

--- a/app/assets/stylesheets/layouts/starrydark.css
+++ b/app/assets/stylesheets/layouts/starrydark.css
@@ -15,8 +15,8 @@ body { background-color: #211E2F; color: #DADADA; }
 #post-menu-box { border-top: 1px solid #808080; border-top: 1px solid rgba(128,128,128,0.5); }
 #post-menu-box div { border-bottom: 1px solid #808080; border-bottom: 1px solid rgba(128,128,128,0.5); }
 #post-menu-box a { color: inherit; }
-#content .even, .post-post, .post-reply:nth-child(even), #post-editor, .post-reply:nth-child(odd) blockquote { background-color: #31323B; }
-#content .odd, .post-reply:nth-child(odd), .post-post + #post-editor, .post-post + a + #post-editor, .post-post blockquote, .post-reply:nth-child(even) blockquote { background-color: #25262E; }
+#content .even, .post-post, .post-reply:nth-child(even), #post-editor, .odd blockquote, .post-reply:nth-child(odd) blockquote { background-color: #31323B; }
+#content .odd, .post-reply:nth-child(odd), .post-post + #post-editor, .post-post + a + #post-editor, .even blockquote, .post-post blockquote, .post-reply:nth-child(even) blockquote { background-color: #25262E; }
 
 .post-navheader .view-button, .view-button.selected, .view-button, .link-box.green, .link-box.blue, .link-box.red, .tag-item { background-color: #463C65; }
 #content .beige .link-box, #content .subber .link-box, .subber .link-box { background-color: #5C5778; }

--- a/app/assets/stylesheets/layouts/starrylight.css
+++ b/app/assets/stylesheets/layouts/starrylight.css
@@ -15,8 +15,8 @@ body { background-color: #B0AFB7; }
 #post-menu-box a:hover div { background-color: #D3D3D3; }
 #post-menu-box div { border-bottom: 1px solid #808080; border-bottom: 1px solid rgba(128,128,128,0.5); }
 #post-menu-box a { color: inherit; }
-#content .even, .post-post, .post-reply:nth-child(even), #post-editor, .post-reply:nth-child(odd) blockquote { background-color: #E3E3E3; }
-#content .odd, .post-reply:nth-child(odd), .post-post + #post-editor, .post-post + a + #post-editor, .post-post blockquote, .post-reply:nth-child(even) blockquote { background-color: #D8D8D8; }
+#content .even, .post-post, .post-reply:nth-child(even), #post-editor, .odd blockquote, .post-reply:nth-child(odd) blockquote { background-color: #E3E3E3; }
+#content .odd, .post-reply:nth-child(odd), .post-post + #post-editor, .post-post + a + #post-editor, .even blockquote, .post-post blockquote, .post-reply:nth-child(even) blockquote { background-color: #D8D8D8; }
 
 .post-navheader .view-button, .view-button.selected, .view-button, .link-box.green, .link-box.blue, .link-box.red { background-color: #6565AE; }
 #content .beige .link-box, #content .subber .link-box, .subber .link-box { background-color: #8689B7; }

--- a/app/assets/stylesheets/replies.css
+++ b/app/assets/stylesheets/replies.css
@@ -70,8 +70,9 @@
 /* Written content */
 /* - Blockquotes */
 /* -- Color on even/odd background */
-.even blockquote, .beige blockquote, .post-post blockquote, .post-reply:nth-child(even) blockquote { background-color: #D8D8D8; }
+.even blockquote, .post-post blockquote, .post-reply:nth-child(even) blockquote { background-color: #D8D8D8; }
 .odd blockquote, .post-reply:nth-child(odd) blockquote { background-color: #E3E3E3; }
+.beige blockquote { background-color: rgba(128, 128, 128, 0.3); }
 .post-content blockquote, .written-content blockquote, .message-content blockquote { margin: 0.5em 1.5em; padding: 0.5em; }
 .post-content img, .written-content img, .message-content img { max-width: 100%; height: auto; }
 

--- a/app/assets/stylesheets/replies.css
+++ b/app/assets/stylesheets/replies.css
@@ -67,7 +67,22 @@
 .post-expander .info { padding: 5px; text-align: center; font-size: 14px; cursor: pointer; }
 .post-ender { min-height: 5px; padding: 5px; background-color: #3e384f; color: #FEFEFE; font-size: 16px; font-weight: bold; text-align: center; }
 
-/* Post content */
+/* Written content */
+/* - Blockquotes */
+/* -- Color on even/odd background */
+.even blockquote, .beige blockquote, .post-post blockquote, .post-reply:nth-child(even) blockquote { background-color: #D8D8D8; }
+.odd blockquote, .post-reply:nth-child(odd) blockquote { background-color: #E3E3E3; }
+.post-content blockquote, .written-content blockquote, .message-content blockquote { margin: 0.5em 1.5em; padding: 0.5em; }
+.post-content img, .written-content img, .message-content img { max-width: 100%; height: auto; }
+
+/* - Paragraphs */
+.post-content > p:first-child, .written-content > p:first-child, .message-content > p:first-child { margin-top: 0; }
+.post-content > p:last-child, .written-content > p:last-child, .message-content > p:last-child { margin-bottom: 0; }
+/* -- Inside blockquotes */
+.post-content blockquote > p:first-child, .written-content blockquote > p:first-child, .message-content blockquote > p:first-child { margin-top: 0; }
+.post-content blockquote > p:last-child, .written-content blockquote > p:last-child, .message-content blockquote > p:last-child { margin-bottom: 0; }
+
+/* Post-specific content & editor */
 #content > .post-container { padding: 0; overflow: auto; }
 .post-edit-box { float: right; margin-left: 10px; margin-bottom: 5px; padding: 5px; }
 .post-info-box {
@@ -105,7 +120,14 @@ select.per-page { margin-top: 5px; margin-bottom: 5px; }
 #post-editor { position: relative; }
 .details { display: inline; font-size: 12px; font-style: italic; }
 
-/* Small icons for selecting characters in post-editor */
+/* - Blockquotes around .post-info-box */
+.post-content blockquote { margin-left: 5.5em; margin-right: 5.5em; }
+
+/* - Lists around .post-info-box */
+.post-content ul, .post-content ol { list-style-position: inside; padding-left: 30px; }
+.post-content ul ul, .post-content ul ol, .post-content ol ul, .post-content ol ol { overflow: auto; }
+
+/* - Character quick switcher - small icons for selecting characters in post-editor */
 .char-access-icon {
   height: 30px;
   width: 30px;
@@ -119,15 +141,7 @@ div.char-access-icon {
   background-color: rgba(128,128,128,0.3);
 }
 
-/* Blockquotes */
-.post-post blockquote, .post-reply:nth-child(even) blockquote { background-color: #D8D8D8; }
-.post-reply:nth-child(odd) blockquote { background-color: #E3E3E3; }
-.post-content blockquote { margin: 0.5em 5.5em; padding: 0.5em; }
-.post-content blockquote > p:first-child { margin-top: 0; }
-.post-content blockquote > p:last-child { margin-bottom: 0; }
-.post-content img { max-width: 100%; height: auto; }
-
-/* Narrow window display */
+/* - Narrow window display */
 @media (max-width: 600px) {
     .post-info-box { float: none; width: 100%; display: inline-block; }
     .post-icon { float: left; margin-right: 0; margin-bottom: 5px; }
@@ -136,7 +150,7 @@ div.char-access-icon {
     #character-selector { left: 0; }
     .post-character { background-color: #B9B6AD; }
     .post-author { background-color: #8B8687; }
-    .post-content blockquote { margin: 0.5em 1.5em; }
+    .post-content blockquote { margin-left: 1.5em; margin-right: 1.5em; }
 }
 
 /* Pagination */
@@ -173,15 +187,6 @@ div.char-access-icon {
 #post-menu-box a { color: #EEEEEE; }
 #post-menu-box img { margin-right: 3px; vertical-align: middle; margin-bottom: 4px; }
 #post-menu-box a:hover div { background-color: #B0BBA9; }
-
-/* Deal with RTF */
-.post-content > p:first-child { margin-top: 0; }
-.post-content > p:last-child { margin-bottom: 0; }
-
-/* Deal with ULs displaying weirdly around the post info box */
-.post-content ul, .post-content ol { list-style-position: inside; padding-left: 30px; }
-.post-content ul ul, .post-content ul ol, .post-content ol ul, .post-content ol ol { overflow: auto; }
-
 
 /* Handle post tables */
 .post-completed { text-align: center; width: 40px; }

--- a/app/views/boards/show.haml
+++ b/app/views/boards/show.haml
@@ -36,7 +36,7 @@
         %th{colspan: 5}= content_for :posts_title
       - if @board.description.present?
         %tr
-          %td.odd{colspan: 5}= sanitize_written_content(@board.description).html_safe
+          %td.odd.written-content{colspan: 5}= sanitize_written_content(@board.description).html_safe
     %tbody
       %tr
         %td.continuity-spacer{colspan: 5}

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -18,7 +18,7 @@
         %b= name
 - if @template && @template.description.present?
   %tr
-    %td.beige.padding-5{colspan: 6}= sanitize_written_content(@template.description).html_safe
+    %td.beige.padding-5.written-content{colspan: 6}= sanitize_written_content(@template.description).html_safe
 %tr
   %td.green.left-align
     .gallery

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -18,7 +18,7 @@
         %b= name
 - if @template && @template.description.present?
   %tr
-    %td.beige.padding-5{colspan: 6}= sanitize_written_content(@template.description).html_safe
+    %td.beige.padding-5.written-content{colspan: 6}= sanitize_written_content(@template.description).html_safe
 - if characters.empty?
   %tr
     %td.centered.padding-5{class: cycle('even', 'odd'), colspan: 6} — No characters yet —

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -121,4 +121,4 @@
       - if @character.description
         %tr
           %th.sub.vtop.width-150 Description
-          %td.character-description{class: cycle('even', 'odd')}= sanitize_written_content(@character.description).html_safe
+          %td.character-description.written-content{class: cycle('even', 'odd')}= sanitize_written_content(@character.description).html_safe

--- a/app/views/posts/_list.haml
+++ b/app/views/posts/_list.haml
@@ -12,7 +12,7 @@
       %th{colspan: col_count}= content_for :posts_title
     - if content_for? :post_list_description
       %tr
-        %td.odd{colspan: col_count}= content_for :post_list_description
+        %td.odd.written-content{colspan: col_count}= content_for :post_list_description
       %tr
         %td.continuity-spacer{colspan: col_count}
     %tr


### PR DESCRIPTION
Mostly addresses #398.

Locations (for paragraph testing):

- [x] boards#show without board sections
- [x] boards#show with board sections
- [x] characters#show (character description)
- [x] characters#icon_view (template description)
- [x] characters#list_section (template description)
- [x] messages#single (`.message-content`)
- [x] posts#flat (`.post-content`)
- [x] posts#generate_flat (`.post-content`)
- [ ] replies#search (reply content; isn't currently properly formatted, maybe don't worry? **check blockquotes display properly here**)
- [x] replies#single (`.post-content`)
- [ ] user_mailer#new_message (not currently formatted, maybe don't worry?)
- [ ] user_mailer#post_has_new_reply (not currently formatted, maybe don't worry?)

And now testing with blockquotes:

- [x] boards#show without board sections
- [x] boards#show with board sections
- [x] characters#show (character description)
- [x] characters#icon_view (template description)
- [x] characters#list_section (template description)
- [x] messages#single (`.message-content`)
- [x] posts#flat (`.post-content`)
- [x] posts#generate_flat (`.post-content`)
- [ ] replies#search (reply content; isn't currently properly formatted, maybe don't worry? **check blockquotes display properly here**)
- [x] replies#single (`.post-content`)
- [ ] user_mailer#new_message (not currently formatted, maybe don't worry?)
- [ ] user_mailer#post_has_new_reply (not currently formatted, maybe don't worry?)