### PR TITLE
Explicitly add empty value when sending empty array to controller

### DIFF
--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -383,7 +383,7 @@ RSpec.describe CharactersController do
       expect(character.characters_galleries.first).not_to be_added_by_group
 
       login_as(user)
-      put :update, id: character.id, character: {ungrouped_gallery_ids: []}
+      put :update, id: character.id, character: {ungrouped_gallery_ids: ['']}
       expect(flash[:success]).to eq('Character saved successfully.')
       character.reload
       expect(character.gallery_groups).to match_array([group])
@@ -428,7 +428,7 @@ RSpec.describe CharactersController do
       character = create(:character, gallery_groups: [group], user: user)
 
       login_as(user)
-      put :update, id: character.id, character: {gallery_group_ids: []}
+      put :update, id: character.id, character: {gallery_group_ids: ['']}
       expect(flash[:success]).to eq('Character saved successfully.')
       character.reload
       expect(character.gallery_groups).to eq([])


### PR DESCRIPTION
In Rails 5, empty params seem to be removed. Testing the controller manually shows that forms send the array with an empty value (so they aren't removed presumably), and so this makes the test more accurately reflect the situation anyway.