### PR TITLE
Specify Rails versions in migrations to avoid future deprecation warning

### DIFF
--- a/db/migrate/20150413062555_create_users.rb
+++ b/db/migrate/20150413062555_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :username, :null => false

--- a/db/migrate/20150413233206_create_icons.rb
+++ b/db/migrate/20150413233206_create_icons.rb
@@ -1,4 +1,4 @@
-class CreateIcons < ActiveRecord::Migration
+class CreateIcons < ActiveRecord::Migration[4.2]
   def up
     create_table :icons do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20150414195302_create_templates.rb
+++ b/db/migrate/20150414195302_create_templates.rb
@@ -1,4 +1,4 @@
-class CreateTemplates < ActiveRecord::Migration
+class CreateTemplates < ActiveRecord::Migration[4.2]
   def change
     create_table :templates do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20150414195307_create_characters.rb
+++ b/db/migrate/20150414195307_create_characters.rb
@@ -1,4 +1,4 @@
-class CreateCharacters < ActiveRecord::Migration
+class CreateCharacters < ActiveRecord::Migration[4.2]
   def change
     create_table :characters do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20150414200044_create_galleries.rb
+++ b/db/migrate/20150414200044_create_galleries.rb
@@ -1,4 +1,4 @@
-class CreateGalleries < ActiveRecord::Migration
+class CreateGalleries < ActiveRecord::Migration[4.2]
   def change
     create_table :galleries do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20150414211752_create_join_table_icon_gallery.rb
+++ b/db/migrate/20150414211752_create_join_table_icon_gallery.rb
@@ -1,4 +1,4 @@
-class CreateJoinTableIconGallery < ActiveRecord::Migration
+class CreateJoinTableIconGallery < ActiveRecord::Migration[4.2]
   def up
     create_table :galleries_icons do |t|
       t.integer :icon_id

--- a/db/migrate/20150415221435_create_boards.rb
+++ b/db/migrate/20150415221435_create_boards.rb
@@ -1,4 +1,4 @@
-class CreateBoards < ActiveRecord::Migration
+class CreateBoards < ActiveRecord::Migration[4.2]
   def change
     create_table :boards do |t|
       t.string :name, :null => false

--- a/db/migrate/20150415221456_create_posts.rb
+++ b/db/migrate/20150415221456_create_posts.rb
@@ -1,4 +1,4 @@
-class CreatePosts < ActiveRecord::Migration
+class CreatePosts < ActiveRecord::Migration[4.2]
   def change
     create_table :posts do |t|
       t.integer :board_id, :null => false

--- a/db/migrate/20150417214406_create_replies.rb
+++ b/db/migrate/20150417214406_create_replies.rb
@@ -1,4 +1,4 @@
-class CreateReplies < ActiveRecord::Migration
+class CreateReplies < ActiveRecord::Migration[4.2]
   def change
     create_table :replies do |t|
       t.integer :post_id, :null => false

--- a/db/migrate/20150624201245_install_audited.rb
+++ b/db/migrate/20150624201245_install_audited.rb
@@ -1,4 +1,4 @@
-class InstallAudited < ActiveRecord::Migration
+class InstallAudited < ActiveRecord::Migration[4.2]
   def self.up
     create_table :audits, :force => true do |t|
       t.column :auditable_id, :integer

--- a/db/migrate/20150704060600_create_post_viewers.rb
+++ b/db/migrate/20150704060600_create_post_viewers.rb
@@ -1,4 +1,4 @@
-class CreatePostViewers < ActiveRecord::Migration
+class CreatePostViewers < ActiveRecord::Migration[4.2]
   def change
     create_table :post_viewers do |t|
       t.integer :post_id, :null => false

--- a/db/migrate/20151125201254_create_messages.rb
+++ b/db/migrate/20151125201254_create_messages.rb
@@ -1,4 +1,4 @@
-class CreateMessages < ActiveRecord::Migration
+class CreateMessages < ActiveRecord::Migration[4.2]
   def change
     create_table :messages do |t|
       t.integer :sender_id, :null => false

