### PR TITLE
Image upload refactoring

### DIFF
--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -1,3 +1,8 @@
+/* global deleteUnusedIcons */
+var done = 0;
+var total = 0;
+var failed = 0;
+
 $(document).ready(function() {
   fixButtons();
   $(".icon-row td:has(input)").each(function() {
@@ -89,8 +94,10 @@ function addNewRow() {
 function bindRem() {
   $(".icon-row-rem").click(function() {
     var remRow = $(this).parent().parent();
+    var removingKey = $(remRow.find('input')[1]).val();
     remRow.remove();
     fixButtons();
+    if (removingKey !== '') { deleteUnusedIcons([removingKey]); }
   });
 }
 
@@ -113,13 +120,17 @@ function cleanUpRows() {
   fixButtons();
 }
 
-function addUploadedIcon(url, data) {
+function addUploadedIcon(url, key, data, fileInput) {
+  done += 1;
+  updateBox();
+
   // create hidden field
   var iconIndex = addNewRow();
   var row = $(".icon-row").filter(function() { return $(this).data('index') === iconIndex; });
   var urlInput = $("#icons_"+iconIndex+"_url");
   var urlCell = $(urlInput.parents('td:first'));
   urlInput.hide().val(url);
+  row.find("input[id$='_s3_key']").val(key);
   urlCell.find('.conf').remove();
 
   // update keyword box with data.files[0].name minus file extension
@@ -133,3 +144,26 @@ function addUploadedIcon(url, data) {
   urlCell.append("<span class='conf'><img src='/images/accept.png' alt='' title='Successfully uploaded' class='vmid' />"+uploaded+"</span>");
   cleanUpRows();
 }
+
+function addCallback() {
+  total += 1;
+  updateBox();
+}
+
+function failCallback() {
+  failed += 1;
+  done += 1;
+  updateBox();
+}
+
+function updateBox() {
+  var progressBox = $(".progress-box");
+  if (!progressBox) return;
+  var progress = parseInt(done / total * 100, 10);
+  progressBox.html(done.toString() + ' / ' + total.toString() + ' (' + progress + '%) ');
+  if (failed) {
+    progressBox.append($("<span style='color: #f00;'>").append(failed.toString() + " failed"));
+  }
+}
+
+function setLoadingIcon() {}

--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -165,5 +165,3 @@ function updateBox() {
     progressBox.append($("<span style='color: #f00;'>").append(failed.toString() + " failed"));
   }
 }
-
-function setLoadingIcon() {}

--- a/app/assets/javascripts/galleries/edit.js
+++ b/app/assets/javascripts/galleries/edit.js
@@ -1,0 +1,11 @@
+function addUploadedIcon(url, s3_key, data, fileInput) {
+  var iconId = fileInput.data('icon-id');
+  var iconRow = "#icon-row-" + iconId;
+  $(iconRow + " .icon_conf").show();
+  $(iconRow + " .icon_url_field").hide();
+  $(iconRow).find('input[id$=_url]').first().hide().val(url);
+  $(iconRow).find('input[id$=_s3_key]').first().hide().val(s3_key);
+  $("#icon-"+iconId).attr('src', url);
+}
+
+function setLoadingIcon() {}

--- a/app/assets/javascripts/galleries/edit.js
+++ b/app/assets/javascripts/galleries/edit.js
@@ -5,7 +5,12 @@ function addUploadedIcon(url, s3_key, data, fileInput) {
   $(iconRow + " .icon_url_field").hide();
   $(iconRow).find('input[id$=_url]').first().hide().val(url);
   $(iconRow).find('input[id$=_s3_key]').first().hide().val(s3_key);
-  $("#icon-"+iconId).attr('src', url);
+  $("#loading-"+iconId).hide();
+  $("#icon-"+iconId).attr('src', url).show().removeClass('uploading-icon');
 }
 
-function setLoadingIcon() {}
+function setLoadingIcon(fileInput) {
+  var iconId = fileInput.data('icon-id');
+  $("#icon-"+iconId).hide().addClass('uploading-icon');
+  $("#loading-"+iconId).show();
+}

--- a/app/assets/javascripts/galleries/update_existing.js
+++ b/app/assets/javascripts/galleries/update_existing.js
@@ -1,16 +1,13 @@
-var originalUrl;
-$(document).ready(function() {
-  originalUrl = $("#edit-icon").attr('src');
-});
-
 function addUploadedIcon(url, s3_key, data, fileInput) {
   $("#icon_conf").show();
   $("#icon_url_field").hide();
   $("#icon_url").hide().val(url);
   $("#icon_s3_key").val(s3_key);
-  $("#edit-icon").attr('src', url).css('height', '');
+  $("#loading").hide();
+  $("#edit-icon").attr('src', url).show().removeClass('uploading-icon');
 }
 
-function setLoadingIcon() {
-  $("#edit-icon").attr('src', '/images/loading.gif').css('height', '20px');
+function setLoadingIcon(fileInput) {
+  $("#edit-icon").hide().addClass('uploading-icon');
+  $("#loading").show();
 }

--- a/app/assets/javascripts/galleries/update_existing.js
+++ b/app/assets/javascripts/galleries/update_existing.js
@@ -1,6 +1,16 @@
-function addUploadedIcon(url, data) {
+var originalUrl;
+$(document).ready(function() {
+  originalUrl = $("#edit-icon").attr('src');
+});
+
+function addUploadedIcon(url, s3_key, data, fileInput) {
   $("#icon_conf").show();
   $("#icon_url_field").hide();
   $("#icon_url").hide().val(url);
-  $("#edit-icon").attr('src', url);
+  $("#icon_s3_key").val(s3_key);
+  $("#edit-icon").attr('src', url).css('height', '');
+}
+
+function setLoadingIcon() {
+  $("#edit-icon").attr('src', '/images/loading.gif').css('height', '20px');
 }

--- a/app/assets/javascripts/galleries/uploader.js
+++ b/app/assets/javascripts/galleries/uploader.js
@@ -1,4 +1,4 @@
-/* global addUploadedIcon, originalUrl, setLoadingIcon, addCallback, failCallback */
+/* global addUploadedIcon, setLoadingIcon, addCallback, failCallback */
 
 var uploadedIcons = {};
 
@@ -7,7 +7,7 @@ $(document).ready(function() {
   var submitButton = form.find('input[type="submit"]');
   var formData = form.data('form-data');
 
-  $(".icon_files").each(function(fileInput) {
+  $(".icon_files").each(function(index, fileInput) {
     bindFileInput($(fileInput), form, submitButton, formData);
   });
 
@@ -51,7 +51,7 @@ function bindFileInput(fileInput, form, submitButton, formData) {
     },
     start: function() {
       submitButton.prop('disabled', true);
-      setLoadingIcon();
+      if (typeof setLoadingIcon !== 'undefined') setLoadingIcon(fileInput);
     },
     done: function(e, data) {
       submitButton.prop('disabled', false);
@@ -100,12 +100,12 @@ function bindFileInput(fileInput, form, submitButton, formData) {
 }
 
 function unsetLoadingIcon() {
-  if ($("#edit-icon").length)
-    $("#edit-icon").attr('src', originalUrl).css('height', '');
+  if ($(".loading-icon").length) $(".loading-icon").hide();
+  if ($(".uploading-icon").length) $(".uploading-icon").show().removeClass('uploading-icon');
 }
 
 function deleteUnusedIcons(keys) {
-  $(keys).each(function(key) {
+  $(keys).each(function(index, key) {
     $.post('/api/v1/icons/s3_delete', {s3_key: key});
   });
 }

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -27,7 +27,8 @@ class Api::ApiController < ActionController::Base
   def handle_param_validation
     yield
   rescue Apipie::ParamMissing, Apipie::ParamInvalid => error
-    render json: {errors: [Sanitize.fragment(error.message.tr('"', "'"))]}, status: :unprocessable_entity
+    error_hash = {message: Sanitize.fragment(error.message.tr('"', "'"))}
+    render json: {errors: [error_hash]}, status: :unprocessable_entity
   end
 
   def access_denied

--- a/app/controllers/api/v1/icons_controller.rb
+++ b/app/controllers/api/v1/icons_controller.rb
@@ -1,0 +1,27 @@
+class Api::V1::IconsController < Api::ApiController
+  before_filter :login_required, only: :s3_delete
+
+  resource_description do
+    description 'Processes S3 uploads that were not used'
+  end
+
+  api! 'Given an S3 key that the user has not turned into an icon, deletes the file from S3'
+  param :s3_key, String, required: true, desc: 'S3 object key'
+  error 401, "You must be logged in"
+  error 403, "Icon does not belong to the user"
+  error 422, "Invalid parameters provided: s3 key is in use."
+  def s3_delete
+    unless params[:s3_key].starts_with?("users/#{current_user.id}/")
+      error = {message: "That is not your icon."}
+      render json: {errors: [error]}, status: :forbidden and return
+    end
+
+    if Icon.where(s3_key: params[:s3_key]).exists?
+      error = {message: "Only unused icons can be deleted."}
+      render json: {errors: [error]}, status: :unprocessable_entity and return
+    end
+
+    S3_BUCKET.delete_objects(delete: {objects: [{key: params[:s3_key]}], quiet: true})
+    render json: {}
+  end
+end

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -3,7 +3,7 @@ class GalleriesController < UploadingController
   before_filter :login_required, except: [:index, :show]
   before_filter :find_gallery, only: [:destroy, :edit, :update]
   before_filter :setup_new_icons, only: [:add, :icon]
-  before_filter :set_s3_url, only: [:add, :icon]
+  before_filter :set_s3_url, only: [:edit, :add, :icon]
   before_filter :setup_editor, only: [:new, :edit]
 
   def index
@@ -81,6 +81,8 @@ class GalleriesController < UploadingController
 
   def edit
     @page_title = 'Edit Gallery: ' + @gallery.name
+    use_javascript('galleries/uploader')
+    use_javascript('galleries/edit')
   end
 
   def update
@@ -92,7 +94,10 @@ class GalleriesController < UploadingController
       flash.now[:error][:message] = "Gallery could not be saved."
       flash.now[:error][:array] = @gallery.errors.full_messages
       @page_title = 'Edit Gallery: ' + @gallery.name_was
+      use_javascript('galleries/uploader')
+      use_javascript('galleries/edit')
       setup_editor
+      set_s3_url
       render action: :edit and return
     end
 
@@ -208,10 +213,10 @@ class GalleriesController < UploadingController
   end
 
   def gallery_params
-    params.fetch(:gallery, {}).permit(:name, galleries_icons_attributes: [:id, :_destroy, icon_attributes: [:url, :keyword, :credit, :id, :_destroy]], icon_ids: [], gallery_group_ids: [])
+    params.fetch(:gallery, {}).permit(:name, galleries_icons_attributes: [:id, :_destroy, icon_attributes: [:url, :keyword, :credit, :id, :_destroy, :s3_key]], icon_ids: [], gallery_group_ids: [])
   end
 
   def icon_params(paramset)
-    paramset.permit(:url, :keyword, :credit)
+    paramset.permit(:url, :keyword, :credit, :s3_key)
   end
 end

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -145,6 +145,6 @@ class IconsController < UploadingController
   end
 
   def icon_params
-    params.fetch(:icon, {}).permit(:url, :keyword, :credit)
+    params.fetch(:icon, {}).permit(:url, :keyword, :credit, :s3_key)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,6 +25,12 @@ module ApplicationHelper
     icon_mem_tag(NO_ICON_URL, NO_ICON, **args)
   end
 
+  def loading_tag(**args)
+    klass = 'vmid loading-icon'
+    klass += ' ' + args[:class] if args[:class]
+    image_tag '/images/loading.gif', title: 'Loading...', class: klass, alt: '...', style: 'width: 16px; height: 16px;', id: args[:id]
+  end
+
   def quick_switch_tag(image_url, short_text, hover_name, char_id)
     if image_url.nil?
       return content_tag :div, short_text, class: CHAR_ICON, title: hover_name, data: { character_id: char_id }

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -1,9 +1,12 @@
 class Icon < ActiveRecord::Base
   include Presentable
 
+  S3_DOMAIN = '.s3.amazonaws.com'
+
   belongs_to :user
-  belongs_to :template
+  has_many :posts
   has_many :replies
+  has_many :reply_drafts
   has_and_belongs_to_many :galleries
 
   validates_presence_of :url, :user, :keyword
@@ -11,11 +14,12 @@ class Icon < ActiveRecord::Base
   validate :uploaded_url_not_in_use
   nilify_blanks types: [:string, :text, :citext] # nilify_blanks does not touch citext by default
 
+  before_validation :use_icon_host
   before_update :delete_from_s3
   after_destroy :clear_icon_ids, :delete_from_s3
 
   def uploaded?
-    self.class.uploaded_url?(url)
+    s3_key.present?
   end
 
   private
@@ -26,18 +30,27 @@ class Icon < ActiveRecord::Base
     errors.add(:url, "must be an actual fully qualified url (http://www.example.com)")
   end
 
+  def use_icon_host
+    return unless uploaded?
+    return unless ENV['ICON_HOST'].present?
+    return if url.to_s.include?(ENV['ICON_HOST'])
+    self.url = ENV['ICON_HOST'] + url[(url.index(S3_DOMAIN).to_i + S3_DOMAIN.length)..-1]
+  end
+
   def delete_from_s3
-    return unless destroyed? || url_changed?
-    return unless self.class.uploaded_url?(url_was)
-    S3_BUCKET.delete_objects(delete: {objects: [{key: self.class.s3_key(url_was)}], quiet: true})
+    return unless destroyed? || s3_key_changed?
+    return unless s3_key_was.present?
+    Rails.logger.info("Deleting S3 object: #{s3_key_was}")
+    S3_BUCKET.delete_objects(delete: {objects: [{key: s3_key_was}], quiet: true})
   end
 
   def uploaded_url_not_in_use
     return unless uploaded?
-    check = Icon.where(url: url)
+    check = Icon.where(s3_key: s3_key)
     check = check.where('id != ?', id) unless new_record?
     return unless check.exists?
     self.url = url_was
+    self.s3_key = s3_key_was
     errors.add(:url, 'has already been taken')
   end
 
@@ -49,14 +62,5 @@ class Icon < ActiveRecord::Base
   end
 
   class UploadError < Exception
-  end
-
-  def self.uploaded_url?(url)
-    url.to_s.starts_with?('https://d1anwqy6ci9o1i.cloudfront.net/')
-  end
-
-  def self.s3_key(url)
-    return unless uploaded_url?(url)
-    url[url.index('net/')+4..-1]
   end
 end

--- a/app/views/galleries/_add_new.haml
+++ b/app/views/galleries/_add_new.haml
@@ -14,7 +14,7 @@
     %tr
       %th.subber.width-150.centered Upload Files
       %td.odd
-        = file_field_tag "icons[][file]", id: "icon_files", multiple: true
+        = file_field_tag "icons[][file]", id: "icon_files", class: 'icon_files', multiple: true
         %span.progress-box{style: 'margin-left: 5px;'}
   %table#icon-table
     %tr
@@ -35,6 +35,7 @@
             = text_field_tag "icons[][url]", url, placeholder: "URL", class: 'hidden', id: "icons_#{i}_url"
           - else
             = text_field_tag "icons[][url]", url, placeholder: "URL", id: "icons_#{i}_url"
+            = hidden_field_tag "icons[][s3_key]", @icons[i].try(:[], :s3_key)
         %td.padding-5{class: klass}
           = text_field_tag "icons[][keyword]", @icons[i].try(:[], :keyword), placeholder: "Keyword"
         %td.padding-5{class: klass}

--- a/app/views/galleries/edit.haml
+++ b/app/views/galleries/edit.haml
@@ -5,7 +5,7 @@
   &raquo;
   %b Edit
 
-= form_for @gallery, :url => gallery_path(@gallery), :method => :put do |f|
+= form_for @gallery, method: :put, html: {class: 'icon-upload'}, data: { 'form-data' => (@s3_direct_post.fields), url: @s3_direct_post.url, host: URI.parse(@s3_direct_post.url).host, limit: 1 } do |f|
   %table.form-table
     %tr
       %th.centered{colspan: 3}
@@ -21,18 +21,24 @@
       %th.subber{colspan: 3} Edit Icons
     = f.fields_for :galleries_icons, @gallery.galleries_icons.joins(:icon).order('LOWER(keyword)') do |gif|
       = gif.fields_for :icon do |i|
-        %tr
-          %td.green.centered{rowspan: 5}
-            = icon_tag i.object
+        %tr{id: "icon-row-#{i.object.id}"}
+          %td.green.centered{rowspan: 6}
+            = icon_tag i.object, id: "icon-#{i.object.id}"
             = i.hidden_field :id
           - klass = cycle('even','odd')
           %td.centered{class: klass} URL
           %td{class: klass}
-            - if i.object.uploaded?
+            .icon_conf{class: ('hidden' unless i.object.uploaded?)}
               = image_tag "/images/accept.png", class: 'vmid'
               Uploaded to site
-            - else
-              = i.text_field :url, :placeholder => "URL", :class => 'text'
+            .icon_url_field{class: ('hidden' if i.object.uploaded?)}
+              = i.text_field :url, placeholder: "URL", class: 'text'
+            = i.hidden_field :s3_key
+        %tr
+          - klass = cycle('even','odd')
+          - file_id = "icon_files_#{i.object.id}"
+          %td.centered{class: klass} Upload
+          %td{class: klass}= file_field_tag file_id, id: file_id, class: 'icon_files', data: {icon_id: i.object.id}
         %tr
           - klass = cycle('even','odd')
           %td.centered{class: klass} Keyword

--- a/app/views/galleries/edit.haml
+++ b/app/views/galleries/edit.haml
@@ -25,6 +25,7 @@
           %td.green.centered{rowspan: 6}
             = icon_tag i.object, id: "icon-#{i.object.id}"
             = i.hidden_field :id
+            = loading_tag class: 'hidden', id: "loading-#{i.object.id}"
           - klass = cycle('even','odd')
           %td.centered{class: klass} URL
           %td{class: klass}

--- a/app/views/icons/edit.haml
+++ b/app/views/icons/edit.haml
@@ -16,7 +16,9 @@
       %th.centered{colspan: 2}
         Edit Icon
     %tr
-      %td.green.centered{colspan: 2}= icon_tag @icon, id: 'edit-icon'
+      %td.green.centered{colspan: 2}
+        = icon_tag @icon, id: 'edit-icon'
+        = loading_tag class: 'hidden', id: "loading"
     %tr
       %th.sub URL
       %td.even

--- a/app/views/icons/edit.haml
+++ b/app/views/icons/edit.haml
@@ -24,16 +24,17 @@
           = image_tag "/images/accept.png", class: 'vmid'
           Uploaded to site
         #icon_url_field{class: ('hidden' if @icon.uploaded?)}
-          = f.text_field :url, :placeholder => "URL", :class => 'text'
+          = f.text_field :url, placeholder: "URL", class: 'text'
+        = f.hidden_field :s3_key
     %tr
       %th.sub Upload
-      %td.odd= file_field_tag :icon_files, id: "icon_files"
+      %td.odd= file_field_tag :icon_files, id: "icon_files", class: "icon_files"
     %tr
       %th.sub Keyword
-      %td.even= f.text_field :keyword, :placeholder => "Keyword", :class => 'text'
+      %td.even= f.text_field :keyword, placeholder: "Keyword", class: 'text'
     %tr
       %th.sub Credit
-      %td.odd= f.text_field :credit, :placeholder => "Credit", :class => 'text'
+      %td.odd= f.text_field :credit, placeholder: "Credit", class: 'text'
     %tr.submit-row
       %th.subber{colspan: 2}
         = submit_tag "Save", class: 'button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,9 @@ Rails.application.routes.draw do
         collection { post :reorder }
       end
       resources :galleries, only: :show
+      resources :icons do
+        collection { post :s3_delete }
+      end
       resources :posts, only: :show do
         resources :replies, only: :index
         collection { post :reorder }

--- a/db/migrate/20170907180029_add_s3_key_to_icon.rb
+++ b/db/migrate/20170907180029_add_s3_key_to_icon.rb
@@ -5,7 +5,7 @@ class AddS3KeyToIcon < ActiveRecord::Migration
     add_column :icons, :s3_key, :string
 
     index = CLOUDFRONT_URL.size
-    Icon.where("url LIKE '%#{CLOUDFRONT_URL}'").each do |icon|
+    Icon.where("url LIKE '#{CLOUDFRONT_URL}%'").each do |icon|
       key = icon.url[index..-1]
       url = icon.url[0...index] + ERB::Util.url_encode(key)
 

--- a/db/migrate/20170907180029_add_s3_key_to_icon.rb
+++ b/db/migrate/20170907180029_add_s3_key_to_icon.rb
@@ -1,0 +1,26 @@
+class AddS3KeyToIcon < ActiveRecord::Migration
+  CLOUDFRONT_URL = 'https://d1anwqy6ci9o1i.cloudfront.net/'
+
+  def self.up
+    add_column :icons, :s3_key, :string
+
+    index = CLOUDFRONT_URL.size
+    Icon.where("url LIKE '%#{CLOUDFRONT_URL}'").each do |icon|
+      key = icon.url[index..-1]
+      url = icon.url[0...index] + ERB::Util.url_encode(key)
+
+      icon.s3_key = key
+      icon.url = url
+      icon.save!
+    end
+  end
+
+  def self.down
+    Icon.where('s3_key is not null').each do |icon|
+      icon.url = CLOUDFRONT_URL + icon.s3_key
+      icon.save!
+    end
+
+    remove_column :icons, :s3_key
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.4
--- Dumped by pg_dump version 9.6.4
+-- Dumped from database version 9.6.5
+-- Dumped by pg_dump version 9.6.5
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -564,7 +564,8 @@ CREATE TABLE icons (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     credit character varying,
-    has_gallery boolean DEFAULT false
+    has_gallery boolean DEFAULT false,
+    s3_key character varying
 );
 
 
@@ -2033,4 +2034,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170821210336');
 INSERT INTO schema_migrations (version) VALUES ('20170826211901');
 
 INSERT INTO schema_migrations (version) VALUES ('20170828144608');
+
+INSERT INTO schema_migrations (version) VALUES ('20170907180029');
 

--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -29,18 +29,18 @@
       "query": null,
       "request_data": {
         "ordered_section_ids": [
-          "3140",
-          "3138",
-          "3141",
-          "3139"
+          "3841",
+          "3839",
+          "3842",
+          "3840"
         ]
       },
       "response_data": {
         "section_ids": [
-          3140,
-          3138,
-          3141,
-          3139
+          3841,
+          3839,
+          3842,
+          3840
         ]
       },
       "code": "200",
@@ -56,16 +56,16 @@
       "query": null,
       "request_data": {
         "ordered_section_ids": [
-          "3145",
-          "3143"
+          "3846",
+          "3844"
         ]
       },
       "response_data": {
         "section_ids": [
-          3145,
-          3143,
-          3144,
-          3146
+          3846,
+          3844,
+          3845,
+          3847
         ]
       },
       "code": "200",
@@ -85,11 +85,11 @@
       "response_data": {
         "results": [
           {
-            "id": 55460,
+            "id": 65352,
             "name": "baa"
           },
           {
-            "id": 55464,
+            "id": 65356,
             "name": "BAAc"
           }
         ]
@@ -108,7 +108,9 @@
       "request_data": null,
       "response_data": {
         "errors": [
-          "Invalid parameter 'page' value 'b': Must be a number."
+          {
+            "message": "Invalid parameter 'page' value 'b': Must be a number."
+          }
         ]
       },
       "code": "422",
@@ -138,24 +140,24 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/boards/55468",
+      "path": "/api/v1/boards/65360",
       "versions": [
         "1.0"
       ],
       "query": "",
       "request_data": null,
       "response_data": {
-        "id": 55468,
-        "name": "test board",
+        "id": 65360,
+        "name": "test board 10",
         "board_sections": [
           {
-            "id": 3149,
-            "name": "TestSection",
+            "id": 3850,
+            "name": "TestSection12",
             "order": 0
           },
           {
-            "id": 3148,
-            "name": "TestSection",
+            "id": 3849,
+            "name": "TestSection11",
             "order": 1
           }
         ]
@@ -177,8 +179,8 @@
       "response_data": {
         "results": [
           {
-            "id": 18349,
-            "name": "test character",
+            "id": 21972,
+            "name": "test character 1",
             "screenname": null
           }
         ]
@@ -198,7 +200,7 @@
       "response_data": {
         "results": [
           {
-            "id": 18350,
+            "id": 21973,
             "name": "search",
             "screenname": null
           }
@@ -233,7 +235,7 @@
       "versions": [
         "1.0"
       ],
-      "query": "post_id=55381",
+      "query": "post_id=65279",
       "request_data": null,
       "response_data": {
         "errors": [
@@ -252,13 +254,13 @@
       "versions": [
         "1.0"
       ],
-      "query": "post_id=55382",
+      "query": "post_id=65280",
       "request_data": null,
       "response_data": {
         "results": [
           {
-            "id": 18354,
-            "name": "test character",
+            "id": 21977,
+            "name": "test character 4",
             "screenname": null
           }
         ]
@@ -298,18 +300,18 @@
       "query": null,
       "request_data": {
         "ordered_characters_gallery_ids": [
-          "4032",
-          "4030",
-          "4033",
-          "4031"
+          "5124",
+          "5122",
+          "5125",
+          "5123"
         ]
       },
       "response_data": {
         "characters_gallery_ids": [
-          4032,
-          4030,
-          4033,
-          4031
+          5124,
+          5122,
+          5125,
+          5123
         ]
       },
       "code": "200",
@@ -325,16 +327,16 @@
       "query": null,
       "request_data": {
         "ordered_characters_gallery_ids": [
-          "4037",
-          "4035"
+          "5129",
+          "5127"
         ]
       },
       "response_data": {
         "characters_gallery_ids": [
-          4037,
-          4035,
-          4036,
-          4038
+          5129,
+          5127,
+          5128,
+          5130
         ]
       },
       "code": "200",
@@ -364,21 +366,21 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/characters/18356",
+      "path": "/api/v1/characters/21979",
       "versions": [
         "1.0"
       ],
       "query": "",
       "request_data": null,
       "response_data": {
-        "id": 18356,
-        "name": "test character",
+        "id": 21979,
+        "name": "test character 6",
         "screenname": null,
         "default": null,
         "aliases": [
           {
-            "id": 1479,
-            "name": "Alias"
+            "id": 1727,
+            "name": "TestAlias1"
           }
         ],
         "galleries": [
@@ -386,12 +388,12 @@
             "name": "test gallery",
             "icons": [
               {
-                "id": 9885,
+                "id": 11610,
                 "url": "http://www.fakeicon.com",
                 "keyword": "totally fake"
               },
               {
-                "id": 9886,
+                "id": 11611,
                 "url": "http://www.fakeicon.com",
                 "keyword": "totally fake"
               }
@@ -401,7 +403,7 @@
             "name": "test gallery",
             "icons": [
               {
-                "id": 9887,
+                "id": 11612,
                 "url": "http://www.fakeicon.com",
                 "keyword": "totally fake"
               }
@@ -415,7 +417,7 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/characters/18357",
+      "path": "/api/v1/characters/21980",
       "versions": [
         "1.0"
       ],
@@ -434,11 +436,11 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/characters/18358",
+      "path": "/api/v1/characters/21981",
       "versions": [
         "1.0"
       ],
-      "query": "post_id=55383",
+      "query": "post_id=65281",
       "request_data": null,
       "response_data": {
         "errors": [
@@ -453,22 +455,22 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/characters/18359",
+      "path": "/api/v1/characters/21982",
       "versions": [
         "1.0"
       ],
-      "query": "post_id=55384",
+      "query": "post_id=65282",
       "request_data": null,
       "response_data": {
-        "id": 18359,
-        "name": "test character",
+        "id": 21982,
+        "name": "test character 9",
         "screenname": null,
-        "alias_id_for_post": 1480,
+        "alias_id_for_post": 1728,
         "default": null,
         "aliases": [
           {
-            "id": 1480,
-            "name": "Alias"
+            "id": 1728,
+            "name": "TestAlias2"
           }
         ],
         "galleries": [
@@ -523,7 +525,7 @@
     },
     {
       "verb": "PUT",
-      "path": "/api/v1/characters/18360",
+      "path": "/api/v1/characters/21983",
       "versions": [
         "1.0"
       ],
@@ -543,22 +545,22 @@
     },
     {
       "verb": "PUT",
-      "path": "/api/v1/characters/18361",
+      "path": "/api/v1/characters/21984",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
         "character": {
-          "default_icon_id": "9889"
+          "default_icon_id": "11614"
         }
       },
       "response_data": {
-        "id": 18361,
-        "name": "test character",
+        "id": 21984,
+        "name": "test character 11",
         "screenname": null,
         "default": {
-          "id": 9889,
+          "id": 11614,
           "url": "http://www.fakeicon.com",
           "keyword": "totally fake"
         }
@@ -569,14 +571,14 @@
     },
     {
       "verb": "PUT",
-      "path": "/api/v1/characters/18362",
+      "path": "/api/v1/characters/21985",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
         "character": {
-          "default_icon_id": "9891",
+          "default_icon_id": "11616",
           "name": "",
           "user_id": null
         }
@@ -619,7 +621,7 @@
       "versions": [
         "1.0"
       ],
-      "query": "user_id=171338",
+      "query": "user_id=203996",
       "request_data": null,
       "response_data": {
         "name": "Galleryless",
@@ -652,7 +654,7 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/galleries/6702",
+      "path": "/api/v1/galleries/8394",
       "versions": [
         "1.0"
       ],
@@ -662,11 +664,111 @@
         "name": "test gallery",
         "icons": [
           {
-            "id": 9892,
+            "id": 11617,
             "url": "http://www.fakeicon.com",
             "keyword": "totally fake"
           }
         ]
+      },
+      "code": "200",
+      "show_in_doc": 1,
+      "recorded": true
+    }
+  ],
+  "icons#s3_delete": [
+    {
+      "verb": "POST",
+      "path": "/api/v1/icons/s3_delete",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+      },
+      "response_data": {
+        "errors": [
+          {
+            "message": "You must be logged in to view that page."
+          }
+        ]
+      },
+      "code": "401",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/api/v1/icons/s3_delete",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+      },
+      "response_data": {
+        "errors": [
+          {
+            "message": "Missing parameter s3_key"
+          }
+        ]
+      },
+      "code": "422",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/api/v1/icons/s3_delete",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "s3_key": "users/2039991/icons/hash_name.png"
+      },
+      "response_data": {
+        "errors": [
+          {
+            "message": "That is not your icon."
+          }
+        ]
+      },
+      "code": "403",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/api/v1/icons/s3_delete",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "s3_key": "users/204000/icons/nonsense-fakeimg.png"
+      },
+      "response_data": {
+        "errors": [
+          {
+            "message": "Only unused icons can be deleted."
+          }
+        ]
+      },
+      "code": "422",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/api/v1/icons/s3_delete",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "s3_key": "users/204001/icons/nonsense-fakeimg.png"
+      },
+      "response_data": {
       },
       "code": "200",
       "show_in_doc": 1,
@@ -703,18 +805,18 @@
       "query": null,
       "request_data": {
         "ordered_post_ids": [
-          "55389",
-          "55387",
-          "55390",
-          "55388"
+          "65287",
+          "65285",
+          "65288",
+          "65286"
         ]
       },
       "response_data": {
         "post_ids": [
-          55389,
-          55387,
-          55390,
-          55388
+          65287,
+          65285,
+          65288,
+          65286
         ]
       },
       "code": "200",
@@ -730,16 +832,16 @@
       "query": null,
       "request_data": {
         "ordered_post_ids": [
-          "55394",
-          "55392"
+          "65292",
+          "65290"
         ]
       },
       "response_data": {
         "post_ids": [
-          55394,
-          55392,
-          55393,
-          55395
+          65292,
+          65290,
+          65291,
+          65293
         ]
       },
       "code": "200",
@@ -755,19 +857,19 @@
       "query": null,
       "request_data": {
         "ordered_post_ids": [
-          "55399",
-          "55397",
-          "55400",
-          "55398"
+          "65297",
+          "65295",
+          "65298",
+          "65296"
         ],
-        "section_id": "3150"
+        "section_id": "3851"
       },
       "response_data": {
         "post_ids": [
-          55399,
-          55397,
-          55400,
-          55398
+          65297,
+          65295,
+          65298,
+          65296
         ]
       },
       "code": "200",
@@ -783,17 +885,17 @@
       "query": null,
       "request_data": {
         "ordered_post_ids": [
-          "55404",
-          "55402"
+          "65302",
+          "65300"
         ],
-        "section_id": "3152"
+        "section_id": "3853"
       },
       "response_data": {
         "post_ids": [
-          55404,
-          55402,
-          55403,
-          55405
+          65302,
+          65300,
+          65301,
+          65303
         ]
       },
       "code": "200",
@@ -823,7 +925,7 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/posts/55385",
+      "path": "/api/v1/posts/65283",
       "versions": [
         "1.0"
       ],
@@ -842,38 +944,38 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/posts/55386",
+      "path": "/api/v1/posts/65284",
       "versions": [
         "1.0"
       ],
       "query": "",
       "request_data": null,
       "response_data": {
-        "id": 55386,
-        "subject": "test subject",
+        "id": 65284,
+        "subject": "test subject 6",
         "content": "test content",
-        "created_at": "2017-09-05T14:31:01.918Z",
+        "created_at": "2017-09-09T00:29:13.214Z",
         "status": 0,
         "description": null,
-        "edited_at": "2017-09-05T14:31:01.918Z",
-        "tagged_at": "2017-09-05T14:31:01.918Z",
+        "edited_at": "2017-09-09T00:29:13.214Z",
+        "tagged_at": "2017-09-09T00:29:13.214Z",
         "board": {
-          "id": 55474,
-          "name": "test board"
+          "id": 65366,
+          "name": "test board 16"
         },
         "section": null,
         "user": {
-          "id": 171342,
-          "username": "JohnDoe53"
+          "id": 204004,
+          "username": "JohnDoe57"
         },
         "character": {
-          "id": 18367,
-          "name": "test character",
+          "id": 21990,
+          "name": "test character 17",
           "screenname": null
         },
-        "character_name": "Alias",
+        "character_name": "TestAlias3",
         "icon": {
-          "id": 9893,
+          "id": 11619,
           "url": "http://www.fakeicon.com",
           "keyword": "totally fake"
         }
@@ -905,7 +1007,7 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/posts/55407/replies",
+      "path": "/api/v1/posts/65305/replies",
       "versions": [
         "1.0"
       ],
@@ -924,7 +1026,7 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/posts/55408/replies",
+      "path": "/api/v1/posts/65306/replies",
       "versions": [
         "1.0"
       ],
@@ -932,50 +1034,50 @@
       "request_data": null,
       "response_data": [
         {
-          "id": 31030,
+          "id": 36607,
           "content": "test content",
-          "created_at": "2017-09-05T14:31:03.582Z",
-          "updated_at": "2017-09-05T14:31:03.582Z",
+          "created_at": "2017-09-09T00:29:14.261Z",
+          "updated_at": "2017-09-09T00:29:14.261Z",
           "character_name": null,
           "character": null,
           "icon": null,
           "user": {
-            "id": 171370,
-            "username": "JohnDoe81"
+            "id": 204032,
+            "username": "JohnDoe85"
           }
         },
         {
-          "id": 31031,
+          "id": 36608,
           "content": "test content",
-          "created_at": "2017-09-05T14:31:03.640Z",
-          "updated_at": "2017-09-05T14:31:03.640Z",
+          "created_at": "2017-09-09T00:29:14.315Z",
+          "updated_at": "2017-09-09T00:29:14.315Z",
           "character_name": null,
           "character": null,
           "icon": null,
           "user": {
-            "id": 171370,
-            "username": "JohnDoe81"
+            "id": 204032,
+            "username": "JohnDoe85"
           }
         },
         {
-          "id": 31032,
+          "id": 36609,
           "content": "test content",
-          "created_at": "2017-09-05T14:31:03.714Z",
-          "updated_at": "2017-09-05T14:31:03.714Z",
-          "character_name": "Alias",
+          "created_at": "2017-09-09T00:29:14.359Z",
+          "updated_at": "2017-09-09T00:29:14.359Z",
+          "character_name": "TestAlias4",
           "character": {
-            "id": 18369,
-            "name": "test character",
+            "id": 21992,
+            "name": "test character 19",
             "screenname": null
           },
           "icon": {
-            "id": 9895,
+            "id": 11621,
             "url": "http://www.fakeicon.com",
             "keyword": "totally fake"
           },
           "user": {
-            "id": 171372,
-            "username": "JohnDoe83"
+            "id": 204034,
+            "username": "JohnDoe87"
           }
         }
       ],
@@ -996,7 +1098,7 @@
       "response_data": {
         "results": [
           {
-            "id": 6052,
+            "id": 8771,
             "text": "Tag1"
           }
         ]
@@ -1016,7 +1118,7 @@
       "response_data": {
         "results": [
           {
-            "id": 6053,
+            "id": 8772,
             "text": "Tag2"
           }
         ]
@@ -1036,7 +1138,7 @@
       "response_data": {
         "results": [
           {
-            "id": 6054,
+            "id": 8773,
             "text": "Tag3"
           }
         ]
@@ -1055,7 +1157,9 @@
       "request_data": null,
       "response_data": {
         "errors": [
-          "Invalid parameter 't' value 'b': Must be one of: Setting, Label, ContentWarning, GalleryGroup."
+          {
+            "message": "Invalid parameter 't' value 'b': Must be one of: Setting, Label, ContentWarning, GalleryGroup."
+          }
         ]
       },
       "code": "422",
@@ -1066,18 +1170,18 @@
   "tags#show": [
     {
       "verb": "GET",
-      "path": "/api/v1/tags/6055",
+      "path": "/api/v1/tags/8774",
       "versions": [
         "1.0"
       ],
-      "query": "user_id=171376",
+      "query": "user_id=204038",
       "request_data": null,
       "response_data": {
-        "id": 6055,
+        "id": 8774,
         "text": "Tag4",
         "gallery_ids": [
-          6704,
-          6703
+          8396,
+          8395
         ]
       },
       "code": "200",
@@ -1116,11 +1220,11 @@
       "response_data": {
         "results": [
           {
-            "id": 4437,
+            "id": 5335,
             "name": "baa"
           },
           {
-            "id": 4441,
+            "id": 5339,
             "name": "BAAc"
           }
         ]
@@ -1139,7 +1243,9 @@
       "request_data": null,
       "response_data": {
         "errors": [
-          "Invalid parameter 'page' value 'b': Must be a number."
+          {
+            "message": "Invalid parameter 'page' value 'b': Must be a number."
+          }
         ]
       },
       "code": "422",
@@ -1156,7 +1262,9 @@
       "request_data": null,
       "response_data": {
         "errors": [
-          "Invalid parameter 'user_id' value 'b': Must be a number."
+          {
+            "message": "Invalid parameter 'user_id' value 'b': Must be a number."
+          }
         ]
       },
       "code": "422",
@@ -1188,12 +1296,12 @@
       "versions": [
         "1.0"
       ],
-      "query": "user_id=171387",
+      "query": "user_id=204049",
       "request_data": null,
       "response_data": {
         "results": [
           {
-            "id": 4445,
+            "id": 5343,
             "name": "test template"
           }
         ]
@@ -1215,11 +1323,11 @@
       "response_data": {
         "results": [
           {
-            "id": 171389,
+            "id": 204051,
             "username": "baa"
           },
           {
-            "id": 171393,
+            "id": 204055,
             "username": "BAAc"
           }
         ]
@@ -1238,7 +1346,9 @@
       "request_data": null,
       "response_data": {
         "errors": [
-          "Invalid parameter 'page' value 'b': Must be a number."
+          {
+            "message": "Invalid parameter 'page' value 'b': Must be a number."
+          }
         ]
       },
       "code": "422",

--- a/spec/controllers/api/v1/icons_controller_spec.rb
+++ b/spec/controllers/api/v1/icons_controller_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+RSpec.describe Api::V1::IconsController do
+  describe "POST s3_delete", show_in_doc: true do
+    it "should require login" do
+      expect(S3_BUCKET).not_to receive(:delete_objects)
+      post :s3_delete
+      expect(response).to have_http_status(401)
+      expect(response.json['errors'][0]['message']).to eq("You must be logged in to view that page.")
+    end
+
+    it "should require s3_key param" do
+      expect(S3_BUCKET).not_to receive(:delete_objects)
+      login
+      post :s3_delete
+      expect(response).to have_http_status(422)
+      expect(response.json['errors'][0]['message']).to eq("Missing parameter s3_key")
+    end
+
+    it "should require your own icon" do
+      user = create(:user)
+      login_as(user)
+
+      expect(S3_BUCKET).not_to receive(:delete_objects)
+      post :s3_delete, s3_key: "users/#{user.id}1/icons/hash_name.png"
+
+      expect(response).to have_http_status(403)
+      expect(response.json['errors'][0]['message']).to eq("That is not your icon.")
+    end
+
+    it "should not allow deleting a URL in use" do
+      icon = create(:uploaded_icon)
+      login_as(icon.user)
+      expect(S3_BUCKET).not_to receive(:delete_objects)
+      post :s3_delete, s3_key: icon.s3_key
+      expect(response).to have_http_status(422)
+      expect(response.json['errors'][0]['message']).to eq("Only unused icons can be deleted.")
+    end
+
+    it "should delete the URL" do
+      icon = build(:uploaded_icon)
+      login_as(icon.user)
+      delete_key = {delete: {objects: [{key: icon.s3_key}], quiet: true}}
+      expect(S3_BUCKET).to receive(:delete_objects).with(delete_key)
+      post :s3_delete, s3_key: icon.s3_key
+      expect(response).to have_http_status(200)
+      expect(response.json).to eq({})
+    end
+  end
+end

--- a/spec/controllers/api/v1/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/tags_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Api::V1::TagsController do
         get :index, t: 'b'
         expect(response).to have_http_status(422)
         expect(response.json).to have_key('errors')
-        expect(response.json['errors'].first).to include("Invalid parameter 't'")
+        expect(response.json['errors'].first['message']).to include("Invalid parameter 't'")
       end
 
       context "in gallery group search with user_id" do

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -607,10 +607,8 @@ RSpec.describe GalleriesController do
         login_as(gallery.user)
 
         icons = [
-          {keyword: 'test1', url: uploaded_icon.url, credit: ''},
-          {keyword: '',
-          url: 'http://example.com/image3141.png',
-          credit: ''},
+          {keyword: 'test1', url: uploaded_icon.url, s3_key: uploaded_icon.s3_key, credit: ''},
+          {keyword: '', url: 'http://example.com/image3141.png', credit: ''},
           {keyword: 'test2', url: '', credit: ''},
           {keyword: 'test3', url: 'fake', credit: ''},
           {keyword: '', url: '', credit: ''}
@@ -621,12 +619,13 @@ RSpec.describe GalleriesController do
         expect(flash[:error][:message]).to eq('Your icons could not be saved.')
         expect(assigns(:icons).length).to eq(icons.length-1) # removes blank icons
         expect(assigns(:icons).first[:url]).to be_empty # removes duplicate uploaded icon URLs
-        expect(flash.now[:error][:array]).to include(
+        expect(flash.now[:error][:array]).to match_array([
           "Icon 1: url has already been taken",
           "Icon 2: keyword can't be blank",
           "Icon 3: url can't be blank",
-          "Icon 3: url must be an actual fully qualified url (http://www.example.com)"
-        )
+          "Icon 3: url must be an actual fully qualified url (http://www.example.com)",
+          "Icon 4: url must be an actual fully qualified url (http://www.example.com)"
+        ])
       end
 
       it "succeeds with gallery" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -67,7 +67,8 @@ FactoryGirl.define do
     keyword "totally fake"
 
     factory :uploaded_icon do
-      url { "https://d1anwqy6ci9o1i.cloudfront.net/users/#{user.id}/icons/nonsense-fakeimg.png" }
+      url { "https://d1anwqy6ci9o1i.cloudfront.net/users%2F#{user.id}%2Ficons%2Fnonsense-fakeimg.png" }
+      s3_key { "users/#{user.id}/icons/nonsense-fakeimg.png" }
     end
   end
 


### PR DESCRIPTION
Improvements include:
* Storing the icon URL and S3 key separately, since S3 actions are taken on the key but the URL needs to be properly escaped to handle characters like + in icon filenames.
* Migration to add the new s3_key column will properly parse it out of existing icons and backfill.
* Supports showing a loading gif while icon uploads process; on edit pages, rolls back the image to the original image if upload fails.
* Adds multi-file-upload support. Installs it into the gallery#edit page.
* File upload pages now keep track of files they have uploaded, and attempts to intelligently delete unused ones upon form submission / page close / row deletion.
** NOTE: page close is on hold for now, since the async nature of Javascript makes this trickier than I'd like.
* API endpoint for deleting S3 files added, with tests and docs

Remaining:
- [x] Call deleteUnused() on form submit
- [x] Call deleteUnused() on row deletion (galleries#add only)
- [x] Tests for API endpoint
- [x] Generate docs from API endpoint tests
- [x] Fix up the conflicts with the progress bar to not be quite so hacky