### PR TITLE
Fix deprecation warnings for Rails 5.0

### DIFF
--- a/db/migrate/20150413062555_create_users.rb
+++ b/db/migrate/20150413062555_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :username, :null => false

--- a/db/migrate/20150413233206_create_icons.rb
+++ b/db/migrate/20150413233206_create_icons.rb
@@ -1,4 +1,4 @@
-class CreateIcons < ActiveRecord::Migration
+class CreateIcons < ActiveRecord::Migration[4.2]
   def up
     create_table :icons do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20150414195302_create_templates.rb
+++ b/db/migrate/20150414195302_create_templates.rb
@@ -1,4 +1,4 @@
-class CreateTemplates < ActiveRecord::Migration
+class CreateTemplates < ActiveRecord::Migration[4.2]
   def change
     create_table :templates do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20150414195307_create_characters.rb
+++ b/db/migrate/20150414195307_create_characters.rb
@@ -1,4 +1,4 @@
-class CreateCharacters < ActiveRecord::Migration
+class CreateCharacters < ActiveRecord::Migration[4.2]
   def change
     create_table :characters do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20150414200044_create_galleries.rb
+++ b/db/migrate/20150414200044_create_galleries.rb
@@ -1,4 +1,4 @@
-class CreateGalleries < ActiveRecord::Migration
+class CreateGalleries < ActiveRecord::Migration[4.2]
   def change
     create_table :galleries do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20150414211752_create_join_table_icon_gallery.rb
+++ b/db/migrate/20150414211752_create_join_table_icon_gallery.rb
@@ -1,4 +1,4 @@
-class CreateJoinTableIconGallery < ActiveRecord::Migration
+class CreateJoinTableIconGallery < ActiveRecord::Migration[4.2]
   def up
     create_table :galleries_icons do |t|
       t.integer :icon_id

--- a/db/migrate/20150415221435_create_boards.rb
+++ b/db/migrate/20150415221435_create_boards.rb
@@ -1,4 +1,4 @@
-class CreateBoards < ActiveRecord::Migration
+class CreateBoards < ActiveRecord::Migration[4.2]
   def change
     create_table :boards do |t|
       t.string :name, :null => false

--- a/db/migrate/20150415221456_create_posts.rb
+++ b/db/migrate/20150415221456_create_posts.rb
@@ -1,4 +1,4 @@
-class CreatePosts < ActiveRecord::Migration
+class CreatePosts < ActiveRecord::Migration[4.2]
   def change
     create_table :posts do |t|
       t.integer :board_id, :null => false

--- a/db/migrate/20150417214406_create_replies.rb
+++ b/db/migrate/20150417214406_create_replies.rb
@@ -1,4 +1,4 @@
-class CreateReplies < ActiveRecord::Migration
+class CreateReplies < ActiveRecord::Migration[4.2]
   def change
     create_table :replies do |t|
       t.integer :post_id, :null => false

--- a/db/migrate/20150624201245_install_audited.rb
+++ b/db/migrate/20150624201245_install_audited.rb
@@ -1,4 +1,4 @@
-class InstallAudited < ActiveRecord::Migration
+class InstallAudited < ActiveRecord::Migration[4.2]
   def self.up
     create_table :audits, :force => true do |t|
       t.column :auditable_id, :integer

--- a/db/migrate/20150704060600_create_post_viewers.rb
+++ b/db/migrate/20150704060600_create_post_viewers.rb
@@ -1,4 +1,4 @@
-class CreatePostViewers < ActiveRecord::Migration
+class CreatePostViewers < ActiveRecord::Migration[4.2]
   def change
     create_table :post_viewers do |t|
       t.integer :post_id, :null => false

--- a/db/migrate/20151125201254_create_messages.rb
+++ b/db/migrate/20151125201254_create_messages.rb
@@ -1,4 +1,4 @@
-class CreateMessages < ActiveRecord::Migration
+class CreateMessages < ActiveRecord::Migration[4.2]
   def change
     create_table :messages do |t|
       t.integer :sender_id, :null => false

--- a/db/migrate/20151127033352_add_status_to_posts.rb
+++ b/db/migrate/20151127033352_add_status_to_posts.rb
@@ -1,4 +1,4 @@
-class AddStatusToPosts < ActiveRecord::Migration
+class AddStatusToPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :status, :integer, default: 0
   end

--- a/db/migrate/20151127181237_add_pb_to_characters.rb
+++ b/db/migrate/20151127181237_add_pb_to_characters.rb
@@ -1,4 +1,4 @@
-class AddPbToCharacters < ActiveRecord::Migration
+class AddPbToCharacters < ActiveRecord::Migration[4.2]
   def change
     add_column :characters, :pb, :string
   end

--- a/db/migrate/20151127183038_remove_uniqueness_from_character_usernames.rb
+++ b/db/migrate/20151127183038_remove_uniqueness_from_character_usernames.rb
@@ -1,4 +1,4 @@
-class RemoveUniquenessFromCharacterUsernames < ActiveRecord::Migration
+class RemoveUniquenessFromCharacterUsernames < ActiveRecord::Migration[4.2]
   def change
     remove_index :characters, :screenname
   end

--- a/db/migrate/20151127210938_create_board_sections.rb
+++ b/db/migrate/20151127210938_create_board_sections.rb
@@ -1,4 +1,4 @@
-class CreateBoardSections < ActiveRecord::Migration
+class CreateBoardSections < ActiveRecord::Migration[4.2]
   def change
     create_table :board_sections do |t|
       t.integer :board_id, :null => false

--- a/db/migrate/20151130050434_add_group_to_characters.rb
+++ b/db/migrate/20151130050434_add_group_to_characters.rb
@@ -1,4 +1,4 @@
-class AddGroupToCharacters < ActiveRecord::Migration
+class AddGroupToCharacters < ActiveRecord::Migration[4.2]
   def change
     create_table :character_groups do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20151215041641_add_icon_attribution.rb
+++ b/db/migrate/20151215041641_add_icon_attribution.rb
@@ -1,4 +1,4 @@
-class AddIconAttribution < ActiveRecord::Migration
+class AddIconAttribution < ActiveRecord::Migration[4.2]
   def change
     add_column :icons, :credit, :string
   end

--- a/db/migrate/20160108230631_add_setting.rb
+++ b/db/migrate/20160108230631_add_setting.rb
@@ -1,4 +1,4 @@
-class AddSetting < ActiveRecord::Migration
+class AddSetting < ActiveRecord::Migration[4.2]
   def change
     add_column :characters, :setting, :string
     remove_column :icons, :attribution

--- a/db/migrate/20160218041741_create_board_view.rb
+++ b/db/migrate/20160218041741_create_board_view.rb
@@ -1,4 +1,4 @@
-class CreateBoardView < ActiveRecord::Migration
+class CreateBoardView < ActiveRecord::Migration[4.2]
   def change
     create_table :board_views do |t|
       t.integer :board_id, :null => false

--- a/db/migrate/20160218041751_create_post_view.rb
+++ b/db/migrate/20160218041751_create_post_view.rb
@@ -1,4 +1,4 @@
-class CreatePostView < ActiveRecord::Migration
+class CreatePostView < ActiveRecord::Migration[4.2]
   def change
     create_table :post_views do |t|
       t.integer :post_id, :null => false

--- a/db/migrate/20160222042730_create_join_table_character_gallery.rb.rb
+++ b/db/migrate/20160222042730_create_join_table_character_gallery.rb.rb
@@ -1,4 +1,4 @@
-class CreateJoinTableCharacterGallery < ActiveRecord::Migration
+class CreateJoinTableCharacterGallery < ActiveRecord::Migration[4.2]
   def change
     create_table :characters_galleries do |t|
       t.integer :character_id, null: false

--- a/db/migrate/20160223065123_add_galleryless_to_icons.rb
+++ b/db/migrate/20160223065123_add_galleryless_to_icons.rb
@@ -1,4 +1,4 @@
-class AddGallerylessToIcons < ActiveRecord::Migration
+class AddGallerylessToIcons < ActiveRecord::Migration[4.2]
   def change
     add_column :icons, :has_gallery, :boolean, default: false
     add_index :icons, :has_gallery

--- a/db/migrate/20160303032220_add_user_settings.rb
+++ b/db/migrate/20160303032220_add_user_settings.rb
@@ -1,4 +1,4 @@
-class AddUserSettings < ActiveRecord::Migration
+class AddUserSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :timezone, :string
   end

--- a/db/migrate/20160306053517_add_description_to_posts.rb
+++ b/db/migrate/20160306053517_add_description_to_posts.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToPosts < ActiveRecord::Migration
+class AddDescriptionToPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :description, :string
   end

--- a/db/migrate/20160318021845_add_url_index_to_icons.rb
+++ b/db/migrate/20160318021845_add_url_index_to_icons.rb
@@ -1,4 +1,4 @@
-class AddUrlIndexToIcons < ActiveRecord::Migration
+class AddUrlIndexToIcons < ActiveRecord::Migration[4.2]
   def change
     add_index :icons, :url
   end

--- a/db/migrate/20160322032647_add_email_to_users.rb
+++ b/db/migrate/20160322032647_add_email_to_users.rb
@@ -1,4 +1,4 @@
-class AddEmailToUsers < ActiveRecord::Migration
+class AddEmailToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :email, :string
     add_column :users, :email_notifications, :boolean

--- a/db/migrate/20160326210104_add_user_setting_icon_picker_grouping.rb
+++ b/db/migrate/20160326210104_add_user_setting_icon_picker_grouping.rb
@@ -1,4 +1,4 @@
-class AddUserSettingIconPickerGrouping < ActiveRecord::Migration
+class AddUserSettingIconPickerGrouping < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :icon_picker_grouping, :boolean, default: true
   end

--- a/db/migrate/20160410024710_add_last_fields_to_post.rb
+++ b/db/migrate/20160410024710_add_last_fields_to_post.rb
@@ -1,4 +1,4 @@
-class AddLastFieldsToPost < ActiveRecord::Migration
+class AddLastFieldsToPost < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :last_user_id, :integer
     add_column :posts, :last_reply_id, :integer