--- a/db/migrate/20151127033352_add_status_to_posts.rb
+++ b/db/migrate/20151127033352_add_status_to_posts.rb
@@ -1,4 +1,4 @@
-class AddStatusToPosts < ActiveRecord::Migration
+class AddStatusToPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :status, :integer, default: 0
   end

--- a/db/migrate/20151127181237_add_pb_to_characters.rb
+++ b/db/migrate/20151127181237_add_pb_to_characters.rb
@@ -1,4 +1,4 @@
-class AddPbToCharacters < ActiveRecord::Migration
+class AddPbToCharacters < ActiveRecord::Migration[4.2]
   def change
     add_column :characters, :pb, :string
   end

--- a/db/migrate/20151127183038_remove_uniqueness_from_character_usernames.rb
+++ b/db/migrate/20151127183038_remove_uniqueness_from_character_usernames.rb
@@ -1,4 +1,4 @@
-class RemoveUniquenessFromCharacterUsernames < ActiveRecord::Migration
+class RemoveUniquenessFromCharacterUsernames < ActiveRecord::Migration[4.2]
   def change
     remove_index :characters, :screenname
   end

--- a/db/migrate/20151127210938_create_board_sections.rb
+++ b/db/migrate/20151127210938_create_board_sections.rb
@@ -1,4 +1,4 @@
-class CreateBoardSections < ActiveRecord::Migration
+class CreateBoardSections < ActiveRecord::Migration[4.2]
   def change
     create_table :board_sections do |t|
       t.integer :board_id, :null => false

--- a/db/migrate/20151130050434_add_group_to_characters.rb
+++ b/db/migrate/20151130050434_add_group_to_characters.rb
@@ -1,4 +1,4 @@
-class AddGroupToCharacters < ActiveRecord::Migration
+class AddGroupToCharacters < ActiveRecord::Migration[4.2]
   def change
     create_table :character_groups do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20151215041641_add_icon_attribution.rb
+++ b/db/migrate/20151215041641_add_icon_attribution.rb
@@ -1,4 +1,4 @@
-class AddIconAttribution < ActiveRecord::Migration
+class AddIconAttribution < ActiveRecord::Migration[4.2]
   def change
     add_column :icons, :credit, :string
   end

--- a/db/migrate/20160108230631_add_setting.rb
+++ b/db/migrate/20160108230631_add_setting.rb
@@ -1,4 +1,4 @@
-class AddSetting < ActiveRecord::Migration
+class AddSetting < ActiveRecord::Migration[4.2]
   def change
     add_column :characters, :setting, :string
     remove_column :icons, :attribution

--- a/db/migrate/20160218041741_create_board_view.rb
+++ b/db/migrate/20160218041741_create_board_view.rb
@@ -1,4 +1,4 @@
-class CreateBoardView < ActiveRecord::Migration
+class CreateBoardView < ActiveRecord::Migration[4.2]
   def change
     create_table :board_views do |t|
       t.integer :board_id, :null => false

--- a/db/migrate/20160218041751_create_post_view.rb
+++ b/db/migrate/20160218041751_create_post_view.rb
@@ -1,4 +1,4 @@
-class CreatePostView < ActiveRecord::Migration
+class CreatePostView < ActiveRecord::Migration[4.2]
   def change
     create_table :post_views do |t|
       t.integer :post_id, :null => false

--- a/db/migrate/20160222042730_create_join_table_character_gallery.rb.rb
+++ b/db/migrate/20160222042730_create_join_table_character_gallery.rb.rb
@@ -1,4 +1,4 @@
-class CreateJoinTableCharacterGallery < ActiveRecord::Migration
+class CreateJoinTableCharacterGallery < ActiveRecord::Migration[4.2]
   def change
     create_table :characters_galleries do |t|
       t.integer :character_id, null: false

--- a/db/migrate/20160223065123_add_galleryless_to_icons.rb
+++ b/db/migrate/20160223065123_add_galleryless_to_icons.rb
@@ -1,4 +1,4 @@
-class AddGallerylessToIcons < ActiveRecord::Migration
+class AddGallerylessToIcons < ActiveRecord::Migration[4.2]
   def change
     add_column :icons, :has_gallery, :boolean, default: false
     add_index :icons, :has_gallery

