### PR TITLE
Fix character new

### DIFF
--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -31,11 +31,13 @@ $(document).ready(function() {
       $("#character_template_attributes_name").val('');
       $("#create_template").show();
       oldTemplate = $("#character_template_id").val();
-      $("#character_template_id").attr("disabled", true).val('').trigger("change.select2");;
+      $("#character_template_id").attr("disabled", true).val('').trigger("change.select2");
     } else {
       $("#create_template").hide();
       $("#character_template_id").attr("disabled", false).val(oldTemplate).trigger("change.select2");
-      $("#character_template_attributes_name").val($("#character_template_id option:selected").text());
+      if (oldTemplate) {
+        $("#character_template_attributes_name").val($("#character_template_id option:selected").text());
+      }
     }
   });
 

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -25,7 +25,7 @@ class CharactersController < ApplicationController
   def new
     @page_title = 'New Character'
     @character = Character.new(template_id: params[:template_id])
-    @character.build_template(user: current_user)
+    @character.build_template(user: current_user) unless @character.template
   end
 
   def create

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe CharactersController do
       expect(response.status).to eq(200)
     end
 
+    it "sets correct variables with template_id" do
+      template = create(:template)
+      login_as(template.user)
+      get :new, template_id: template.id
+      expect(response.status).to eq(200)
+      expect(assigns(:character).template).to eq(template)
+    end
+
     context "with views" do
       render_views
       it "sets correct variables" do


### PR DESCRIPTION
This fixes two issues:

- The "new instance" button (with a test)
- Toggling "new template" on and off causing an obscure error when you try to save (template user is blank) – this is because it tries creating a new template with the name "— Create Template —" and no user, due to setting the box to that selected value. (Now checks the selected value has an ID and hence isn't a placeholder.)