--- a/db/migrate/20160410060405_add_moiety_to_user.rb
+++ b/db/migrate/20160410060405_add_moiety_to_user.rb
@@ -1,4 +1,4 @@
-class AddMoietyToUser < ActiveRecord::Migration
+class AddMoietyToUser < ActiveRecord::Migration[4.2]
   MOIETIES = {
     1 => 'AA0000',
     2 => '00BF80',

--- a/db/migrate/20160410170309_add_more_user_settings.rb
+++ b/db/migrate/20160410170309_add_more_user_settings.rb
@@ -1,4 +1,4 @@
-class AddMoreUserSettings < ActiveRecord::Migration
+class AddMoreUserSettings < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :layout, :string
     add_column :users, :moiety_name, :string

--- a/db/migrate/20160412035353_create_reply_drafts.rb
+++ b/db/migrate/20160412035353_create_reply_drafts.rb
@@ -1,4 +1,4 @@
-class CreateReplyDrafts < ActiveRecord::Migration
+class CreateReplyDrafts < ActiveRecord::Migration[4.2]
   def change
     create_table :reply_drafts do |t|
       t.integer :post_id, :null => false

--- a/db/migrate/20160416031844_create_password_reset.rb
+++ b/db/migrate/20160416031844_create_password_reset.rb
@@ -1,4 +1,4 @@
-class CreatePasswordReset < ActiveRecord::Migration
+class CreatePasswordReset < ActiveRecord::Migration[4.2]
   def change
     create_table :password_resets do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20160429033350_create_tags.rb
+++ b/db/migrate/20160429033350_create_tags.rb
@@ -1,4 +1,4 @@
-class CreateTags < ActiveRecord::Migration
+class CreateTags < ActiveRecord::Migration[4.2]
   def change
     create_table :tags do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20160604181644_add_tagged_at_to_posts.rb
+++ b/db/migrate/20160604181644_add_tagged_at_to_posts.rb
@@ -1,4 +1,4 @@
-class AddTaggedAtToPosts < ActiveRecord::Migration
+class AddTaggedAtToPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :tagged_at, :datetime
     ActiveRecord::Base.record_timestamps = false

--- a/db/migrate/20160615094301_remove_not_null_from_content.rb
+++ b/db/migrate/20160615094301_remove_not_null_from_content.rb
@@ -1,4 +1,4 @@
-class RemoveNotNullFromContent < ActiveRecord::Migration
+class RemoveNotNullFromContent < ActiveRecord::Migration[4.2]
   def change
     change_column :posts, :content, :text, null: true
     change_column :replies, :content, :text, null: true

--- a/db/migrate/20160627210836_add_user_setting_time_display.rb
+++ b/db/migrate/20160627210836_add_user_setting_time_display.rb
@@ -1,4 +1,4 @@
-class AddUserSettingTimeDisplay < ActiveRecord::Migration
+class AddUserSettingTimeDisplay < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :time_display, :string, default: "%b %d, %Y %l:%M %p"
   end

--- a/db/migrate/20160702213101_create_board_authors.rb
+++ b/db/migrate/20160702213101_create_board_authors.rb
@@ -1,4 +1,4 @@
-class CreateBoardAuthors < ActiveRecord::Migration
+class CreateBoardAuthors < ActiveRecord::Migration[4.2]
   def up
     create_table :board_authors do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20160704224416_use_cloudfront_url.rb
+++ b/db/migrate/20160704224416_use_cloudfront_url.rb
@@ -1,4 +1,4 @@
-class UseCloudfrontUrl < ActiveRecord::Migration
+class UseCloudfrontUrl < ActiveRecord::Migration[4.2]
   def up
     uploaded_icons = Icon.where("url like 'http://glowfic-constellation.s3.amazonaws.com%'")
     uploaded_icons.each do |icon|

--- a/db/migrate/20160716055457_add_tag_types.rb
+++ b/db/migrate/20160716055457_add_tag_types.rb
@@ -1,4 +1,4 @@
-class AddTagTypes < ActiveRecord::Migration
+class AddTagTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :tags, :type, :string
     add_index :tags, :type

--- a/db/migrate/20160719012330_add_order_to_sectionless_posts.rb
+++ b/db/migrate/20160719012330_add_order_to_sectionless_posts.rb
@@ -1,4 +1,4 @@
-class AddOrderToSectionlessPosts < ActiveRecord::Migration
+class AddOrderToSectionlessPosts < ActiveRecord::Migration[4.2]
   def up
     Board.all.each do |board|
       posts = board.posts.where(section_id: nil).order('created_at asc')

--- a/db/migrate/20160723172304_add_description_to_continuity.rb
+++ b/db/migrate/20160723172304_add_description_to_continuity.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToContinuity < ActiveRecord::Migration
+class AddDescriptionToContinuity < ActiveRecord::Migration[4.2]
   def change
     add_column :boards, :description, :text
   end

--- a/db/migrate/20160731040017_add_type_to_coauthors.rb
+++ b/db/migrate/20160731040017_add_type_to_coauthors.rb
@@ -1,4 +1,4 @@
-class AddTypeToCoauthors < ActiveRecord::Migration
+class AddTypeToCoauthors < ActiveRecord::Migration[4.2]
   def change
     add_column :board_authors, :cameo, :boolean, default: false
   end

--- a/db/migrate/20160813025151_add_read_at_to_views.rb
+++ b/db/migrate/20160813025151_add_read_at_to_views.rb
@@ -1,4 +1,4 @@
-class AddReadAtToViews < ActiveRecord::Migration
+class AddReadAtToViews < ActiveRecord::Migration[4.2]
   def change
     add_column :post_views, :read_at, :datetime
     add_column :board_views, :read_at, :datetime

--- a/db/migrate/20160827161416_create_favorites.rb
+++ b/db/migrate/20160827161416_create_favorites.rb
@@ -1,4 +1,4 @@
-class CreateFavorites < ActiveRecord::Migration
+class CreateFavorites < ActiveRecord::Migration[4.2]
   def up
     create_table :favorites do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20160925032329_create_pg_search_documents.rb
+++ b/db/migrate/20160925032329_create_pg_search_documents.rb
@@ -1,4 +1,4 @@
-class CreatePgSearchDocuments < ActiveRecord::Migration
+class CreatePgSearchDocuments < ActiveRecord::Migration[4.2]
   def self.up
     execute "CREATE INDEX idx_fts_post_content ON posts USING gin(to_tsvector('english', coalesce(\"posts\".\"content\"::text, '')))"
     execute "CREATE INDEX idx_fts_post_subject ON posts USING gin(to_tsvector('english', coalesce(\"posts\".\"subject\"::text, '')))"

--- a/db/migrate/20161008224853_add_order_to_galleries.rb
+++ b/db/migrate/20161008224853_add_order_to_galleries.rb
@@ -1,4 +1,4 @@
-class AddOrderToGalleries < ActiveRecord::Migration
+class AddOrderToGalleries < ActiveRecord::Migration[4.2]
   def up
     add_column :characters_galleries, :section_order, :integer, null: false, default: 0
     Character.all.each do |character|

--- a/db/migrate/20161024185615_add_authors_locked_to_post.rb
+++ b/db/migrate/20161024185615_add_authors_locked_to_post.rb
@@ -1,4 +1,4 @@
-class AddAuthorsLockedToPost < ActiveRecord::Migration
+class AddAuthorsLockedToPost < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :authors_locked, :boolean, default: false
   end

--- a/db/migrate/20161107014948_add_salt_to_users.rb
+++ b/db/migrate/20161107014948_add_salt_to_users.rb
@@ -1,4 +1,4 @@
-class AddSaltToUsers < ActiveRecord::Migration
+class AddSaltToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :salt_uuid, :string
     add_column :users, :unread_opened, :boolean, default: false

--- a/db/migrate/20161110055637_add_description_blurbs.rb
+++ b/db/migrate/20161110055637_add_description_blurbs.rb
@@ -1,4 +1,4 @@
-class AddDescriptionBlurbs < ActiveRecord::Migration
+class AddDescriptionBlurbs < ActiveRecord::Migration[4.2]
   def change
     add_column :characters, :description, :text
     add_column :templates, :description, :text

--- a/db/migrate/20161126195558_add_pinned_to_continuities.rb
+++ b/db/migrate/20161126195558_add_pinned_to_continuities.rb
@@ -1,4 +1,4 @@
-class AddPinnedToContinuities < ActiveRecord::Migration
+class AddPinnedToContinuities < ActiveRecord::Migration[4.2]
   def change
     add_column :boards, :pinned, :boolean, default: false
   end

--- a/db/migrate/20161129195022_change_tag_name_to_citext.rb
+++ b/db/migrate/20161129195022_change_tag_name_to_citext.rb
@@ -1,4 +1,4 @@
-class ChangeTagNameToCitext < ActiveRecord::Migration
+class ChangeTagNameToCitext < ActiveRecord::Migration[4.2]
   def up
     execute "CREATE EXTENSION IF NOT EXISTS citext;"
     change_column :tags, :name, :citext

--- a/db/migrate/20161218194918_add_hide_hiatused_tags_owed_to_users.rb
+++ b/db/migrate/20161218194918_add_hide_hiatused_tags_owed_to_users.rb
@@ -1,4 +1,4 @@
-class AddHideHiatusedTagsOwedToUsers < ActiveRecord::Migration
+class AddHideHiatusedTagsOwedToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :hide_hiatused_tags_owed, :boolean, :default => false
   end

--- a/db/migrate/20170103184309_create_flat_posts.rb
+++ b/db/migrate/20170103184309_create_flat_posts.rb
@@ -1,4 +1,4 @@
-class CreateFlatPosts < ActiveRecord::Migration
+class CreateFlatPosts < ActiveRecord::Migration[4.2]
   def up
     create_table :flat_posts do |t|
       t.integer :post_id, :null => false

--- a/db/migrate/20170109000120_add_hide_warnings_to_user.rb
+++ b/db/migrate/20170109000120_add_hide_warnings_to_user.rb
@@ -1,4 +1,4 @@
-class AddHideWarningsToUser < ActiveRecord::Migration
+class AddHideWarningsToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :hide_warnings, :boolean, default: false
   end

--- a/db/migrate/20170210013443_create_character_aliases.rb
+++ b/db/migrate/20170210013443_create_character_aliases.rb
@@ -1,4 +1,4 @@
-class CreateCharacterAliases < ActiveRecord::Migration
+class CreateCharacterAliases < ActiveRecord::Migration[4.2]
   def change
     create_table :character_aliases do |t|
       t.integer :character_id, null: false

--- a/db/migrate/20170221171959_make_usernames_emails_case_insensitive.rb
+++ b/db/migrate/20170221171959_make_usernames_emails_case_insensitive.rb
@@ -1,4 +1,4 @@
-class MakeUsernamesEmailsCaseInsensitive < ActiveRecord::Migration
+class MakeUsernamesEmailsCaseInsensitive < ActiveRecord::Migration[4.2]
   def up
     change_column :users, :username, :citext
     change_column :users, :email, :citext

--- a/db/migrate/20170331133925_move_tag_field_to_labels.rb
+++ b/db/migrate/20170331133925_move_tag_field_to_labels.rb
@@ -1,4 +1,4 @@
-class MoveTagFieldToLabels < ActiveRecord::Migration
+class MoveTagFieldToLabels < ActiveRecord::Migration[4.2]
   def up
     Tag.where(type: nil).update_all(type: 'Label')
   end

--- a/db/migrate/20170413195840_add_visible_unread_to_users.rb
+++ b/db/migrate/20170413195840_add_visible_unread_to_users.rb
@@ -1,4 +1,4 @@
-class AddVisibleUnreadToUsers < ActiveRecord::Migration
+class AddVisibleUnreadToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :visible_unread, :boolean, default: false
   end

--- a/db/migrate/20170501214439_add_show_user_in_switcher_to_user.rb
+++ b/db/migrate/20170501214439_add_show_user_in_switcher_to_user.rb
@@ -1,4 +1,4 @@
-class AddShowUserInSwitcherToUser < ActiveRecord::Migration
+class AddShowUserInSwitcherToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :show_user_in_switcher, :boolean, default: true
   end

--- a/db/migrate/20170505173455_set_character_default_icons.rb
+++ b/db/migrate/20170505173455_set_character_default_icons.rb
@@ -1,4 +1,4 @@
-class SetCharacterDefaultIcons < ActiveRecord::Migration
+class SetCharacterDefaultIcons < ActiveRecord::Migration[4.2]
   def up
     Character.where(default_icon_id: nil).includes(:galleries).find_each do |char|
       next if char.galleries.blank?

--- a/db/migrate/20170513052413_add_report_indexes_to_date_fields.rb
+++ b/db/migrate/20170513052413_add_report_indexes_to_date_fields.rb
@@ -1,4 +1,4 @@
-class AddReportIndexesToDateFields < ActiveRecord::Migration
+class AddReportIndexesToDateFields < ActiveRecord::Migration[4.2]
   def change
     add_index :replies, :created_at
     add_index :posts, :tagged_at

--- a/db/migrate/20170519123223_add_request_uuid_to_audits.rb
+++ b/db/migrate/20170519123223_add_request_uuid_to_audits.rb
@@ -1,4 +1,4 @@
-class AddRequestUuidToAudits < ActiveRecord::Migration
+class AddRequestUuidToAudits < ActiveRecord::Migration[4.2]
   def self.up
     add_column :audits, :request_uuid, :string
     add_index :audits, :request_uuid

--- a/db/migrate/20170612015922_add_report_view.rb
+++ b/db/migrate/20170612015922_add_report_view.rb
@@ -1,4 +1,4 @@
-class AddReportView < ActiveRecord::Migration
+class AddReportView < ActiveRecord::Migration[4.2]
   def change
     create_table :report_views do |t|
       t.integer :user_id, :null => false

--- a/db/migrate/20170617180015_add_ignore_unread_daily_report_to_user.rb
+++ b/db/migrate/20170617180015_add_ignore_unread_daily_report_to_user.rb
@@ -1,4 +1,4 @@
-class AddIgnoreUnreadDailyReportToUser < ActiveRecord::Migration
+class AddIgnoreUnreadDailyReportToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :ignore_unread_daily_report, :boolean, default: false
   end

--- a/db/migrate/20170619010707_drop_gallery_cover_icon.rb
+++ b/db/migrate/20170619010707_drop_gallery_cover_icon.rb
@@ -1,4 +1,4 @@
-class DropGalleryCoverIcon < ActiveRecord::Migration
+class DropGalleryCoverIcon < ActiveRecord::Migration[4.2]
   def change
     remove_column :galleries, :cover_icon_id
   end

--- a/db/migrate/20170814042150_use_ci_columns.rb
+++ b/db/migrate/20170814042150_use_ci_columns.rb
@@ -1,4 +1,4 @@
-class UseCiColumns < ActiveRecord::Migration
+class UseCiColumns < ActiveRecord::Migration[4.2]
   def up
     change_column :boards, :name, :citext
     change_column :characters, :name, :citext

--- a/db/migrate/20170819222420_add_gets_favorite_notifications_to_users.rb
+++ b/db/migrate/20170819222420_add_gets_favorite_notifications_to_users.rb
@@ -1,4 +1,4 @@
-class AddGetsFavoriteNotificationsToUsers < ActiveRecord::Migration
+class AddGetsFavoriteNotificationsToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :favorite_notifications, :boolean, default: true
   end

--- a/db/migrate/20170821210336_add_default_character_split_to_users.rb
+++ b/db/migrate/20170821210336_add_default_character_split_to_users.rb
@@ -1,4 +1,4 @@
-class AddDefaultCharacterSplitToUsers < ActiveRecord::Migration
+class AddDefaultCharacterSplitToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :default_character_split, :string, default: 'template'
   end

--- a/db/migrate/20170826211901_add_gallery_tags.rb
+++ b/db/migrate/20170826211901_add_gallery_tags.rb
@@ -1,4 +1,4 @@
-class AddGalleryTags < ActiveRecord::Migration
+class AddGalleryTags < ActiveRecord::Migration[4.2]
   def change
     create_table :gallery_tags do |t|
       t.integer :gallery_id, null: false

--- a/db/migrate/20170828144608_add_added_by_group_to_characters_galleries.rb
+++ b/db/migrate/20170828144608_add_added_by_group_to_characters_galleries.rb
@@ -1,4 +1,4 @@
-class AddAddedByGroupToCharactersGalleries < ActiveRecord::Migration
+class AddAddedByGroupToCharactersGalleries < ActiveRecord::Migration[4.2]
   def change
     add_column :characters_galleries, :added_by_group, :boolean, default: false
   end

--- a/db/migrate/20170907180029_add_s3_key_to_icon.rb
+++ b/db/migrate/20170907180029_add_s3_key_to_icon.rb
@@ -1,4 +1,4 @@
-class AddS3KeyToIcon < ActiveRecord::Migration
+class AddS3KeyToIcon < ActiveRecord::Migration[4.2]
   CLOUDFRONT_URL = 'https://d1anwqy6ci9o1i.cloudfront.net/'
 
   def self.up

--- a/db/migrate/20170911235423_make_views_unique.rb
+++ b/db/migrate/20170911235423_make_views_unique.rb
@@ -1,4 +1,4 @@
-class MakeViewsUnique < ActiveRecord::Migration
+class MakeViewsUnique < ActiveRecord::Migration[4.2]
   def change
     remove_index :board_views, column: [:user_id, :board_id]
     add_index :board_views, [:user_id, :board_id], unique: true

--- a/db/migrate/20170914191425_change_timestamps_to_utc.rb
+++ b/db/migrate/20170914191425_change_timestamps_to_utc.rb
@@ -1,4 +1,4 @@
-class ChangeTimestampsToUtc < ActiveRecord::Migration
+class ChangeTimestampsToUtc < ActiveRecord::Migration[4.2]
   TABLES = {
     audits: [:created_at],
     board_authors: [:created_at, :updated_at],

--- a/spec/controllers/aliases_controller_spec.rb
+++ b/spec/controllers/aliases_controller_spec.rb
@@ -3,14 +3,14 @@ require "spec_helper"
 RSpec.describe AliasesController do
   describe "GET new" do
     it "requires login" do
-      get :new, character_id: -1
+      get :new, params: { character_id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid character" do
       login
-      get :new, character_id: -1
+      get :new, params: { character_id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("Character could not be found.")
     end
@@ -20,7 +20,7 @@ RSpec.describe AliasesController do
       login_as(user)
       character = create(:character)
       expect(character.user_id).not_to eq(user.id)
-      get :new, character_id: character.id
+      get :new, params: { character_id: character.id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("That is not your character.")
     end
@@ -28,7 +28,7 @@ RSpec.describe AliasesController do
     it "succeeds" do
       character = create(:character)
       login_as(character.user)
-      get :new, character_id: character.id
+      get :new, params: { character_id: character.id }
       expect(response.status).to eq(200)
       expect(assigns(:page_title)).to eq("New Alias: #{character.name}")
       expect(assigns(:alias)).to be_a_new_record
@@ -38,14 +38,14 @@ RSpec.describe AliasesController do
 
   describe "POST create" do
     it "requires login" do
-      post :create, character_id: -1
+      post :create, params: { character_id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid character" do
       login
-      post :create, character_id: -1
+      post :create, params: { character_id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("Character could not be found.")
     end
@@ -55,7 +55,7 @@ RSpec.describe AliasesController do
       login_as(user)
       character = create(:character)
       expect(character.user_id).not_to eq(user.id)
-      post :create, character_id: character.id
+      post :create, params: { character_id: character.id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("That is not your character.")
     end
@@ -63,7 +63,7 @@ RSpec.describe AliasesController do
     it "fails with missing params" do
       character = create(:character)
       login_as(character.user)
-      post :create, character_id: character.id
+      post :create, params: { character_id: character.id }
       expect(response.status).to eq(200)
       expect(flash[:error][:message]).to eq("Alias could not be created.")
       expect(assigns(:page_title)).to eq("New Alias: #{character.name}")
@@ -73,7 +73,7 @@ RSpec.describe AliasesController do
     it "fails with invalid params" do
       character = create(:character)
       login_as(character.user)
-      post :create, character_id: character.id, character_alias: {name: ''}
+      post :create, params: { character_id: character.id, character_alias: {name: ''} }
       expect(response.status).to eq(200)
       expect(flash[:error][:message]).to eq("Alias could not be created.")
       expect(assigns(:page_title)).to eq("New Alias: #{character.name}")
@@ -87,7 +87,7 @@ RSpec.describe AliasesController do
       character = create(:character)
       login_as(character.user)
 
-      post :create, character_id: character.id, character_alias: {name: test_name}
+      post :create, params: { character_id: character.id, character_alias: {name: test_name} }
 
       expect(response).to redirect_to(edit_character_url(character))
       expect(flash[:success]).to eq("Alias created.")
@@ -99,14 +99,14 @@ RSpec.describe AliasesController do
 
   describe "DELETE destroy" do
     it "requires login" do
-      delete :destroy, id: -1, character_id: -1
+      delete :destroy, params: { id: -1, character_id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid character" do
       login
-      delete :destroy, id: -1, character_id: -1
+      delete :destroy, params: { id: -1, character_id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("Character could not be found.")
     end
@@ -116,7 +116,7 @@ RSpec.describe AliasesController do
       login_as(user)
       character = create(:character)
       expect(character.user_id).not_to eq(user.id)
-      delete :destroy, id: -1, character_id: character.id
+      delete :destroy, params: { id: -1, character_id: character.id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("That is not your character.")
     end
@@ -124,7 +124,7 @@ RSpec.describe AliasesController do
     it "requires valid alias" do
       character = create(:character)
       login_as(character.user)
-      delete :destroy, id: -1, character_id: character.id
+      delete :destroy, params: { id: -1, character_id: character.id }
       expect(response).to redirect_to(edit_character_url(character))
       expect(flash[:error]).to eq("Alias could not be found.")
     end
@@ -134,7 +134,7 @@ RSpec.describe AliasesController do
       calias = create(:alias)
       login_as(character.user)
       expect(character.id).not_to eq(calias.character_id)
-      delete :destroy, id: calias.id, character_id: character.id
+      delete :destroy, params: { id: calias.id, character_id: character.id }
       expect(response).to redirect_to(edit_character_url(character))
       expect(flash[:error]).to eq("Alias could not be found for that character.")
     end
@@ -143,7 +143,7 @@ RSpec.describe AliasesController do
       calias = create(:alias)
       reply = create(:reply, user: calias.character.user, character: calias.character, character_alias: calias)
       login_as(calias.character.user)
-      delete :destroy, id: calias.id, character_id: calias.character_id
+      delete :destroy, params: { id: calias.id, character_id: calias.character_id }
       expect(response).to redirect_to(edit_character_url(calias.character))
       expect(flash[:success]).to eq("Alias removed.")
       expect(reply.reload.character_alias_id).to be_nil

--- a/spec/controllers/api/v1/board_sections_controller_spec.rb
+++ b/spec/controllers/api/v1/board_sections_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Api::V1::BoardSectionsController do
       section_ids = [board_section2.id, board_section1.id]
 
       login
-      post :reorder, ordered_section_ids: section_ids
+      post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(403)
       expect(board_section1.reload.section_order).to eq(0)
       expect(board_section2.reload.section_order).to eq(1)
@@ -38,7 +38,7 @@ RSpec.describe Api::V1::BoardSectionsController do
 
       section_ids = [board_section3.id, board_section2.id, board_section1.id]
       login_as(user)
-      post :reorder, ordered_section_ids: section_ids
+      post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(422)
       expect(response.json['errors'][0]['message']).to eq('Sections must be from one board')
       expect(board_section1.reload.section_order).to eq(0)
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::BoardSectionsController do
       section_ids = [-1]
 
       login_as(board.creator)
-      post :reorder, ordered_section_ids: section_ids
+      post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(404)
       expect(response.json['errors'][0]['message']).to eq('Some sections could not be found: -1')
       expect(board_section1.reload.section_order).to eq(0)
@@ -80,7 +80,7 @@ RSpec.describe Api::V1::BoardSectionsController do
       section_ids = [board_section3.id, board_section1.id, board_section4.id, board_section2.id]
 
       login_as(board.creator)
-      post :reorder, ordered_section_ids: section_ids
+      post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(200)
       expect(response.json).to eq({'section_ids' => section_ids})
       expect(board_section1.reload.section_order).to eq(1)
@@ -108,7 +108,7 @@ RSpec.describe Api::V1::BoardSectionsController do
       section_ids = [board_section3.id, board_section1.id]
 
       login_as(board.creator)
-      post :reorder, ordered_section_ids: section_ids
+      post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(200)
       expect(response.json).to eq({'section_ids' => [board_section3.id, board_section1.id, board_section2.id, board_section4.id]})
       expect(board_section1.reload.section_order).to eq(1)

--- a/spec/controllers/api/v1/boards_controller_spec.rb
+++ b/spec/controllers/api/v1/boards_controller_spec.rb
@@ -22,20 +22,20 @@ RSpec.describe Api::V1::BoardsController do
 
     it "works logged out", show_in_doc: true do
       create_search_boards
-      get :index, q: 'b'
+      get :index, params: { q: 'b' }
       expect(response).to have_http_status(200)
       expect(response.json['results'].count).to eq(2)
     end
 
     it "raises error on invalid page", show_in_doc: true do
-      get :index, page: 'b'
+      get :index, params: { page: 'b' }
       expect(response).to have_http_status(422)
     end
   end
 
   describe "GET show" do
     it "requires valid board", :show_in_doc do
-      get :show, id: 0
+      get :show, params: { id: 0 }
       expect(response).to have_http_status(404)
       expect(response.json['errors'].size).to eq(1)
       expect(response.json['errors'][0]['message']).to eq("Continuity could not be found.")
@@ -45,7 +45,7 @@ RSpec.describe Api::V1::BoardsController do
       board = create(:board)
       section1 = create(:board_section, board: board)
       section2 = create(:board_section, board: board)
-      get :show, id: board.id
+      get :show, params: { id: board.id }
       expect(response).to have_http_status(200)
       expect(response.json['id']).to eq(board.id)
       expect(response.json['board_sections'].size).to eq(2)
@@ -58,7 +58,7 @@ RSpec.describe Api::V1::BoardsController do
       board = create(:board)
       section1 = create(:board_section, board: board)
       section2 = create(:board_section, board: board)
-      get :show, id: board.id
+      get :show, params: { id: board.id }
       expect(response).to have_http_status(200)
       expect(response.json['id']).to eq(board.id)
       expect(response.json['board_sections'].size).to eq(2)
@@ -74,7 +74,7 @@ RSpec.describe Api::V1::BoardsController do
       section1.save
       section2.section_order = 0
       section2.save
-      get :show, id: board.id
+      get :show, params: { id: board.id }
       expect(response).to have_http_status(200)
       expect(response.json['id']).to eq(board.id)
       expect(response.json['board_sections'].size).to eq(2)

--- a/spec/controllers/api/v1/characters_controller_spec.rb
+++ b/spec/controllers/api/v1/characters_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::V1::CharactersController do
       it "should support search", show_in_doc: in_doc do
         char = create(:character, name: 'search')
         char2 = create(:character, name: 'no')
-        get :index, q: 'se'
+        get :index, params: { q: 'se' }
         expect(response).to have_http_status(200)
         expect(response.json).to have_key('results')
         expect(response.json['results']).to contain_exactly(char.as_json.stringify_keys)
@@ -22,7 +22,7 @@ RSpec.describe Api::V1::CharactersController do
 
       it "requires valid post id if provided", show_in_doc: in_doc do
         char = create(:character)
-        get :index, post_id: -1
+        get :index, params: { post_id: -1 }
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.json['errors'].size).to eq(1)
         expect(response.json['errors'][0]['message']).to eq("Post could not be found.")
@@ -30,7 +30,7 @@ RSpec.describe Api::V1::CharactersController do
 
       it "requires post with permission", show_in_doc: in_doc do
         post = create(:post, privacy: Post::PRIVACY_PRIVATE, with_character: true)
-        get :index, post_id: post.id
+        get :index, params: { post_id: post.id }
         expect(response).to have_http_status(:forbidden)
         expect(response.json['errors'].size).to eq(1)
         expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
@@ -40,7 +40,7 @@ RSpec.describe Api::V1::CharactersController do
         char = create(:character)
         char2 = create(:character)
         post = create(:post, character: char, user: char.user)
-        get :index, post_id: post.id
+        get :index, params: { post_id: post.id }
         expect(response).to have_http_status(200)
         expect(response.json).to have_key('results')
         expect(response.json['results']).to contain_exactly(char.as_json.stringify_keys)
@@ -59,7 +59,7 @@ RSpec.describe Api::V1::CharactersController do
 
   describe "GET show" do
     it "requires valid character", :show_in_doc do
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to have_http_status(404)
       expect(response.json['errors'].size).to eq(1)
       expect(response.json['errors'][0]['message']).to eq("Character could not be found.")
@@ -67,7 +67,7 @@ RSpec.describe Api::V1::CharactersController do
 
     it "succeeds with valid character" do
       character = create(:character)
-      get :show, id: character.id
+      get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
       expect(response.json['name']).to eq(character.name)
     end
@@ -75,7 +75,7 @@ RSpec.describe Api::V1::CharactersController do
     it "succeeds for logged in users with valid character" do
       character = create(:character)
       login
-      get :show, id: character.id
+      get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
       expect(response.json['name']).to eq(character.name)
     end
@@ -83,7 +83,7 @@ RSpec.describe Api::V1::CharactersController do
     it "has single gallery when present" do
       character = create(:character)
       character.galleries << create(:gallery, user: character.user)
-      get :show, id: character.id
+      get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
       expect(response.json['galleries'].size).to eq(1)
     end
@@ -92,7 +92,7 @@ RSpec.describe Api::V1::CharactersController do
       character = create(:character)
       character.default_icon = create(:icon, user: character.user)
       character.save
-      get :show, id: character.id
+      get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
       expect(response.json['galleries'].size).to eq(1)
     end
@@ -105,7 +105,7 @@ RSpec.describe Api::V1::CharactersController do
       expect(gallery.icons.pluck(:keyword)).to eq(['xxx', 'yyy', 'zzz'])
       character = create(:character, user: gallery.user)
       character.galleries << gallery
-      get :show, id: character.id
+      get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
       expect(response.json['galleries'].size).to eq(1)
       expect(response.json['galleries'][0]['icons'].map { |i| i['keyword'] }).to eq(['xxx', 'yyy', 'zzz'])
@@ -116,7 +116,7 @@ RSpec.describe Api::V1::CharactersController do
       calias = create(:alias, character: character)
       character.galleries << create(:gallery, user: character.user, icon_count: 2)
       character.galleries << create(:gallery, user: character.user, icon_count: 1)
-      get :show, id: character.id
+      get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
       expect(response.json['galleries'].size).to eq(2)
       expect(response.json['aliases'].size).to eq(1)
@@ -130,14 +130,14 @@ RSpec.describe Api::V1::CharactersController do
       character.galleries << create(:gallery, user: user)
       character.galleries[0].icons << create(:icon, user: user)
       character.galleries[1].icons << create(:icon, user: user)
-      get :show, id: character.id
+      get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
       expect(response.json['galleries'].size).to eq(1)
     end
 
     it "requires post to exist when provided a post_id", :show_in_doc do
       character = create(:character)
-      get :show, id: character.id, post_id: 0
+      get :show, params: { id: character.id, post_id: 0 }
       expect(response).to have_http_status(422)
       expect(response.json['errors'].size).to eq(1)
       expect(response.json['errors'][0]['message']).to eq("Post could not be found.")
@@ -145,7 +145,7 @@ RSpec.describe Api::V1::CharactersController do
 
     it "requires post to have permission when provided a post_id", :show_in_doc do
       post = create(:post, privacy: Post::PRIVACY_PRIVATE, with_character: true)
-      get :show, id: post.character_id, post_id: post.id
+      get :show, params: { id: post.character_id, post_id: post.id }
       expect(response).to have_http_status(:forbidden)
       expect(response.json['errors'].size).to eq(1)
       expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
@@ -154,7 +154,7 @@ RSpec.describe Api::V1::CharactersController do
     it "includes alias_id_for_post field when given post_id" do
       character = create(:character)
       post = create(:post, user: character.user)
-      get :show, id: character.id, post_id: post.id
+      get :show, params: { id: character.id, post_id: post.id }
       expect(response).to have_http_status(200)
       expect(response.json).to have_key('alias_id_for_post')
       expect(response.json['alias_id_for_post']).to be_nil
@@ -164,7 +164,7 @@ RSpec.describe Api::V1::CharactersController do
       calias = create(:alias)
       character = calias.character
       post = create(:post, user: character.user, character: character, character_alias_id: calias.id)
-      get :show, id: character.id, post_id: post.id
+      get :show, params: { id: character.id, post_id: post.id }
       expect(response).to have_http_status(200)
       expect(response.json).to have_key('alias_id_for_post')
       expect(response.json['alias_id_for_post']).to eq(calias.id)
@@ -175,7 +175,7 @@ RSpec.describe Api::V1::CharactersController do
       character = calias.character
       post = create(:post, user: character.user, character: character)
       reply = create(:reply, post: post, user: character.user, character: character, character_alias_id: calias.id)
-      get :show, id: character.id, post_id: post.id
+      get :show, params: { id: character.id, post_id: post.id }
       expect(response).to have_http_status(200)
       expect(response.json).to have_key('alias_id_for_post')
       expect(response.json['alias_id_for_post']).to eq(calias.id)
@@ -184,14 +184,14 @@ RSpec.describe Api::V1::CharactersController do
 
   describe "PUT update" do
     it "requires login", :show_in_doc do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to have_http_status(401)
       expect(response.json['errors'][0]['message']).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid character", :show_in_doc do
       login
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to have_http_status(404)
       expect(response.json['errors'][0]['message']).to eq("Character could not be found.")
     end
@@ -199,7 +199,7 @@ RSpec.describe Api::V1::CharactersController do
     it "requires permission", :show_in_doc do
       character = create(:character)
       login
-      put :update, id: character.id
+      put :update, params: { id: character.id }
       expect(response).to have_http_status(403)
       expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
     end
@@ -208,7 +208,7 @@ RSpec.describe Api::V1::CharactersController do
       icon = create(:icon)
       character = create(:character, user: icon.user, default_icon_id: icon.id)
       login_as(character.user)
-      put :update, id: character.id, character: {default_icon_id: -1}
+      put :update, params: { id: character.id, character: {default_icon_id: -1} }
       expect(response).to have_http_status(422)
       expect(response.json['errors'][0]['message']).to eq("Default icon could not be found")
       expect(character.reload.default_icon_id).to eq(icon.id)
@@ -218,7 +218,7 @@ RSpec.describe Api::V1::CharactersController do
       icon = create(:icon)
       character = create(:character, user: icon.user, default_icon_id: icon.id)
       login_as(character.user)
-      put :update, id: character.id, character: {default_icon_id: create(:icon).id}
+      put :update, params: { id: character.id, character: {default_icon_id: create(:icon).id} }
       expect(response).to have_http_status(422)
       expect(response.json['errors'][0]['message']).to eq("Default icon must be yours")
       expect(character.reload.default_icon_id).to eq(icon.id)
@@ -228,7 +228,7 @@ RSpec.describe Api::V1::CharactersController do
       icon = create(:icon)
       character = create(:character, user: icon.user, default_icon_id: icon.id)
       login_as(character.user)
-      put :update, id: character.id, character: {default_icon_id: ''}
+      put :update, params: { id: character.id, character: {default_icon_id: ''} }
       expect(response.status).to eq(200)
       expect(response.json['name']).to eq(character.name)
       expect(character.reload.default_icon_id).to be_nil
@@ -240,7 +240,7 @@ RSpec.describe Api::V1::CharactersController do
       new_icon = create(:icon, user: icon.user)
       login_as(character.user)
 
-      put :update, id: character.id, character: {default_icon_id: new_icon.id}
+      put :update, params: { id: character.id, character: {default_icon_id: new_icon.id} }
 
       expect(response.status).to eq(200)
       expect(response.json['name']).to eq(character.name)
@@ -253,7 +253,7 @@ RSpec.describe Api::V1::CharactersController do
       new_icon = create(:icon, user: icon.user)
       login_as(character.user)
 
-      put :update, id: character.id, character: {default_icon_id: new_icon.id, name: '', user_id: nil}
+      put :update, params: { id: character.id, character: {default_icon_id: new_icon.id, name: '', user_id: nil} }
 
       expect(response.status).to eq(422)
       expect(response.json['errors'][0]['message']).to eq("Name can't be blank")
@@ -279,7 +279,7 @@ RSpec.describe Api::V1::CharactersController do
       section_ids = [char_gal2.id, char_gal1.id]
 
       login
-      post :reorder, ordered_characters_gallery_ids: section_ids
+      post :reorder, params: { ordered_characters_gallery_ids: section_ids }
       expect(response).to have_http_status(403)
       expect(char_gal1.reload.section_order).to eq(0)
       expect(char_gal2.reload.section_order).to eq(1)
@@ -299,7 +299,7 @@ RSpec.describe Api::V1::CharactersController do
 
       section_ids = [char_gal3.id, char_gal2.id, char_gal1.id]
       login_as(user)
-      post :reorder, ordered_characters_gallery_ids: section_ids
+      post :reorder, params: { ordered_characters_gallery_ids: section_ids }
       expect(response).to have_http_status(422)
       expect(response.json['errors'][0]['message']).to eq('Character galleries must be from one character')
       expect(char_gal1.reload.section_order).to eq(0)
@@ -316,7 +316,7 @@ RSpec.describe Api::V1::CharactersController do
       section_ids = [-1]
 
       login_as(character.user)
-      post :reorder, ordered_characters_gallery_ids: section_ids
+      post :reorder, params: { ordered_characters_gallery_ids: section_ids }
       expect(response).to have_http_status(404)
       expect(response.json['errors'][0]['message']).to eq('Some character galleries could not be found: -1')
       expect(char_gal1.reload.section_order).to eq(0)
@@ -341,7 +341,7 @@ RSpec.describe Api::V1::CharactersController do
       section_ids = [char_gal3.id, char_gal1.id, char_gal4.id, char_gal2.id]
 
       login_as(character.user)
-      post :reorder, ordered_characters_gallery_ids: section_ids
+      post :reorder, params: { ordered_characters_gallery_ids: section_ids }
       expect(response).to have_http_status(200)
       expect(response.json).to eq({'characters_gallery_ids' => section_ids})
       expect(char_gal1.reload.section_order).to eq(1)
@@ -369,7 +369,7 @@ RSpec.describe Api::V1::CharactersController do
       section_ids = [char_gal3.id, char_gal1.id]
 
       login_as(character.user)
-      post :reorder, ordered_characters_gallery_ids: section_ids
+      post :reorder, params: { ordered_characters_gallery_ids: section_ids }
       expect(response).to have_http_status(200)
       expect(response.json).to eq({'characters_gallery_ids' => [char_gal3.id, char_gal1.id, char_gal2.id, char_gal4.id]})
       expect(char_gal1.reload.section_order).to eq(1)

--- a/spec/controllers/api/v1/galleries_controller_spec.rb
+++ b/spec/controllers/api/v1/galleries_controller_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Api::V1::GalleriesController do
   describe "GET show" do
     context "with zero gallery id" do
       it "requires valid user", :show_in_doc do
-        get :show, id: '0'
+        get :show, params: { id: '0' }
         expect(response).to have_http_status(422)
         expect(response.json['errors'][0]['message']).to eq("Gallery user could not be found.")
       end
 
       it "returns galleryless icons for logged in user" do
         login
-        get :show, id: '0'
+        get :show, params: { id: '0' }
         expect(response).to have_http_status(200)
         expect(response.json['name']).to eq('Galleryless')
         expect(response.json['icons']).to be_empty
@@ -19,7 +19,7 @@ RSpec.describe Api::V1::GalleriesController do
 
       it "returns galleryless icons for specified user", :show_in_doc do
         user = create(:user)
-        get :show, id: '0', user_id: user.id
+        get :show, params: { id: '0', user_id: user.id }
         expect(response).to have_http_status(200)
         expect(response.json['name']).to eq('Galleryless')
         expect(response.json['icons']).to be_empty
@@ -29,7 +29,7 @@ RSpec.describe Api::V1::GalleriesController do
     context "with normal gallery id" do
       it "requires valid gallery id", :show_in_doc do
         expect(Gallery.find_by_id(1)).to be_nil
-        get :show, id: 1
+        get :show, params: { id: 1 }
         expect(response).to have_http_status(404)
         expect(response.json['errors'][0]['message']).to eq("Gallery could not be found.")
       end
@@ -38,7 +38,7 @@ RSpec.describe Api::V1::GalleriesController do
         gallery = create(:gallery)
         gallery.icons << create(:icon, user: gallery.user)
         login_as(gallery.user)
-        get :show, id: gallery.id
+        get :show, params: { id: gallery.id }
         expect(response).to have_http_status(200)
         expect(response.json['name']).to eq(gallery.name)
         expect(response.json['icons'].size).to eq(1)

--- a/spec/controllers/api/v1/icons_controller_spec.rb
+++ b/spec/controllers/api/v1/icons_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Api::V1::IconsController do
       login_as(user)
 
       expect(S3_BUCKET).not_to receive(:delete_objects)
-      post :s3_delete, s3_key: "users/#{user.id}1/icons/hash_name.png"
+      post :s3_delete, params: { s3_key: "users/#{user.id}1/icons/hash_name.png" }
 
       expect(response).to have_http_status(403)
       expect(response.json['errors'][0]['message']).to eq("That is not your icon.")
@@ -32,7 +32,7 @@ RSpec.describe Api::V1::IconsController do
       icon = create(:uploaded_icon)
       login_as(icon.user)
       expect(S3_BUCKET).not_to receive(:delete_objects)
-      post :s3_delete, s3_key: icon.s3_key
+      post :s3_delete, params: { s3_key: icon.s3_key }
       expect(response).to have_http_status(422)
       expect(response.json['errors'][0]['message']).to eq("Only unused icons can be deleted.")
     end
@@ -42,7 +42,7 @@ RSpec.describe Api::V1::IconsController do
       login_as(icon.user)
       delete_key = {delete: {objects: [{key: icon.s3_key}], quiet: true}}
       expect(S3_BUCKET).to receive(:delete_objects).with(delete_key)
-      post :s3_delete, s3_key: icon.s3_key
+      post :s3_delete, params: { s3_key: icon.s3_key }
       expect(response).to have_http_status(200)
       expect(response.json).to eq({})
     end

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe Api::V1::PostsController do
   describe "GET show" do
     it "requires valid post", :show_in_doc do
-      get :show, id: 0
+      get :show, params: { id: 0 }
       expect(response).to have_http_status(404)
       expect(response.json['errors'].size).to eq(1)
       expect(response.json['errors'][0]['message']).to eq("Post could not be found.")
@@ -11,7 +11,7 @@ RSpec.describe Api::V1::PostsController do
 
     it "requires access to post", :show_in_doc do
       post = create(:post, privacy: Post::PRIVACY_PRIVATE)
-      get :show, id: post.id
+      get :show, params: { id: post.id }
       expect(response).to have_http_status(403)
       expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
     end
@@ -20,7 +20,7 @@ RSpec.describe Api::V1::PostsController do
       calias = create(:alias)
       post = create(:post, user: calias.character.user, with_icon: true, character: calias.character, character_alias: calias)
       expect(calias.name).not_to eq(calias.character.name)
-      get :show, id: post.id
+      get :show, params: { id: post.id }
       expect(response).to have_http_status(200)
       expect(response.json['id']).to eq(post.id)
       expect(response.json['icon']['id']).to eq(post.icon_id)
@@ -48,7 +48,7 @@ RSpec.describe Api::V1::PostsController do
         post_ids = [board_post2.id, board_post1.id]
 
         login
-        post :reorder, ordered_post_ids: post_ids
+        post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(403)
         expect(board_post1.reload.section_order).to eq(0)
         expect(board_post2.reload.section_order).to eq(1)
@@ -68,7 +68,7 @@ RSpec.describe Api::V1::PostsController do
 
         post_ids = [board_post3.id, board_post2.id, board_post1.id]
         login_as(user)
-        post :reorder, ordered_post_ids: post_ids
+        post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(422)
         expect(response.json['errors'][0]['message']).to eq('Posts must be from one board')
         expect(board_post1.reload.section_order).to eq(0)
@@ -88,7 +88,7 @@ RSpec.describe Api::V1::PostsController do
 
         post_ids = [board_post2.id, board_post1.id]
         login_as(user)
-        post :reorder, ordered_post_ids: post_ids
+        post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(422)
         expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the board, or no section')
         expect(board_post1.reload.section_order).to eq(0)
@@ -105,7 +105,7 @@ RSpec.describe Api::V1::PostsController do
 
         post_ids = [-1]
         login_as(user)
-        post :reorder, ordered_post_ids: post_ids
+        post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(404)
         expect(response.json['errors'][0]['message']).to eq('Some posts could not be found: -1')
       end
@@ -128,7 +128,7 @@ RSpec.describe Api::V1::PostsController do
         post_ids = [board_post3.id, board_post1.id, board_post4.id, board_post2.id]
 
         login_as(board.creator)
-        post :reorder, ordered_post_ids: post_ids
+        post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(200)
         expect(response.json).to eq({'post_ids' => post_ids})
         expect(board_post1.reload.section_order).to eq(1)
@@ -156,7 +156,7 @@ RSpec.describe Api::V1::PostsController do
         post_ids = [board_post3.id, board_post1.id]
 
         login_as(board.creator)
-        post :reorder, ordered_post_ids: post_ids
+        post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(200)
         expect(response.json).to eq({'post_ids' => [board_post3.id, board_post1.id, board_post2.id, board_post4.id]})
         expect(board_post1.reload.section_order).to eq(1)
@@ -179,7 +179,7 @@ RSpec.describe Api::V1::PostsController do
         post_ids = [board_post2.id, board_post1.id]
 
         login
-        post :reorder, ordered_post_ids: post_ids, section_id: section.id
+        post :reorder, params: { ordered_post_ids: post_ids, section_id: section.id }
         expect(response).to have_http_status(403)
         expect(board_post1.reload.section_order).to eq(0)
         expect(board_post2.reload.section_order).to eq(1)
@@ -200,7 +200,7 @@ RSpec.describe Api::V1::PostsController do
 
         post_ids = [board_post3.id, board_post2.id, board_post1.id]
         login_as(user)
-        post :reorder, ordered_post_ids: post_ids, section_id: board_section1.id
+        post :reorder, params: { ordered_post_ids: post_ids, section_id: board_section1.id }
         expect(response).to have_http_status(422)
         expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the board, or no section')
         expect(board_post1.reload.section_order).to eq(0)
@@ -220,7 +220,7 @@ RSpec.describe Api::V1::PostsController do
 
         post_ids = [board_post2.id, board_post1.id]
         login_as(user)
-        post :reorder, ordered_post_ids: post_ids, section_id: 0
+        post :reorder, params: { ordered_post_ids: post_ids, section_id: 0 }
         expect(response).to have_http_status(422)
         expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the board, or no section')
         expect(board_post1.reload.section_order).to eq(0)
@@ -242,7 +242,7 @@ RSpec.describe Api::V1::PostsController do
 
         post_ids = [board_post3.id, board_post2.id]
         login_as(user)
-        post :reorder, ordered_post_ids: post_ids, section_id: board_section1.id
+        post :reorder, params: { ordered_post_ids: post_ids, section_id: board_section1.id }
         expect(response).to have_http_status(422)
         expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the board, or no section')
         expect(board_post1.reload.section_order).to eq(0)
@@ -262,7 +262,7 @@ RSpec.describe Api::V1::PostsController do
 
         post_ids = [board_post2.id, board_post1.id]
         login_as(user)
-        post :reorder, ordered_post_ids: post_ids, section_id: section.id
+        post :reorder, params: { ordered_post_ids: post_ids, section_id: section.id }
         expect(response).to have_http_status(422)
         expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the board, or no section')
         expect(board_post1.reload.section_order).to eq(0)
@@ -280,7 +280,7 @@ RSpec.describe Api::V1::PostsController do
 
         post_ids = [-1]
         login_as(user)
-        post :reorder, ordered_post_ids: post_ids, section_id: section.id
+        post :reorder, params: { ordered_post_ids: post_ids, section_id: section.id }
         expect(response).to have_http_status(404)
         expect(response.json['errors'][0]['message']).to eq('Some posts could not be found: -1')
       end
@@ -304,7 +304,7 @@ RSpec.describe Api::V1::PostsController do
         post_ids = [board_post3.id, board_post1.id, board_post4.id, board_post2.id]
 
         login_as(board.creator)
-        post :reorder, ordered_post_ids: post_ids, section_id: section.id
+        post :reorder, params: { ordered_post_ids: post_ids, section_id: section.id }
         expect(response).to have_http_status(200)
         expect(response.json).to eq({'post_ids' => post_ids})
         expect(board_post1.reload.section_order).to eq(1)
@@ -333,7 +333,7 @@ RSpec.describe Api::V1::PostsController do
         post_ids = [board_post3.id, board_post1.id]
 
         login_as(board.creator)
-        post :reorder, ordered_post_ids: post_ids, section_id: section.id
+        post :reorder, params: { ordered_post_ids: post_ids, section_id: section.id }
         expect(response).to have_http_status(200)
         expect(response.json).to eq({'post_ids' => [board_post3.id, board_post1.id, board_post2.id, board_post4.id]})
         expect(board_post1.reload.section_order).to eq(1)

--- a/spec/controllers/api/v1/replies_controller_spec.rb
+++ b/spec/controllers/api/v1/replies_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe Api::V1::RepliesController do
   describe "GET index" do
     it "requires valid post", :show_in_doc do
-      get :index, post_id: 0
+      get :index, params: { post_id: 0 }
       expect(response).to have_http_status(404)
       expect(response.json['errors'].size).to eq(1)
       expect(response.json['errors'][0]['message']).to eq("Post could not be found.")
@@ -11,7 +11,7 @@ RSpec.describe Api::V1::RepliesController do
 
     it "requires access to post", :show_in_doc do
       post = create(:post, privacy: Post::PRIVACY_PRIVATE)
-      get :index, post_id: post.id
+      get :index, params: { post_id: post.id }
       expect(response).to have_http_status(403)
       expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
     end
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::RepliesController do
       calias = create(:alias)
       reply = create(:reply, post: post, user: calias.character.user, character: calias.character, character_alias: calias, with_icon: true)
       expect(calias.name).not_to eq(reply.character.name)
-      get :index, post_id: post.id
+      get :index, params: { post_id: post.id }
       expect(response).to have_http_status(200)
       expect(response.json.size).to eq(3)
       expect(response.json[2]['id']).to eq(reply.id)
@@ -33,7 +33,7 @@ RSpec.describe Api::V1::RepliesController do
 
     it "paginates" do
       post = create(:post, num_replies: 5, with_icon: true, with_character: true)
-      get :index, post_id: post.id, per_page: 2, page: 3
+      get :index, params: { post_id: post.id, per_page: 2, page: 3 }
       expect(response).to have_http_status(200)
       expect(response.headers['Per-Page'].to_i).to eq(2)
       expect(response.headers['Page'].to_i).to eq(3)

--- a/spec/controllers/api/v1/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/tags_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1::TagsController do
     shared_examples_for "index.json" do |in_doc|
       it "should support label search", show_in_doc: in_doc do
         tag = create(:label)
-        get :index, q: tag.name, t: 'Label'
+        get :index, params: { q: tag.name, t: 'Label' }
         expect(response).to have_http_status(200)
         expect(response.json).to have_key('results')
         expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::TagsController do
 
       it "should support setting search", show_in_doc: in_doc do
         tag = create(:setting)
-        get :index, q: tag.name, t: 'Setting'
+        get :index, params: { q: tag.name, t: 'Setting' }
         expect(response).to have_http_status(200)
         expect(response.json).to have_key('results')
         expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::TagsController do
 
       it "should support content warning search", show_in_doc: in_doc do
         tag = create(:content_warning)
-        get :index, q: tag.name, t: 'ContentWarning'
+        get :index, params: { q: tag.name, t: 'ContentWarning' }
         expect(response).to have_http_status(200)
         expect(response.json).to have_key('results')
         expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
@@ -29,14 +29,14 @@ RSpec.describe Api::V1::TagsController do
 
       it "should support gallery group search" do
         tag = create(:gallery_group)
-        get :index, q: tag.name, t: 'GalleryGroup'
+        get :index, params: { q: tag.name, t: 'GalleryGroup' }
         expect(response).to have_http_status(200)
         expect(response.json).to have_key('results')
         expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
       end
 
       it "should handle invalid input", show_in_doc: in_doc do
-        get :index, t: 'b'
+        get :index, params: { t: 'b' }
         expect(response).to have_http_status(422)
         expect(response.json).to have_key('errors')
         expect(response.json['errors'].first['message']).to include("Invalid parameter 't'")
@@ -46,7 +46,7 @@ RSpec.describe Api::V1::TagsController do
         it "should not display unused tags" do
           user = create(:user)
           ungrouped_tag = create(:gallery_group)
-          get :index, q: ungrouped_tag.name, t: 'GalleryGroup', user_id: user.id
+          get :index, params: { q: ungrouped_tag.name, t: 'GalleryGroup', user_id: user.id }
           expect(response).to have_http_status(200)
           expect(response.json).to have_key('results')
           expect(response.json['results']).to eq([])
@@ -56,7 +56,7 @@ RSpec.describe Api::V1::TagsController do
           user = create(:user)
           gal_grouped_tag = create(:gallery_group)
           create(:gallery, user: user, gallery_groups: [gal_grouped_tag])
-          get :index, q: gal_grouped_tag.name, t: 'GalleryGroup', user_id: user.id
+          get :index, params: { q: gal_grouped_tag.name, t: 'GalleryGroup', user_id: user.id }
           expect(response).to have_http_status(200)
           expect(response.json).to have_key('results')
           expect(response.json['results']).to contain_exactly(gal_grouped_tag.as_json.stringify_keys)
@@ -66,7 +66,7 @@ RSpec.describe Api::V1::TagsController do
           user = create(:user)
           char_grouped_tag = create(:gallery_group)
           create(:character, user: user, gallery_groups: [char_grouped_tag])
-          get :index, q: char_grouped_tag.name, t: 'GalleryGroup', user_id: user.id
+          get :index, params: { q: char_grouped_tag.name, t: 'GalleryGroup', user_id: user.id }
           expect(response).to have_http_status(200)
           expect(response.json).to have_key('results')
           expect(response.json['results']).to contain_exactly(char_grouped_tag.as_json.stringify_keys)
@@ -90,7 +90,7 @@ RSpec.describe Api::V1::TagsController do
       group = create(:gallery_group)
       galleries = Array.new(2) { create(:gallery, user: user, gallery_groups: [group]) }
       create(:gallery, gallery_groups: [group])
-      get :show, id: group.id, user_id: user.id
+      get :show, params: { id: group.id, user_id: user.id }
       expect(response).to have_http_status(200)
       expect(response.json['id']).to eq(group.id)
       expect(response.json['text']).to eq(group.name)
@@ -100,14 +100,14 @@ RSpec.describe Api::V1::TagsController do
     [:setting, :label, :content_warning].each do |type|
       it "should support getting #{type} tags" do
         tag = create(type)
-        get :show, id: tag.id
+        get :show, params: { id: tag.id }
         expect(response).to have_http_status(200)
         expect(response.json['id']).to eq(tag.id)
       end
     end
 
     it "should handle invalid tag", show_in_doc: true do
-      get :show, id: 99
+      get :show, params: { id: 99 }
       expect(response).to have_http_status(404)
       expect(response.json).to have_key('errors')
       expect(response.json['errors'][0]['message']).to eq("Tag could not be found")

--- a/spec/controllers/api/v1/templates_controller_spec.rb
+++ b/spec/controllers/api/v1/templates_controller_spec.rb
@@ -22,23 +22,23 @@ RSpec.describe Api::V1::TemplatesController do
 
     it "works logged out", show_in_doc: true do
       create_search_templates
-      get :index, q: 'b'
+      get :index, params: { q: 'b' }
       expect(response).to have_http_status(200)
       expect(response.json['results'].count).to eq(2)
     end
 
     it "raises error on invalid page", show_in_doc: true do
-      get :index, page: 'b'
+      get :index, params: { page: 'b' }
       expect(response).to have_http_status(422)
     end
 
     it "raises error on invalid user", show_in_doc: true do
-      get :index, user_id: 'b'
+      get :index, params: { user_id: 'b' }
       expect(response).to have_http_status(422)
     end
 
     it "raises error on not found user", show_in_doc: true do
-      get :index, user_id: '12'
+      get :index, params: { user_id: '12' }
       expect(response).to have_http_status(422)
     end
 
@@ -48,7 +48,7 @@ RSpec.describe Api::V1::TemplatesController do
       template = create(:template, user: user)
       nottemplate = create(:template, user: notuser)
 
-      get :index, user_id: template.user_id
+      get :index, params: { user_id: template.user_id }
       expect(response.json['results'].count).to eq(1)
     end
   end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe Api::V1::UsersController do
 
     it "works logged out", show_in_doc: true do
       create_search_users
-      get :index, q: 'b'
+      get :index, params: { q: 'b' }
       expect(response).to have_http_status(200)
       expect(response.json['results'].count).to eq(2)
     end
 
     it "raises error on invalid page", show_in_doc: true do
-      get :index, page: 'b'
+      get :index, params: { page: 'b' }
       expect(response).to have_http_status(422)
     end
   end

--- a/spec/controllers/board_sections_controller_spec.rb
+++ b/spec/controllers/board_sections_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BoardSectionsController do
       expect(board.editable_by?(user)).to eq(false)
       login_as(user)
 
-      get :new, board_id: board.id
+      get :new, params: { board_id: board.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to edit this continuity.")
     end
@@ -22,7 +22,7 @@ RSpec.describe BoardSectionsController do
     it "works with board_id" do
       board = create(:board)
       login_as(board.creator)
-      get :new, board_id: board.id
+      get :new, params: { board_id: board.id }
       expect(response.status).to eq(200)
       expect(assigns(:page_title)).to eq("New Section")
     end
@@ -48,7 +48,7 @@ RSpec.describe BoardSectionsController do
       expect(board.editable_by?(user)).to eq(false)
       login_as(user)
 
-      post :create, board_section: {board_id: board.id}
+      post :create, params: { board_section: {board_id: board.id} }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to edit this continuity.")
     end
@@ -56,7 +56,7 @@ RSpec.describe BoardSectionsController do
     it "requires valid section" do
       board = create(:board)
       login_as(board.creator)
-      post :create, board_section: {board_id: board.id}
+      post :create, params: { board_section: {board_id: board.id} }
       expect(response).to have_http_status(200)
       expect(response).to render_template(:new)
       expect(flash[:error][:message]).to eq("Section could not be created.")
@@ -66,7 +66,7 @@ RSpec.describe BoardSectionsController do
       board = create(:board)
       login_as(board.creator)
       section_name = 'ValidSection'
-      post :create, board_section: {board_id: board.id, name: section_name}
+      post :create, params: { board_section: {board_id: board.id, name: section_name} }
       expect(response).to redirect_to(edit_board_url(board))
       expect(flash[:success]).to eq("New section, #{section_name}, has successfully been created for #{board.name}.")
       expect(assigns(:board_section).name).to eq(section_name)
@@ -75,7 +75,7 @@ RSpec.describe BoardSectionsController do
 
   describe "GET show" do
     it "requires valid section" do
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Section not found.")
     end
@@ -85,7 +85,7 @@ RSpec.describe BoardSectionsController do
       posts = Array.new(2) { create(:post, board: section.board, section: section) }
       create(:post)
       create(:post, board: section.board)
-      get :show, id: section.id
+      get :show, params: { id: section.id }
       expect(response).to have_http_status(200)
       expect(assigns(:page_title)).to eq(section.name)
       expect(assigns(:posts)).to match_array(posts)
@@ -96,7 +96,7 @@ RSpec.describe BoardSectionsController do
       posts = Array.new(2) { create(:post, board: section.board, section: section) }
       create(:post)
       create(:post, board: section.board)
-      get :show, id: section.id
+      get :show, params: { id: section.id }
       expect(response).to have_http_status(200)
       expect(assigns(:page_title)).to eq(section.name)
       expect(assigns(:posts)).to match_array(posts)
@@ -105,14 +105,14 @@ RSpec.describe BoardSectionsController do
 
   describe "GET edit" do
     it "requires login" do
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid section" do
       login
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Section not found.")
     end
@@ -120,7 +120,7 @@ RSpec.describe BoardSectionsController do
     it "requires permission" do
       section = create(:board_section)
       login
-      get :edit, id: section.id
+      get :edit, params: { id: section.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to edit this continuity.")
     end
@@ -128,7 +128,7 @@ RSpec.describe BoardSectionsController do
     it "works" do
       section = create(:board_section)
       login_as(section.board.creator)
-      get :edit, id: section.id
+      get :edit, params: { id: section.id }
       expect(response).to have_http_status(200)
       expect(assigns(:page_title)).to eq("Edit #{section.name}")
       expect(assigns(:board_section)).to eq(section)
@@ -137,7 +137,7 @@ RSpec.describe BoardSectionsController do
 
   describe "PUT update" do
     it "requires login" do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
@@ -148,7 +148,7 @@ RSpec.describe BoardSectionsController do
       board_section = create(:board_section)
       expect(board_section.board).not_to be_editable_by(user)
 
-      put :update, id: board_section.id
+      put :update, params: { id: board_section.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to edit this continuity.")
     end
@@ -156,7 +156,7 @@ RSpec.describe BoardSectionsController do
     it "requires valid params" do
       board_section = create(:board_section)
       login_as(board_section.board.creator)
-      put :update, id: board_section.id, board_section: {name: ''}
+      put :update, params: { id: board_section.id, board_section: {name: ''} }
       expect(response).to have_http_status(200)
       expect(response).to render_template(:edit)
       expect(flash[:error][:message]).to eq("Section could not be updated.")
@@ -166,7 +166,7 @@ RSpec.describe BoardSectionsController do
       board_section = create(:board_section, name: 'TestSection1')
       login_as(board_section.board.creator)
       section_name = 'TestSection2'
-      put :update, id: board_section.id, board_section: {name: section_name}
+      put :update, params: { id: board_section.id, board_section: {name: section_name} }
       expect(response).to redirect_to(board_section_path(board_section))
       expect(board_section.reload.name).to eq(section_name)
       expect(flash[:success]).to eq("#{section_name} has been successfully updated.")
@@ -175,14 +175,14 @@ RSpec.describe BoardSectionsController do
 
   describe "DELETE destroy" do
     it "requires login" do
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid section" do
       login
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Section not found.")
     end
@@ -190,7 +190,7 @@ RSpec.describe BoardSectionsController do
     it "requires permission" do
       section = create(:board_section)
       login
-      delete :destroy, id: section.id
+      delete :destroy, params: { id: section.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to edit this continuity.")
     end
@@ -198,7 +198,7 @@ RSpec.describe BoardSectionsController do
     it "works" do
       section = create(:board_section)
       login_as(section.board.creator)
-      delete :destroy, id: section.id
+      delete :destroy, params: { id: section.id }
       expect(response).to redirect_to(edit_board_url(section.board))
       expect(flash[:success]).to eq("Section deleted.")
       expect(BoardSection.find_by_id(section.id)).to be_nil

--- a/spec/controllers/boards_controller_spec.rb
+++ b/spec/controllers/boards_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe BoardsController do
     context "with a user_id" do
       it "does not require login" do
         user = create(:user)
-        get :index, user_id: user.id
+        get :index, params: { user_id: user.id }
         expect(response.status).to eq(200)
         expect(assigns(:user)).to eq(user)
         expect(assigns(:page_title)).to eq("#{user.username}'s Continuities")
@@ -37,14 +37,14 @@ RSpec.describe BoardsController do
       it "defaults to current user if user id invalid" do
         user = create(:user)
         login_as(user)
-        get :index, user_id: -1
+        get :index, params: { user_id: -1 }
         expect(response.status).to eq(200)
         expect(assigns(:user)).to eq(user)
         expect(assigns(:page_title)).to eq('Your Continuities')
       end
 
       it "displays error if user id invalid and logged out" do
-        get :index, user_id: -1
+        get :index, params: { user_id: -1 }
         expect(flash[:error]).to eq('User could not be found.')
         expect(response).to redirect_to(root_url)
       end
@@ -53,7 +53,7 @@ RSpec.describe BoardsController do
         user = create(:user)
         owned_board = create(:board, creator_id: user.id)
 
-        get :index, user_id: user.id
+        get :index, params: { user_id: user.id }
         expect(assigns(:boards)).to match_array([owned_board])
 
         coauthor = create(:user)
@@ -62,7 +62,7 @@ RSpec.describe BoardsController do
         owned_board3 = create(:board, creator_id: user.id)
         owned_board3.cameos << coauthor
 
-        get :index, user_id: coauthor.id
+        get :index, params: { user_id: coauthor.id }
         expect(assigns(:boards)).to match_array([owned_board2])
         expect(assigns(:cameo_boards)).to match_array([owned_board3])
       end
@@ -152,7 +152,7 @@ RSpec.describe BoardsController do
       user2 = create(:user)
       user3 = create(:user)
 
-      post :create, board: {name: 'TestCreateBoard', description: 'Test description', coauthor_ids: [user2.id], cameo_ids: [user3.id]}
+      post :create, params: { board: {name: 'TestCreateBoard', description: 'Test description', coauthor_ids: [user2.id], cameo_ids: [user3.id]} }
       expect(response).to redirect_to(boards_url)
       expect(flash[:success]).to eq("Continuity created!")
       expect(Board.count).to eq(1)
@@ -168,49 +168,49 @@ RSpec.describe BoardsController do
 
   describe "GET show" do
     it "requires valid board" do
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Continuity could not be found.")
     end
 
     it "succeeds with valid board" do
       board = create(:board)
-      get :show, id: board.id
+      get :show, params: { id: board.id }
       expect(response.status).to eq(200)
     end
 
     it "succeeds for logged in users with valid board" do
       login
       board = create(:board)
-      get :show, id: board.id
+      get :show, params: { id: board.id }
       expect(response.status).to eq(200)
     end
 
     it "only fetches the board's first 25 posts" do
       board = create(:board)
       26.times do create(:post, board: board) end
-      get :show, id: board.id
+      get :show, params: { id: board.id }
       expect(assigns(:posts).size).to eq(25)
     end
 
     it "orders the posts by updated_at" do
       board = create(:board)
       3.times do create(:post, board: board, tagged_at: Time.now + rand(5..30).hours) end
-      get :show, id: board.id
+      get :show, params: { id: board.id }
       expect(assigns(:posts)).to eq(assigns(:posts).sort_by(&:tagged_at).reverse)
     end
   end
 
   describe "GET edit" do
     it "requires login" do
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid board" do
       login
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Continuity could not be found.")
     end
@@ -220,7 +220,7 @@ RSpec.describe BoardsController do
       login_as(user)
       board = create(:board)
       expect(board).not_to be_editable_by(user)
-      get :edit, id: board.id
+      get :edit, params: { id: board.id }
       expect(response).to redirect_to(board_url(board))
       expect(flash[:error]).to eq("You do not have permission to edit that continuity.")
     end
@@ -228,7 +228,7 @@ RSpec.describe BoardsController do
     it "succeeds with valid board" do
       board = create(:board)
       login_as(board.creator)
-      get :edit, id: board.id
+      get :edit, params: { id: board.id }
       expect(response.status).to eq(200)
     end
 
@@ -238,7 +238,7 @@ RSpec.describe BoardsController do
       posts = [create(:post, board: board), create(:post, board: board)]
       board.coauthors << create(:user)
       login_as(board.creator)
-      get :edit, id: board.id
+      get :edit, params: { id: board.id }
       expect(assigns(:board_sections)).to eq(sections)
       expect(assigns(:unsectioned_posts)).to eq(posts)
     end
@@ -246,14 +246,14 @@ RSpec.describe BoardsController do
 
   describe "PUT update" do
     it "requires login" do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid board" do
       login
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Continuity could not be found.")
     end
@@ -263,7 +263,7 @@ RSpec.describe BoardsController do
       login_as(user)
       board = create(:board)
       expect(board).not_to be_editable_by(user)
-      put :update, id: board.id
+      put :update, params: { id: board.id }
       expect(response).to redirect_to(board_url(board))
       expect(flash[:error]).to eq("You do not have permission to edit that continuity.")
     end
@@ -272,7 +272,7 @@ RSpec.describe BoardsController do
       user = create(:user)
       board = create(:board, creator: user)
       login_as(user)
-      put :update, id: board.id, board: {name: ''}
+      put :update, params: { id: board.id, board: {name: ''} }
       expect(response).to render_template('edit')
       expect(flash[:error][:message]).to eq("Continuity could not be created.")
       expect(flash[:error][:array]).to be_present
@@ -285,7 +285,7 @@ RSpec.describe BoardsController do
       login_as(user)
       user2 = create(:user)
       user3 = create(:user)
-      put :update, id: board.id, board: {name: name + 'edit', description: 'New description', coauthor_ids: [user2.id], cameo_ids: [user3.id]}
+      put :update, params: { id: board.id, board: {name: name + 'edit', description: 'New description', coauthor_ids: [user2.id], cameo_ids: [user3.id]} }
       expect(response).to redirect_to(board_url(board))
       expect(flash[:success]).to eq("Continuity saved!")
       board.reload
@@ -298,14 +298,14 @@ RSpec.describe BoardsController do
 
   describe "DELETE destroy" do
     it "requires login" do
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid board" do
       login
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Continuity could not be found.")
     end
@@ -315,7 +315,7 @@ RSpec.describe BoardsController do
       login_as(user)
       board = create(:board)
       expect(board).not_to be_editable_by(user)
-      delete :destroy, id: board.id
+      delete :destroy, params: { id: board.id }
       expect(response).to redirect_to(board_url(board))
       expect(flash[:error]).to eq("You do not have permission to edit that continuity.")
     end
@@ -323,7 +323,7 @@ RSpec.describe BoardsController do
     it "succeeds" do
       board = create(:board)
       login_as(board.creator)
-      delete :destroy, id: board.id
+      delete :destroy, params: { id: board.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:success]).to eq("Continuity deleted.")
     end
@@ -333,7 +333,7 @@ RSpec.describe BoardsController do
       section = create(:board_section, board: board)
       post = create(:post, board: board, section: section)
       login_as(board.creator)
-      delete :destroy, id: board.id
+      delete :destroy, params: { id: board.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:success]).to eq('Continuity deleted.')
       post.reload
@@ -359,14 +359,14 @@ RSpec.describe BoardsController do
 
     it "requires valid board id" do
       login
-      post :mark, board_id: -1
+      post :mark, params: { board_id: -1 }
       expect(response).to redirect_to(unread_posts_url)
       expect(flash[:error]).to eq("Continuity could not be found.")
     end
 
     it "requires valid action" do
       login
-      post :mark, board_id: create(:board).id
+      post :mark, params: { board_id: create(:board).id }
       expect(response).to redirect_to(unread_posts_url)
       expect(flash[:error]).to eq("Please choose a valid action.")
     end
@@ -377,7 +377,7 @@ RSpec.describe BoardsController do
       login_as(user)
       now = Time.now
       expect(board.last_read(user)).to be_nil
-      post :mark, board_id: board.id, commit: "Mark Read"
+      post :mark, params: { board_id: board.id, commit: "Mark Read" }
       expect(Board.find(board.id).last_read(user)).to be >= now # reload to reset cached @view
       expect(response).to redirect_to(unread_posts_url)
       expect(flash[:success]).to eq("#{board.name} marked as read.")
@@ -388,7 +388,7 @@ RSpec.describe BoardsController do
       user = create(:user)
       login_as(user)
       expect(board).not_to be_ignored_by(user)
-      post :mark, board_id: board.id, commit: "Hide from Unread"
+      post :mark, params: { board_id: board.id, commit: "Hide from Unread" }
       expect(Board.find(board.id)).to be_ignored_by(user) # reload to reset cached @view
       expect(response).to redirect_to(unread_posts_url)
       expect(flash[:success]).to eq("#{board.name} hidden from this page.")

--- a/spec/controllers/bugs_controller_spec.rb
+++ b/spec/controllers/bugs_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BugsController do
       user = User.find(user_id)
       params = data.merge(controller: 'bugs', action: 'create', user_id: user.id).stringify_keys
       expect(ExceptionNotifier).to receive(:notify_exception).with(an_instance_of(Icon::UploadError), data: params)
-      post :create, data
+      post :create, params: data
       expect(response.status).to eq(200)
       expect(response.json).to eq({})
     end

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe CharactersController do
     end
 
     it "requires valid id" do
-      get :index, user_id: -1
+      get :index, params: { user_id: -1 }
       expect(response).to redirect_to(users_url)
       expect(flash[:error]).to eq("User could not be found.")
     end
 
     it "succeeds with an id" do
       user = create(:user)
-      get :index, user_id: user.id
+      get :index, params: { user_id: user.id }
       expect(response.status).to eq(200)
     end
 
@@ -29,7 +29,7 @@ RSpec.describe CharactersController do
     it "succeeds with an id when logged in" do
       user = create(:user)
       login
-      get :index, user_id: user.id
+      get :index, params: { user_id: user.id }
       expect(response.status).to eq(200)
     end
 
@@ -43,14 +43,14 @@ RSpec.describe CharactersController do
       it "successfully renders the page in template group" do
         character = create(:character)
         character2 = create(:template_character, user: character.user)
-        get :index, user_id: character.user_id, character_split: 'template'
+        get :index, params: { user_id: character.user_id, character_split: 'template' }
         expect(response.status).to eq(200)
       end
 
       it "successfully renders the page with no group" do
         character = create(:character)
         character2 = create(:template_character, user: character.user)
-        get :index, user_id: character.user_id, character_split: 'none'
+        get :index, params: { user_id: character.user_id, character_split: 'none' }
         expect(response.status).to eq(200)
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe CharactersController do
     it "sets correct variables with template_id" do
       template = create(:template)
       login_as(template.user)
-      get :new, template_id: template.id
+      get :new, params: { template_id: template.id }
       expect(response.status).to eq(200)
       expect(assigns(:character).template).to eq(template)
     end
@@ -113,7 +113,7 @@ RSpec.describe CharactersController do
 
     it "fails with invalid params" do
       login
-      post :create, character: {}
+      post :create, params: { character: {} }
       expect(response.status).to eq(200)
       expect(flash[:error][:message]).to eq("Your character could not be saved.")
     end
@@ -126,7 +126,7 @@ RSpec.describe CharactersController do
       gallery = create(:gallery, user: user)
 
       login_as(user)
-      post :create, character: {name: test_name, template_name: 'TempName', screenname: 'just-a-test', setting: 'A World', template_id: template.id, pb: 'Facecast', description: 'Desc', ungrouped_gallery_ids: [gallery.id]}
+      post :create, params: { character: {name: test_name, template_name: 'TempName', screenname: 'just-a-test', setting: 'A World', template_id: template.id, pb: 'Facecast', description: 'Desc', ungrouped_gallery_ids: [gallery.id]} }
 
       expect(response).to redirect_to(assigns(:character))
       expect(flash[:success]).to eq("Character saved successfully.")
@@ -146,7 +146,7 @@ RSpec.describe CharactersController do
     it "creates new templates when specified" do
       expect(Template.count).to eq(0)
       login
-      post :create, new_template: '1', character: {template_attributes: {name: 'TemplateTest'}, name: 'Test'}
+      post :create, params: { new_template: '1', character: {template_attributes: {name: 'TemplateTest'}, name: 'Test'} }
       expect(Template.count).to eq(1)
       expect(Template.first.name).to eq('TemplateTest')
       expect(assigns(:character).template_id).to eq(Template.first.id)
@@ -163,7 +163,7 @@ RSpec.describe CharactersController do
         create(:template)
 
         login_as(user)
-        post :create, character: {ungrouped_gallery_ids: [gallery.id, group_gallery.id], gallery_group_ids: [group.id]}
+        post :create, params: { character: {ungrouped_gallery_ids: [gallery.id, group_gallery.id], gallery_group_ids: [group.id]} }
 
         expect(response).to render_template(:new)
         expect(controller.gon.character_id).to eq('')
@@ -176,28 +176,28 @@ RSpec.describe CharactersController do
 
   describe "GET show" do
     it "requires valid character" do
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("Character could not be found.")
     end
 
     it "should succeed when logged out" do
       character = create(:character)
-      get :show, id: character.id
+      get :show, params: { id: character.id }
       expect(response.status).to eq(200)
     end
 
     it "should succeed when logged in" do
       character = create(:character)
       login
-      get :show, id: character.id
+      get :show, params: { id: character.id }
       expect(response.status).to eq(200)
     end
 
     it "should set correct variables" do
       character = create(:character)
       Array.new(26) { create(:post, character: character, user: character.user) }
-      get :show, id: character.id
+      get :show, params: { id: character.id }
       expect(response.status).to eq(200)
       expect(assigns(:page_title)).to eq(character.name)
       expect(assigns(:posts).size).to eq(25)
@@ -207,28 +207,28 @@ RSpec.describe CharactersController do
     it "should only show visible posts" do
       character = create(:character)
       create(:post, character: character, user: character.user, privacy: Post::PRIVACY_PRIVATE)
-      get :show, id: character.id
+      get :show, params: { id: character.id }
       expect(assigns(:posts)).to be_blank
     end
   end
 
   describe "GET edit" do
     it "requires login" do
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid character id" do
       login
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("Character could not be found.")
     end
 
     it "requires character with permissions" do
       login
-      get :edit, id: create(:character).id
+      get :edit, params: { id: create(:character).id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("You do not have permission to edit that character.")
     end
@@ -236,7 +236,7 @@ RSpec.describe CharactersController do
     it "succeeds when logged in" do
       character = create(:character)
       login_as(character.user)
-      get :edit, id: character.id
+      get :edit, params: { id: character.id }
       expect(response.status).to eq(200)
     end
 
@@ -252,7 +252,7 @@ RSpec.describe CharactersController do
         create(:template)
 
         login_as(user)
-        get :edit, id: character.id
+        get :edit, params: { id: character.id }
 
         expect(assigns(:page_title)).to eq("Edit Character: #{character.name}")
         expect(controller.gon.character_id).to eq(character.id)
@@ -268,21 +268,21 @@ RSpec.describe CharactersController do
 
   describe "PUT update" do
     it "requires login" do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid character id" do
       login
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("Character could not be found.")
     end
 
     it "requires character with permissions" do
       login
-      put :update, id: create(:character).id
+      put :update, params: { id: create(:character).id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("You do not have permission to edit that character.")
     end
@@ -290,7 +290,7 @@ RSpec.describe CharactersController do
     it "fails with invalid params" do
       character = create(:character)
       login_as(character.user)
-      put :update, id: character.id, character: {name: ''}
+      put :update, params: { id: character.id, character: {name: ''} }
       expect(response.status).to eq(200)
       expect(flash[:error][:message]).to eq("Your character could not be saved.")
     end
@@ -299,7 +299,7 @@ RSpec.describe CharactersController do
       character = create(:character)
       login_as(character.user)
       new_name = character.name + 'aaa'
-      put :update, id: character.id, new_template: '1', character: {template_attributes: {name: ''}, name: new_name}
+      put :update, params: { id: character.id, new_template: '1', character: {template_attributes: {name: ''}, name: new_name} }
       expect(response.status).to eq(200)
       expect(flash[:error][:message]).to eq("Your character could not be saved.")
       expect(character.reload.name).not_to eq(new_name)
@@ -312,7 +312,7 @@ RSpec.describe CharactersController do
       new_name = character.name + 'aaa'
       template = create(:template, user: user)
       gallery = create(:gallery, user: user)
-      put :update, id: character.id, character: {name: new_name, template_name: 'TemplateName', screenname: 'a-new-test', setting: 'Another World', template_id: template.id, pb: 'Actor', description: 'Description', ungrouped_gallery_ids: [gallery.id]}
+      put :update, params: { id: character.id, character: {name: new_name, template_name: 'TemplateName', screenname: 'a-new-test', setting: 'Another World', template_id: template.id, pb: 'Actor', description: 'Description', ungrouped_gallery_ids: [gallery.id]} }
 
       expect(response).to redirect_to(assigns(:character))
       expect(flash[:success]).to eq("Character saved successfully.")
@@ -333,7 +333,7 @@ RSpec.describe CharactersController do
       gallery = create(:gallery, gallery_groups: [group], user: user)
       character = create(:character, user: user)
       login_as(user)
-      put :update, id: character.id, character: {gallery_group_ids: [group.id]}
+      put :update, params: { id: character.id, character: {gallery_group_ids: [group.id]} }
 
       expect(flash[:success]).to eq('Character saved successfully.')
       character.reload
@@ -347,7 +347,7 @@ RSpec.describe CharactersController do
       expect(Template.count).to eq(0)
       character = create(:character)
       login_as(character.user)
-      put :update, id: character.id, new_template: '1', character: {template_attributes: {name: 'Test'}}
+      put :update, params: { id: character.id, new_template: '1', character: {template_attributes: {name: 'Test'}} }
       expect(Template.count).to eq(1)
       expect(Template.first.name).to eq('Test')
       expect(character.reload.template_id).to eq(Template.first.id)
@@ -363,7 +363,7 @@ RSpec.describe CharactersController do
       gallery2 = create(:gallery, gallery_groups: [group3, group4], user: user)
       character = create(:character, gallery_groups: [group1, group3, group4], user: user)
       login_as(user)
-      put :update, id: character.id, character: {gallery_group_ids: [group2.id, group4.id]}
+      put :update, params: { id: character.id, character: {gallery_group_ids: [group2.id, group4.id]} }
 
       expect(flash[:success]).to eq('Character saved successfully.')
       character.reload
@@ -383,7 +383,7 @@ RSpec.describe CharactersController do
       expect(character.characters_galleries.first).not_to be_added_by_group
 
       login_as(user)
-      put :update, id: character.id, character: {ungrouped_gallery_ids: ['']}
+      put :update, params: { id: character.id, character: {ungrouped_gallery_ids: ['']} }
       expect(flash[:success]).to eq('Character saved successfully.')
       character.reload
       expect(character.gallery_groups).to match_array([group])
@@ -399,7 +399,7 @@ RSpec.describe CharactersController do
       character = create(:character, user: user)
 
       login_as(user)
-      put :update, id: character.id, character: {gallery_group_ids: [group.id], ungrouped_gallery_ids: [gallery.id]}
+      put :update, params: { id: character.id, character: {gallery_group_ids: [group.id], ungrouped_gallery_ids: [gallery.id]} }
       expect(flash[:success]).to eq('Character saved successfully.')
       character.reload
       expect(character.gallery_groups).to match_array([group])
@@ -414,7 +414,7 @@ RSpec.describe CharactersController do
       character = create(:character)
 
       login_as(character.user)
-      put :update, id: character.id, character: {gallery_group_ids: [group.id]}
+      put :update, params: { id: character.id, character: {gallery_group_ids: [group.id]} }
       expect(flash[:success]).to eq('Character saved successfully.')
       character.reload
       expect(character.gallery_groups).to match_array([group])
@@ -428,7 +428,7 @@ RSpec.describe CharactersController do
       character = create(:character, gallery_groups: [group], user: user)
 
       login_as(user)
-      put :update, id: character.id, character: {gallery_group_ids: ['']}
+      put :update, params: { id: character.id, character: {gallery_group_ids: ['']} }
       expect(flash[:success]).to eq('Character saved successfully.')
       character.reload
       expect(character.gallery_groups).to eq([])
@@ -439,7 +439,7 @@ RSpec.describe CharactersController do
       expect(Template.count).to eq(0)
       character = create(:character)
       login_as(character.user)
-      put :update, id: character.id, new_template: '1', character: {template_attributes: {name: 'Test'}}
+      put :update, params: { id: character.id, new_template: '1', character: {template_attributes: {name: 'Test'}} }
       expect(Template.count).to eq(1)
       expect(Template.first.name).to eq('Test')
       expect(character.reload.template_id).to eq(Template.first.id)
@@ -456,7 +456,7 @@ RSpec.describe CharactersController do
         create(:template)
 
         login_as(user)
-        put :update, id: character.id, character: {name: ''}
+        put :update, params: { id: character.id, character: {name: ''} }
 
         expect(response).to render_template(:edit)
         expect(controller.gon.character_id).to eq(character.id)
@@ -480,7 +480,7 @@ RSpec.describe CharactersController do
       expect(g2_cg.section_order).to eq(1)
 
       login_as(character.user)
-      put :update, id: character.id, character: {ungrouped_gallery_ids: [g2.id.to_s]}
+      put :update, params: { id: character.id, character: {ungrouped_gallery_ids: [g2.id.to_s]} }
 
       expect(character.reload.galleries.pluck(:id)).to eq([g2.id])
       expect(g2_cg.reload.section_order).to eq(0)
@@ -503,14 +503,14 @@ RSpec.describe CharactersController do
 
     it "sets correct variables for character name sort: character only" do
       chars = Array.new(3) { create(:character, pb: SecureRandom.urlsafe_base64) }
-      get :facecasts, sort: 'name'
+      get :facecasts, params: { sort: 'name' }
       names = assigns(:pbs).map(&:item_name)
       expect(names).to match_array(chars.map(&:name))
     end
 
     it "sets correct variables for character name sort: template only" do
       chars = Array.new(3) { create(:template_character, pb: SecureRandom.urlsafe_base64) }
-      get :facecasts, sort: 'name'
+      get :facecasts, params: { sort: 'name' }
       names = assigns(:pbs).map(&:item_name)
       expect(names).to match_array(chars.map(&:template).map(&:name))
     end
@@ -518,7 +518,7 @@ RSpec.describe CharactersController do
     it "sets correct variables for character name sort: character and template mixed" do
       chars = Array.new(3) { create(:template_character, pb: SecureRandom.urlsafe_base64) }
       chars += Array.new(3) { create(:character, pb: SecureRandom.urlsafe_base64) }
-      get :facecasts, sort: 'name'
+      get :facecasts, params: { sort: 'name' }
       names = assigns(:pbs).map(&:item_name)
       expect(names).to match_array(chars.map { |c| (c.template || c).name })
     end
@@ -526,7 +526,7 @@ RSpec.describe CharactersController do
     it "sets correct variables for writer sort" do
       chars = Array.new(3) { create(:template_character, pb: SecureRandom.urlsafe_base64) }
       chars += Array.new(3) { create(:character, pb: SecureRandom.urlsafe_base64) }
-      get :facecasts, sort: 'writer'
+      get :facecasts, params: { sort: 'writer' }
       user_ids = assigns(:pbs).map(&:user_id)
       expect(user_ids).to match_array(chars.map(&:user).map(&:id))
     end
@@ -534,14 +534,14 @@ RSpec.describe CharactersController do
 
   describe "DELETE destroy" do
     it "requires login" do
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid character" do
       login
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("Character could not be found.")
     end
@@ -551,7 +551,7 @@ RSpec.describe CharactersController do
       login_as(user)
       character = create(:character)
       expect(character.user_id).not_to eq(user.id)
-      delete :destroy, id: character.id
+      delete :destroy, params: { id: character.id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("You do not have permission to edit that character.")
     end
@@ -559,7 +559,7 @@ RSpec.describe CharactersController do
     it "succeeds" do
       character = create(:character)
       login_as(character.user)
-      delete :destroy, id: character.id
+      delete :destroy, params: { id: character.id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:success]).to eq("Character deleted successfully.")
       expect(Character.find_by_id(character.id)).to be_nil
@@ -569,14 +569,14 @@ RSpec.describe CharactersController do
   describe "GET replace" do
     it "requires login" do
       character = create(:character)
-      get :replace, id: character.id
+      get :replace, params: { id: character.id }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq('You must be logged in to view that page.')
     end
 
     it "requires valid character" do
       login
-      get :replace, id: -1
+      get :replace, params: { id: -1 }
       expect(response).to redirect_to(characters_path)
       expect(flash[:error]).to eq('Character could not be found.')
     end
@@ -584,7 +584,7 @@ RSpec.describe CharactersController do
     it "requires own character" do
       character = create(:character)
       login
-      get :replace, id: character.id
+      get :replace, params: { id: character.id }
       expect(response).to redirect_to(characters_path)
       expect(flash[:error]).to eq('You do not have permission to edit that character.')
     end
@@ -602,7 +602,7 @@ RSpec.describe CharactersController do
       char_reply2 = create(:reply, user: user, character: character) # other reply
 
       login_as(user)
-      get :replace, id: character.id
+      get :replace, params: { id: character.id }
       expect(response).to have_http_status(200)
       expect(assigns(:page_title)).to eq('Replace Character: ' + character.name)
 
@@ -620,7 +620,7 @@ RSpec.describe CharactersController do
         create(:character, user: user) # other character
 
         login_as(user)
-        get :replace, id: character.id
+        get :replace, params: { id: character.id }
         expect(response).to have_http_status(200)
         expect(assigns(:page_title)).to eq('Replace Character: ' + character.name)
         expect(assigns(:alts)).to match_array(alts)
@@ -634,7 +634,7 @@ RSpec.describe CharactersController do
         create(:character, user: user) # other character
 
         login_as(user)
-        get :replace, id: character.id
+        get :replace, params: { id: character.id }
         expect(response).to have_http_status(200)
         expect(assigns(:alts)).to match_array([character])
       end
@@ -649,7 +649,7 @@ RSpec.describe CharactersController do
         create(:character, user: user, template: template) # other character
 
         login_as(user)
-        get :replace, id: character.id
+        get :replace, params: { id: character.id }
         expect(response).to have_http_status(200)
         expect(assigns(:page_title)).to eq('Replace Character: ' + character.name)
         expect(assigns(:alts)).to match_array(alts)
@@ -663,7 +663,7 @@ RSpec.describe CharactersController do
         create(:character, user: user, template: template) # other character
 
         login_as(user)
-        get :replace, id: character.id
+        get :replace, params: { id: character.id }
         expect(response).to have_http_status(200)
         expect(assigns(:alts)).to match_array([character])
       end
@@ -673,14 +673,14 @@ RSpec.describe CharactersController do
   describe "POST do_replace" do
     it "requires login" do
       character = create(:character)
-      post :do_replace, id: character.id
+      post :do_replace, params: { id: character.id }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq('You must be logged in to view that page.')
     end
 
     it "requires valid character" do
       login
-      post :do_replace, id: -1
+      post :do_replace, params: { id: -1 }
       expect(response).to redirect_to(characters_path)
       expect(flash[:error]).to eq('Character could not be found.')
     end
@@ -688,7 +688,7 @@ RSpec.describe CharactersController do
     it "requires own character" do
       character = create(:character)
       login
-      post :do_replace, id: character.id
+      post :do_replace, params: { id: character.id }
       expect(response).to redirect_to(characters_path)
       expect(flash[:error]).to eq('You do not have permission to edit that character.')
     end
@@ -696,7 +696,7 @@ RSpec.describe CharactersController do
     it "requires valid other character" do
       character = create(:character)
       login_as(character.user)
-      post :do_replace, id: character.id, icon_dropdown: -1
+      post :do_replace, params: { id: character.id, icon_dropdown: -1 }
       expect(response).to redirect_to(replace_character_path(character))
       expect(flash[:error]).to eq('Character could not be found.')
     end
@@ -705,7 +705,7 @@ RSpec.describe CharactersController do
       character = create(:character)
       other_char = create(:character)
       login_as(character.user)
-      post :do_replace, id: character.id, icon_dropdown: other_char.id
+      post :do_replace, params: { id: character.id, icon_dropdown: other_char.id }
       expect(response).to redirect_to(replace_character_path(character))
       expect(flash[:error]).to eq('That is not your character.')
     end
@@ -713,7 +713,7 @@ RSpec.describe CharactersController do
     it "requires valid new alias if parameter provided" do
       character = create(:character)
       login_as(character.user)
-      post :do_replace, id: character.id, alias_dropdown: -1
+      post :do_replace, params: { id: character.id, alias_dropdown: -1 }
       expect(response).to redirect_to(replace_character_path(character))
       expect(flash[:error]).to eq('Invalid new alias.')
     end
@@ -723,7 +723,7 @@ RSpec.describe CharactersController do
       other_char = create(:character, user: character.user)
       calias = create(:alias)
       login_as(character.user)
-      post :do_replace, id: character.id, alias_dropdown: calias.id, icon_dropdown: other_char.id
+      post :do_replace, params: { id: character.id, alias_dropdown: calias.id, icon_dropdown: other_char.id }
       expect(response).to redirect_to(replace_character_path(character))
       expect(flash[:error]).to eq('Invalid new alias.')
     end
@@ -731,7 +731,7 @@ RSpec.describe CharactersController do
     it "requires valid old alias if parameter provided" do
       character = create(:character)
       login_as(character.user)
-      post :do_replace, id: character.id, orig_alias: -1
+      post :do_replace, params: { id: character.id, orig_alias: -1 }
       expect(response).to redirect_to(replace_character_path(character))
       expect(flash[:error]).to eq('Invalid old alias.')
     end
@@ -740,7 +740,7 @@ RSpec.describe CharactersController do
       character = create(:character)
       calias = create(:alias)
       login_as(character.user)
-      post :do_replace, id: character.id, orig_alias: calias.id
+      post :do_replace, params: { id: character.id, orig_alias: calias.id }
       expect(response).to redirect_to(replace_character_path(character))
       expect(flash[:error]).to eq('Invalid old alias.')
     end
@@ -754,7 +754,7 @@ RSpec.describe CharactersController do
       reply_post_char = reply.post.character_id
 
       login_as(user)
-      post :do_replace, id: character.id, icon_dropdown: other_char.id
+      post :do_replace, params: { id: character.id, icon_dropdown: other_char.id }
       expect(response).to redirect_to(character_path(character))
       expect(flash[:success]).to eq('All uses of this character have been replaced.')
 
@@ -770,7 +770,7 @@ RSpec.describe CharactersController do
       reply = create(:reply, user: user, character: character)
 
       login_as(user)
-      post :do_replace, id: character.id
+      post :do_replace, params: { id: character.id }
       expect(response).to redirect_to(character_path(character))
       expect(flash[:success]).to eq('All uses of this character have been replaced.')
 
@@ -787,7 +787,7 @@ RSpec.describe CharactersController do
       reply = create(:reply, user: user, character: character)
 
       login_as(user)
-      post :do_replace, id: character.id, icon_dropdown: other_char.id, alias_dropdown: calias.id
+      post :do_replace, params: { id: character.id, icon_dropdown: other_char.id, alias_dropdown: calias.id }
 
       expect(char_post.reload.character_id).to eq(other_char.id)
       expect(reply.reload.character_id).to eq(other_char.id)
@@ -804,7 +804,7 @@ RSpec.describe CharactersController do
       other_post = create(:post, user: user, character: character)
 
       login_as(user)
-      post :do_replace, id: character.id, icon_dropdown: other_char.id, post_ids: [char_post.id, char_reply.post.id]
+      post :do_replace, params: { id: character.id, icon_dropdown: other_char.id, post_ids: [char_post.id, char_reply.post.id] }
       expect(response).to redirect_to(character_path(character))
       expect(flash[:success]).to eq('All uses of this character in the specified posts have been replaced.')
 
@@ -822,7 +822,7 @@ RSpec.describe CharactersController do
       char_reply = create(:reply, user: user, character: character, character_alias_id: calias.id)
 
       login_as(user)
-      post :do_replace, id: character.id, icon_dropdown: other_char.id, orig_alias: calias.id
+      post :do_replace, params: { id: character.id, icon_dropdown: other_char.id, orig_alias: calias.id }
 
       expect(char_post.reload.character_id).to eq(character.id)
       expect(char_reply.reload.character_id).to eq(other_char.id)
@@ -837,7 +837,7 @@ RSpec.describe CharactersController do
       char_reply = create(:reply, user: user, character: character, character_alias_id: calias.id)
 
       login_as(user)
-      post :do_replace, id: character.id, icon_dropdown: other_char.id, orig_alias: ''
+      post :do_replace, params: { id: character.id, icon_dropdown: other_char.id, orig_alias: '' }
 
       expect(char_post.reload.character_id).to eq(other_char.id)
       expect(char_reply.reload.character_id).to eq(character.id)
@@ -852,7 +852,7 @@ RSpec.describe CharactersController do
       char_reply = create(:reply, user: user, character: character, character_alias_id: calias.id)
 
       login_as(user)
-      post :do_replace, id: character.id, icon_dropdown: other_char.id, orig_alias: 'all'
+      post :do_replace, params: { id: character.id, icon_dropdown: other_char.id, orig_alias: 'all' }
 
       expect(char_post.reload.character_id).to eq(other_char.id)
       expect(char_reply.reload.character_id).to eq(other_char.id)
@@ -878,7 +878,7 @@ RSpec.describe CharactersController do
       author = create(:user)
       found = create(:character, user: author)
       notfound = create(:character, user: create(:user))
-      get :search, commit: true, author_id: author.id
+      get :search, params: { commit: true, author_id: author.id }
       expect(response).to have_http_status(200)
       expect(assigns(:users)).to match_array([author])
       expect(assigns(:search_results)).to match_array([found])
@@ -886,7 +886,7 @@ RSpec.describe CharactersController do
 
     it "doesn't search missing author" do
       character = create(:template_character)
-      get :search, commit: true, author_id: 9999
+      get :search, params: { commit: true, author_id: 9999 }
       expect(response).to have_http_status(200)
       expect(flash[:error]).to eq('The specified author could not be found.')
       expect(assigns(:users)).to be_empty
@@ -897,13 +897,13 @@ RSpec.describe CharactersController do
       author = create(:user)
       template = create(:template, user: author)
       create(:template)
-      get :search, commit: true, author_id: author.id
+      get :search, params: { commit: true, author_id: author.id }
       expect(assigns(:templates)).to eq([template])
     end
 
     it "doesn't search missing template" do
       character = create(:template_character)
-      get :search, commit: true, template_id: 9999
+      get :search, params: { commit: true, template_id: 9999 }
       expect(response).to have_http_status(200)
       expect(flash[:error]).to eq('The specified template could not be found.')
       expect(assigns(:templates)).to be_empty
@@ -913,7 +913,7 @@ RSpec.describe CharactersController do
     it "doesn't search author/template mismatch" do
       character = create(:template_character)
       character2 = create(:character)
-      get :search, commit: true, template_id: character.template_id, author_id: character2.user_id
+      get :search, params: { commit: true, template_id: character.template_id, author_id: character2.user_id }
       expect(response).to have_http_status(200)
       expect(flash[:error]).to eq('The specified author and template do not match; template filter will be ignored.')
       expect(assigns(:templates)).to be_empty
@@ -925,7 +925,7 @@ RSpec.describe CharactersController do
       template = create(:template, user: author)
       found = create(:character, user: author, template: template)
       notfound = create(:character, user: author, template: create(:template, user: author))
-      get :search, commit: true, template_id: template.id
+      get :search, params: { commit: true, template_id: template.id }
       expect(response).to have_http_status(200)
       expect(assigns(:templates)).to match_array([template])
       expect(assigns(:search_results)).to match_array([found])
@@ -939,37 +939,37 @@ RSpec.describe CharactersController do
       end
 
       it "searches names correctly" do
-        get :search, commit: true, name: 'a', search_name: true
+        get :search, params: { commit: true, name: 'a', search_name: true }
         expect(assigns(:search_results)).to match_array([@name])
       end
 
       it "searches screenname correctly" do
-        get :search, commit: true, name: 'a', search_screenname: true
+        get :search, params: { commit: true, name: 'a', search_screenname: true }
         expect(assigns(:search_results)).to match_array([@screenname])
       end
 
       it "searches nickname correctly" do
-        get :search, commit: true, name: 'a', search_nickname: true
+        get :search, params: { commit: true, name: 'a', search_nickname: true }
         expect(assigns(:search_results)).to match_array([@nickname])
       end
 
       it "searches name + screenname correctly" do
-        get :search, commit: true, name: 'a', search_name: true, search_screenname: true
+        get :search, params: { commit: true, name: 'a', search_name: true, search_screenname: true }
         expect(assigns(:search_results)).to match_array([@name, @screenname])
       end
 
       it "searches name + nickname correctly" do
-        get :search, commit: true, name: 'a', search_name: true, search_nickname: true
+        get :search, params: { commit: true, name: 'a', search_name: true, search_nickname: true }
         expect(assigns(:search_results)).to match_array([@name, @nickname])
       end
 
       it "searches nickname + screenname correctly" do
-        get :search, commit: true, name: 'a', search_nickname: true, search_screenname: true
+        get :search, params: { commit: true, name: 'a', search_nickname: true, search_screenname: true }
         expect(assigns(:search_results)).to match_array([@nickname, @screenname])
       end
 
       it "searches all correctly" do
-        get :search, commit: true, name: 'a', search_name: true, search_screenname: true, search_nickname: true
+        get :search, params: { commit: true, name: 'a', search_name: true, search_screenname: true, search_nickname: true }
         expect(assigns(:search_results)).to match_array([@name, @screenname, @nickname])
       end
     end
@@ -977,21 +977,21 @@ RSpec.describe CharactersController do
 
   describe "POST duplicate" do
     it "requires login" do
-      post :duplicate, id: -1
+      post :duplicate, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq('You must be logged in to view that page.')
     end
 
     it "requires valid character id" do
       login
-      post :duplicate, id: -1
+      post :duplicate, params: { id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq('Character could not be found.')
     end
 
     it "requires character with permissions" do
       login
-      post :duplicate, id: create(:character).id
+      post :duplicate, params: { id: create(:character).id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq('You do not have permission to edit that character.')
     end
@@ -1017,7 +1017,7 @@ RSpec.describe CharactersController do
 
       login_as(user)
       expect do
-        post :duplicate, id: character.id
+        post :duplicate, params: { id: character.id }
       end.to not_change {
         [Template.count, Gallery.count, Icon.count, Reply.count, Post.count, Tag.count]
       }.and change { Character.count }.by(1).and change { CharactersGallery.count }.by(3).and change { CharacterTag.count }.by(1)

--- a/spec/controllers/favorites_controller_spec.rb
+++ b/spec/controllers/favorites_controller_spec.rb
@@ -123,21 +123,21 @@ RSpec.describe FavoritesController do
 
     it "requires valid user if given" do
       login
-      post :create, user_id: -1
+      post :create, params: { user_id: -1 }
       expect(response).to redirect_to(users_path)
       expect(flash[:error]).to eq('User could not be found.')
     end
 
     it "requires valid post if given" do
       login
-      post :create, post_id: -1
+      post :create, params: { post_id: -1 }
       expect(response).to redirect_to(posts_path)
       expect(flash[:error]).to eq('Post could not be found.')
     end
 
     it "requires valid board if given" do
       login
-      post :create, board_id: -1
+      post :create, params: { board_id: -1 }
       expect(response).to redirect_to(boards_path)
       expect(flash[:error]).to eq('Continuity could not be found.')
     end
@@ -146,7 +146,7 @@ RSpec.describe FavoritesController do
       user = create(:user)
       fav = create(:user)
       login_as(user)
-      post :create, user_id: fav.id
+      post :create, params: { user_id: fav.id }
       expect(Favorite.between(user, fav)).not_to be_nil
       expect(response).to redirect_to(user_url(fav))
       expect(flash[:success]).to eq("Your favorite has been saved.")
@@ -156,7 +156,7 @@ RSpec.describe FavoritesController do
       user = create(:user)
       fav = create(:post)
       login_as(user)
-      post :create, post_id: fav.id
+      post :create, params: { post_id: fav.id }
       expect(Favorite.between(user, fav)).not_to be_nil
       expect(response).to redirect_to(post_url(fav))
       expect(flash[:success]).to eq("Your favorite has been saved.")
@@ -166,7 +166,7 @@ RSpec.describe FavoritesController do
       user = create(:user)
       fav = create(:post)
       login_as(user)
-      post :create, post_id: fav.id, page: 3, per_page: 10
+      post :create, params: { post_id: fav.id, page: 3, per_page: 10 }
       expect(Favorite.between(user, fav)).not_to be_nil
       expect(response).to redirect_to(post_url(fav, page: 3, per_page: 10))
       expect(flash[:success]).to eq("Your favorite has been saved.")
@@ -176,7 +176,7 @@ RSpec.describe FavoritesController do
       user = create(:user)
       fav = create(:post)
       login_as(user)
-      post :create, post_id: fav.id, page: 1, per_page: 25
+      post :create, params: { post_id: fav.id, page: 1, per_page: 25 }
       expect(Favorite.between(user, fav)).not_to be_nil
       expect(response).to redirect_to(post_url(fav))
       expect(flash[:success]).to eq("Your favorite has been saved.")
@@ -186,7 +186,7 @@ RSpec.describe FavoritesController do
       user = create(:user)
       board = create(:board)
       login_as(user)
-      post :create, board_id: board.id
+      post :create, params: { board_id: board.id }
       expect(Favorite.between(user, board)).not_to be_nil
       expect(response).to redirect_to(board_url(board))
       expect(flash[:success]).to eq("Your favorite has been saved.")
@@ -195,21 +195,21 @@ RSpec.describe FavoritesController do
 
   describe "DELETE destroy" do
     it "requires login" do
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid favorite" do
       login
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(favorites_url)
       expect(flash[:error]).to eq("Favorite could not be found.")
     end
 
     it "requires your favorite" do
       login
-      delete :destroy, id: create(:favorite, favorite: create(:user)).id
+      delete :destroy, params: { id: create(:favorite, favorite: create(:user)).id }
       expect(response).to redirect_to(favorites_url)
       expect(flash[:error]).to eq("That is not your favorite.")
     end
@@ -217,7 +217,7 @@ RSpec.describe FavoritesController do
     it "destroys board favorite" do
       favorite = create(:favorite, favorite: create(:board))
       login_as(favorite.user)
-      delete :destroy, id: favorite.id
+      delete :destroy, params: { id: favorite.id }
       expect(response).to redirect_to(board_url(favorite.favorite))
       expect(flash[:success]).to eq("Favorite removed.")
     end
@@ -225,7 +225,7 @@ RSpec.describe FavoritesController do
     it "destroys post favorite" do
       favorite = create(:favorite, favorite: create(:post))
       login_as(favorite.user)
-      delete :destroy, id: favorite.id
+      delete :destroy, params: { id: favorite.id }
       expect(response).to redirect_to(post_url(favorite.favorite))
       expect(flash[:success]).to eq("Favorite removed.")
     end
@@ -233,7 +233,7 @@ RSpec.describe FavoritesController do
     it "destroys user favorite" do
       favorite = create(:favorite, favorite: create(:user))
       login_as(favorite.user)
-      delete :destroy, id: favorite.id
+      delete :destroy, params: { id: favorite.id }
       expect(response).to redirect_to(user_url(favorite.favorite))
       expect(flash[:success]).to eq("Favorite removed.")
     end

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe GalleriesController do
     context "with a user_id" do
       it "does not require login" do
         user = create(:user)
-        get :index, user_id: user.id
+        get :index, params: { user_id: user.id }
         expect(response.status).to eq(200)
         expect(assigns(:user)).to eq(user)
         expect(assigns(:page_title)).to eq("#{user.username}'s Galleries")
@@ -31,14 +31,14 @@ RSpec.describe GalleriesController do
       it "defaults to current user if user id invalid" do
         user = create(:user)
         login_as(user)
-        get :index, user_id: -1
+        get :index, params: { user_id: -1 }
         expect(response.status).to eq(200)
         expect(assigns(:user)).to eq(user)
         expect(assigns(:page_title)).to eq('Your Galleries')
       end
 
       it "displays error if user id invalid and logged out" do
-        get :index, user_id: -1
+        get :index, params: { user_id: -1 }
         expect(flash[:error]).to eq('User could not be found.')
         expect(response).to redirect_to(root_url)
       end
@@ -75,7 +75,7 @@ RSpec.describe GalleriesController do
         icon = create(:icon)
         group = create(:gallery_group)
         login_as(icon.user)
-        post :create, gallery: {gallery_group_ids: [group.id], icon_ids: [icon.id]}
+        post :create, params: { gallery: {gallery_group_ids: [group.id], icon_ids: [icon.id]} }
         expect(response.status).to eq(200)
         expect(response).to render_template(:new)
         expect(assigns(:page_title)).to eq('New Gallery')
@@ -89,7 +89,7 @@ RSpec.describe GalleriesController do
     it "does not set icon has_gallery on failure" do
       icon = create(:icon)
       login_as(icon.user)
-      post :create, gallery: {icon_ids: [icon.id]}
+      post :create, params: { gallery: {icon_ids: [icon.id]} }
       expect(response).to have_http_status(200)
       expect(assigns(:page_title)).to eq('New Gallery')
       expect(flash[:error]).to eq('Your gallery could not be saved.')
@@ -101,7 +101,7 @@ RSpec.describe GalleriesController do
       icon = create(:icon)
       group = create(:gallery_group)
       login_as(icon.user)
-      post :create, gallery: {name: 'Test Gallery', icon_ids: [icon.id], gallery_group_ids: [group.id]}
+      post :create, params: { gallery: {name: 'Test Gallery', icon_ids: [icon.id], gallery_group_ids: [group.id]} }
       expect(Gallery.count).to eq(1)
       gallery = assigns(:gallery).reload
       expect(response).to redirect_to(gallery_url(gallery))
@@ -118,7 +118,7 @@ RSpec.describe GalleriesController do
       tags = ['_atag', '_atag', create(:gallery_group).id, '', '_' + existing_name.name, '_' + existing_case.name.upcase]
       login
       expect {
-        post :create, gallery: {name: 'a', gallery_group_ids: tags}
+        post :create, params: { gallery: {name: 'a', gallery_group_ids: tags} }
       }.to change{GalleryGroup.count}.by(1)
       expect(GalleryGroup.last.name).to eq('atag')
       expect(assigns(:gallery).gallery_groups.count).to eq(4)
@@ -129,7 +129,7 @@ RSpec.describe GalleriesController do
     context "with zero gallery id" do
       context "with user id" do
         it "requires valid user" do
-          get :show, id: '0', user_id: -1
+          get :show, params: { id: '0', user_id: -1 }
           expect(response).to redirect_to(root_url)
           expect(flash[:error]).to eq('User could not be found.')
         end
@@ -138,7 +138,7 @@ RSpec.describe GalleriesController do
           user = create(:user)
           gallery_user = create(:user)
           login_as(user)
-          get :show, id: '0', user_id: gallery_user.id
+          get :show, params: { id: '0', user_id: gallery_user.id }
           expect(response).to render_template('show')
           expect(assigns(:page_title)).to eq('Galleryless Icons')
           expect(assigns(:user)).to eq(gallery_user)
@@ -146,7 +146,7 @@ RSpec.describe GalleriesController do
 
         it "succeeds when logged out" do
           user = create(:user)
-          get :show, id: '0', user_id: user.id
+          get :show, params: { id: '0', user_id: user.id }
           expect(response).to render_template('show')
           expect(assigns(:page_title)).to eq('Galleryless Icons')
           expect(assigns(:user)).to eq(user)
@@ -155,7 +155,7 @@ RSpec.describe GalleriesController do
 
       context "without user id" do
         it "requires login" do
-          get :show, id: '0'
+          get :show, params: { id: '0' }
           expect(response).to redirect_to(root_url)
           expect(flash[:error]).to eq("You must be logged in to view that page.")
         end
@@ -163,7 +163,7 @@ RSpec.describe GalleriesController do
         it "succeeds when logged in" do
           user = create(:user)
           login_as(user)
-          get :show, id: '0'
+          get :show, params: { id: '0' }
           expect(response).to render_template('show')
           expect(assigns(:page_title)).to eq('Galleryless Icons')
           expect(assigns(:user)).to eq(user)
@@ -173,21 +173,21 @@ RSpec.describe GalleriesController do
 
     context "with normal gallery id" do
       it "requires valid gallery id" do
-        get :show, id: -1
+        get :show, params: { id: -1 }
         expect(response).to redirect_to(galleries_url)
         expect(flash[:error]).to eq('Gallery could not be found.')
       end
 
       it "successfully loads logged out" do
         gallery = create(:gallery)
-        get :show, id: gallery.id
+        get :show, params: { id: gallery.id }
         expect(response.status).to eq(200)
       end
 
       it "successfully loads logged in" do
         gallery = create(:gallery)
         login
-        get :show, id: gallery.id
+        get :show, params: { id: gallery.id }
         expect(response.status).to eq(200)
       end
     end
@@ -195,14 +195,14 @@ RSpec.describe GalleriesController do
 
   describe "GET edit" do
     it "requires login" do
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid gallery" do
       login
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("Gallery could not be found.")
     end
@@ -211,7 +211,7 @@ RSpec.describe GalleriesController do
       user_id = login
       gallery = create(:gallery)
       expect(gallery.user_id).not_to eq(user_id)
-      get :edit, id: gallery.id
+      get :edit, params: { id: gallery.id }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("That is not your gallery.")
     end
@@ -222,7 +222,7 @@ RSpec.describe GalleriesController do
         user_id = login
         group = create(:gallery_group)
         gallery = create(:gallery, user_id: user_id, gallery_groups: [group])
-        get :edit, id: gallery.id
+        get :edit, params: { id: gallery.id }
         expect(response.status).to eq(200)
         expect(assigns(:gallery_groups)).to match_array([group])
       end
@@ -231,14 +231,14 @@ RSpec.describe GalleriesController do
 
   describe "PUT update" do
     it "requires login" do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid gallery" do
       login
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("Gallery could not be found.")
     end
@@ -247,7 +247,7 @@ RSpec.describe GalleriesController do
       user_id = login
       gallery = create(:gallery)
       expect(gallery.user_id).not_to eq(user_id)
-      put :update, id: gallery.id
+      put :update, params: { id: gallery.id }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("That is not your gallery.")
     end
@@ -256,7 +256,7 @@ RSpec.describe GalleriesController do
       user = create(:user)
       gallery = create(:gallery, user: user)
       login_as(user)
-      put :update, id: gallery.id, gallery: {name: ''}
+      put :update, params: { id: gallery.id, gallery: {name: ''} }
       expect(response).to render_template('edit')
       expect(flash[:error][:message]).to eq("Gallery could not be saved.")
     end
@@ -264,7 +264,7 @@ RSpec.describe GalleriesController do
     it "sets right variables on failed save" do
       gallery = create(:gallery, name: 'Example Gallery')
       login_as(gallery.user)
-      post :update, id: gallery.id, gallery: {name: ''}
+      post :update, params: { id: gallery.id, gallery: {name: ''} }
       expect(response.status).to eq(200)
       expect(response).to render_template(:edit)
       expect(assigns(:page_title)).to eq('Edit Gallery: Example Gallery')
@@ -279,7 +279,7 @@ RSpec.describe GalleriesController do
         icon = create(:icon, user: gallery.user)
         group = create(:gallery_group)
         login_as(gallery.user)
-        post :update, id: gallery.id, gallery: {name: '', gallery_group_ids: [group.id]}
+        post :update, params: { id: gallery.id, gallery: {name: '', gallery_group_ids: [group.id]} }
         expect(response.status).to eq(200)
         expect(response).to render_template(:edit)
         expect(assigns(:gallery).gallery_groups.map(&:id)).to eq([group.id])
@@ -292,7 +292,7 @@ RSpec.describe GalleriesController do
       gallery = create(:gallery, user: user)
       group = create(:gallery_group)
       login_as(user)
-      put :update, id: gallery.id, gallery: {name: 'NewGalleryName', gallery_group_ids: [group.id]}
+      put :update, params: { id: gallery.id, gallery: {name: 'NewGalleryName', gallery_group_ids: [group.id]} }
       expect(response).to redirect_to(edit_gallery_url(gallery))
       expect(flash[:success]).to eq('Gallery saved.')
       gallery.reload
@@ -312,7 +312,7 @@ RSpec.describe GalleriesController do
       gid = gallery.galleries_icons.first.id
       gallery_icon_attributes = {id: gid, icon_attributes: icon_attributes}
 
-      put :update, id: gallery.id, gallery: {galleries_icons_attributes: {gid.to_s => gallery_icon_attributes}}
+      put :update, params: { id: gallery.id, gallery: {galleries_icons_attributes: {gid.to_s => gallery_icon_attributes}} }
       expect(response).to redirect_to(edit_gallery_url(gallery))
       expect(flash[:success]).to eq('Gallery saved.')
       expect(icon.reload.keyword).to eq(newkey)
@@ -330,7 +330,7 @@ RSpec.describe GalleriesController do
       gid = gallery.galleries_icons.first.id
       gallery_icon_attributes = {id: gid, _destroy: '1', icon_attributes: icon_attributes}
 
-      put :update, id: gallery.id, gallery: {galleries_icons_attributes: {gid.to_s => gallery_icon_attributes}}
+      put :update, params: { id: gallery.id, gallery: {galleries_icons_attributes: {gid.to_s => gallery_icon_attributes}} }
       expect(response).to redirect_to(edit_gallery_url(gallery))
       expect(flash[:success]).to eq('Gallery saved.')
       expect(gallery.reload.icons).to be_empty
@@ -349,7 +349,7 @@ RSpec.describe GalleriesController do
       gid = gallery.galleries_icons.first.id
       gallery_icon_attributes = {id: gid, icon_attributes: icon_attributes}
 
-      put :update, id: gallery.id, gallery: {galleries_icons_attributes: {gid.to_s => gallery_icon_attributes}}
+      put :update, params: { id: gallery.id, gallery: {galleries_icons_attributes: {gid.to_s => gallery_icon_attributes}} }
       expect(response).to redirect_to(edit_gallery_url(gallery))
       expect(flash[:success]).to eq('Gallery saved.')
       expect(gallery.reload.icons).to be_empty
@@ -363,7 +363,7 @@ RSpec.describe GalleriesController do
       login_as(gallery.user)
       tags = ['_atag', '_atag', create(:gallery_group).id, '', '_' + existing_name.name, '_' + existing_case.name.upcase]
       expect {
-        post :update, id: gallery.id, gallery: {gallery_group_ids: tags}
+        post :update, params: { id: gallery.id, gallery: {gallery_group_ids: tags} }
       }.to change{GalleryGroup.count}.by(1)
       expect(GalleryGroup.last.name).to eq('atag')
       expect(assigns(:gallery).gallery_groups.count).to eq(4)
@@ -372,14 +372,14 @@ RSpec.describe GalleriesController do
 
   describe "DELETE destroy" do
     it "requires login" do
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid gallery" do
       login
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("Gallery could not be found.")
     end
@@ -388,7 +388,7 @@ RSpec.describe GalleriesController do
       user_id = login
       gallery = create(:gallery)
       expect(gallery.user_id).not_to eq(user_id)
-      delete :destroy, id: gallery.id
+      delete :destroy, params: { id: gallery.id }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("That is not your gallery.")
     end
@@ -396,7 +396,7 @@ RSpec.describe GalleriesController do
     it "successfully destroys" do
       user_id = login
       gallery = create(:gallery, user_id: user_id)
-      delete :destroy, id: gallery.id
+      delete :destroy, params: { id: gallery.id }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:success]).to eq("Gallery deleted successfully.")
       expect(Gallery.find_by_id(gallery.id)).to be_nil
@@ -409,7 +409,7 @@ RSpec.describe GalleriesController do
       gallery.icons << icon
       gallery.save
       expect(icon.reload.has_gallery).to eq(true)
-      delete :destroy, id: gallery.id
+      delete :destroy, params: { id: gallery.id }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:success]).to eq("Gallery deleted successfully.")
       expect(icon.reload.has_gallery).not_to eq(true)
@@ -429,14 +429,14 @@ RSpec.describe GalleriesController do
     end
 
     it "requires login" do
-      get :add, id: -1
+      get :add, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid gallery" do
       login
-      get :add, id: -1
+      get :add, params: { id: -1 }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("Gallery could not be found.")
     end
@@ -445,7 +445,7 @@ RSpec.describe GalleriesController do
       user_id = login
       gallery = create(:gallery)
       expect(gallery.user_id).not_to eq(user_id)
-      get :add, id: gallery.id
+      get :add, params: { id: gallery.id }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("That is not your gallery.")
     end
@@ -453,7 +453,7 @@ RSpec.describe GalleriesController do
     it "correctly stubs S3 bucket for devs without local buckets" do
       stub_const("S3_BUCKET", nil)
       login
-      get :add, id: 0
+      get :add, params: { id: 0 }
       expect(response).to render_template('add')
       expect(assigns(:page_title)).to eq("Add Icons")
       expect(assigns(:s3_direct_post)).to be_a(Struct)
@@ -462,7 +462,7 @@ RSpec.describe GalleriesController do
     it "supports galleryless" do
       handle_s3_bucket
       login
-      get :add, id: 0
+      get :add, params: { id: 0 }
       expect(response).to render_template('add')
       expect(assigns(:page_title)).to eq("Add Icons")
       expect(assigns(:s3_direct_post)).not_to be_nil
@@ -472,7 +472,7 @@ RSpec.describe GalleriesController do
       handle_s3_bucket
       gallery = create(:gallery)
       login_as(gallery.user)
-      get :add, id: gallery.id
+      get :add, params: { id: gallery.id }
       expect(response).to render_template('add')
       expect(assigns(:page_title)).to eq("Add Icons: #{gallery.name}")
       expect(assigns(:s3_direct_post)).not_to be_nil
@@ -481,7 +481,7 @@ RSpec.describe GalleriesController do
     it "supports existing view for normal gallery" do
       gallery = create(:gallery)
       login_as(gallery.user)
-      get :add, id: gallery.id, type: 'existing'
+      get :add, params: { id: gallery.id, type: 'existing' }
       expect(response).to render_template('add')
       expect(assigns(:page_title)).to eq("Add Icons: #{gallery.name}")
       expect(assigns(:s3_direct_post)).to be_nil
@@ -489,7 +489,7 @@ RSpec.describe GalleriesController do
 
     it "doesn't support existing view for galleryless" do
       login
-      get :add, id: 0, type: 'existing'
+      get :add, params: { id: 0, type: 'existing' }
       expect(response).to redirect_to(gallery_url(0))
       expect(flash[:error]).to eq('Cannot add existing icons to galleryless. Please remove from existing galleries instead.')
     end
@@ -497,14 +497,14 @@ RSpec.describe GalleriesController do
 
   describe "POST icon" do
     it "requires login" do
-      post :icon, id: -1
+      post :icon, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid gallery" do
       login
-      post :icon, id: -1
+      post :icon, params: { id: -1 }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq('Gallery could not be found.')
     end
@@ -512,7 +512,7 @@ RSpec.describe GalleriesController do
     it "requires your gallery" do
       gallery = create(:gallery)
       login
-      post :icon, id: gallery.id
+      post :icon, params: { id: gallery.id }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq('That is not your gallery.')
     end
@@ -524,7 +524,7 @@ RSpec.describe GalleriesController do
         gallery = create(:gallery, user_id: user_id, icon_ids: [icon.id])
         expect(gallery.icons).to match_array([icon])
 
-        post :icon, id: 0, image_ids: icon.id.to_s
+        post :icon, params: { id: 0, image_ids: icon.id.to_s }
         expect(response).to redirect_to(galleries_url)
         expect(flash[:error]).to eq('Gallery could not be found.')
       end
@@ -534,7 +534,7 @@ RSpec.describe GalleriesController do
         gallery = create(:gallery)
         login_as(gallery.user)
 
-        post :icon, id: gallery.id, image_ids: icon.id.to_s
+        post :icon, params: { id: gallery.id, image_ids: icon.id.to_s }
         expect(response).to redirect_to(gallery_path(gallery))
         expect(flash[:success]).to eq('Icons added to gallery successfully.')
         expect(icon.reload.has_gallery).not_to eq(true)
@@ -548,7 +548,7 @@ RSpec.describe GalleriesController do
         expect(gallery.galleries_icons.count).to eq(1)
         login_as(gallery.user)
 
-        post :icon, id: gallery.id, image_ids: icon.id.to_s
+        post :icon, params: { id: gallery.id, image_ids: icon.id.to_s }
         expect(response).to redirect_to(gallery_path(gallery))
         expect(flash[:success]).to eq('Icons added to gallery successfully.')
         expect(icon.reload.has_gallery).to eq(true)
@@ -564,7 +564,7 @@ RSpec.describe GalleriesController do
         expect(icon2.has_gallery).not_to eq(true)
 
         login_as(user)
-        post :icon, id: gallery.id, image_ids: "#{icon1.id},#{icon2.id}"
+        post :icon, params: { id: gallery.id, image_ids: "#{icon1.id},#{icon2.id}" }
         expect(response).to redirect_to(gallery_path(gallery))
         expect(flash[:success]).to eq('Icons added to gallery successfully.')
         expect(icon1.reload.has_gallery).to eq(true)
@@ -582,7 +582,7 @@ RSpec.describe GalleriesController do
         expect(gallery2.icons).to be_empty
 
         login_as(user)
-        post :icon, id: gallery2.id, image_ids: "#{icon1.id},#{icon2.id}"
+        post :icon, params: { id: gallery2.id, image_ids: "#{icon1.id},#{icon2.id}" }
         expect(response).to redirect_to(gallery_path(gallery2))
         expect(flash[:success]).to eq('Icons added to gallery successfully.')
         expect(icon1.reload.has_gallery).to eq(true)
@@ -596,7 +596,7 @@ RSpec.describe GalleriesController do
       it "requires icons" do
         gallery = create(:gallery)
         login_as(gallery.user)
-        post :icon, id: gallery.id, icons: []
+        post :icon, params: { id: gallery.id, icons: [] }
         expect(response).to render_template(:add)
         expect(flash[:error]).to eq('You have to enter something.')
       end
@@ -614,7 +614,7 @@ RSpec.describe GalleriesController do
           {keyword: '', url: '', credit: ''}
         ]
 
-        post :icon, id: gallery.id, icons: icons
+        post :icon, params: { id: gallery.id, icons: icons }
         expect(response).to render_template(:add)
         expect(flash[:error][:message]).to eq('Your icons could not be saved.')
         expect(assigns(:icons).length).to eq(icons.length-1) # removes blank icons
@@ -637,7 +637,7 @@ RSpec.describe GalleriesController do
           {keyword: 'test2', url: "https://d1anwqy6ci9o1i.cloudfront.net/users/#{user.id}/icons/nonsense-fakeimg.png"}
         ]
 
-        post :icon, id: gallery.id, icons: icons
+        post :icon, params: { id: gallery.id, icons: icons }
         expect(response).to redirect_to(gallery_path(gallery))
         expect(flash[:success]).to eq('Icons saved successfully.')
 
@@ -662,7 +662,7 @@ RSpec.describe GalleriesController do
           {keyword: 'test2', url: "https://d1anwqy6ci9o1i.cloudfront.net/users/#{user.id}/icons/nonsense-fakeimg.png"}
         ]
 
-        post :icon, id: 0, icons: icons
+        post :icon, params: { id: 0, icons: icons }
         expect(response).to redirect_to(gallery_path(id: 0))
         expect(flash[:success]).to eq('Icons saved successfully.')
 

--- a/spec/controllers/icons_controller_spec.rb
+++ b/spec/controllers/icons_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe IconsController do
       icon = create(:icon)
       icon.destroy
       login
-      delete :delete_multiple, marked_ids: [0, '0', 'abc', -1, '-1', icon.id]
+      delete :delete_multiple, params: { marked_ids: [0, '0', 'abc', -1, '-1', icon.id] }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("No icons selected.")
     end
@@ -30,7 +30,7 @@ RSpec.describe IconsController do
 
       it "requires gallery" do
         icon = create(:icon, user: user)
-        delete :delete_multiple, marked_ids: [icon.id], gallery_delete: true
+        delete :delete_multiple, params: { marked_ids: [icon.id], gallery_delete: true }
         expect(response).to redirect_to(galleries_url)
         expect(flash[:error]).to eq("Gallery could not be found.")
       end
@@ -38,7 +38,7 @@ RSpec.describe IconsController do
       it "requires your gallery" do
         icon = create(:icon, user: user)
         gallery = create(:gallery)
-        delete :delete_multiple, marked_ids: [icon.id], gallery_id: gallery.id, gallery_delete: true
+        delete :delete_multiple, params: { marked_ids: [icon.id], gallery_id: gallery.id, gallery_delete: true }
         expect(response).to redirect_to(galleries_url)
         expect(flash[:error]).to eq("That is not your gallery.")
       end
@@ -49,7 +49,7 @@ RSpec.describe IconsController do
         gallery.icons << icon
         icon.reload
         expect(icon.galleries.count).to eq(1)
-        delete :delete_multiple, marked_ids: [icon.id], gallery_id: gallery.id, gallery_delete: true
+        delete :delete_multiple, params: { marked_ids: [icon.id], gallery_id: gallery.id, gallery_delete: true }
         icon.reload
         expect(icon.galleries.count).to eq(1)
       end
@@ -59,7 +59,7 @@ RSpec.describe IconsController do
         gallery = create(:gallery, user: user)
         gallery.icons << icon
         expect(icon.galleries.count).to eq(1)
-        delete :delete_multiple, marked_ids: [icon.id], gallery_id: gallery.id, gallery_delete: true
+        delete :delete_multiple, params: { marked_ids: [icon.id], gallery_id: gallery.id, gallery_delete: true }
         expect(icon.galleries.count).to eq(0)
         expect(response).to redirect_to(gallery_url(gallery))
         expect(flash[:success]).to eq("Icons removed from gallery.")
@@ -70,7 +70,7 @@ RSpec.describe IconsController do
         gallery = create(:gallery, user: user)
         gallery.icons << icon
         expect(icon.galleries.count).to eq(1)
-        delete :delete_multiple, marked_ids: [icon.id.to_s], gallery_id: gallery.id, gallery_delete: true
+        delete :delete_multiple, params: { marked_ids: [icon.id.to_s], gallery_id: gallery.id, gallery_delete: true }
         expect(icon.galleries.count).to eq(0)
         expect(response).to redirect_to(gallery_url(gallery))
         expect(flash[:success]).to eq("Icons removed from gallery.")
@@ -83,20 +83,20 @@ RSpec.describe IconsController do
 
       it "skips other people's icons" do
         icon = create(:icon)
-        delete :delete_multiple, marked_ids: [icon.id]
+        delete :delete_multiple, params: { marked_ids: [icon.id] }
         icon.reload
       end
 
       it "removes int ids from gallery" do
         icon = create(:icon, user: user)
-        delete :delete_multiple, marked_ids: [icon.id]
+        delete :delete_multiple, params: { marked_ids: [icon.id] }
         expect(Icon.find_by_id(icon.id)).to be_nil
       end
 
       it "removes string ids from gallery" do
         icon = create(:icon, user: user)
         icon2 = create(:icon, user: user)
-        delete :delete_multiple, marked_ids: [icon.id.to_s, icon2.id.to_s]
+        delete :delete_multiple, params: { marked_ids: [icon.id.to_s, icon2.id.to_s] }
         expect(Icon.find_by_id(icon.id)).to be_nil
         expect(Icon.find_by_id(icon2.id)).to be_nil
       end
@@ -105,14 +105,14 @@ RSpec.describe IconsController do
 
   describe "GET show" do
     it "requires valid icon" do
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("Icon could not be found.")
     end
 
     it "successfully loads when logged out" do
       icon = create(:icon)
-      get :show, id: icon.id
+      get :show, params: { id: icon.id }
       expect(response).to have_http_status(200)
       expect(assigns(:posts)).to be_nil
     end
@@ -120,7 +120,7 @@ RSpec.describe IconsController do
     it "successfully loads when logged in" do
       login
       icon = create(:icon)
-      get :show, id: icon.id
+      get :show, params: { id: icon.id }
       expect(response).to have_http_status(200)
       expect(assigns(:posts)).to be_nil
     end
@@ -138,14 +138,14 @@ RSpec.describe IconsController do
       end
 
       it "loads posts logged out" do
-        get :show, id: icon.id, view: 'posts'
+        get :show, params: { id: icon.id, view: 'posts' }
         expect(response).to have_http_status(200)
         expect(assigns(:posts)).to match_array([post, other_post])
       end
 
       it "loads posts logged in" do
         login
-        get :show, id: icon.id, view: 'posts'
+        get :show, params: { id: icon.id, view: 'posts' }
         expect(response).to have_http_status(200)
         expect(assigns(:posts)).to match_array([post, other_post])
       end
@@ -160,14 +160,14 @@ RSpec.describe IconsController do
       end
 
       it "loads logged out" do
-        get :show, id: icon.id, view: 'galleries'
+        get :show, params: { id: icon.id, view: 'galleries' }
         expect(response).to have_http_status(200)
         expect(assigns(:javascripts)).to include('galleries/expander_old')
       end
 
       it "loads logged in" do
         login
-        get :show, id: icon.id, view: 'galleries'
+        get :show, params: { id: icon.id, view: 'galleries' }
         expect(response).to have_http_status(200)
         expect(assigns(:javascripts)).to include('galleries/expander_old')
       end
@@ -176,14 +176,14 @@ RSpec.describe IconsController do
 
   describe "GET edit" do
     it "requires login" do
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response.status).to eq(302)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid icon" do
       login
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response.status).to eq(302)
       expect(response.redirect_url).to eq(galleries_url)
       expect(flash[:error]).to eq("Icon could not be found.")
@@ -191,7 +191,7 @@ RSpec.describe IconsController do
 
     it "requires your icon" do
       login
-      get :edit, id: create(:icon).id
+      get :edit, params: { id: create(:icon).id }
       expect(response.status).to eq(302)
       expect(response.redirect_url).to eq(galleries_url)
       expect(flash[:error]).to eq("That is not your icon.")
@@ -200,28 +200,28 @@ RSpec.describe IconsController do
     it "successfully loads" do
       user_id = login
       icon = create(:icon, user_id: user_id)
-      get :edit, id: icon.id
+      get :edit, params: { id: icon.id }
       expect(response.status).to eq(200)
     end
   end
 
   describe "PUT update" do
     it "requires login" do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid icon" do
       login
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("Icon could not be found.")
     end
 
     it "requires your icon" do
       login
-      put :update, id: create(:icon).id
+      put :update, params: { id: create(:icon).id }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("That is not your icon.")
     end
@@ -229,7 +229,7 @@ RSpec.describe IconsController do
     it "requires valid params" do
       icon = create(:icon)
       login_as(icon.user)
-      put :update, id: icon.id, icon: {url: ''}
+      put :update, params: { id: icon.id, icon: {url: ''} }
       expect(response).to render_template(:edit)
       expect(flash[:error][:message]).to eq("Your icon could not be saved due to the following problems:")
     end
@@ -238,7 +238,7 @@ RSpec.describe IconsController do
       icon = create(:icon)
       login_as(icon.user)
       new_url = icon.url + '?param'
-      put :update, id: icon.id, icon: {url: new_url, keyword: 'new keyword', credit: 'new credit'}
+      put :update, params: { id: icon.id, icon: {url: new_url, keyword: 'new keyword', credit: 'new credit'} }
       expect(response).to redirect_to(icon_url(icon))
       expect(flash[:success]).to eq("Icon updated.")
       icon.reload
@@ -250,14 +250,14 @@ RSpec.describe IconsController do
 
   describe "DELETE destroy" do
     it "requires login" do
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response.status).to eq(302)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid icon" do
       login
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response.status).to eq(302)
       expect(response.redirect_url).to eq(galleries_url)
       expect(flash[:error]).to eq("Icon could not be found.")
@@ -265,7 +265,7 @@ RSpec.describe IconsController do
 
     it "requires your icon" do
       login
-      delete :destroy, id: create(:icon).id
+      delete :destroy, params: { id: create(:icon).id }
       expect(response.status).to eq(302)
       expect(response.redirect_url).to eq(galleries_url)
       expect(flash[:error]).to eq("That is not your icon.")
@@ -274,7 +274,7 @@ RSpec.describe IconsController do
     it "successfully destroys" do
       user_id = login
       icon = create(:icon, user_id: user_id)
-      delete :destroy, id: icon.id
+      delete :destroy, params: { id: icon.id }
       expect(response.status).to eq(302)
       expect(response.redirect_url).to eq(galleries_url)
       expect(flash[:success]).to eq("Icon deleted successfully.")
@@ -286,7 +286,7 @@ RSpec.describe IconsController do
       gallery = create(:gallery, user: icon.user)
       icon.galleries << gallery
       login_as(icon.user)
-      delete :destroy, id: icon.id
+      delete :destroy, params: { id: icon.id }
       expect(response.status).to eq(302)
       expect(response.redirect_url).to eq(gallery_url(gallery))
       expect(flash[:success]).to eq("Icon deleted successfully.")
@@ -296,21 +296,21 @@ RSpec.describe IconsController do
 
   describe "POST avatar" do
     it "requires login" do
-      post :avatar, id: -1
+      post :avatar, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid icon" do
       login
-      post :avatar, id: -1
+      post :avatar, params: { id: -1 }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("Icon could not be found.")
     end
 
     it "requires your icon" do
       login
-      post :avatar, id: create(:icon).id
+      post :avatar, params: { id: create(:icon).id }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("That is not your icon.")
     end
@@ -322,7 +322,7 @@ RSpec.describe IconsController do
       login_as(user)
 
       expect_any_instance_of(User).to receive(:update_attributes).and_return(false)
-      post :avatar, id: icon.id
+      post :avatar, params: { id: icon.id }
 
       expect(response).to redirect_to(icon_url(icon))
       expect(flash[:error]).to eq("Something went wrong.")
@@ -335,7 +335,7 @@ RSpec.describe IconsController do
       expect(user.avatar_id).to be_nil
       login_as(user)
 
-      post :avatar, id: icon.id
+      post :avatar, params: { id: icon.id }
 
       expect(response).to redirect_to(icon_url(icon))
       expect(flash[:success]).to eq("Avatar has been set!")
@@ -345,21 +345,21 @@ RSpec.describe IconsController do
 
   describe "GET replace" do
     it "requires login" do
-      get :replace, id: create(:icon).id
+      get :replace, params: { id: create(:icon).id }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid icon" do
       login
-      get :replace, id: -1
+      get :replace, params: { id: -1 }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("Icon could not be found.")
     end
 
     it "requires your icon" do
       login
-      get :replace, id: create(:icon).id
+      get :replace, params: { id: create(:icon).id }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("That is not your icon.")
     end
@@ -380,7 +380,7 @@ RSpec.describe IconsController do
         create(:reply, user_id: user.id, icon_id: other_icon.id) # other reply
 
         login_as(icon.user)
-        get :replace, id: icon.id
+        get :replace, params: { id: icon.id }
         expect(response).to have_http_status(200)
         expect(assigns(:alts)).to match_array(alts)
         expect(assigns(:posts)).to match_array([post, reply.post])
@@ -406,7 +406,7 @@ RSpec.describe IconsController do
         create(:reply, user: user, icon: other_icon) # other reply
 
         login_as(icon.user)
-        get :replace, id: icon.id
+        get :replace, params: { id: icon.id }
         expect(response).to have_http_status(200)
         expect(assigns(:alts)).to match_array(alts)
         expect(assigns(:posts)).to match_array([post, reply.post])
@@ -417,21 +417,21 @@ RSpec.describe IconsController do
 
   describe "POST do_replace" do
     it "requires login" do
-      post :do_replace, id: create(:icon).id
+      post :do_replace, params: { id: create(:icon).id }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid icon" do
       login
-      post :do_replace, id: -1
+      post :do_replace, params: { id: -1 }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("Icon could not be found.")
     end
 
     it "requires your icon" do
       login
-      post :do_replace, id: create(:icon).id
+      post :do_replace, params: { id: create(:icon).id }
       expect(response).to redirect_to(galleries_url)
       expect(flash[:error]).to eq("That is not your icon.")
     end
@@ -439,7 +439,7 @@ RSpec.describe IconsController do
     it "requires valid other icon" do
       icon = create(:icon)
       login_as(icon.user)
-      post :do_replace, id: icon.id, icon_dropdown: -1
+      post :do_replace, params: { id: icon.id, icon_dropdown: -1 }
       expect(response).to redirect_to(replace_icon_path(icon))
       expect(flash[:error]).to eq('Icon could not be found.')
     end
@@ -448,7 +448,7 @@ RSpec.describe IconsController do
       icon = create(:icon)
       other_icon = create(:icon)
       login_as(icon.user)
-      post :do_replace, id: icon.id, icon_dropdown: other_icon.id
+      post :do_replace, params: { id: icon.id, icon_dropdown: other_icon.id }
       expect(response).to redirect_to(replace_icon_path(icon))
       expect(flash[:error]).to eq('That is not your icon.')
     end
@@ -462,7 +462,7 @@ RSpec.describe IconsController do
       reply_post_icon = reply.post.icon_id
 
       login_as(user)
-      post :do_replace, id: icon.id, icon_dropdown: other_icon.id
+      post :do_replace, params: { id: icon.id, icon_dropdown: other_icon.id }
       expect(response).to redirect_to(icon_path(icon))
       expect(flash[:success]).to eq('All uses of this icon have been replaced.')
 
@@ -478,7 +478,7 @@ RSpec.describe IconsController do
       reply = create(:reply, user: user, icon: icon)
 
       login_as(user)
-      post :do_replace, id: icon.id
+      post :do_replace, params: { id: icon.id }
       expect(response).to redirect_to(icon_path(icon))
       expect(flash[:success]).to eq('All uses of this icon have been replaced.')
 
@@ -495,7 +495,7 @@ RSpec.describe IconsController do
       other_post = create(:post, user: user, icon: icon)
 
       login_as(user)
-      post :do_replace, id: icon.id, icon_dropdown: other_icon.id, post_ids: [icon_post.id, icon_reply.post.id]
+      post :do_replace, params: { id: icon.id, icon_dropdown: other_icon.id, post_ids: [icon_post.id, icon_reply.post.id] }
       expect(response).to redirect_to(icon_path(icon))
       expect(flash[:success]).to eq('All uses of this icon have been replaced.')
 

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -26,33 +26,33 @@ RSpec.describe PasswordResetsController do
     end
 
     it "requires username" do
-      post :create, email: 'fake_email'
+      post :create, params: { email: 'fake_email' }
       expect(response).to render_template('new')
       expect(flash[:error]).to eq("Username is required.")
     end
 
     it "requires email" do
-      post :create, username: 'fake_username'
+      post :create, params: { username: 'fake_username' }
       expect(response).to render_template('new')
       expect(flash[:error]).to eq("Email is required.")
     end
 
     it "handles user not found" do
-      post :create, username: 'fake_username', email: 'fake_email'
+      post :create, params: { username: 'fake_username', email: 'fake_email' }
       expect(response).to render_template('new')
       expect(flash[:error]).to eq("Account could not be found.")
     end
 
     it "handles email match but not username" do
       user = create(:user)
-      post :create, username: 'fake_username', email: user.email
+      post :create, params: { username: 'fake_username', email: user.email }
       expect(response).to render_template('new')
       expect(flash[:error]).to eq("Account could not be found.")
     end
 
     it "handles username match but not email" do
       user = create(:user)
-      post :create, username: user.username, email: 'fake_email'
+      post :create, params: { username: user.username, email: 'fake_email' }
       expect(response).to render_template('new')
       expect(flash[:error]).to eq("Account could not be found.")
     end
@@ -60,7 +60,7 @@ RSpec.describe PasswordResetsController do
     it "handles failed save" do
       user = create(:user)
       expect_any_instance_of(PasswordReset).to receive(:generate_auth_token).and_return(nil)
-      post :create, username: user.username, email: user.email
+      post :create, params: { username: user.username, email: user.email }
       expect(response).to render_template('new')
       expect(flash[:error]).to eq("Password reset could not be saved.")
     end
@@ -70,7 +70,7 @@ RSpec.describe PasswordResetsController do
       user = create(:user)
       reset = create(:password_reset, user: user)
       expect(PasswordReset.count).to eq(1)
-      post :create, username: user.username, email: user.email
+      post :create, params: { username: user.username, email: user.email }
       expect(flash[:success]).to eq("Your password reset link has been re-sent.")
       expect(UserMailer).to have_queued(:password_reset_link, [reset.id])
       expect(PasswordReset.count).to eq(1)
@@ -79,7 +79,7 @@ RSpec.describe PasswordResetsController do
     it "sends password reset" do
       ActionMailer::Base.deliveries.clear
       user = create(:user)
-      post :create, username: user.username, email: user.email
+      post :create, params: { username: user.username, email: user.email }
       expect(response).to redirect_to(new_password_reset_url)
       expect(flash[:success]).to eq("A password reset link has been emailed to you.")
       expect(PasswordReset.count).to eq(1)
@@ -92,34 +92,34 @@ RSpec.describe PasswordResetsController do
     it "requires logout" do
       user = create(:user)
       login_as(user)
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to redirect_to(edit_user_url(user))
       expect(flash[:error]).to eq("You are already logged in.")
     end
 
     it "requires valid token" do
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("Authentication token not found.")
     end
 
     it "requires active token" do
       token = create(:expired_password_reset)
-      get :show, id: token.auth_token
+      get :show, params: { id: token.auth_token }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("Authentication token expired.")
     end
 
     it "requires unused token" do
       token = create(:used_password_reset)
-      get :show, id: token.auth_token
+      get :show, params: { id: token.auth_token }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("Authentication token has already been used.")
     end
 
     it "succeeds" do
       token = create(:password_reset)
-      get :show, id: token.auth_token
+      get :show, params: { id: token.auth_token }
       expect(response.status).to eq(200)
     end
   end
@@ -128,55 +128,55 @@ RSpec.describe PasswordResetsController do
     it "requires logout" do
       user = create(:user)
       login_as(user)
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(edit_user_url(user))
       expect(flash[:error]).to eq("You are already logged in.")
     end
 
     it "requires valid token" do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("Authentication token not found.")
     end
 
     it "requires active token" do
       token = create(:expired_password_reset)
-      put :update, id: token.auth_token
+      put :update, params: { id: token.auth_token }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("Authentication token expired.")
     end
 
     it "requires unused token" do
       token = create(:used_password_reset)
-      put :update, id: token.auth_token
+      put :update, params: { id: token.auth_token }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("Authentication token has already been used.")
     end
 
     it "requires password" do
       token = create(:password_reset)
-      put :update, id: token.auth_token, password_confirmation: 'newpass'
+      put :update, params: { id: token.auth_token, password_confirmation: 'newpass' }
       expect(flash[:error][:message]).to eq("Could not update password.")
       expect(response).to render_template('show')
     end
 
     it "requires long enough password" do
       token = create(:password_reset)
-      put :update, id: token.auth_token, password: 'new', password_confirmation: 'new'
+      put :update, params: { id: token.auth_token, password: 'new', password_confirmation: 'new' }
       expect(flash[:error][:message]).to eq("Could not update password.")
       expect(response).to render_template('show')
     end
 
     it "requires password confirmation" do
       token = create(:password_reset)
-      put :update, id: token.auth_token, password: 'newpass'
+      put :update, params: { id: token.auth_token, password: 'newpass' }
       expect(flash[:error][:message]).to eq("Could not update password.")
       expect(response).to render_template('show')
     end
 
     it "requires password and confirmation to match" do
       token = create(:password_reset)
-      put :update, id: token.auth_token, password: 'newpass', password_confirmation: 'notnewpass'
+      put :update, params: { id: token.auth_token, password: 'newpass', password_confirmation: 'notnewpass' }
       expect(flash[:error][:message]).to eq("Could not update password.")
       expect(response).to render_template('show')
     end
@@ -184,7 +184,7 @@ RSpec.describe PasswordResetsController do
     it "succeeds" do
       token = create(:password_reset)
       expect(token.user.authenticate('newpass')).to eq(false)
-      put :update, id: token.auth_token, password: 'newpass', password_confirmation: 'newpass'
+      put :update, params: { id: token.auth_token, password: 'newpass', password_confirmation: 'newpass' }
       expect(response).to redirect_to(root_url)
       expect(flash[:success]).to eq("Password successfully changed.")
       expect(token.reload).to be_used

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe PostsController do
     context "searching" do
       it "finds all when no arguments given" do
         4.times do create(:post) end
-        get :search, commit: true
+        get :search, params: { commit: true }
         expect(assigns(:search_results)).to match_array(Post.all)
       end
 
@@ -62,7 +62,7 @@ RSpec.describe PostsController do
         post = create(:post)
         post2 = create(:post, board: post.board)
         create(:post)
-        get :search, commit: true, board_id: post.board_id
+        get :search, params: { commit: true, board_id: post.board_id }
         expect(assigns(:search_results)).to match_array([post, post2])
       end
 
@@ -71,7 +71,7 @@ RSpec.describe PostsController do
         post = create(:post)
         post.settings << setting
         create(:post)
-        get :search, commit: true, setting_id: setting.id
+        get :search, params: { commit: true, setting_id: setting.id }
         expect(assigns(:search_results)).to match_array([post])
       end
 
@@ -79,20 +79,20 @@ RSpec.describe PostsController do
         post1 = create(:post, subject: 'contains stars')
         post2 = create(:post, subject: 'contains Stars cased')
         create(:post, subject: 'unrelated')
-        get :search, commit: true, subject: 'stars'
+        get :search, params: { commit: true, subject: 'stars' }
         expect(assigns(:search_results)).to match_array([post1, post2])
       end
 
       it "does not mix up subject with content" do
         create(:post, subject: 'unrelated', content: 'contains stars')
-        get :search, commit: true, subject: 'stars'
+        get :search, params: { commit: true, subject: 'stars' }
         expect(assigns(:search_results)).to be_empty
       end
 
       it "restricts to visible posts" do
         create(:post, subject: 'contains stars', privacy: Post::PRIVACY_PRIVATE)
         post = create(:post, subject: 'visible contains stars')
-        get :search, commit: true, subject: 'stars'
+        get :search, params: { commit: true, subject: 'stars' }
         expect(assigns(:search_results)).to match_array([post])
       end
 
@@ -105,7 +105,7 @@ RSpec.describe PostsController do
         filtered_post = posts.last
         first_post = posts.first
         create(:reply, post: first_post, user: filtered_post.user)
-        get :search, commit: true, author_id: [filtered_post.user_id]
+        get :search, params: { commit: true, author_id: [filtered_post.user_id] }
         expect(assigns(:search_results)).to match_array([filtered_post, first_post])
       end
 
@@ -128,7 +128,7 @@ RSpec.describe PostsController do
         create(:reply, post: post, user: author2)
         found_posts << post
 
-        get :search, commit: true, author_id: [author1.id, author2.id]
+        get :search, params: { commit: true, author_id: [author1.id, author2.id] }
         expect(assigns(:search_results)).to match_array(found_posts)
       end
 
@@ -136,14 +136,14 @@ RSpec.describe PostsController do
         create(:reply, with_character: true)
         reply = create(:reply, with_character: true)
         post = create(:post, character: reply.character, user: reply.user)
-        get :search, commit: true, character_id: reply.character_id
+        get :search, params: { commit: true, character_id: reply.character_id }
         expect(assigns(:search_results)).to match_array([reply.post, post])
       end
 
       it "filters by completed" do
         create(:post)
         post = create(:post, status: Post::STATUS_COMPLETE)
-        get :search, commit: true, completed: true
+        get :search, params: { commit: true, completed: true }
         expect(assigns(:search_results)).to match_array(post)
       end
     end
@@ -195,7 +195,7 @@ RSpec.describe PostsController do
 
     it "works for importer" do
       login
-      get :new, view: :import
+      get :new, params: { view: :import }
       expect(response).to have_http_status(200)
     end
   end
@@ -211,7 +211,7 @@ RSpec.describe PostsController do
       it "requires valid user" do
         user = create(:user, id: PostsController::SCRAPE_USERS.max + 1)
         login_as(user)
-        post :create, button_import: true
+        post :create, params: { button_import: true }
         expect(response).to render_template(:new)
         expect(flash[:error]).to eq("You do not have access to this feature.")
       end
@@ -219,7 +219,7 @@ RSpec.describe PostsController do
       it "requires url" do
         user = create(:user, id: PostsController::SCRAPE_USERS.first)
         login_as(user)
-        post :create, button_import: true
+        post :create, params: { button_import: true }
         expect(response).to render_template(:new)
         expect(flash[:error]).to eq("Invalid URL provided.")
       end
@@ -227,7 +227,7 @@ RSpec.describe PostsController do
       it "requires dreamwidth url" do
         user = create(:user, id: PostsController::SCRAPE_USERS.first)
         login_as(user)
-        post :create, button_import: true, dreamwidth_url: 'http://www.google.com'
+        post :create, params: { button_import: true, dreamwidth_url: 'http://www.google.com' }
         expect(response).to render_template(:new)
         expect(flash[:error]).to eq("Invalid URL provided.")
       end
@@ -235,7 +235,7 @@ RSpec.describe PostsController do
       it "requires dreamwidth.org url" do
         user = create(:user, id: PostsController::SCRAPE_USERS.first)
         login_as(user)
-        post :create, button_import: true, dreamwidth_url: 'http://www.dreamwidth.com'
+        post :create, params: { button_import: true, dreamwidth_url: 'http://www.dreamwidth.com' }
         expect(response).to render_template(:new)
         expect(flash[:error]).to eq("Invalid URL provided.")
       end
@@ -244,7 +244,7 @@ RSpec.describe PostsController do
         user = create(:user, id: PostsController::SCRAPE_USERS.first)
         login_as(user)
         expect(URI).to receive(:parse).and_raise(URI::InvalidURIError)
-        post :create, button_import: true, dreamwidth_url: 'dreamwidth'
+        post :create, params: { button_import: true, dreamwidth_url: 'dreamwidth' }
         expect(response).to render_template(:new)
         expect(flash[:error]).to eq("Invalid URL provided.")
       end
@@ -256,7 +256,7 @@ RSpec.describe PostsController do
         url = 'http://wild-pegasus-appeared.dreamwidth.org/403.html?style=site&view=flat'
         file = File.join(Rails.root, 'spec', 'support', 'fixtures', 'scrape_no_replies.html')
         stub_request(:get, url).to_return(status: 200, body: File.new(file))
-        post :create, button_import: true, dreamwidth_url: url
+        post :create, params: { button_import: true, dreamwidth_url: url }
         expect(response).to render_template(:new)
         expect(flash[:error][:message]).to start_with("The following usernames were not recognized")
         expect(flash[:error][:array]).to include("wild_pegasus_appeared")
@@ -269,7 +269,7 @@ RSpec.describe PostsController do
         login_as(user)
         url = 'http://www.dreamwidth.org'
         stub_request(:get, url).to_return(status: 200, body: '')
-        post :create, button_import: true, dreamwidth_url: url
+        post :create, params: { button_import: true, dreamwidth_url: url }
         expect(response).to redirect_to(posts_url)
         expect(flash[:success]).to eq("Post has begun importing. You will be updated on progress via site message.")
         expect(ScrapePostJob).to have_queue_size_of(1)
@@ -290,13 +290,16 @@ RSpec.describe PostsController do
         char2 = create(:template_character, user: user)
         expect(controller).to receive(:editor_setup).and_call_original
         expect(controller).to receive(:setup_layout_gon).and_call_original
-        post :create, button_preview: true, post: {
-          subject: 'test',
-          content: 'orign',
-          setting_ids: [setting1.id, '_'+setting2.name, '_other'],
-          content_warning_ids: [warning1.id, '_'+warning2.name, '_other'],
-          label_ids: [label1.id, '_'+label2.name, '_other'],
-          character_id: char1.id
+        post :create, params: {
+          button_preview: true,
+          post: {
+            subject: 'test',
+            content: 'orign',
+            setting_ids: [setting1.id, '_'+setting2.name, '_other'],
+            content_warning_ids: [warning1.id, '_'+warning2.name, '_other'],
+            label_ids: [label1.id, '_'+label2.name, '_other'],
+            character_id: char1.id
+          }
         }
         expect(response).to render_template(:preview)
         expect(assigns(:written)).to be_an_instance_of(Post)
@@ -331,7 +334,7 @@ RSpec.describe PostsController do
       it "does not crash without arguments" do
         user = create(:user)
         login_as(user)
-        post :create, button_preview: true
+        post :create, params: { button_preview: true }
         expect(response).to render_template(:preview)
         expect(assigns(:written)).to be_an_instance_of(Post)
         expect(assigns(:written)).to be_a_new_record
@@ -345,7 +348,7 @@ RSpec.describe PostsController do
       tags = ['_atag', '_atag', create(:label).id, '', '_' + existing_name.name, '_' + existing_case.name.upcase]
       login
       expect {
-        post :create, post: {subject: 'a', board_id: create(:board).id, label_ids: tags}
+        post :create, params: { post: {subject: 'a', board_id: create(:board).id, label_ids: tags} }
       }.to change{Label.count}.by(1)
       expect(Label.last.name).to eq('atag')
       expect(assigns(:post).labels.count).to eq(4)
@@ -357,7 +360,7 @@ RSpec.describe PostsController do
       tags = ['_atag', '_atag', create(:setting).id, '', '_' + existing_name.name, '_' + existing_case.name.upcase]
       login
       expect {
-        post :create, post: {subject: 'a', board_id: create(:board).id, setting_ids: tags}
+        post :create, params: { post: {subject: 'a', board_id: create(:board).id, setting_ids: tags} }
       }.to change{Setting.count}.by(1)
       expect(Setting.last.name).to eq('atag')
       expect(assigns(:post).settings.count).to eq(4)
@@ -369,7 +372,7 @@ RSpec.describe PostsController do
       tags = ['_atag', '_atag', create(:content_warning).id, '', '_' + existing_name.name, '_' + existing_case.name.upcase]
       login
       expect {
-        post :create, post: {subject: 'a', board_id: create(:board).id, content_warning_ids: tags}
+        post :create, params: { post: {subject: 'a', board_id: create(:board).id, content_warning_ids: tags} }
       }.to change{ContentWarning.count}.by(1)
       expect(ContentWarning.last.name).to eq('atag')
       expect(assigns(:post).content_warnings.count).to eq(4)
@@ -388,13 +391,15 @@ RSpec.describe PostsController do
       char2 = create(:template_character, user: user)
       expect(controller).to receive(:editor_setup).and_call_original
       expect(controller).to receive(:setup_layout_gon).and_call_original
-      post :create, post: {
-        subject: 'asubjct',
-        content: 'acontnt',
-        setting_ids: [setting1.id, '_'+setting2.name, '_other'],
-        content_warning_ids: [warning1.id, '_'+warning2.name, '_other'],
-        label_ids: [label1.id, '_'+label2.name, '_other'],
-        character_id: char1.id
+      post :create, params: {
+        post: {
+          subject: 'asubjct',
+          content: 'acontnt',
+          setting_ids: [setting1.id, '_'+setting2.name, '_other'],
+          content_warning_ids: [warning1.id, '_'+warning2.name, '_other'],
+          label_ids: [label1.id, '_'+label2.name, '_other'],
+          character_id: char1.id
+        }
       }
       expect(response).to render_template(:new)
       expect(flash[:error][:message]).to eq("Your post could not be saved because of the following problems:")
@@ -444,20 +449,22 @@ RSpec.describe PostsController do
       label2 = create(:label)
 
       expect {
-        post :create, post: {
-          subject: 'asubjct',
-          content: 'acontnt',
-          description: 'adesc',
-          board_id: board.id,
-          section_id: section.id,
-          character_id: char.id,
-          icon_id: icon.id,
-          character_alias_id: calias.id,
-          privacy: Post::PRIVACY_LIST,
-          viewer_ids: [viewer.id],
-          setting_ids: [setting1.id, '_'+setting2.name, '_other'],
-          content_warning_ids: [warning1.id, '_'+warning2.name, '_other'],
-          label_ids: [label1.id, '_'+label2.name, '_other']
+        post :create, params: {
+          post: {
+            subject: 'asubjct',
+            content: 'acontnt',
+            description: 'adesc',
+            board_id: board.id,
+            section_id: section.id,
+            character_id: char.id,
+            icon_id: icon.id,
+            character_alias_id: calias.id,
+            privacy: Post::PRIVACY_LIST,
+            viewer_ids: [viewer.id],
+            setting_ids: [setting1.id, '_'+setting2.name, '_other'],
+            content_warning_ids: [warning1.id, '_'+warning2.name, '_other'],
+            label_ids: [label1.id, '_'+label2.name, '_other']
+          }
         }
       }.to change{Post.count}.by(1)
       expect(response).to redirect_to(post_path(assigns(:post)))
@@ -488,14 +495,14 @@ RSpec.describe PostsController do
   describe "GET show" do
     it "does not require login" do
       post = create(:post)
-      get :show, id: post.id
+      get :show, params: { id: post.id }
       expect(response).to have_http_status(200)
       expect(assigns(:javascripts)).to include('posts/show')
     end
 
     it "requires permission" do
       post = create(:post, privacy: Post::PRIVACY_PRIVATE)
-      get :show, id: post.id
+      get :show, params: { id: post.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
@@ -503,7 +510,7 @@ RSpec.describe PostsController do
     it "works with login" do
       post = create(:post)
       login
-      get :show, id: post.id
+      get :show, params: { id: post.id }
       expect(response).to have_http_status(200)
       expect(assigns(:javascripts)).to include('posts/show')
     end
@@ -513,14 +520,14 @@ RSpec.describe PostsController do
       user = create(:user)
       login_as(user)
       expect(post.last_read(user)).to be_nil
-      get :show, id: post.id
+      get :show, params: { id: post.id }
       last_read = post.reload.last_read(user)
       expect(last_read).not_to be_nil
 
       Timecop.freeze(last_read + 1.second) do
         reply = create(:reply, post: post)
         expect(reply.created_at).not_to be_the_same_time_as(last_read)
-        get :show, id: post.id
+        get :show, params: { id: post.id }
         cur_read = post.reload.last_read(user)
         expect(last_read).not_to be_the_same_time_as(cur_read)
         expect(last_read.to_i).to be < cur_read.to_i
@@ -534,7 +541,7 @@ RSpec.describe PostsController do
       post.ignore(user)
       expect(post.reload.first_unread_for(user)).to eq(post)
 
-      get :show, id: post.id
+      get :show, params: { id: post.id }
       expect(post.reload.first_unread_for(user)).to be_nil
       last_read = post.last_read(user)
 
@@ -542,14 +549,14 @@ RSpec.describe PostsController do
         reply = create(:reply, post: post)
         expect(reply.created_at).not_to be_the_same_time_as(last_read)
         expect(post.reload.first_unread_for(user)).to eq(reply)
-        get :show, id: post.id
+        get :show, params: { id: post.id }
         expect(post.reload.first_unread_for(user)).to be_nil
       end
     end
 
     it "handles invalid pages" do
       post = create(:post)
-      get :show, id: post.id, page: 'invalid'
+      get :show, params: { id: post.id, page: 'invalid' }
       expect(flash[:error]).to eq('Page not recognized, defaulting to page 1.')
       expect(assigns(:page)).to eq(1)
       expect(response).to have_http_status(200)
@@ -558,7 +565,7 @@ RSpec.describe PostsController do
 
     it "handles invalid unread page when logged out" do
       post = create(:post)
-      get :show, id: post.id, page: 'unread'
+      get :show, params: { id: post.id, page: 'unread' }
       expect(flash[:error]).to eq("You must be logged in to view unread posts.")
       expect(assigns(:page)).to eq(1)
       expect(response).to have_http_status(200)
@@ -568,14 +575,14 @@ RSpec.describe PostsController do
     it "handles pages outside range" do
       post = create(:post)
       5.times { create(:reply, post: post) }
-      get :show, id: post.id, per_page: 1, page: 10
+      get :show, params: { id: post.id, per_page: 1, page: 10 }
       expect(response).to redirect_to(post_url(post, page: 5, per_page: 1))
     end
 
     it "handles page=last with replies" do
       post = create(:post)
       5.times { create(:reply, post: post) }
-      get :show, id: post.id, per_page: 1, page: 'last'
+      get :show, params: { id: post.id, per_page: 1, page: 'last' }
       expect(assigns(:page)).to eq(5)
       expect(response).to have_http_status(200)
       expect(response).to render_template(:show)
@@ -583,7 +590,7 @@ RSpec.describe PostsController do
 
     it "handles page=last with no replies" do
       post = create(:post)
-      get :show, id: post.id, page: 'last'
+      get :show, params: { id: post.id, page: 'last' }
       expect(assigns(:page)).to eq(1)
       expect(response).to have_http_status(200)
       expect(response).to render_template(:show)
@@ -595,7 +602,7 @@ RSpec.describe PostsController do
       it "renders HAML with additional attributes" do
         post = create(:post, with_icon: true, with_character: true)
         create(:reply, post: post, with_icon: true, with_character: true)
-        get :show, id: post.id
+        get :show, params: { id: post.id }
         expect(response.status).to eq(200)
         expect(response.body).to include(post.subject)
         expect(response.body).to include('header-right')
@@ -606,7 +613,7 @@ RSpec.describe PostsController do
         create(:reply, post: post)
         character = create(:character)
         login_as(character.user)
-        get :show, id: post.id
+        get :show, params: { id: post.id }
         expect(response.status).to eq(200)
         expect(response.body).to include('Join Thread')
       end
@@ -614,7 +621,7 @@ RSpec.describe PostsController do
       it "flat view renders HAML properly" do
         post = create(:post, with_icon: true, with_character: true)
         create(:reply, post: post, with_icon: true, with_character: true)
-        get :show, id: post.id, view: 'flat'
+        get :show, params: { id: post.id, view: 'flat' }
         expect(response.status).to eq(200)
         expect(response.body).to include(post.subject)
         expect(response.body).not_to include('header-right')
@@ -624,7 +631,7 @@ RSpec.describe PostsController do
         post = create(:post)
         reply = create(:reply, post: post, with_icon: true, with_character: true)
         login_as(reply.user)
-        get :show, id: post.id
+        get :show, params: { id: post.id }
         expect(response.status).to eq(200)
       end
     end
@@ -636,13 +643,13 @@ RSpec.describe PostsController do
       end
 
       it "shows error if reply not found" do
-        get :show, id: post.id, at_id: -1
+        get :show, params: { id: post.id, at_id: -1 }
         expect(flash[:error]).to eq("Could not locate specified reply, defaulting to first page.")
         expect(assigns(:replies).count).to eq(5)
       end
 
       it "shows error if unread not logged in" do
-        get :show, id: post.id, at_id: 'unread'
+        get :show, params: { id: post.id, at_id: 'unread' }
         expect(flash[:error]).to eq("Could not locate specified reply, defaulting to first page.")
         expect(assigns(:replies).count).to eq(5)
       end
@@ -651,20 +658,20 @@ RSpec.describe PostsController do
         user = create(:user)
         post.mark_read(user)
         login_as(user)
-        get :show, id: post.id, at_id: 'unread'
+        get :show, params: { id: post.id, at_id: 'unread' }
         expect(flash[:error]).to eq("Could not locate specified reply, defaulting to first page.")
         expect(assigns(:replies).count).to eq(5)
       end
 
       it "shows error when reply is wrong post" do
-        get :show, id: post.id, at_id: create(:reply).id
+        get :show, params: { id: post.id, at_id: create(:reply).id }
         expect(flash[:error]).to eq("Could not locate specified reply, defaulting to first page.")
         expect(assigns(:replies).count).to eq(5)
       end
 
       it "works for specified reply" do
         last_reply = post.replies.order('id asc').last
-        get :show, id: post.id, at_id: last_reply.id
+        get :show, params: { id: post.id, at_id: last_reply.id }
         expect(assigns(:replies)).to eq([last_reply])
         expect(assigns(:replies).current_page.to_i).to eq(1)
         expect(assigns(:replies).per_page).to eq(25)
@@ -672,7 +679,7 @@ RSpec.describe PostsController do
 
       it "works for specified reply with page settings" do
         second_last_reply = post.replies.order('id asc').last(2).first
-        get :show, id: post.id, at_id: second_last_reply.id, per_page: 1
+        get :show, params: { id: post.id, at_id: second_last_reply.id, per_page: 1 }
         expect(assigns(:replies)).to eq([second_last_reply])
         expect(assigns(:replies).current_page.to_i).to eq(1)
         expect(assigns(:replies).per_page).to eq(1)
@@ -681,7 +688,7 @@ RSpec.describe PostsController do
       it "works for specified reply with page settings" do
         last_reply = post.replies.order('id asc').last
         second_last_reply = post.replies.order('id asc').last(2).first
-        get :show, id: post.id, at_id: second_last_reply.id, per_page: 1, page: 2
+        get :show, params: { id: post.id, at_id: second_last_reply.id, per_page: 1, page: 2 }
         expect(assigns(:replies)).to eq([last_reply])
         expect(assigns(:replies).current_page.to_i).to eq(2)
         expect(assigns(:replies).per_page).to eq(1)
@@ -694,7 +701,7 @@ RSpec.describe PostsController do
         post.mark_read(user, third_reply.created_at)
         expect(post.first_unread_for(user)).to eq(second_last_reply)
         login_as(user)
-        get :show, id: post.id, at_id: 'unread', per_page: 1
+        get :show, params: { id: post.id, at_id: 'unread', per_page: 1 }
         expect(assigns(:replies)).to eq([second_last_reply])
         expect(assigns(:unread)).to eq(second_last_reply)
         expect(assigns(:paginate_params)['at_id']).to eq(second_last_reply.id)
@@ -708,7 +715,7 @@ RSpec.describe PostsController do
         user = create(:user)
         post.mark_read(user)
         login_as(user)
-        get :show, id: post.id, page: 'unread', per_page: 1
+        get :show, params: { id: post.id, page: 'unread', per_page: 1 }
         expect(assigns(:page)).to eq(3)
       end
 
@@ -716,7 +723,7 @@ RSpec.describe PostsController do
         post = create(:post)
         user = create(:user)
         login_as(user)
-        get :show, id: post.id, page: 'unread'
+        get :show, params: { id: post.id, page: 'unread' }
         expect(assigns(:page)).to eq(1)
       end
 
@@ -728,7 +735,7 @@ RSpec.describe PostsController do
         user = create(:user)
         post.mark_read(user, reply1.created_at)
         login_as(user)
-        get :show, id: post.id, page: 'unread', per_page: 1
+        get :show, params: { id: post.id, page: 'unread', per_page: 1 }
         expect(assigns(:page)).to eq(2)
       end
     end
@@ -737,7 +744,7 @@ RSpec.describe PostsController do
       it "works" do
         post = create(:post)
         login_as(post.user)
-        get :show, id: post.id
+        get :show, params: { id: post.id }
         expect(response).to have_http_status(200)
       end
 
@@ -754,7 +761,7 @@ RSpec.describe PostsController do
         expect(post).to receive(:build_new_reply_for).with(user).and_call_original
         expect(controller).to receive(:setup_layout_gon).and_call_original
 
-        get :show, id: post.id
+        get :show, params: { id: post.id }
         expect(response).to have_http_status(200)
         expect(assigns(:reply)).not_to be_nil
         expect(assigns(:javascripts)).to include('posts/show', 'posts/editor')
@@ -767,7 +774,7 @@ RSpec.describe PostsController do
         user = create(:user)
         login_as(user)
         expect(post).to be_taggable_by(user)
-        get :show, id: post.id
+        get :show, params: { id: post.id }
         expect(response).to have_http_status(200)
       end
 
@@ -783,7 +790,7 @@ RSpec.describe PostsController do
         expect(post).to be_taggable_by(user)
         expect(post).to receive(:build_new_reply_for).with(user).and_call_original
 
-        get :show, id: post.id
+        get :show, params: { id: post.id }
         expect(response).to have_http_status(200)
         expect(assigns(:reply)).not_to be_nil
       end
@@ -802,7 +809,7 @@ RSpec.describe PostsController do
         expect(post).not_to be_taggable_by(user)
         expect(post).not_to receive(:build_new_reply_for)
 
-        get :show, id: post.id
+        get :show, params: { id: post.id }
         expect(response).to have_http_status(200)
         expect(assigns(:reply)).to be_nil
       end
@@ -814,19 +821,19 @@ RSpec.describe PostsController do
   describe "GET history" do
     it "requires post" do
       login
-      get :history, id: -1
+      get :history, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
     it "works logged out" do
-      get :history, id: create(:post).id
+      get :history, params: { id: create(:post).id }
       expect(response.status).to eq(200)
     end
 
     it "works logged in" do
       login
-      get :history, id: create(:post).id
+      get :history, params: { id: create(:post).id }
       expect(response.status).to eq(200)
     end
   end
@@ -834,33 +841,33 @@ RSpec.describe PostsController do
   describe "GET stats" do
     it "requires post" do
       login
-      get :stats, id: -1
+      get :stats, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
     it "works logged out" do
-      get :stats, id: create(:post).id
+      get :stats, params: { id: create(:post).id }
       expect(response.status).to eq(200)
     end
 
     it "works logged in" do
       login
-      get :stats, id: create(:post).id
+      get :stats, params: { id: create(:post).id }
       expect(response.status).to eq(200)
     end
   end
 
   describe "GET edit" do
     it "requires login" do
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires post" do
       login
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
@@ -868,7 +875,7 @@ RSpec.describe PostsController do
     it "requires your post" do
       login
       post = create(:post)
-      get :edit, id: post.id
+      get :edit, params: { id: post.id }
       expect(response).to redirect_to(post_url(post))
       expect(flash[:error]).to eq("You do not have permission to modify this post.")
     end
@@ -890,7 +897,7 @@ RSpec.describe PostsController do
       expect(controller).to receive(:editor_setup).and_call_original
       expect(controller).to receive(:setup_layout_gon).and_call_original
 
-      get :edit, id: post.id
+      get :edit, params: { id: post.id }
 
       expect(response.status).to eq(200)
       expect(assigns(:post)).to eq(post)
@@ -921,14 +928,14 @@ RSpec.describe PostsController do
 
   describe "PUT update" do
     it "requires login" do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid post" do
       login
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
@@ -939,7 +946,7 @@ RSpec.describe PostsController do
       login_as(user)
       expect(post.visible_to?(user)).not_to eq(true)
 
-      put :update, id: post.id
+      put :update, params: { id: post.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
@@ -965,7 +972,7 @@ RSpec.describe PostsController do
         login_as(post.user)
         create(:admin_user) # to receive the alert message
         expect {
-          put :update, id: post.id, unread: true, at_id: unread_reply.id
+          put :update, params: { id: post.id, unread: true, at_id: unread_reply.id }
         }.to change{ Message.count }.by(1)
 
         expect(response).to redirect_to(unread_posts_url)
@@ -982,7 +989,7 @@ RSpec.describe PostsController do
         expect(post.last_read(post.user)).to be_the_same_time_as(time)
         login_as(post.user)
 
-        put :update, id: post.id, unread: true, at_id: unread_reply.id
+        put :update, params: { id: post.id, unread: true, at_id: unread_reply.id }
 
         expect(response).to redirect_to(unread_posts_url)
         expect(flash[:success]).to eq("Post has been marked as read until reply ##{unread_reply.id}.")
@@ -996,7 +1003,7 @@ RSpec.describe PostsController do
         expect(post.reload.send(:view_for, user)).not_to be_nil
         login_as(user)
 
-        put :update, id: post.id, unread: true
+        put :update, params: { id: post.id, unread: true }
 
         expect(response).to redirect_to(unread_posts_url)
         expect(flash[:success]).to eq("Post has been marked as unread")
@@ -1013,7 +1020,7 @@ RSpec.describe PostsController do
         expect(post.reload.first_unread_for(user)).to be_nil
         login_as(user)
 
-        put :update, id: post.id, unread: true, at_id: unread_reply.id
+        put :update, params: { id: post.id, unread: true, at_id: unread_reply.id }
 
         expect(response).to redirect_to(unread_posts_url)
         expect(flash[:success]).to eq("Post has been marked as read until reply ##{unread_reply.id}.")
@@ -1029,7 +1036,7 @@ RSpec.describe PostsController do
         expect(post.reload.first_unread_for(user)).to be_nil
         login_as(user)
 
-        put :update, id: post.id, unread: true
+        put :update, params: { id: post.id, unread: true }
 
         expect(response).to redirect_to(unread_posts_url)
         expect(flash[:success]).to eq("Post has been marked as unread")
@@ -1041,7 +1048,7 @@ RSpec.describe PostsController do
       it "requires permission" do
         post = create(:post)
         login
-        put :update, id: post.id, status: 'complete'
+        put :update, params: { id: post.id, status: 'complete' }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:error]).to eq("You do not have permission to modify this post.")
         expect(post.reload).to be_active
@@ -1050,7 +1057,7 @@ RSpec.describe PostsController do
       it "requires valid status" do
         post = create(:post)
         login_as(post.user)
-        put :update, id: post.id, status: 'invalid'
+        put :update, params: { id: post.id, status: 'invalid' }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:error]).to eq("Invalid status selected.")
         expect(post.reload).to be_active
@@ -1062,7 +1069,7 @@ RSpec.describe PostsController do
 
           it "works for creator" do
             login_as(post.user)
-            put :update, id: post.id, status: status
+            put :update, params: { id: post.id, status: status }
             expect(response).to redirect_to(post_url(post))
             expect(flash[:success]).to eq("Post has been marked #{status}.")
             expect(post.reload.send("#{method}?")).to eq(true)
@@ -1071,7 +1078,7 @@ RSpec.describe PostsController do
           it "works for coauthor" do
             reply = create(:reply, post: post)
             login_as(reply.user)
-            put :update, id: post.id, status: status
+            put :update, params: { id: post.id, status: status }
             expect(response).to redirect_to(post_url(post))
             expect(flash[:success]).to eq("Post has been marked #{status}.")
             expect(post.reload.send("#{method}?")).to eq(true)
@@ -1079,7 +1086,7 @@ RSpec.describe PostsController do
 
           it "works for admin" do
             login_as(create(:admin_user))
-            put :update, id: post.id, status: status
+            put :update, params: { id: post.id, status: status }
             expect(response).to redirect_to(post_url(post))
             expect(flash[:success]).to eq("Post has been marked #{status}.")
             expect(post.reload.send("#{method}?")).to eq(true)
@@ -1098,7 +1105,7 @@ RSpec.describe PostsController do
             it "works for creator" do
               login_as(post.user)
               expect(post.reload.tagged_at).to be_the_same_time_as(time)
-              put :update, id: post.id, status: status
+              put :update, params: { id: post.id, status: status }
               expect(response).to redirect_to(post_url(post))
               expect(flash[:success]).to eq("Post has been marked #{status}.")
               expect(post.reload.send("on_hiatus?")).to eq(true)
@@ -1108,7 +1115,7 @@ RSpec.describe PostsController do
             it "works for coauthor" do
               login_as(reply.user)
               expect(post.reload.tagged_at).to be_the_same_time_as(time)
-              put :update, id: post.id, status: status
+              put :update, params: { id: post.id, status: status }
               expect(response).to redirect_to(post_url(post))
               expect(flash[:success]).to eq("Post has been marked #{status}.")
               expect(post.reload.send("on_hiatus?")).to eq(true)
@@ -1118,7 +1125,7 @@ RSpec.describe PostsController do
             it "works for admin" do
               login_as(create(:admin_user))
               expect(post.reload.tagged_at).to be_the_same_time_as(time)
-              put :update, id: post.id, status: status
+              put :update, params: { id: post.id, status: status }
               expect(response).to redirect_to(post_url(post))
               expect(flash[:success]).to eq("Post has been marked #{status}.")
               expect(post.reload.send("on_hiatus?")).to eq(true)
@@ -1134,7 +1141,7 @@ RSpec.describe PostsController do
 
       it "requires permission" do
         login
-        put :update, id: post.id, authors_locked: 'true'
+        put :update, params: { id: post.id, authors_locked: 'true' }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:error]).to eq("You do not have permission to modify this post.")
         expect(post.reload).not_to be_authors_locked
@@ -1142,12 +1149,12 @@ RSpec.describe PostsController do
 
       it "works for creator" do
         login_as(post.user)
-        put :update, id: post.id, authors_locked: 'true'
+        put :update, params: { id: post.id, authors_locked: 'true' }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:success]).to eq("Post has been locked to current authors.")
         expect(post.reload).to be_authors_locked
 
-        put :update, id: post.id, authors_locked: 'false'
+        put :update, params: { id: post.id, authors_locked: 'false' }
         expect(flash[:success]).to eq("Post has been unlocked from current authors.")
         expect(post.reload).not_to be_authors_locked
       end
@@ -1155,24 +1162,24 @@ RSpec.describe PostsController do
       it "works for coauthor" do
         reply = create(:reply, post: post)
         login_as(reply.user)
-        put :update, id: post.id, authors_locked: 'true'
+        put :update, params: { id: post.id, authors_locked: 'true' }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:success]).to eq("Post has been locked to current authors.")
         expect(post.reload).to be_authors_locked
 
