### PR TITLE
[WIP] Use Rails 4.2's built-in sanitizer (based on Loofah) instead of a separate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem 'resque'
 gem 'resque_mailer'
 gem 'resque-retry'
 gem 'resque-web', require: 'resque_web'
-gem 'sanitize'
 gem 'sass-rails'
 gem 'select2-rails'
 gem 'test-unit', '~> 3.0' # required by Heroku for production console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,6 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.2)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -193,8 +192,6 @@ GEM
       activesupport (>= 3.0.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
-    nokogumbo (1.4.13)
-      nokogiri
     pg (0.21.0)
     pg_search (2.1.0)
       activerecord (>= 4.2)
@@ -318,10 +315,6 @@ GEM
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
     safe_yaml (1.0.4)
-    sanitize (4.5.0)
-      crass (~> 1.0.2)
-      nokogiri (>= 1.4.4)
-      nokogumbo (~> 1.4.1)
     sass (3.5.1)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -438,7 +431,6 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails
-  sanitize
   sass-rails
   seed_dump (~> 3.2)
   select2-rails

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -27,7 +27,7 @@ class Api::ApiController < ActionController::Base
   def handle_param_validation
     yield
   rescue Apipie::ParamMissing, Apipie::ParamInvalid => error
-    error_hash = {message: Sanitize.fragment(error.message.tr('"', "'"))}
+    error_hash = {message: Rails::Html::FullSanitizer.new.sanitize(error.message.tr('"', "'"))}
     render json: {errors: [error_hash]}, status: :unprocessable_entity
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -182,7 +182,7 @@ module ApplicationHelper
   end
 
   def generate_short(msg)
-    short_msg = Sanitize.fragment(msg) # strip all tags, replacing appropriately with spaces
+    short_msg = Rails::Html::FullSanitizer.new.sanitize(msg) # strip all tags, replacing appropriately with spaces
     return short_msg if short_msg.length <= 75
     short_msg[0...73] + '…' # make the absolute max length 75 characters
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -162,7 +162,7 @@ module ApplicationHelper
     end
   end
 
-  P_TAG = "<p>".freeze
+  P_TAG = /<p( [^>]*)?>/
   BR_TAG = /<br *\/?>/
   BLOCKQUOTE_QUICK_SEARCH = '<blockquote'.freeze
   BLOCKQUOTE_TAG = /<blockquote( |>)/

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -130,7 +130,7 @@ module ApplicationHelper
   end
 
   def sanitize_post_description(desc)
-    Sanitize.fragment(desc, elements: ['a'], attributes: {'a' => ['href']})
+    sanitize desc, scrubber: Glowfic::DescriptionScrubber.new
   end
 
   # modified version of split_paragraphs that doesn't mangle large breaks
@@ -166,7 +166,7 @@ module ApplicationHelper
   BR_TAG = /<br *\/?>/
   BLOCKQUOTE_QUICK_SEARCH = '<blockquote'.freeze
   BLOCKQUOTE_TAG = /<blockquote( |>)/
-  LINEBREAK = "\n".freeze
+  LINEBREAK = /\r?\n/
   BR = '<br>'.freeze
 
   # specific blockquote handling is due to simple_format wanting to wrap a blockquote in a paragraph
@@ -178,7 +178,7 @@ module ApplicationHelper
         simple_format_largebreak(content, sanitize: false)
       end
     end
-    Sanitize.fragment(content, Glowfic::POST_CONTENT_SANITIZER)
+    sanitize content, scrubber: Glowfic::WrittenScrubber.new
   end
 
   def generate_short(msg)

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,22 @@ module Glowfic
     def initialize
       super
       self.tags = ALLOWED_TAGS
-      self.attributes = ALLOWED_ATTRIBUTES.map{|_,x| x}.flatten.uniq # TODO: get more specific about allowed attributes
+    end
+
+    def scrub_attribute?(name, node)
+      node_name = node.name.downcase
+      name = name.downcase
+      return false if ALLOWED_ATTRIBUTES[:all].include?(name)
+      !ALLOWED_ATTRIBUTES[node_name].try(:include?, name)
+    end
+
+    def scrub_attributes(node)
+      node.attribute_nodes.each do |attr|
+        attr.remove if scrub_attribute?(attr.name, node)
+        scrub_attribute(node, attr)
+      end
+
+      scrub_css_attribute(node)
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,10 +21,22 @@ module Glowfic
     "blockquote" => %w(cite),
     "cite" => %w(href)
   }