--- a/db/migrate/20160303032220_add_user_settings.rb
+++ b/db/migrate/20160303032220_add_user_settings.rb
@@ -1,4 +1,4 @@
-class AddUserSettings < ActiveRecord::Migration
+class AddUserSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :timezone, :string
   end

--- a/db/migrate/20160306053517_add_description_to_posts.rb
+++ b/db/migrate/20160306053517_add_description_to_posts.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToPosts < ActiveRecord::Migration
+class AddDescriptionToPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :description, :string
   end

--- a/db/migrate/20160318021845_add_url_index_to_icons.rb
+++ b/db/migrate/20160318021845_add_url_index_to_icons.rb
@@ -1,4 +1,4 @@
-class AddUrlIndexToIcons < ActiveRecord::Migration
+class AddUrlIndexToIcons < ActiveRecord::Migration[4.2]
   def change
     add_index :icons, :url
   end

--- a/db/migrate/20160322032647_add_email_to_users.rb
+++ b/db/migrate/20160322032647_add_email_to_users.rb
@@ -1,4 +1,4 @@
-class AddEmailToUsers < ActiveRecord::Migration
+class AddEmailToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :email, :string
     add_column :users, :email_notifications, :boolean

--- a/db/migrate/20160326210104_add_user_setting_icon_picker_grouping.rb
+++ b/db/migrate/20160326210104_add_user_setting_icon_picker_grouping.rb
@@ -1,4 +1,4 @@
-class AddUserSettingIconPickerGrouping < ActiveRecord::Migration
+class AddUserSettingIconPickerGrouping < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :icon_picker_grouping, :boolean, default: true
   end

--- a/db/migrate/20160410024710_add_last_fields_to_post.rb
+++ b/db/migrate/20160410024710_add_last_fields_to_post.rb
@@ -1,4 +1,4 @@
-class AddLastFieldsToPost < ActiveRecord::Migration
+class AddLastFieldsToPost < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :last_user_id, :integer
     add_column :posts, :last_reply_id, :integer