-        put :update, id: post.id, authors_locked: 'false'
+        put :update, params: { id: post.id, authors_locked: 'false' }
         expect(flash[:success]).to eq("Post has been unlocked from current authors.")
         expect(post.reload).not_to be_authors_locked
       end
 
       it "works for admin" do
         login_as(create(:admin_user))
-        put :update, id: post.id, authors_locked: 'true'
+        put :update, params: { id: post.id, authors_locked: 'true' }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:success]).to eq("Post has been locked to current authors.")
         expect(post.reload).to be_authors_locked
 
-        put :update, id: post.id, authors_locked: 'false'
+        put :update, params: { id: post.id, authors_locked: 'false' }
         expect(flash[:success]).to eq("Post has been unlocked from current authors.")
         expect(post.reload).not_to be_authors_locked
       end
@@ -1189,7 +1196,7 @@ RSpec.describe PostsController do
         login_as(user)
         expect(post.ignored_by?(user)).not_to eq(true)
 
-        put :update, id: post.id, hidden: 'true'
+        put :update, params: { id: post.id, hidden: 'true' }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:success]).to eq("Post has been hidden")
         expect(post.reload.ignored_by?(user)).to eq(true)
@@ -1207,7 +1214,7 @@ RSpec.describe PostsController do
         post.ignore(user)
         expect(post.reload.ignored_by?(user)).to eq(true)
 
