### PR TITLE
Extract board#ordered?

### DIFF
--- a/app/concerns/orderable.rb
+++ b/app/concerns/orderable.rb
@@ -11,7 +11,7 @@ module Orderable
     def reorder_others
       return unless destroyed? || order_change?
       board_checking = Board.find_by_id(board_id_was) || board
-      return if board_checking.open_to_anyone? && !board_checking.board_sections.exists?
+      return unless board_checking.ordered?
 
       other_where = Hash[ordered_attributes.map { |atr| [atr, send("#{atr}_was")] }]
       others = self.class.where(other_where).order('section_order asc')

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -56,7 +56,7 @@ class BoardsController < ApplicationController
     @page_title = @board.name
     @board_sections = @board.board_sections.order('section_order asc')
     order = 'section_order asc, tagged_at asc'
-    order = 'tagged_at desc' if @board.open_to_anyone? && @board_sections.empty?
+    order = 'tagged_at desc' unless @board.ordered?
     @posts = posts_from_relation(@board.posts.where(section_id: nil).order(order), false)
   end
 

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -41,6 +41,10 @@ class Board < ActiveRecord::Base
     board_coauthors.where(user_id: user.id).exists?
   end
 
+  def ordered?
+    !open_to_anyone? || board_sections.exists?
+  end
+
   private
 
   def move_posts_to_sandbox

--- a/app/views/boards/edit.haml
+++ b/app/views/boards/edit.haml
@@ -45,7 +45,7 @@
     - if @board_sections.empty?
       %li.centered.padding-10{class: cycle('even', 'odd')} — No items yet —
 
-- if (!@board.open_to_anyone? || @board_sections.present?) && @unsectioned_posts.present?
+- if @board.ordered? && @unsectioned_posts.present?
   %br
   - reset_cycle
   #reorder-posts-table

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -56,4 +56,26 @@ RSpec.describe Board do
     board.send(:fix_ordering)
     expect(board.posts.order('section_order asc').pluck(:section_order)).to eq([0, 1, 2, 3])
   end
+
+  describe "#ordered?" do
+    it "should be unordered for default board" do
+      expect(create(:board).ordered?).to eq(false)
+    end
+
+    it "should be ordered if board is not open to anyone" do
+      board = create(:board)
+      board.update_attributes(coauthors: [create(:user)])
+      expect(board.ordered?).to eq(true)
+      board.update_attributes(coauthors: [])
+      expect(board.ordered?).to eq(false)
+      board.update_attributes(cameos: [create(:user)])
+      expect(board.ordered?).to eq(true)
+    end
+
+    it "should be ordered if board has sections" do
+      board = create(:board)
+      create(:board_section, board: board)
+      expect(board.ordered?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
The logic was being used in a few places and it seems kinda nonobvious, so I've put it in a single point on the board itself instead.