-  POST_CONTENT_SANITIZER = Sanitize::Config.merge(Sanitize::Config::RELAXED,
-    :elements => ALLOWED_TAGS,
-    :attributes => ALLOWED_ATTRIBUTES
-  )
+
+  class WrittenScrubber < Rails::Html::PermitScrubber
+    def initialize
+      super
+      self.tags = ALLOWED_TAGS
+      self.attributes = ALLOWED_ATTRIBUTES.map{|_,x| x}.flatten.uniq # TODO: get more specific about allowed attributes
+    end
+  end
+
+  class DescriptionScrubber < Rails::Html::PermitScrubber
+    def initialize
+      super
+      self.tags = %w(a)
+      self.attributes = %w(href)
+    end
+  end
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,21 +8,22 @@ Bundler.require(*Rails.groups)
 
 module Glowfic
   ALLOWED_TAGS = %w(b i u sub sup del hr p br div span pre code h1 h2 h3 h4 h5 h6 ul ol li dl dt dd a img blockquote q table td th tr strike s strong em big small font cite abbr var samp kbd mark ruby rp rt bdo wbr)
+  ALLOWED_ATTRIBUTES = {
+    :all => %w(xml:lang class style title lang dir),
+    "hr" => %w(width),
+    "li" => %w(value),
+    "ol" => %w(reversed start type),
+    "a" => %w(href hreflang rel target type),
+    "del" => %w(cite datetime),
+    "table" => %w(width),
+    "td" => %w(abbr width),
+    "th" => %w(abbr width),
+    "blockquote" => %w(cite),
+    "cite" => %w(href)
+  }
   POST_CONTENT_SANITIZER = Sanitize::Config.merge(Sanitize::Config::RELAXED,
     :elements => ALLOWED_TAGS,
-    :attributes => {
-      :all => ["xml:lang", "class", "style", "title", "lang", "dir"],
-      "hr" => ["width"],
-      "li" => ["value"],
-      "ol" => ["reversed", "start", "type"],
-      "a" => ["href", "hreflang", "rel", "target", "type"],
-      "del" => ["cite", "datetime"],
-      "table" => ["width"],
-      "td" => ["abbr", "width"],
-      "th" => ["abbr", "width"],
-      "blockquote" => ["cite"],
-      "cite" => ["href"]
-    }
+    :attributes => ALLOWED_ATTRIBUTES
   )
 
   class Application < Rails::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module Glowfic