-        put :update, id: post.id, hidden: 'false'
+        put :update, params: { id: post.id, hidden: 'false' }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:success]).to eq("Post has been unhidden")
         expect(post.reload.ignored_by?(user)).not_to eq(true)
@@ -1230,13 +1237,17 @@ RSpec.describe PostsController do
         char2 = create(:template_character, user: user)
         expect(controller).to receive(:editor_setup).and_call_original
         expect(controller).to receive(:setup_layout_gon).and_call_original
-        put :update, id: post.id, button_preview: true, post: {
-          subject: 'test',
-          content: 'orign',
-          setting_ids: [setting1.id, '_'+setting2.name, '_other'],
-          content_warning_ids: [warning1.id, '_'+warning2.name, '_other'],
-          label_ids: [label1.id, '_'+label2.name, '_other'],
-          character_id: char1.id
+        put :update, params: {
+          id: post.id,
+          button_preview: true,
+          post: {
+            subject: 'test',
+            content: 'orign',
+            setting_ids: [setting1.id, '_'+setting2.name, '_other'],
+            content_warning_ids: [warning1.id, '_'+warning2.name, '_other'],
+            label_ids: [label1.id, '_'+label2.name, '_other'],
+            character_id: char1.id
+          }
         }
         expect(response).to render_template(:preview)
         expect(assigns(:written)).to be_an_instance_of(Post)
@@ -1275,7 +1286,7 @@ RSpec.describe PostsController do
         user = create(:user)
         login_as(user)
         post = create(:post, user: user)
-        put :update, id: post.id, button_preview: true
+        put :update, params: { id: post.id, button_preview: true }
         expect(response).to render_template(:preview)
         expect(assigns(:written).user).to eq(user)
       end
@@ -1295,7 +1306,7 @@ RSpec.describe PostsController do
         setting_ids = ['_setting']
         warning_ids = ['_warning']
         label_ids = ['_label']
-        put :update, id: post.id, post: {setting_ids: setting_ids, content_warning_ids: warning_ids, label_ids: label_ids}
+        put :update, params: { id: post.id, post: {setting_ids: setting_ids, content_warning_ids: warning_ids, label_ids: label_ids} }
         expect(response).to redirect_to(post_url(post))
         post = assigns(:post)
         expect(post.settings).to be_all(&:persisted?)
@@ -1316,7 +1327,7 @@ RSpec.describe PostsController do
         warning = create(:content_warning, name: 'warning')
         label_ids = ['_label']
         tag = create(:label, name: 'label')
-        put :update, id: post.id, post: {setting_ids: setting_ids, content_warning_ids: warning_ids, label_ids: label_ids}
+        put :update, params: { id: post.id, post: {setting_ids: setting_ids, content_warning_ids: warning_ids, label_ids: label_ids} }
         expect(response).to redirect_to(post_url(post))
         post = assigns(:post)
         expect(post.settings).to eq([setting])
@@ -1332,7 +1343,7 @@ RSpec.describe PostsController do
         char2 = create(:template_character, user: user)
         expect(controller).to receive(:editor_setup).and_call_original
         expect(controller).to receive(:setup_layout_gon).and_call_original
-        put :update, id: post.id, post: {subject: ''}
+        put :update, params: { id: post.id, post: {subject: ''} }
         expect(response).to render_template(:edit)
         expect(flash[:error][:message]).to eq("Your post could not be saved because of the following problems:")
         expect(post.reload.subject).not_to be_empty
@@ -1370,7 +1381,7 @@ RSpec.describe PostsController do
         warning = create(:content_warning)
         tag = create(:label)
 
-        put :update, id: post.id, post: {content: newcontent, subject: newsubj, description: 'desc', board_id: board.id, section_id: section.id, character_id: char.id, character_alias_id: calias.id, icon_id: icon.id, privacy: Post::PRIVACY_LIST, viewer_ids: [viewer.id], setting_ids: [setting.id], content_warning_ids: [warning.id], label_ids: [tag.id]}
+        put :update, params: { id: post.id, post: {content: newcontent, subject: newsubj, description: 'desc', board_id: board.id, section_id: section.id, character_id: char.id, character_alias_id: calias.id, icon_id: icon.id, privacy: Post::PRIVACY_LIST, viewer_ids: [viewer.id], setting_ids: [setting.id], content_warning_ids: [warning.id], label_ids: [tag.id]} }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:success]).to eq("Your post has been updated.")
 
