### PR TITLE
Update RSpec config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ tmux-server-*
 
 # Ignore simplecov reports; generate locally as desired.
 coverage/*
+
+# Ignore rspec persistence file
+spec/examples.txt

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe MessagesController do
         recents = messages[-5..-1].map(&:recipient)
         recents_data = recents.reverse.map{|x| [x.username, x.id] }
         users_data = messages.map(&:recipient).map{|x| [x.username, x.id]}
+        users_data.sort_by! {|x| x[0]}
         login_as(user)
         get :new
         expect(response).to have_http_status(200)
@@ -98,6 +99,7 @@ RSpec.describe MessagesController do
       recents_data = recents.reverse
       other_user = create(:user)
       users_data = recents + [[other_user.username, other_user.id]]
+      users_data.sort_by! {|x| x[0]}
 
       post :create, message: {}
       expect(response).to render_template(:new)
@@ -186,6 +188,7 @@ RSpec.describe MessagesController do
         recents_data = recents.reverse
         other_user = create(:user)
         users_data = recents + [[other_user.username, other_user.id]]
+        users_data.sort_by! {|x| x[0]}
 
         expect {
           post :create, message: {subject: 'Preview', message: 'example'}, button_preview: true

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,9 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -21,6 +21,10 @@ require 'rspec/rails'
 # require only the support files necessary.
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+
+# Checks for pending migration and applies them before tests are run.
+# If you are not using ActiveRecord, you can remove this line.
+ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,15 +62,22 @@ RSpec.configure do |config|
 
   config.filter_run :show_in_doc => true if ENV['APIPIE_RECORD']
 
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin
-  # These two settings work together to allow you to limit a spec run
-  # to individual examples or groups you care about by tagging them with
-  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
-  # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,7 +71,6 @@ RSpec.configure do |config|
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
-=begin
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -91,6 +90,7 @@ RSpec.configure do |config|
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   config.disable_monkey_patching!
 
+=begin
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
@@ -100,6 +100,7 @@ RSpec.configure do |config|
     # (e.g. via a command-line flag).
     config.default_formatter = 'doc'
   end
+=end
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
@@ -117,7 +118,6 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
 end
 
 RSpec::Matchers.define :be_the_same_time_as do |expected|


### PR DESCRIPTION
I noticed we didn't have `maintain_test_schema!` in our spec_helper file, so I decided to regenerate the RSpec config file, see the changes, and then reapply our changes on top.