-  ALLOWED_TAGS = ["b", "i", "u", "sub", "sup", "del", "hr", "p", "br", "div", "span", "pre", "code", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "dl", "dt", "dd", "a", "img", "blockquote", "q", "table", "td", "th", "tr", "strike", "s", "strong", "em", "big", "small", "font", "cite", "abbr", "var", "samp", "kbd", "mark", "ruby", "rp", "rt", "bdo", "wbr"]
+  ALLOWED_TAGS = %w(b i u sub sup del hr p br div span pre code h1 h2 h3 h4 h5 h6 ul ol li dl dt dd a img blockquote q table td th tr strike s strong em big small font cite abbr var samp kbd mark ruby rp rt bdo wbr)
   POST_CONTENT_SANITIZER = Sanitize::Config.merge(Sanitize::Config::RELAXED,
     :elements => ALLOWED_TAGS,
     :attributes => {

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ApplicationHelper do
 
     it "removes unpermitted elements" do
       text = '<b>test</b> <script type="text/javascript">alert("bad!");</script> <p>text</p>'
-      expect(helper.sanitize_post_description(text)).to eq('test alert("bad!");  text ')
+      expect(helper.sanitize_post_description(text)).to eq('test alert("bad!"); text')
     end
 
     it "fixes unending tags" do
@@ -88,13 +88,13 @@ RSpec.describe ApplicationHelper do
 
     it "defaults to old linebreak-to-br format when blockquote detected" do
       text = "<blockquote>Blah. Blah.\r\nBlah.\r\n\r\nBlah blah.</blockquote>\r\nBlah."
-      expected = "<blockquote>Blah. Blah.\n<br>Blah.\n<br>\n<br>Blah blah.</blockquote>\n<br>Blah."
+      expected = "<blockquote>Blah. Blah.<br>Blah.<br><br>Blah blah.</blockquote><br>Blah."
       expect(helper.sanitize_written_content(text)).to eq(expected)
     end
 
     it "does not touch blockquotes if <br> or <p> detected" do
       text = "<blockquote>Blah. Blah.<br />Blah.</blockquote>\r\n<blockquote>Blah blah.</blockquote>\r\n<p>Blah.</p>"
-      expected = "<blockquote>Blah. Blah.<br>Blah.</blockquote>\n<blockquote>Blah blah.</blockquote>\n<p>Blah.</p>"
+      expected = "<blockquote>Blah. Blah.<br>Blah.</blockquote>\r\n<blockquote>Blah blah.</blockquote>\r\n<p>Blah.</p>"
       expect(helper.sanitize_written_content(text)).to eq(expected)
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe ApplicationHelper do
       expect(helper.sanitize_written_content(text)).to eq('<b>test</b> alert("bad!"); <p>text</p>')
     end
 
+    it "permits some attributes on only some tags" do
+      text = '<p><a width="100%" href="https://example.com">test</a></p> <hr width="100%">'
+      expected = '<p><a href="https://example.com">test</a></p> <hr width="100%">'
+      expect(helper.sanitize_written_content(text)).to eq(expected)
+    end
+
     it "fixes unending tags" do
       text = '<a>test'
       expect(helper.sanitize_written_content(text)).to eq('<p><a>test</a></p>')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -98,6 +98,11 @@ RSpec.describe ApplicationHelper do
       expect(helper.sanitize_written_content(text)).to eq(text)
     end
 
+    it "does not convert linbreaks in text with complicated <p> tags" do
+      text = "<p style=\"width: 100%;\">line1\nline2</p>"
+      expect(helper.sanitize_written_content(text)).to eq(text)
+    end
+
     it "defaults to old linebreak-to-br format when blockquote detected" do
       text = "<blockquote>Blah. Blah.\r\nBlah.\r\n\r\nBlah blah.</blockquote>\r\nBlah."
       expected = "<blockquote>Blah. Blah.<br>Blah.<br><br>Blah blah.</blockquote><br>Blah."

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe ApplicationHelper do
       expect(helper.sanitize_written_content(text)).to eq(expected)
     end
 
+    it "permits valid CSS" do
+      text = '<p><a style="color: red;">test</a></p>'
+      expected = text
+      expect(helper.sanitize_written_content(text)).to eq(expected)
+    end
+
     it "fixes unending tags" do
       text = '<a>test'
       expect(helper.sanitize_written_content(text)).to eq('<p><a>test</a></p>')


### PR DESCRIPTION
(See #248.)

As a result of the upgrade to Rails 4.2, we have access to the [rails-html-sanitizer](https://github.com/rails/rails-html-sanitizer) gem! This means we can dump the `sanitize` gem in favor of using the built-in gem (based on Loofah instead) and a custom class to enable the old behavior of specifying specific attributes for specific nodes.

[Loofah claims to be faster than Sanitize](https://github.com/flavorjones/loofah#compare-and-contrast), too, so we may drop in rendering times, as well as the fact we're very likely to reduce memory usage with this (at least some) since added gems are annoying.

Note that nokogumbo is removed (not nokogiri – I'm not sure of the difference between the two), and the old tests needed very slight changes (to whitespace) to ensure they still passed.

This also adds two new tests: the `width` attribute is cleared on `<a>` but not on `<hr>` (so we have selective attribute scrubbing by node name), and the `style="color: red;"` attribute is not cleared on `<a>` (so we have CSS definitely permitted on nodes).