@@ -1396,14 +1407,14 @@ RSpec.describe PostsController do
 
   describe "POST warnings" do
     it "requires a valid post" do
-      post :warnings, id: -1
+      post :warnings, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
     it "requires permission" do
       warn_post = create(:post, privacy: Post::PRIVACY_PRIVATE)
-      post :warnings, id: warn_post.id
+      post :warnings, params: { id: warn_post.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
@@ -1411,7 +1422,7 @@ RSpec.describe PostsController do
     it "works for logged out" do
       warn_post = create(:post)
       expect(session[:ignore_warnings]).to be_nil
-      post :warnings, id: warn_post.id, per_page: 10, page: 2
+      post :warnings, params: { id: warn_post.id, per_page: 10, page: 2 }
       expect(response).to redirect_to(post_url(warn_post, per_page: 10, page: 2))
       expect(flash[:success]).to eq("All content warnings have been hidden. Proceed at your own risk.")
       expect(session[:ignore_warnings]).to eq(true)
@@ -1423,7 +1434,7 @@ RSpec.describe PostsController do
       expect(session[:ignore_warnings]).to be_nil
       expect(warn_post.send(:view_for, user)).to be_a_new_record
       login_as(user)
-      post :warnings, id: warn_post.id
+      post :warnings, params: { id: warn_post.id }
       expect(response).to redirect_to(post_url(warn_post))
       expect(flash[:success]).to start_with("Content warnings have been hidden for this thread. Proceed at your own risk.")
       expect(session[:ignore_warnings]).to be_nil
@@ -1435,14 +1446,14 @@ RSpec.describe PostsController do
 
   describe "DELETE destroy" do
     it "requires login" do
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid post" do
       login
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
@@ -1452,7 +1463,7 @@ RSpec.describe PostsController do
       login_as(user)
       post = create(:post)
       expect(post).not_to be_editable_by(user)
-      delete :destroy, id: post.id
+      delete :destroy, params: { id: post.id }
       expect(response).to redirect_to(post_url(post))
       expect(flash[:error]).to eq("You do not have permission to modify this post.")
     end
@@ -1460,7 +1471,7 @@ RSpec.describe PostsController do
     it "succeeds" do
       post = create(:post)
       login_as(post.user)
-      delete :destroy, id: post.id
+      delete :destroy, params: { id: post.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:success]).to eq("Post deleted.")
     end