--- a/db/migrate/20160410060405_add_moiety_to_user.rb
+++ b/db/migrate/20160410060405_add_moiety_to_user.rb
@@ -1,4 +1,4 @@
-class AddMoietyToUser < ActiveRecord::Migration
+class AddMoietyToUser < ActiveRecord::Migration[4.2]
   MOIETIES = {
     1 => 'AA0000',
     2 => '00BF80',

--- a/db/migrate/20160410170309_add_more_user_settings.rb
+++ b/db/migrate/20160410170309_add_more_user_settings.rb
@@ -1,4 +1,4 @@
-class AddMoreUserSettings < ActiveRecord::Migration
+class AddMoreUserSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :layout, :string
     add_column :users, :moiety_name, :string

--- a/db/migrate/20160412035353_create_reply_drafts.rb
+++ b/db/migrate/20160412035353_create_reply_drafts.rb
@@ -1,4 +1,4 @@
-class CreateReplyDrafts < ActiveRecord::Migration
+class CreateReplyDrafts < ActiveRecord::Migration[4.2]
   def change
     create_table :reply_drafts do |t|
       t.integer :post_id, :null => false

--- a/db/migrate/20160416031844_create_password_reset.rb
+++ b/db/migrate/20160416031844_create_password_reset.rb
@@ -1,4 +1,4 @@
-class CreatePasswordReset < ActiveRecord::Migration
+class CreatePasswordReset < ActiveRecord::Migration[4.2]
   def change
     create_table :password_resets do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20160429033350_create_tags.rb
+++ b/db/migrate/20160429033350_create_tags.rb
@@ -1,4 +1,4 @@
-class CreateTags < ActiveRecord::Migration
+class CreateTags < ActiveRecord::Migration[4.2]
   def change
     create_table :tags do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20160604181644_add_tagged_at_to_posts.rb
+++ b/db/migrate/20160604181644_add_tagged_at_to_posts.rb
@@ -1,4 +1,4 @@
-class AddTaggedAtToPosts < ActiveRecord::Migration
+class AddTaggedAtToPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :tagged_at, :datetime
     ActiveRecord::Base.record_timestamps = false

--- a/db/migrate/20160615094301_remove_not_null_from_content.rb
+++ b/db/migrate/20160615094301_remove_not_null_from_content.rb
@@ -1,4 +1,4 @@
-class RemoveNotNullFromContent < ActiveRecord::Migration
+class RemoveNotNullFromContent < ActiveRecord::Migration[4.2]
   def change
     change_column :posts, :content, :text, null: true
     change_column :replies, :content, :text, null: true

--- a/db/migrate/20160627210836_add_user_setting_time_display.rb
+++ b/db/migrate/20160627210836_add_user_setting_time_display.rb
@@ -1,4 +1,4 @@
-class AddUserSettingTimeDisplay < ActiveRecord::Migration
+class AddUserSettingTimeDisplay < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :time_display, :string, default: "%b %d, %Y %l:%M %p"
   end

--- a/db/migrate/20160702213101_create_board_authors.rb
+++ b/db/migrate/20160702213101_create_board_authors.rb
@@ -1,4 +1,4 @@
-class CreateBoardAuthors < ActiveRecord::Migration
+class CreateBoardAuthors < ActiveRecord::Migration[4.2]
   def up
     create_table :board_authors do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20160704224416_use_cloudfront_url.rb
+++ b/db/migrate/20160704224416_use_cloudfront_url.rb
@@ -1,4 +1,4 @@
-class UseCloudfrontUrl < ActiveRecord::Migration
+class UseCloudfrontUrl < ActiveRecord::Migration[4.2]
   def up
     uploaded_icons = Icon.where("url like 'http://glowfic-constellation.s3.amazonaws.com%'")
     uploaded_icons.each do |icon|

--- a/db/migrate/20160716055457_add_tag_types.rb
+++ b/db/migrate/20160716055457_add_tag_types.rb
@@ -1,4 +1,4 @@
-class AddTagTypes < ActiveRecord::Migration
+class AddTagTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :tags, :type, :string
     add_index :tags, :type

--- a/db/migrate/20160719012330_add_order_to_sectionless_posts.rb
+++ b/db/migrate/20160719012330_add_order_to_sectionless_posts.rb
@@ -1,4 +1,4 @@
-class AddOrderToSectionlessPosts < ActiveRecord::Migration
+class AddOrderToSectionlessPosts < ActiveRecord::Migration[4.2]
   def up
     Board.all.each do |board|
       posts = board.posts.where(section_id: nil).order('created_at asc')

--- a/db/migrate/20160723172304_add_description_to_continuity.rb
+++ b/db/migrate/20160723172304_add_description_to_continuity.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToContinuity < ActiveRecord::Migration
+class AddDescriptionToContinuity < ActiveRecord::Migration[4.2]
   def change
     add_column :boards, :description, :text
   end

--- a/db/migrate/20160731040017_add_type_to_coauthors.rb
+++ b/db/migrate/20160731040017_add_type_to_coauthors.rb
@@ -1,4 +1,4 @@
-class AddTypeToCoauthors < ActiveRecord::Migration
+class AddTypeToCoauthors < ActiveRecord::Migration[4.2]
   def change
     add_column :board_authors, :cameo, :boolean, default: false
   end

--- a/db/migrate/20160813025151_add_read_at_to_views.rb
+++ b/db/migrate/20160813025151_add_read_at_to_views.rb
@@ -1,4 +1,4 @@
-class AddReadAtToViews < ActiveRecord::Migration
+class AddReadAtToViews < ActiveRecord::Migration[4.2]
   def change
     add_column :post_views, :read_at, :datetime
     add_column :board_views, :read_at, :datetime

--- a/db/migrate/20160827161416_create_favorites.rb
+++ b/db/migrate/20160827161416_create_favorites.rb
@@ -1,4 +1,4 @@
-class CreateFavorites < ActiveRecord::Migration
+class CreateFavorites < ActiveRecord::Migration[4.2]
   def up
     create_table :favorites do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20160925032329_create_pg_search_documents.rb
+++ b/db/migrate/20160925032329_create_pg_search_documents.rb
@@ -1,4 +1,4 @@
-class CreatePgSearchDocuments < ActiveRecord::Migration
+class CreatePgSearchDocuments < ActiveRecord::Migration[4.2]
   def self.up
     execute "CREATE INDEX idx_fts_post_content ON posts USING gin(to_tsvector('english', coalesce(\"posts\".\"content\"::text, '')))"
     execute "CREATE INDEX idx_fts_post_subject ON posts USING gin(to_tsvector('english', coalesce(\"posts\".\"subject\"::text, '')))"

--- a/db/migrate/20161008224853_add_order_to_galleries.rb
+++ b/db/migrate/20161008224853_add_order_to_galleries.rb
@@ -1,4 +1,4 @@
-class AddOrderToGalleries < ActiveRecord::Migration
+class AddOrderToGalleries < ActiveRecord::Migration[4.2]
   def up
     add_column :characters_galleries, :section_order, :integer, null: false, default: 0
     Character.all.each do |character|

--- a/db/migrate/20161024185615_add_authors_locked_to_post.rb
+++ b/db/migrate/20161024185615_add_authors_locked_to_post.rb
@@ -1,4 +1,4 @@
-class AddAuthorsLockedToPost < ActiveRecord::Migration
+class AddAuthorsLockedToPost < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :authors_locked, :boolean, default: false
   end

--- a/db/migrate/20161107014948_add_salt_to_users.rb
+++ b/db/migrate/20161107014948_add_salt_to_users.rb
@@ -1,4 +1,4 @@
-class AddSaltToUsers < ActiveRecord::Migration
+class AddSaltToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :salt_uuid, :string
     add_column :users, :unread_opened, :boolean, default: false

--- a/db/migrate/20161110055637_add_description_blurbs.rb
+++ b/db/migrate/20161110055637_add_description_blurbs.rb
@@ -1,4 +1,4 @@
-class AddDescriptionBlurbs < ActiveRecord::Migration
+class AddDescriptionBlurbs < ActiveRecord::Migration[4.2]
   def change
     add_column :characters, :description, :text
     add_column :templates, :description, :text

--- a/db/migrate/20161126195558_add_pinned_to_continuities.rb
+++ b/db/migrate/20161126195558_add_pinned_to_continuities.rb
@@ -1,4 +1,4 @@
-class AddPinnedToContinuities < ActiveRecord::Migration
+class AddPinnedToContinuities < ActiveRecord::Migration[4.2]
   def change
     add_column :boards, :pinned, :boolean, default: false
   end

--- a/db/migrate/20161129195022_change_tag_name_to_citext.rb
+++ b/db/migrate/20161129195022_change_tag_name_to_citext.rb
@@ -1,4 +1,4 @@
-class ChangeTagNameToCitext < ActiveRecord::Migration
+class ChangeTagNameToCitext < ActiveRecord::Migration[4.2]
   def up
     execute "CREATE EXTENSION IF NOT EXISTS citext;"
     change_column :tags, :name, :citext

--- a/db/migrate/20161218194918_add_hide_hiatused_tags_owed_to_users.rb
+++ b/db/migrate/20161218194918_add_hide_hiatused_tags_owed_to_users.rb
@@ -1,4 +1,4 @@
-class AddHideHiatusedTagsOwedToUsers < ActiveRecord::Migration
+class AddHideHiatusedTagsOwedToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :hide_hiatused_tags_owed, :boolean, :default => false
   end

--- a/db/migrate/20170103184309_create_flat_posts.rb
+++ b/db/migrate/20170103184309_create_flat_posts.rb
@@ -1,4 +1,4 @@
-class CreateFlatPosts < ActiveRecord::Migration
+class CreateFlatPosts < ActiveRecord::Migration[4.2]
   def up
     create_table :flat_posts do |t|
       t.integer :post_id, :null => false

--- a/db/migrate/20170109000120_add_hide_warnings_to_user.rb
+++ b/db/migrate/20170109000120_add_hide_warnings_to_user.rb
@@ -1,4 +1,4 @@
-class AddHideWarningsToUser < ActiveRecord::Migration
+class AddHideWarningsToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :hide_warnings, :boolean, default: false
   end

--- a/db/migrate/20170210013443_create_character_aliases.rb
+++ b/db/migrate/20170210013443_create_character_aliases.rb
@@ -1,4 +1,4 @@
-class CreateCharacterAliases < ActiveRecord::Migration
+class CreateCharacterAliases < ActiveRecord::Migration[4.2]
   def change
     create_table :character_aliases do |t|
       t.integer :character_id, null: false

--- a/db/migrate/20170221171959_make_usernames_emails_case_insensitive.rb
+++ b/db/migrate/20170221171959_make_usernames_emails_case_insensitive.rb
@@ -1,4 +1,4 @@
-class MakeUsernamesEmailsCaseInsensitive < ActiveRecord::Migration
+class MakeUsernamesEmailsCaseInsensitive < ActiveRecord::Migration[4.2]
   def up
     change_column :users, :username, :citext
     change_column :users, :email, :citext

--- a/db/migrate/20170331133925_move_tag_field_to_labels.rb
+++ b/db/migrate/20170331133925_move_tag_field_to_labels.rb
@@ -1,4 +1,4 @@
-class MoveTagFieldToLabels < ActiveRecord::Migration
+class MoveTagFieldToLabels < ActiveRecord::Migration[4.2]
   def up
     Tag.where(type: nil).update_all(type: 'Label')
   end

--- a/db/migrate/20170413195840_add_visible_unread_to_users.rb
+++ b/db/migrate/20170413195840_add_visible_unread_to_users.rb
@@ -1,4 +1,4 @@
-class AddVisibleUnreadToUsers < ActiveRecord::Migration
+class AddVisibleUnreadToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :visible_unread, :boolean, default: false
   end

--- a/db/migrate/20170501214439_add_show_user_in_switcher_to_user.rb
+++ b/db/migrate/20170501214439_add_show_user_in_switcher_to_user.rb
@@ -1,4 +1,4 @@
-class AddShowUserInSwitcherToUser < ActiveRecord::Migration
+class AddShowUserInSwitcherToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :show_user_in_switcher, :boolean, default: true
   end

--- a/db/migrate/20170505173455_set_character_default_icons.rb
+++ b/db/migrate/20170505173455_set_character_default_icons.rb
@@ -1,4 +1,4 @@
-class SetCharacterDefaultIcons < ActiveRecord::Migration
+class SetCharacterDefaultIcons < ActiveRecord::Migration[4.2]
   def up
     Character.where(default_icon_id: nil).includes(:galleries).find_each do |char|
       next if char.galleries.blank?

--- a/db/migrate/20170513052413_add_report_indexes_to_date_fields.rb
+++ b/db/migrate/20170513052413_add_report_indexes_to_date_fields.rb
@@ -1,4 +1,4 @@
-class AddReportIndexesToDateFields < ActiveRecord::Migration
+class AddReportIndexesToDateFields < ActiveRecord::Migration[4.2]
   def change
     add_index :replies, :created_at
     add_index :posts, :tagged_at

--- a/db/migrate/20170519123223_add_request_uuid_to_audits.rb
+++ b/db/migrate/20170519123223_add_request_uuid_to_audits.rb
@@ -1,4 +1,4 @@
-class AddRequestUuidToAudits < ActiveRecord::Migration
+class AddRequestUuidToAudits < ActiveRecord::Migration[4.2]
   def self.up
     add_column :audits, :request_uuid, :string
     add_index :audits, :request_uuid

--- a/db/migrate/20170612015922_add_report_view.rb
+++ b/db/migrate/20170612015922_add_report_view.rb
@@ -1,4 +1,4 @@
-class AddReportView < ActiveRecord::Migration
+class AddReportView < ActiveRecord::Migration[4.2]
   def change
     create_table :report_views do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20170617180015_add_ignore_unread_daily_report_to_user.rb
+++ b/db/migrate/20170617180015_add_ignore_unread_daily_report_to_user.rb
@@ -1,4 +1,4 @@
-class AddIgnoreUnreadDailyReportToUser < ActiveRecord::Migration
+class AddIgnoreUnreadDailyReportToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :ignore_unread_daily_report, :boolean, default: false
   end

--- a/db/migrate/20170619010707_drop_gallery_cover_icon.rb
+++ b/db/migrate/20170619010707_drop_gallery_cover_icon.rb
@@ -1,4 +1,4 @@
-class DropGalleryCoverIcon < ActiveRecord::Migration
+class DropGalleryCoverIcon < ActiveRecord::Migration[4.2]
   def change
     remove_column :galleries, :cover_icon_id
   end

--- a/db/migrate/20170814042150_use_ci_columns.rb
+++ b/db/migrate/20170814042150_use_ci_columns.rb
@@ -1,4 +1,4 @@
-class UseCiColumns < ActiveRecord::Migration
+class UseCiColumns < ActiveRecord::Migration[4.2]
   def up
     change_column :boards, :name, :citext
     change_column :characters, :name, :citext

--- a/db/migrate/20170819222420_add_gets_favorite_notifications_to_users.rb
+++ b/db/migrate/20170819222420_add_gets_favorite_notifications_to_users.rb
@@ -1,4 +1,4 @@
-class AddGetsFavoriteNotificationsToUsers < ActiveRecord::Migration
+class AddGetsFavoriteNotificationsToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :favorite_notifications, :boolean, default: true
   end

--- a/db/migrate/20170821210336_add_default_character_split_to_users.rb
+++ b/db/migrate/20170821210336_add_default_character_split_to_users.rb
@@ -1,4 +1,4 @@
-class AddDefaultCharacterSplitToUsers < ActiveRecord::Migration
+class AddDefaultCharacterSplitToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :default_character_split, :string, default: 'template'
   end

--- a/db/migrate/20170826211901_add_gallery_tags.rb
+++ b/db/migrate/20170826211901_add_gallery_tags.rb
@@ -1,4 +1,4 @@
-class AddGalleryTags < ActiveRecord::Migration
+class AddGalleryTags < ActiveRecord::Migration[4.2]
   def change
     create_table :gallery_tags do |t|
       t.integer :gallery_id, null: false

--- a/db/migrate/20170828144608_add_added_by_group_to_characters_galleries.rb
+++ b/db/migrate/20170828144608_add_added_by_group_to_characters_galleries.rb
@@ -1,4 +1,4 @@
-class AddAddedByGroupToCharactersGalleries < ActiveRecord::Migration
+class AddAddedByGroupToCharactersGalleries < ActiveRecord::Migration[4.2]
   def change
     add_column :characters_galleries, :added_by_group, :boolean, default: false
   end

--- a/db/migrate/20170907180029_add_s3_key_to_icon.rb
+++ b/db/migrate/20170907180029_add_s3_key_to_icon.rb
@@ -1,4 +1,4 @@
-class AddS3KeyToIcon < ActiveRecord::Migration
+class AddS3KeyToIcon < ActiveRecord::Migration[4.2]
   CLOUDFRONT_URL = 'https://d1anwqy6ci9o1i.cloudfront.net/'
 
   def self.up

--- a/db/migrate/20170911235423_make_views_unique.rb
+++ b/db/migrate/20170911235423_make_views_unique.rb
@@ -1,4 +1,4 @@
-class MakeViewsUnique < ActiveRecord::Migration
+class MakeViewsUnique < ActiveRecord::Migration[4.2]
   def change
     remove_index :board_views, column: [:user_id, :board_id]
     add_index :board_views, [:user_id, :board_id], unique: true


### PR DESCRIPTION
Accepted values: 4.2 (, 5.0)