### PR TITLE
Test that formatting tags across lines are preserved by sanitizer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'resque'
 gem 'resque_mailer'
 gem 'resque-retry'
 gem 'resque-web', require: 'resque_web'
+gem 'sanitize'
 gem 'sass-rails'
 gem 'select2-rails'
 gem 'test-unit', '~> 3.0' # required by Heroku for production console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    crass (1.0.2)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -192,6 +193,8 @@ GEM
       activesupport (>= 3.0.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    nokogumbo (1.4.13)
+      nokogiri
     pg (0.21.0)
     pg_search (2.1.0)
       activerecord (>= 4.2)
@@ -315,6 +318,10 @@ GEM
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
     safe_yaml (1.0.4)
+    sanitize (4.5.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (~> 1.4.1)
     sass (3.5.1)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -431,6 +438,7 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails
+  sanitize
   sass-rails
   seed_dump (~> 3.2)
   select2-rails

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -27,7 +27,7 @@ class Api::ApiController < ActionController::Base
   def handle_param_validation
     yield
   rescue Apipie::ParamMissing, Apipie::ParamInvalid => error
-    error_hash = {message: Rails::Html::FullSanitizer.new.sanitize(error.message.tr('"', "'"))}
+    error_hash = {message: Glowfic::Sanitizers.full(error.message.tr('"', "'"))}
     render json: {errors: [error_hash]}, status: :unprocessable_entity
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -130,7 +130,7 @@ module ApplicationHelper
   end
 
   def sanitize_post_description(desc)
-    sanitize desc, scrubber: Glowfic::DescriptionScrubber.new
+    Glowfic::Sanitizers.description(desc)
   end
 
   # modified version of split_paragraphs that doesn't mangle large breaks
@@ -178,11 +178,12 @@ module ApplicationHelper
         simple_format_largebreak(content, sanitize: false)
       end
     end
-    sanitize content, scrubber: Glowfic::WrittenScrubber.new
+
+    Glowfic::Sanitizers.written(content)
   end
 
   def generate_short(msg)
-    short_msg = Rails::Html::FullSanitizer.new.sanitize(msg) # strip all tags, replacing appropriately with spaces
+    short_msg = Glowfic::Sanitizers.full(msg) # strip all tags, replacing appropriately with spaces
     return short_msg if short_msg.length <= 75
     short_msg[0...73] + '…' # make the absolute max length 75 characters
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ApplicationHelper do
 
     it "removes unpermitted elements" do
       text = '<b>test</b> <script type="text/javascript">alert("bad!");</script> <p>text</p>'
-      expect(helper.sanitize_post_description(text)).to eq('test alert("bad!"); text')
+      expect(helper.sanitize_post_description(text)).to eq('test alert("bad!");  text ')
     end
 
     it "fixes unending tags" do
@@ -110,8 +110,8 @@ RSpec.describe ApplicationHelper do
     end
 
     it "does not touch blockquotes if <br> or <p> detected" do
-      text = "<blockquote>Blah. Blah.<br />Blah.</blockquote>\r\n<blockquote>Blah blah.</blockquote>\r\n<p>Blah.</p>"
-      expected = "<blockquote>Blah. Blah.<br>Blah.</blockquote>\r\n<blockquote>Blah blah.</blockquote>\r\n<p>Blah.</p>"
+      text = "<blockquote>Blah. Blah.<br />Blah.</blockquote>\n<blockquote>Blah blah.</blockquote>\n<p>Blah.</p>"
+      expected = "<blockquote>Blah. Blah.<br>Blah.</blockquote>\n<blockquote>Blah blah.</blockquote>\n<p>Blah.</p>"
       expect(helper.sanitize_written_content(text)).to eq(expected)
     end
 
@@ -131,7 +131,7 @@ RSpec.describe ApplicationHelper do
       expect(helper.sanitize_written_content(text)).to eq(expected)
 
       text = "line1<b>text\n\nline2</b>"
-      expected = "<p>line1<b>text</b></p>\n\n<p><b>line2</b></p>"
+      expected = "<p>line1<b>text</b></p><b>\n\n</b><p><b>line2</b></p>"
       expect(helper.sanitize_written_content(text)).to eq(expected)
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -124,5 +124,15 @@ RSpec.describe ApplicationHelper do
       expected = "<p>line1</p>\n\n<p>\u00A0</p>\n\n<p>line2</p>" # U+00A0 is NBSP
       expect(helper.sanitize_written_content(text)).to eq(expected)
     end
+
+    it "does not mangle tags continuing over linebreaks in HTML mode" do
+      text = "line1<b>text\nline2</b>"
+      expected = "<p>line1<b>text\n<br>line2</b></p>"
+      expect(helper.sanitize_written_content(text)).to eq(expected)
+
+      text = "line1<b>text\n\nline2</b>"
+      expected = "<p>line1<b>text</b></p>\n\n<p><b>line2</b></p>"
+      expect(helper.sanitize_written_content(text)).to eq(expected)
+    end
   end
 end


### PR DESCRIPTION
Seems like Loofah doesn't use Nokogumbo, but only Nokogiri. Nokogumbo adds the Gumbo parser, which is HTML5-compliant.

Here's an example of the difference in parsing:

```ruby
2.4.1 :013 > doc = Nokogiri::HTML5.fragment("<p><em>test</p><p>blah</em></p>").to_xhtml
 => "<p>\n  <em>test</em>\n</p><p>\n  <em>blah</em>\n</p>" 
2.4.1 :014 > doc = Nokogiri::HTML.fragment("<p><em>test</p><p>blah</em></p>").to_xhtml
 => "<p>\n  <em>test</em>\n</p><p>blah</p>" 
```

It seems, accordingly, that we need to move back to Sanitize and away from Loofah to have HTML5-compliant parsing (where unclosed tags in a paragraph are then reopened in a new one). Fortunately, Sanitize wasn't much slower (the page load times don't seem to have changed much), nor did it add much memory overhead, so this isn't a huge problem.