@@ -1622,7 +1633,7 @@ RSpec.describe PostsController do
         user = create(:user)
         expect(user.unread_opened).not_to eq(true)
         login_as(user)
-        get :unread, started: 'true'
+        get :unread, params: { started: 'true' }
         expect(response).to have_http_status(200)
         expect(assigns(:started)).to eq(true)
         expect(assigns(:page_title)).to eq('Opened Threads')
@@ -1688,7 +1699,7 @@ RSpec.describe PostsController do
         user = create(:user)
         expect(private_post.visible_to?(user)).not_to eq(true)
         login_as(user)
-        post :mark, marked_ids: [private_post.id], commit: "Mark Read"
+        post :mark, params: { marked_ids: [private_post.id], commit: "Mark Read" }
         expect(response).to redirect_to(unread_posts_url)
         expect(flash[:success]).to eq("0 posts marked as read.")
         expect(private_post.reload.last_read(user)).to be_nil
@@ -1703,7 +1714,7 @@ RSpec.describe PostsController do
         expect(post1.last_read(user)).to be_nil
         expect(post2.last_read(user)).to be_nil
 
-        post :mark, marked_ids: [post1.id.to_s, post2.id.to_s], commit: "Mark Read"
+        post :mark, params: { marked_ids: [post1.id.to_s, post2.id.to_s], commit: "Mark Read" }
 
         expect(response).to redirect_to(unread_posts_url)
         expect(flash[:success]).to eq("2 posts marked as read.")
@@ -1718,7 +1729,7 @@ RSpec.describe PostsController do
         user = create(:user)
         expect(private_post.visible_to?(user)).not_to eq(true)
         login_as(user)
-        post :mark, marked_ids: [private_post.id]
+        post :mark, params: { marked_ids: [private_post.id] }
         expect(response).to redirect_to(unread_posts_url)
         expect(flash[:success]).to eq("0 posts hidden from this page.")
         expect(private_post.reload.ignored_by?(user)).not_to eq(true)
@@ -1733,7 +1744,7 @@ RSpec.describe PostsController do
         expect(post1.visible_to?(user)).to eq(true)
         expect(post2.visible_to?(user)).to eq(true)
 
-        post :mark, marked_ids: [post1.id.to_s, post2.id.to_s]
+        post :mark, params: { marked_ids: [post1.id.to_s, post2.id.to_s] }
 
         expect(response).to redirect_to(unread_posts_url)
         expect(flash[:success]).to eq("2 posts hidden from this page.")
@@ -1766,7 +1777,7 @@ RSpec.describe PostsController do
         expect(post2.reload.last_read(user)).to be_the_same_time_as(time2)
         expect(post3.reload.last_read(user)).to be_the_same_time_as(time3)
 
-        post :mark, marked_ids: [post1, post2, post3].map(&:id).map(&:to_s)
+        post :mark, params: { marked_ids: [post1, post2, post3].map(&:id).map(&:to_s) }
 
         expect(response).to redirect_to(unread_posts_url)
         expect(flash[:success]).to eq("3 posts hidden from this page.")
@@ -1841,7 +1852,7 @@ RSpec.describe PostsController do
       hidden_post.ignore(user)
       stay_hidden_post.ignore(user)
       login_as(user)
-      post :unhide, unhide_posts: [hidden_post.id]
+      post :unhide, params: { unhide_posts: [hidden_post.id] }
       expect(response).to redirect_to(hidden_posts_url)
       hidden_post.reload
       stay_hidden_post.reload
@@ -1856,7 +1867,7 @@ RSpec.describe PostsController do
       board.ignore(user)
       stay_hidden_board.ignore(user)
       login_as(user)
-      post :unhide, unhide_boards: [board.id]
+      post :unhide, params: { unhide_boards: [board.id] }
       expect(response).to redirect_to(hidden_posts_url)
       board.reload
       stay_hidden_board.reload
@@ -1872,7 +1883,7 @@ RSpec.describe PostsController do
       hidden_post.ignore(user)
       login_as(user)
 
-      post :unhide, unhide_boards: [board.id], unhide_posts: [hidden_post.id]
+      post :unhide, params: { unhide_boards: [board.id], unhide_posts: [hidden_post.id] }
 
       expect(response).to redirect_to(hidden_posts_url)
       board.reload

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RepliesController do
         expect(controller).to receive(:make_draft).and_call_original
         expect(controller).to receive(:setup_layout_gon).and_call_original
 
-        post :create, button_preview: true, reply: {post_id: reply_post.id}
+        post :create, params: { button_preview: true, reply: {post_id: reply_post.id} }
         expect(response).to render_template(:preview)
         expect(assigns(:javascripts)).to include('posts/editor')
         expect(assigns(:page_title)).to eq(reply_post.subject)
@@ -53,7 +53,7 @@ RSpec.describe RepliesController do
       it "displays errors if relevant" do
         draft = create(:reply_draft)
         login_as(draft.user)
-        post :create, button_draft: true, reply: {post_id: ''}
+        post :create, params: { button_draft: true, reply: {post_id: ''} }
         expect(flash[:error][:message]).to eq("Your draft could not be saved because of the following problems:")
         expect(draft.reload.post_id).not_to be_nil
         expect(response).to redirect_to(posts_url)
@@ -68,7 +68,7 @@ RSpec.describe RepliesController do
         calias = create(:alias, character: char)
 
         expect(ReplyDraft.count).to eq(0)
-        post :create, button_draft: true, reply: {post_id: reply_post.id, character_id: char.id, icon_id: icon.id, content: 'testcontent', character_alias_id: calias.id}
+        post :create, params: { button_draft: true, reply: {post_id: reply_post.id, character_id: char.id, icon_id: icon.id, content: 'testcontent', character_alias_id: calias.id} }
         expect(response).to redirect_to(post_url(reply_post, page: :unread, anchor: :unread))
         expect(flash[:success]).to eq("Draft saved!")
         expect(ReplyDraft.count).to eq(1)
@@ -85,7 +85,7 @@ RSpec.describe RepliesController do
       it "updates the existing draft if one exists" do
         draft = create(:reply_draft)
         login_as(draft.user)
-        post :create, button_draft: true, reply: {post_id: draft.post.id, content: 'new draft'}
+        post :create, params: { button_draft: true, reply: {post_id: draft.post.id, content: 'new draft'} }
         expect(flash[:success]).to eq("Draft saved!")
         expect(draft.reload.content).to eq('new draft')
         expect(ReplyDraft.count).to eq(1)
@@ -105,7 +105,7 @@ RSpec.describe RepliesController do
       reply_post.mark_read(reply_post.user)
       create(:reply, post: reply_post)
 
-      post :create, reply: {post_id: reply_post.id, user_id: reply_post.user_id}
+      post :create, params: { reply: {post_id: reply_post.id, user_id: reply_post.user_id} }
       expect(response.status).to eq(200)
       expect(flash[:error]).to eq("There has been 1 new reply since you last viewed this post.")
     end
@@ -116,14 +116,14 @@ RSpec.describe RepliesController do
       reply_post.mark_read(reply_post.user)
       last_seen = create(:reply, post: reply_post)
 
-      post :create, reply: {post_id: reply_post.id, user_id: reply_post.user_id}
+      post :create, params: { reply: {post_id: reply_post.id, user_id: reply_post.user_id} }
       expect(response.status).to eq(200)
       expect(flash[:error]).to eq("There has been 1 new reply since you last viewed this post.")
 
       create(:reply, post: reply_post)
       create(:reply, post: reply_post)
 
-      post :create, reply: {post_id: reply_post.id, user_id: reply_post.user_id}
+      post :create, params: { reply: {post_id: reply_post.id, user_id: reply_post.user_id} }
       expect(response.status).to eq(200)
       expect(flash[:error]).to eq("There have been 2 new replies since you last viewed this post.")
     end
@@ -134,11 +134,11 @@ RSpec.describe RepliesController do
       dupe_reply = create(:reply, user: reply_post.user, post: reply_post)
       reply_post.mark_read(reply_post.user, dupe_reply.created_at + 1.second, true)
 
-      post :create, reply: {post_id: reply_post.id, user_id: reply_post.user_id, content: dupe_reply.content}
+      post :create, params: { reply: {post_id: reply_post.id, user_id: reply_post.user_id, content: dupe_reply.content} }
       expect(response).to have_http_status(200)
       expect(flash[:error]).to eq("This looks like a duplicate. Did you attempt to post this twice? Please resubmit if this was intentional.")
 
-      post :create, reply: {post_id: reply_post.id, user_id: reply_post.user_id, content: dupe_reply.content}, allow_dupe: true
+      post :create, params: { reply: {post_id: reply_post.id, user_id: reply_post.user_id, content: dupe_reply.content}, allow_dupe: true }
       expect(response).to have_http_status(302)
       expect(flash[:success]).to eq("Posted!")
     end
@@ -151,7 +151,7 @@ RSpec.describe RepliesController do
       reply_post.mark_read(user, reply_post.created_at + 1.second, true)
 
       expect(character.user_id).not_to eq(user.id)
-      post :create, reply: {character_id: character.id, post_id: reply_post.id}
+      post :create, params: { reply: {character_id: character.id, post_id: reply_post.id} }
       expect(response).to redirect_to(post_url(reply_post))
       expect(flash[:error][:message]).to eq("Your post could not be saved because of the following problems:")
     end
@@ -166,7 +166,7 @@ RSpec.describe RepliesController do
       icon = create(:icon, user: user)
       calias = create(:alias, character: char)
 
-      post :create, reply: {post_id: reply_post.id, content: 'test!', character_id: char.id, icon_id: icon.id, character_alias_id: calias.id}
+      post :create, params: { reply: {post_id: reply_post.id, content: 'test!', character_id: char.id, icon_id: icon.id, character_alias_id: calias.id} }
 
       reply = Reply.first
       expect(reply).not_to be_nil
@@ -187,7 +187,7 @@ RSpec.describe RepliesController do
       reply_post.mark_read(user, reply_post.created_at + 1.second, true)
       expect(Reply.count).to eq(0)
 
-      post :create, reply: {post_id: reply_post.id, content: 'test content!'}
+      post :create, params: { reply: {post_id: reply_post.id, content: 'test content!'} }
       reply = Reply.first
       expect(response).to redirect_to(reply_url(reply, anchor: "reply-#{reply.id}"))
       expect(reply).not_to be_nil
@@ -203,7 +203,7 @@ RSpec.describe RepliesController do
       reply_post.mark_read(user, reply_post.created_at + 1.second, true)
       expect(Reply.count).to eq(0)
 
-      post :create, reply: {post_id: reply_post.id, content: 'test content again!'}
+      post :create, params: { reply: {post_id: reply_post.id, content: 'test content again!'} }
       reply = Reply.first
       expect(response).to redirect_to(reply_url(reply, anchor: "reply-#{reply.id}"))
       expect(reply).not_to be_nil
@@ -220,7 +220,7 @@ RSpec.describe RepliesController do
       reply_post.mark_read(user, reply_old.created_at + 1.second, true)
       expect(Reply.count).to eq(1)
 
-      post :create, reply: {post_id: reply_post.id, content: 'test content the third!'}
+      post :create, params: { reply: {post_id: reply_post.id, content: 'test content the third!'} }
       expect(Reply.count).to eq(2)
       reply = Reply.order(id: :desc).first
       expect(reply).not_to eq(reply_old)
@@ -233,7 +233,7 @@ RSpec.describe RepliesController do
 
   describe "GET show" do
     it "requires valid reply" do
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
@@ -249,14 +249,14 @@ RSpec.describe RepliesController do
       expect(reply.post.visible_to?(reply.user)).to eq(false)
 
       login_as(reply.user)
-      get :show, id: reply.id
+      get :show, params: { id: reply.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
 
     it "succeeds when logged out" do
       reply = create(:reply)
-      get :show, id: reply.id
+      get :show, params: { id: reply.id }
       expect(response).to have_http_status(200)
       expect(assigns(:javascripts)).to include('posts/show')
     end
@@ -264,7 +264,7 @@ RSpec.describe RepliesController do
     it "succeeds when logged in" do
       reply = create(:reply)
       login
-      get :show, id: reply.id
+      get :show, params: { id: reply.id }
       expect(response).to have_http_status(200)
       expect(assigns(:javascripts)).to include('posts/show')
     end
@@ -276,7 +276,7 @@ RSpec.describe RepliesController do
 
   describe "GET history" do
     it "requires valid reply" do
-      get :history, id: -1
+      get :history, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
@@ -292,35 +292,35 @@ RSpec.describe RepliesController do
       expect(reply.post.visible_to?(reply.user)).to eq(false)
 
       login_as(reply.user)
-      get :history, id: reply.id
+      get :history, params: { id: reply.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
 
     it "works when logged out" do
       reply = create(:reply)
-      get :history, id: reply.id
+      get :history, params: { id: reply.id }
       expect(response.status).to eq(200)
     end
 
     it "works when logged in" do
       reply = create(:reply)
       login
-      get :history, id: reply.id
+      get :history, params: { id: reply.id }
       expect(response.status).to eq(200)
     end
   end
 
   describe "GET edit" do
     it "requires login" do
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid reply" do
       login
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
@@ -336,7 +336,7 @@ RSpec.describe RepliesController do
       expect(reply.post.visible_to?(reply.user)).to eq(false)
 
       login_as(reply.user)
-      get :edit, id: reply.id
+      get :edit, params: { id: reply.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
@@ -344,7 +344,7 @@ RSpec.describe RepliesController do
     it "requires reply access" do
       reply = create(:reply)
       login
-      get :edit, id: reply.id
+      get :edit, params: { id: reply.id }
       expect(response).to redirect_to(post_url(reply.post))
       expect(flash[:error]).to eq("You do not have permission to modify this post.")
     end
@@ -358,7 +358,7 @@ RSpec.describe RepliesController do
       expect(controller).to receive(:build_template_groups).and_call_original
       expect(controller).to receive(:setup_layout_gon).and_call_original
 
-      get :edit, id: reply.id
+      get :edit, params: { id: reply.id }
       expect(response).to render_template(:edit)
       expect(assigns(:page_title)).to eq(reply.post.subject)
       expect(assigns(:reply)).to eq(reply)
@@ -379,14 +379,14 @@ RSpec.describe RepliesController do
 
   describe "PUT update" do
     it "requires login" do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid reply" do
       login
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
@@ -402,7 +402,7 @@ RSpec.describe RepliesController do
       expect(reply.post.visible_to?(reply.user)).to eq(false)
 
       login_as(reply.user)
-      put :update, id: reply.id
+      put :update, params: { id: reply.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
@@ -410,7 +410,7 @@ RSpec.describe RepliesController do
     it "requires reply access" do
       reply = create(:reply)
       login
-      put :update, id: reply.id
+      put :update, params: { id: reply.id }
       expect(response).to redirect_to(post_url(reply.post))
       expect(flash[:error]).to eq("You do not have permission to modify this post.")
     end
@@ -428,7 +428,7 @@ RSpec.describe RepliesController do
       icon = create(:icon, user: user)
       calias = create(:alias, character: char)
 
-      put :update, id: reply.id, reply: {content: newcontent, character_id: char.id, icon_id: icon.id, character_alias_id: calias.id}
+      put :update, params: { id: reply.id, reply: {content: newcontent, character_id: char.id, icon_id: icon.id, character_alias_id: calias.id} }
       expect(response).to redirect_to(reply_url(reply, anchor: "reply-#{reply.id}"))
       expect(flash[:success]).to eq("Post updated")
 
@@ -446,14 +446,14 @@ RSpec.describe RepliesController do
 
   describe "DELETE destroy" do
     it "requires login" do
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid reply" do
       login
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
@@ -469,7 +469,7 @@ RSpec.describe RepliesController do
       expect(reply.post.visible_to?(reply.user)).to eq(false)
 
       login_as(reply.user)
-      delete :destroy, id: reply.id
+      delete :destroy, params: { id: reply.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
@@ -477,7 +477,7 @@ RSpec.describe RepliesController do
     it "requires reply access" do
       reply = create(:reply)
       login
-      delete :destroy, id: reply.id
+      delete :destroy, params: { id: reply.id }
       expect(response).to redirect_to(post_url(reply.post))
       expect(flash[:error]).to eq("You do not have permission to modify this post.")
     end
@@ -485,7 +485,7 @@ RSpec.describe RepliesController do
     it "succeeds for reply creator" do
       reply = create(:reply)
       login_as(reply.user)
-      delete :destroy, id: reply.id
+      delete :destroy, params: { id: reply.id }
       expect(response).to redirect_to(post_url(reply.post, page: 1))
       expect(flash[:success]).to eq("Post deleted.")
       expect(Reply.find_by_id(reply.id)).to be_nil
@@ -494,7 +494,7 @@ RSpec.describe RepliesController do
     it "succeeds for admin user" do
       reply = create(:reply)
       login_as(create(:admin_user))
-      delete :destroy, id: reply.id
+      delete :destroy, params: { id: reply.id }
       expect(response).to redirect_to(post_url(reply.post, page: 1))
       expect(flash[:success]).to eq("Post deleted.")
       expect(Reply.find_by_id(reply.id)).to be_nil
@@ -506,7 +506,7 @@ RSpec.describe RepliesController do
       reply = create(:reply, post: reply.post, user: reply.user) # p2
       reply = create(:reply, post: reply.post, user: reply.user) # p2
       login_as(reply.user)
-      delete :destroy, id: reply.id, per_page: 2
+      delete :destroy, params: { id: reply.id, per_page: 2 }
       expect(response).to redirect_to(post_url(reply.post, page: 2))
     end
 
@@ -517,7 +517,7 @@ RSpec.describe RepliesController do
       reply = create(:reply, post: reply.post, user: reply.user) # p2
       reply = create(:reply, post: reply.post, user: reply.user) # p3
       login_as(reply.user)
-      delete :destroy, id: reply.id, per_page: 2
+      delete :destroy, params: { id: reply.id, per_page: 2 }
       expect(response).to redirect_to(post_url(reply.post, page: 2))
     end
   end
@@ -557,12 +557,12 @@ RSpec.describe RepliesController do
         author = create(:user)
         template = create(:template, user: author)
         create(:template)
-        get :search, commit: true, author_id: author.id
+        get :search, params: { commit: true, author_id: author.id }
         expect(assigns(:templates)).to eq([template])
       end
 
       it "handles invalid post" do
-        get :search, post_id: -1
+        get :search, params: { post_id: -1 }
         expect(response).to have_http_status(200)
         expect(assigns(:page_title)).to eq('Search Replies')
         expect(assigns(:post)).to be_nil
@@ -572,7 +572,7 @@ RSpec.describe RepliesController do
       it "handles valid post" do
         templateless_char = Character.where(template_id: nil).first
         post = create(:post, character: templateless_char, user: templateless_char.user)
-        get :search, post_id: post.id
+        get :search, params: { post_id: post.id }
         expect(response).to have_http_status(200)
         expect(assigns(:page_title)).to eq('Search Replies')
         expect(assigns(:post)).to eq(post)
@@ -586,28 +586,28 @@ RSpec.describe RepliesController do
     context "searching" do
       it "finds all when no arguments given" do
         4.times do create(:reply) end
-        get :search, commit: true
+        get :search, params: { commit: true }
         expect(assigns(:search_results)).to match_array(Reply.all)
       end
 
       it "filters by author" do
         replies = Array.new(4) { create(:reply) }
         filtered_reply = replies.last
-        get :search, commit: true, author_id: filtered_reply.user_id
+        get :search, params: { commit: true, author_id: filtered_reply.user_id }
         expect(assigns(:search_results)).to match_array([filtered_reply])
       end
 
       it "filters by icon" do
         create(:reply, with_icon: true)
         reply = create(:reply, with_icon: true)
-        get :search, commit: true, icon_id: reply.icon_id
+        get :search, params: { commit: true, icon_id: reply.icon_id }
         expect(assigns(:search_results)).to match_array([reply])
       end
 
       it "filters by character" do
         create(:reply, with_character: true)
         reply = create(:reply, with_character: true)
-        get :search, commit: true, character_id: reply.character_id
+        get :search, params: { commit: true, character_id: reply.character_id }
         expect(assigns(:search_results)).to match_array([reply])
       end
 
@@ -615,7 +615,7 @@ RSpec.describe RepliesController do
         reply = create(:reply, content: 'contains seagull')
         cap_reply = create(:reply, content: 'Seagull is capital')
         create(:reply, content: 'nope')
-        get :search, commit: true, subj_content: 'seagull'
+        get :search, params: { commit: true, subj_content: 'seagull' }
         expect(assigns(:search_results)).to match_array([reply, cap_reply])
       end
 
@@ -628,7 +628,7 @@ RSpec.describe RepliesController do
         create(:reply, content: 'forks high is not capital')
         create(:reply, content: 'Forks is split from High')
         create(:reply, content: 'nope')
-        get :search, commit: true, subj_content: '"Forks High"'
+        get :search, params: { commit: true, subj_content: '"Forks High"' }
         expect(assigns(:search_results)).to match_array([reply])
       end
 
@@ -638,14 +638,14 @@ RSpec.describe RepliesController do
         reply1.post.update_attributes(privacy: Post::PRIVACY_PRIVATE)
         expect(reply1.post.reload).not_to be_visible_to(nil) # logged out, not visible
         expect(reply2.post.reload).to be_visible_to(nil)
-        get :search, commit: true, subj_content: 'forks'
+        get :search, params: { commit: true, subj_content: 'forks' }
         expect(assigns(:search_results)).to match_array([reply2])
       end
 
       it "filters by post" do
         replies = Array.new(4) { create(:reply) }
         filtered_reply = replies.last
-        get :search, commit: true, post_id: filtered_reply.post_id
+        get :search, params: { commit: true, post_id: filtered_reply.post_id }
         expect(assigns(:search_results)).to match_array([filtered_reply])
       end
 
@@ -653,7 +653,7 @@ RSpec.describe RepliesController do
         reply1 = create(:reply)
         reply1.post.update_attributes(privacy: Post::PRIVACY_PRIVATE)
         expect(reply1.post.reload).not_to be_visible_to(nil)
-        get :search, commit: true, post_id: reply1.post_id
+        get :search, params: { commit: true, post_id: reply1.post_id }
         expect(assigns(:search_results)).to be_nil
         expect(flash[:error]).to eq('You do not have permission to view this post.')
       end
@@ -662,7 +662,7 @@ RSpec.describe RepliesController do
         continuity_post = create(:post, num_replies: 1)
         create(:post, num_replies: 1) # wrong post
         filtered_reply = continuity_post.replies.last
-        get :search, commit: true, board_id: continuity_post.board_id
+        get :search, params: { commit: true, board_id: continuity_post.board_id }
         expect(assigns(:search_results)).to match_array([filtered_reply])
       end
 
@@ -671,7 +671,7 @@ RSpec.describe RepliesController do
         templateless_char = create(:character)
         reply = create(:reply, character: character, user: character.user)
         create(:reply, character: templateless_char, user: templateless_char.user)
-        get :search, commit: true, template_id: character.template_id
+        get :search, params: { commit: true, template_id: character.template_id }
         expect(assigns(:search_results)).to match_array([reply])
       end
     end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe ReportsController do
 
   describe "GET show" do
     it "requires valid type" do
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to redirect_to(reports_url)
       expect(flash[:error]).to eq("Could not identify the type of report.")
     end
 
     it "succeeds with daily" do
-      get :show, id: 'daily'
+      get :show, params: { id: 'daily' }
       expect(response).to have_http_status(200)
     end
 
@@ -32,7 +32,7 @@ RSpec.describe ReportsController do
       post.mark_read(user)
       time = post.last_read(user)
       login_as(user)
-      get :show, id: 'daily'
+      get :show, params: { id: 'daily' }
       expect(response).to have_http_status(200)
       expect(assigns(:board_views)).to be_empty
       expect(assigns(:opened_ids)).to match_array([post.id])
@@ -41,7 +41,7 @@ RSpec.describe ReportsController do
     end
 
     it "succeeds with monthly" do
-      get :show, id: 'monthly'
+      get :show, params: { id: 'monthly' }
       expect(response).to have_http_status(200)
     end
 
@@ -52,7 +52,7 @@ RSpec.describe ReportsController do
         3.times do create(:post) end
         Post.last.user.update_attributes(moiety: 'abcdef')
         create(:post, num_replies: 4, created_at: 2.days.ago)
-        get :show, id: 'daily'
+        get :show, params: { id: 'daily' }
       end
 
       it "works with logged in" do
@@ -60,7 +60,7 @@ RSpec.describe ReportsController do
         DailyReport.mark_read(user, 3.day.ago.to_date)
         PostView.create(user: user, post: create(:post))
         login_as(user)
-        get :show, id: 'daily'
+        get :show, params: { id: 'daily' }
       end
     end
 
@@ -75,7 +75,7 @@ RSpec.describe ReportsController do
           it "does not mark read for today's unfinished report" do
             expect(user.report_view).to be_nil
             login_as(user)
-            get :show, id: 'daily'
+            get :show, params: { id: 'daily' }
             expect(user.reload.report_view).to be_nil
           end
 
@@ -85,7 +85,7 @@ RSpec.describe ReportsController do
             viewed_time = 2.days.ago
             expect_time = viewed_time
 
-            get :show, id: 'daily', day: viewed_time.to_date.to_s
+            get :show, params: { id: 'daily', day: viewed_time.to_date.to_s }
 
             user.reload
             expect(user.report_view).not_to be_nil
@@ -96,7 +96,7 @@ RSpec.describe ReportsController do
             user.update_attributes(ignore_unread_daily_report: true)
             expect(user.report_view).to be_nil
             login_as(user)
-            get :show, id: 'daily', day: 2.days.ago.to_date.to_s
+            get :show, params: { id: 'daily', day: 2.days.ago.to_date.to_s }
             expect(user.report_view).to be_nil
           end
 
@@ -111,7 +111,7 @@ RSpec.describe ReportsController do
             end
 
             login_as(user)
-            get :show, id: 'daily', day: viewed_time.to_date.to_s
+            get :show, params: { id: 'daily', day: viewed_time.to_date.to_s }
 
             user.reload
             expect(user.report_view).not_to be_nil
@@ -129,7 +129,7 @@ RSpec.describe ReportsController do
             end
 
             login_as(user)
-            get :show, id: 'daily', day: viewed_time.to_date.to_s
+            get :show, params: { id: 'daily', day: viewed_time.to_date.to_s }
 
             user.reload
             expect(user.report_view).not_to be_nil

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SessionsController do
     it "requires an existing username" do
       nonusername = 'nonuser'
       expect(User.find_by(username: nonusername)).to be_nil
-      post :create, username: nonusername
+      post :create, params: { username: nonusername }
       expect(flash[:error]).to eq("That username does not exist.")
       expect(controller.send(:logged_in?)).not_to eq(true)
     end
@@ -51,7 +51,7 @@ RSpec.describe SessionsController do
       user = create(:user)
       create(:password_reset, user: user)
       expect(user.password_resets.active.unused).not_to be_empty
-      post :create, username: user.username
+      post :create, params: { username: user.username }
       expect(flash[:error]).to eq("The password for this account has been reset. Please check your email.")
       expect(controller.send(:logged_in?)).not_to eq(true)
     end
@@ -59,7 +59,7 @@ RSpec.describe SessionsController do
     it "requires a valid password" do
       password = 'password'
       user = create(:user, password: password)
-      post :create, username: user.username, password: password + "-not"
+      post :create, params: { username: user.username, password: password + "-not" }
       expect(flash[:error]).to eq("You have entered an incorrect password.")
       expect(controller.send(:logged_in?)).not_to eq(true)
     end
@@ -70,7 +70,7 @@ RSpec.describe SessionsController do
       expect(session[:user_id]).to be_nil
       expect(controller.send(:logged_in?)).not_to eq(true)
 
-      post :create, username: user.username, password: password
+      post :create, params: { username: user.username, password: password }
 
       expect(session[:user_id]).to eq(user.id)
       expect(controller.send(:logged_in?)).to eq(true)
@@ -88,7 +88,7 @@ RSpec.describe SessionsController do
       expect(session[:user_id]).to be_nil
       expect(controller.send(:logged_in?)).not_to eq(true)
 
-      post :create, username: user.username, password: password
+      post :create, params: { username: user.username, password: password }
 
       expect(session[:user_id]).to eq(user.id)
       expect(controller.send(:logged_in?)).to eq(true)
@@ -102,7 +102,7 @@ RSpec.describe SessionsController do
       password = 'password'
       user = create(:user, password: password)
       expect(cookies.signed[:user_id]).to be_nil
-      post :create, username: user.username, password: password, remember_me: true
+      post :create, params: { username: user.username, password: password, remember_me: true }
       expect(controller.send(:logged_in?)).to eq(true)
       expect(cookies.signed[:user_id]).to eq(user.id)
     end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe TagsController do
 
   describe "GET show" do
     it "requires valid tag" do
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to redirect_to(tags_url)
       expect(flash[:error]).to eq("Tag could not be found.")
     end
@@ -52,7 +52,7 @@ RSpec.describe TagsController do
       it "succeeds with valid post tag" do
         tag = create(:label)
         post = create(:post, labels: [tag])
-        get :show, id: tag.id
+        get :show, params: { id: tag.id }
         expect(response.status).to eq(200)
         expect(assigns(:posts)).to match_array([post])
       end
@@ -61,7 +61,7 @@ RSpec.describe TagsController do
         tag = create(:label)
         post = create(:post, labels: [tag])
         login
-        get :show, id: tag.id
+        get :show, params: { id: tag.id }
         expect(response.status).to eq(200)
         expect(assigns(:posts)).to match_array([post])
       end
@@ -69,7 +69,7 @@ RSpec.describe TagsController do
       it "succeeds with valid gallery tag" do
         group = create(:gallery_group)
         gallery = create(:gallery, gallery_groups: [group])
-        get :show, id: group.id
+        get :show, params: { id: group.id }
         expect(response.status).to eq(200)
         expect(assigns(:galleries)).to match_array([gallery])
       end
@@ -78,7 +78,7 @@ RSpec.describe TagsController do
         group = create(:gallery_group)
         gallery = create(:gallery, gallery_groups: [group])
         login
-        get :show, id: group.id
+        get :show, params: { id: group.id }
         expect(response.status).to eq(200)
         expect(assigns(:galleries)).to match_array([gallery])
       end
@@ -86,7 +86,7 @@ RSpec.describe TagsController do
       it "succeeds with valid character tag" do
         group = create(:gallery_group)
         character = create(:character, gallery_groups: [group])
-        get :show, id: group.id
+        get :show, params: { id: group.id }
         expect(response.status).to eq(200)
         expect(assigns(:characters)).to match_array([character])
       end
@@ -95,7 +95,7 @@ RSpec.describe TagsController do
         group = create(:gallery_group)
         character = create(:character, gallery_groups: [group])
         login
-        get :show, id: group.id
+        get :show, params: { id: group.id }
         expect(response.status).to eq(200)
         expect(assigns(:characters)).to match_array([character])
       end
@@ -104,14 +104,14 @@ RSpec.describe TagsController do
 
   describe "GET edit" do
     it "requires login" do
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid tag" do
       login
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(tags_url)
       expect(flash[:error]).to eq("Tag could not be found.")
     end
@@ -119,7 +119,7 @@ RSpec.describe TagsController do
     it "requires permission" do
       tag = create(:label)
       login
-      get :edit, id: tag.id
+      get :edit, params: { id: tag.id }
       expect(response).to redirect_to(tag_url(tag))
       expect(flash[:error]).to eq("You do not have permission to edit this tag.")
     end
@@ -127,21 +127,21 @@ RSpec.describe TagsController do
     it "allows admin to edit the tag" do
       tag = create(:label)
       login_as(create(:admin_user))
-      get :edit, id: tag.id
+      get :edit, params: { id: tag.id }
       expect(response.status).to eq(200)
     end
   end
 
   describe "PUT update" do
     it "requires login" do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid tag" do
       login
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(tags_url)
       expect(flash[:error]).to eq("Tag could not be found.")
     end
@@ -149,7 +149,7 @@ RSpec.describe TagsController do
     it "requires permission" do
       login
       tag = create(:label)
-      put :update, id: tag.id
+      put :update, params: { id: tag.id }
       expect(response).to redirect_to(tag_url(tag))
       expect(flash[:error]).to eq("You do not have permission to edit this tag.")
     end
@@ -157,7 +157,7 @@ RSpec.describe TagsController do
     it "requires valid params" do
       tag = create(:label)
       login_as(create(:admin_user))
-      put :update, id: tag.id, tag: {name: nil}
+      put :update, params: { id: tag.id, tag: {name: nil} }
       expect(response.status).to eq(200)
       expect(flash[:error][:message]).to eq("Tag could not be saved because of the following problems:")
     end
@@ -166,7 +166,7 @@ RSpec.describe TagsController do
       tag = create(:label)
       name = tag.name + 'Edited'
       login_as(create(:admin_user))
-      put :update, id: tag.id, tag: {name: name}
+      put :update, params: { id: tag.id, tag: {name: name} }
       expect(response).to redirect_to(tag_url(tag))
       expect(flash[:success]).to eq("Tag saved!")
       expect(tag.reload.name).to eq(name)
@@ -175,14 +175,14 @@ RSpec.describe TagsController do
 
   describe "DELETE destroy" do
     it "requires login" do
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid tag" do
       login
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(tags_url)
       expect(flash[:error]).to eq("Tag could not be found.")
     end
@@ -190,7 +190,7 @@ RSpec.describe TagsController do
     it "requires permission" do
       tag = create(:label)
       login
-      delete :destroy, id: tag.id
+      delete :destroy, params: { id: tag.id }
       expect(response).to redirect_to(tag_url(tag))
       expect(flash[:error]).to eq("You do not have permission to edit this tag.")
     end
@@ -198,7 +198,7 @@ RSpec.describe TagsController do
     it "allows admin to destroy the tag" do
       tag = create(:label)
       login_as(create(:admin_user))
-      delete :destroy, id: tag.id
+      delete :destroy, params: { id: tag.id }
       expect(response).to redirect_to(tags_path)
       expect(flash[:success]).to eq("Tag deleted.")
     end

--- a/spec/controllers/templates_controller_spec.rb
+++ b/spec/controllers/templates_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe TemplatesController do
     it "works" do
       char = create(:character)
       login_as(char.user)
-      post :create, template: {name: 'testtest', description: 'test desc', character_ids: [char.id]}
+      post :create, params: { template: {name: 'testtest', description: 'test desc', character_ids: [char.id]} }
       created = Template.last
       expect(response).to redirect_to(template_url(created))
       expect(flash[:success]).to eq("Template saved successfully.")
@@ -49,19 +49,19 @@ RSpec.describe TemplatesController do
 
   describe "GET show" do
     it "requires valid template" do
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("Template could not be found.")
     end
 
     it "works logged in" do
       login
-      get :show, id: create(:template).id
+      get :show, params: { id: create(:template).id }
       expect(response).to have_http_status(200)
     end
 
     it "works logged out" do
-      get :show, id: create(:template).id
+      get :show, params: { id: create(:template).id }
       expect(response).to have_http_status(200)
     end
 
@@ -75,7 +75,7 @@ RSpec.describe TemplatesController do
       create(:reply, post: reply_post, user: template.user, character: char2)
       create(:post, character: non_char, user: non_char.user)
 
-      get :show, id: template.id
+      get :show, params: { id: template.id }
       expect(assigns(:page_title)).to eq(template.name)
       expect(assigns(:posts).map(&:id)).to eq([reply_post.id, template_post.id])
       expect(assigns(:user)).to eq(template.user)
@@ -84,14 +84,14 @@ RSpec.describe TemplatesController do
 
   describe "GET edit" do
     it "requires login" do
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid template" do
       login
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("Template could not be found.")
     end
@@ -99,7 +99,7 @@ RSpec.describe TemplatesController do
     it "requires your template" do
       template = create(:template)
       login
-      get :edit, id: template.id
+      get :edit, params: { id: template.id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("That is not your template.")
     end
@@ -107,7 +107,7 @@ RSpec.describe TemplatesController do
     it "works" do
       template = create(:template)
       login_as(template.user)
-      get :edit, id: template.id
+      get :edit, params: { id: template.id }
       expect(response).to have_http_status(200)
       expect(assigns(:page_title)).to eq("Edit Template: #{template.name}")
       expect(assigns(:template)).to eq(template)
@@ -116,14 +116,14 @@ RSpec.describe TemplatesController do
 
   describe "PUT update" do
     it "requires login" do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid template" do
       login
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("Template could not be found.")
     end
@@ -131,7 +131,7 @@ RSpec.describe TemplatesController do
     it "requires your template" do
       template = create(:template)
       login
-      put :update, id: template.id
+      put :update, params: { id: template.id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("That is not your template.")
     end
@@ -139,7 +139,7 @@ RSpec.describe TemplatesController do
     it "requires valid params" do
       template = create(:template)
       login_as(template.user)
-      put :update, id: template.id, template: {name: ''}
+      put :update, params: { id: template.id, template: {name: ''} }
       expect(assigns(:template)).not_to be_valid
       expect(response).to render_template(:edit)
       expect(flash[:error]).to eq("Your template could not be saved.")
@@ -151,7 +151,7 @@ RSpec.describe TemplatesController do
       new_name = template.name + 'new'
       login_as(template.user)
 
-      put :update, id: template.id, template: {name: new_name, description: 'new desc', character_ids: [char.id]}
+      put :update, params: { id: template.id, template: {name: new_name, description: 'new desc', character_ids: [char.id]} }
       expect(response).to redirect_to(template_url(template))
       expect(flash[:success]).to eq("Template saved successfully.")
 
@@ -164,14 +164,14 @@ RSpec.describe TemplatesController do
 
   describe "DELETE destroy" do
     it "requires login" do
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid template" do
       login
-      delete :destroy, id: -1
+      delete :destroy, params: { id: -1 }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("Template could not be found.")
     end
@@ -180,7 +180,7 @@ RSpec.describe TemplatesController do
       user = create(:user)
       login_as(user)
       template = create(:template)
-      delete :destroy, id: template.id
+      delete :destroy, params: { id: template.id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:error]).to eq("That is not your template.")
     end
@@ -188,7 +188,7 @@ RSpec.describe TemplatesController do
     it "succeeds" do
       template = create(:template)
       login_as(template.user)
-      delete :destroy, id: template.id
+      delete :destroy, params: { id: template.id }
       expect(response).to redirect_to(characters_url)
       expect(flash[:success]).to eq("Template deleted successfully.")
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe UsersController do
     end
 
     it "requires valid fields" do
-      post :create, secret: "ALLHAILTHECOIN"
+      post :create, params: { secret: "ALLHAILTHECOIN" }
       expect(response).to render_template(:new)
       expect(flash[:error][:message]).to eq("There was a problem completing your sign up.")
       expect(assigns(:user)).not_to be_valid
@@ -72,7 +72,7 @@ RSpec.describe UsersController do
 
     it "rejects short passwords" do
       user = build(:user).attributes.with_indifferent_access.merge(password: 'short', password_confirmation: 'short')
-      post :create, secret: 'ALLHAILTHECOIN', user: user
+      post :create, params: { secret: 'ALLHAILTHECOIN' }.merge(user: user)
       expect(response).to render_template(:new)
       expect(flash[:error][:message]).to eq('There was a problem completing your sign up.')
       expect(flash[:error][:array]).to eq(['Password is too short (minimum is 6 characters)'])
@@ -85,7 +85,7 @@ RSpec.describe UsersController do
       user = build(:user).attributes.with_indifferent_access.merge(password: pass, password_confirmation: pass, email: 'testemail@example.com')
 
       expect {
-        post :create, {secret: "ALLHAILTHECOIN"}.merge(user: user)
+        post :create, params: { secret: "ALLHAILTHECOIN" }.merge(user: user)
       }.to change{User.count}.by(1)
       expect(response).to redirect_to(root_url)
       expect(flash[:success]).to eq("User created! You have been logged in.")
@@ -101,7 +101,7 @@ RSpec.describe UsersController do
       pass = 'this is a long password to test the password validation feature and to see if it accepts this'
       user = build(:user).attributes.with_indifferent_access.merge(password: pass, password_confirmation: pass)
       expect {
-        post :create, {secret: 'ALLHAILTHECOIN'}.merge(user: user)
+        post :create, params: { secret: 'ALLHAILTHECOIN' }.merge(user: user)
       }.to change{User.count}.by(1)
       expect(response).to redirect_to(root_url)
       expect(flash[:success]).to eq("User created! You have been logged in.")
@@ -113,28 +113,28 @@ RSpec.describe UsersController do
 
   describe "GET show" do
     it "requires valid user" do
-      get :show, id: -1
+      get :show, params: { id: -1 }
       expect(response).to redirect_to(users_url)
       expect(flash[:error]).to eq("User could not be found.")
     end
 
     it "works when logged out" do
       user = create(:user)
-      get :show, id: user.id
+      get :show, params: { id: user.id }
       expect(response.status).to eq(200)
     end
 
     it "works when logged in as someone else" do
       user = create(:user)
       login
-      get :show, id: user.id
+      get :show, params: { id: user.id }
       expect(response.status).to eq(200)
     end
 
     it "works when logged in as yourself" do
       user = create(:user)
       login_as(user)
-      get :show, id: user.id
+      get :show, params: { id: user.id }
       expect(response.status).to eq(200)
     end
 
@@ -142,7 +142,7 @@ RSpec.describe UsersController do
       user = create(:user)
       posts = Array.new(3) { create(:post, user: user) }
       create(:post)
-      get :show, id: user.id
+      get :show, params: { id: user.id }
       expect(assigns(:page_title)).to eq(user.username)
       expect(assigns(:posts).to_a).to match_array(posts)
     end
@@ -150,7 +150,7 @@ RSpec.describe UsersController do
 
   describe "GET edit" do
     it "requires login" do
-      get :edit, id: -1
+      get :edit, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
@@ -158,14 +158,14 @@ RSpec.describe UsersController do
     it "requires own user" do
       user = create(:user)
       login
-      get :edit, id: user.id
+      get :edit, params: { id: user.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq('You do not have permission to edit that user.')
     end
 
     it "succeeds" do
       user_id = login
-      get :edit, id: user_id
+      get :edit, params: { id: user_id }
       expect(response.status).to eq(200)
     end
 
@@ -174,14 +174,14 @@ RSpec.describe UsersController do
 
       it "displays options" do
         user_id = login
-        get :edit, id: user_id
+        get :edit, params: { id: user_id }
       end
     end
   end
 
   describe "PUT update" do
     it "requires login" do
-      put :update, id: -1
+      put :update, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
@@ -189,7 +189,7 @@ RSpec.describe UsersController do
     it "requires valid params" do
       user = create(:user)
       login_as(user)
-      put :update, id: user.id, user: {moiety: 'A'}
+      put :update, params: { id: user.id, user: {moiety: 'A'} }
       expect(response).to redirect_to(edit_user_url(user))
       expect(flash[:error]).to eq('There was a problem with your changes.')
     end
@@ -198,7 +198,7 @@ RSpec.describe UsersController do
       user1 = create(:user)
       user2 = create(:user)
       login_as(user1)
-      put :update, id: user2.id, user: {email: 'bademail@example.com'}
+      put :update, params: { id: user2.id, user: {email: 'bademail@example.com'} }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq('You do not have permission to edit that user.')
       expect(user2.reload.email).not_to eq('bademail@example.com')
@@ -223,7 +223,7 @@ RSpec.describe UsersController do
         expect(user.public_send(key)).not_to eq(value)
       end
 
-      put :update, id: user.id, user: user_details
+      put :update, params: { id: user.id, user: user_details }
       expect(response).to redirect_to(edit_user_url(user))
       expect(flash[:success]).to eq('Changes saved successfully.')
 
@@ -238,7 +238,7 @@ RSpec.describe UsersController do
       user = create(:user, username: 'user123', password: pass)
       expect(user.authenticate(pass)).to eq(true)
       login_as(user)
-      put :update, id: user.id, user: {username: 'user124'}
+      put :update, params: { id: user.id, user: {username: 'user124'} }
       expect(response).to redirect_to(edit_user_url(user))
       expect(flash[:success]).to eq('Changes saved successfully.')
 
@@ -261,20 +261,20 @@ RSpec.describe UsersController do
 
     it "finds user" do
       user = create(:user)
-      post :username, username: user.username
+      post :username, params: { username: user.username }
       expect(response.json['username_free']).not_to eq(true)
     end
 
     it "finds free username" do
       user = create(:user)
-      post :username, username: user.username + 'nope'
+      post :username, params: { username: user.username + 'nope' }
       expect(response.json['username_free']).to eq(true)
     end
   end
 
   describe "PUT password" do
     it "requires login" do
-      put :password, id: -1
+      put :password, params: { id: -1 }
       expect(response).to redirect_to(root_url)
       expect(flash[:error]).to eq("You must be logged in to view that page.")
     end
@@ -282,7 +282,7 @@ RSpec.describe UsersController do
     it "requires own user" do
       user = create(:user)
       login
-      put :password, id: user.id
+      put :password, params: { id: user.id }
       expect(response).to redirect_to(boards_url)
       expect(flash[:error]).to eq('You do not have permission to edit that user.')
     end
@@ -294,7 +294,7 @@ RSpec.describe UsersController do
       user = create(:user, password: 'testpass')
       login_as(user)
 
-      put :password, id: user.id, old_password: fakepass, user: {password: newpass, password_confirmation: newpass}
+      put :password, params: { id: user.id, old_password: fakepass, user: {password: newpass, password_confirmation: newpass} }
 
       expect(response).to render_template(:edit)
       expect(flash[:error]).to eq('Incorrect password entered.')
@@ -310,7 +310,7 @@ RSpec.describe UsersController do
       user = create(:user, password: pass)
       login_as(user)
 
-      put :password, id: user.id, old_password: pass, user: {password: newpass, password_confirmation: newpass}
+      put :password, params: { id: user.id, old_password: pass, user: {password: newpass, password_confirmation: newpass} }
 
       expect(response).to render_template(:edit)
       expect(flash[:error][:message]).to eq('There was a problem with your changes.')
@@ -324,7 +324,7 @@ RSpec.describe UsersController do
       user = create(:user, password: pass)
       login_as(user)
 
-      put :password, id: user.id, old_password: pass, user: {password: newpass, password_confirmation: 'wrongconfirmation'}
+      put :password, params: { id: user.id, old_password: pass, user: {password: newpass, password_confirmation: 'wrongconfirmation'} }
 
       expect(response).to render_template(:edit)
       expect(flash[:error][:message]).to eq('There was a problem with your changes.')
@@ -339,7 +339,7 @@ RSpec.describe UsersController do
       user = create(:user, password: pass)
       login_as(user)
 
-      put :password, id: user.id, old_password: pass, user: {password: newpass, password_confirmation: newpass}
+      put :password, params: { id: user.id, old_password: pass, user: {password: newpass, password_confirmation: newpass} }
 
       expect(response).to redirect_to(edit_user_url(user))
       expect(flash[:success]).to eq('Changes saved successfully.')
@@ -375,7 +375,7 @@ RSpec.describe UsersController do
       User.all.each do |user|
         create(:user, username: user.username.upcase + 'c')
       end
-      get :search, commit: 'Search', username: 'b'
+      get :search, params: { commit: 'Search', username: 'b' }
       expect(response).to have_http_status(200)
       expect(assigns(:search_results)).to be_present
       expect(assigns(:search_results).count).to eq(6)


### PR DESCRIPTION
Builds on #449.

Deprecation:
(*Check the many deprecation warnings, see #448 for more info:*)
- [x] `ActiveRecord::Base.raise_in_transactional_callbacks=` (set to true, now forced true and the config does nothing; removed)
- [ ] Parameters are now objects instead of hashes and comparing equality is deprecated set to be removed in Rails 5.1
- [ ] `alias_method_chain` deprecated (in Presentable)
- [x] `before_filter`, `around_filter`, `after_filter` in basically all the controllers
- [x] Positional parameters in tests (`get :show, id: 1` vs `get :show, params: { id: 1 }`)
- [x] Rails target versions in migration superclasses (`< ActiveRecord::Migration[4.2]`) #