### PR TITLE
Test taggable concern in shared examples

### DIFF
--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "support/shared_examples_for_taggable"
 
 RSpec.describe Character do
   describe "validations" do
@@ -260,111 +261,8 @@ RSpec.describe Character do
     end
   end
 
-  # from Taggable concern; duplicated between PostSpec, CharacterSpec, GallerySpec
+  # from Taggable concern
   context "tags" do
-    let(:taggable) { create(:character) }
-    ['gallery_group'].each do |type|
-      it "creates new #{type} tags if they don't exist" do
-        taggable.send(type + '_ids=', ['_tag'])
-        expect(taggable.send(type + 's').map(&:name)).to match_array(['tag'])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags.map(&:name)).to match_array(['tag'])
-        expect(tags.map(&:user)).to match_array([taggable.user])
-      end
-
-      it "uses extant tags with same name and type for #{type}" do
-        tag = create(type)
-        old_user = tag.user
-        taggable.send(type + '_ids=', ['_' + tag.name])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        expect(tags).to match_array([tag])
-        expect(tags.map(&:user)).to match_array([old_user])
-      end
-
-      it "does not use extant tags of a different type with same name for #{type}" do
-        name = "Example Tag"
-        tag = create(:tag, type: 'NonexistentTag', name: name)
-        taggable.send(type + '_ids=', ['_' + name])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags.map(&:name)).to match_array([name])
-        expect(tags.map(&:user)).to match_array([taggable.user])
-        expect(tags).not_to include(tag)
-        expect(tag_ids).to match_array(tags.map(&:id))
-      end
-
-      it "uses extant #{type} tags by id" do
-        tag = create(type)
-        old_user = tag.user
-        taggable.send(type + '_ids=', [tag.id.to_s])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags).to match_array([tag])
-        expect(tags.map(&:user)).to match_array([old_user])
-        expect(tag_ids).to match_array([tag.id])
-      end
-
-      it "removes #{type} tags when not in list given" do
-        tag = create(type)
-        taggable.send(type + 's=', [tag])
-        taggable.save
-        taggable.reload
-        expect(taggable.send(type + 's')).to match_array([tag])
-        taggable.send(type + '_ids=', [])
-        taggable.save
-        taggable.reload
-        expect(taggable.send(type + 's')).to eq([])
-        expect(taggable.send(type + '_ids')).to eq([])
-      end
-
-      it "only adds #{type} tags once if given multiple times" do
-        name = 'Example Tag'
-        tag = create(type, name: name)
-        old_user = tag.user
-        taggable.send(type + '_ids=', ['_' + name, '_' + name, tag.id.to_s, tag.id.to_s])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags).to match_array([tag])
-        expect(tags.map(&:user)).to match_array([old_user])
-        expect(tag_ids).to match_array([tag.id])
-      end
-
-      it "orders #{type} tag joins by order added to model" do
-        tag1 = create(type)
-        tag2 = create(type)
-        tag3 = create(type)
-        tag4 = create(type)
-
-        taggable.send(type + '_ids=', [tag3.id, '_fake1', '_'+tag1.name, '_fake2', tag4.id, 'broken'])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's').order('character_tags.id')
-        expect(tags[0]).to eq(tag3)
-        expect(tags[2]).to eq(tag1)
-        expect(tags[4]).to eq(tag4)
-        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name])
-
-        taggable.send(type + '_ids=', taggable.send(type + '_ids') + ['_'+tag2.name, '_fake3', '_fake4'])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's').order('character_tags.id')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags[0]).to eq(tag3)
-        expect(tags[2]).to eq(tag1)
-        expect(tags[5]).to eq(tag2)
-        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name, tag2.name, 'fake3', 'fake4'])
-      end
-    end
+    it_behaves_like 'taggable', 'gallery_group', 'character'
   end
 end

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "support/shared_examples_for_taggable"
 
 RSpec.describe Gallery do
   it "adds icons if it saves successfully" do
@@ -31,112 +32,9 @@ RSpec.describe Gallery do
     expect(gallery.icons.pluck(:keyword)).to eq(['xxx', 'yyy', 'zzz'])
   end
 
-  # from Taggable concern; duplicated between PostSpec, CharacterSpec, GallerySpec
+  # from Taggable concern
   context "tags" do
-    let(:taggable) { create(:gallery) }
-    ['gallery_group'].each do |type|
-      it "creates new #{type} tags if they don't exist" do
-        taggable.send(type + '_ids=', ['_tag'])
-        expect(taggable.send(type + 's').map(&:name)).to match_array(['tag'])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags.map(&:name)).to match_array(['tag'])
-        expect(tags.map(&:user)).to match_array([taggable.user])
-      end
-
-      it "uses extant tags with same name and type for #{type}" do
-        tag = create(type)
-        old_user = tag.user
-        taggable.send(type + '_ids=', ['_' + tag.name])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        expect(tags).to match_array([tag])
-        expect(tags.map(&:user)).to match_array([old_user])
-      end
-
-      it "does not use extant tags of a different type with same name for #{type}" do
-        name = "Example Tag"
-        tag = create(:tag, type: 'NonexistentTag', name: name)
-        taggable.send(type + '_ids=', ['_' + name])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags.map(&:name)).to match_array([name])
-        expect(tags.map(&:user)).to match_array([taggable.user])
-        expect(tags).not_to include(tag)
-        expect(tag_ids).to match_array(tags.map(&:id))
-      end
-
-      it "uses extant #{type} tags by id" do
-        tag = create(type)
-        old_user = tag.user
-        taggable.send(type + '_ids=', [tag.id.to_s])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags).to match_array([tag])
-        expect(tags.map(&:user)).to match_array([old_user])
-        expect(tag_ids).to match_array([tag.id])
-      end
-
-      it "removes #{type} tags when not in list given" do
-        tag = create(type)
-        taggable.send(type + 's=', [tag])
-        taggable.save
-        taggable.reload
-        expect(taggable.send(type + 's')).to match_array([tag])
-        taggable.send(type + '_ids=', [])
-        taggable.save
-        taggable.reload
-        expect(taggable.send(type + 's')).to eq([])
-        expect(taggable.send(type + '_ids')).to eq([])
-      end
-
-      it "only adds #{type} tags once if given multiple times" do
-        name = 'Example Tag'
-        tag = create(type, name: name)
-        old_user = tag.user
-        taggable.send(type + '_ids=', ['_' + name, '_' + name, tag.id.to_s, tag.id.to_s])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags).to match_array([tag])
-        expect(tags.map(&:user)).to match_array([old_user])
-        expect(tag_ids).to match_array([tag.id])
-      end
-
-      it "orders #{type} tag joins by order added to model" do
-        tag1 = create(type)
-        tag2 = create(type)
-        tag3 = create(type)
-        tag4 = create(type)
-
-        taggable.send(type + '_ids=', [tag3.id, '_fake1', '_'+tag1.name, '_fake2', tag4.id])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's').order('gallery_tags.id')
-        expect(tags[0]).to eq(tag3)
-        expect(tags[2]).to eq(tag1)
-        expect(tags[4]).to eq(tag4)
-        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name])
-
-        taggable.send(type + '_ids=', taggable.send(type + '_ids') + ['_'+tag2.name, '_fake3', '_fake4'])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's').order('gallery_tags.id')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags[0]).to eq(tag3)
-        expect(tags[2]).to eq(tag1)
-        expect(tags[5]).to eq(tag2)
-        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name, tag2.name, 'fake3', 'fake4'])
-      end
-    end
+    it_behaves_like 'taggable', 'gallery_group', 'gallery'
   end
 
   describe "#gallery_groups_data" do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "support/shared_examples_for_taggable"
 
 RSpec.describe Post do
   it "should have the right timestamps" do
@@ -761,111 +762,10 @@ RSpec.describe Post do
     expect(NotifyFollowersOfNewPostJob).to have_queued(post.id)
   end
 
-  # from Taggable concern; duplicated between PostSpec, CharacterSpec, GallerySpec
+  # from Taggable concern
   context "tags" do
-    let(:taggable) { create(:post) }
-    ['label', 'setting', 'content_warning'].each do |type|
-      it "creates new #{type} tags if they don't exist" do
-        taggable.send(type + '_ids=', ['_tag'])
-        expect(taggable.send(type + 's').map(&:name)).to match_array(['tag'])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags.map(&:name)).to match_array(['tag'])
-        expect(tags.map(&:user)).to match_array([taggable.user])
-      end
-
-      it "uses extant tags with same name and type for #{type}" do
-        tag = create(type)
-        old_user = tag.user
-        taggable.send(type + '_ids=', ['_' + tag.name])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        expect(tags).to match_array([tag])
-        expect(tags.map(&:user)).to match_array([old_user])
-      end
-
-      it "does not use extant tags of a different type with same name for #{type}" do
-        name = "Example Tag"
-        tag = create(:tag, type: 'NonexistentTag', name: name)
-        taggable.send(type + '_ids=', ['_' + name])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags.map(&:name)).to match_array([name])
-        expect(tags.map(&:user)).to match_array([taggable.user])
-        expect(tags).not_to include(tag)
-        expect(tag_ids).to match_array(tags.map(&:id))
-      end
-
-      it "uses extant #{type} tags by id" do
-        tag = create(type)
-        old_user = tag.user
-        taggable.send(type + '_ids=', [tag.id.to_s])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags).to match_array([tag])
-        expect(tags.map(&:user)).to match_array([old_user])
-        expect(tag_ids).to match_array([tag.id])
-      end
-
-      it "removes #{type} tags when not in list given" do
-        tag = create(type)
-        taggable.send(type + 's=', [tag])
-        taggable.save
-        taggable.reload
-        expect(taggable.send(type + 's')).to match_array([tag])
-        taggable.send(type + '_ids=', [])
-        taggable.save
-        taggable.reload
-        expect(taggable.send(type + 's')).to eq([])
-        expect(taggable.send(type + '_ids')).to eq([])
-      end
-
-      it "only adds #{type} tags once if given multiple times" do
-        name = 'Example Tag'
-        tag = create(type, name: name)
-        old_user = tag.user
-        taggable.send(type + '_ids=', ['_' + name, '_' + name, tag.id.to_s, tag.id.to_s])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags).to match_array([tag])
-        expect(tags.map(&:user)).to match_array([old_user])
-        expect(tag_ids).to match_array([tag.id])
-      end
-
-      it "orders #{type} tag joins by order added to model" do
-        tag1 = create(type)
-        tag2 = create(type)
-        tag3 = create(type)
-        tag4 = create(type)
-
-        taggable.send(type + '_ids=', [tag3.id, '_fake1', '_'+tag1.name, '_fake2', tag4.id])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's').order('post_tags.id')
-        expect(tags[0]).to eq(tag3)
-        expect(tags[2]).to eq(tag1)
-        expect(tags[4]).to eq(tag4)
-        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name])
-
-        taggable.send(type + '_ids=', taggable.send(type + '_ids') + ['_'+tag2.name, '_fake3', '_fake4'])
-        taggable.save
-        taggable.reload
-        tags = taggable.send(type + 's').order('post_tags.id')
-        tag_ids = taggable.send(type + '_ids')
-        expect(tags[0]).to eq(tag3)
-        expect(tags[2]).to eq(tag1)
-        expect(tags[5]).to eq(tag2)
-        expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name, tag2.name, 'fake3', 'fake4'])
-      end
-    end
+    it_behaves_like 'taggable', 'label', 'post'
+    it_behaves_like 'taggable', 'setting', 'post'
+    it_behaves_like 'taggable', 'content_warning', 'post'
   end
 end

--- a/spec/support/shared_examples_for_taggable.rb
+++ b/spec/support/shared_examples_for_taggable.rb
@@ -1,0 +1,104 @@
+RSpec.shared_examples "taggable" do |type, model_name|
+  let(:taggable) { create(model_name) }
+  it "creates new #{type} tags if they don't exist" do
+    taggable.send(type + '_ids=', ['_tag'])
+    expect(taggable.send(type + 's').map(&:name)).to match_array(['tag'])
+    taggable.save
+    taggable.reload
+    tags = taggable.send(type + 's')
+    tag_ids = taggable.send(type + '_ids')
+    expect(tags.map(&:name)).to match_array(['tag'])
+    expect(tags.map(&:user)).to match_array([taggable.user])
+  end
+
+  it "uses extant tags with same name and type for #{type}" do
+    tag = create(type)
+    old_user = tag.user
+    taggable.send(type + '_ids=', ['_' + tag.name])
+    taggable.save
+    taggable.reload
+    tags = taggable.send(type + 's')
+    expect(tags).to match_array([tag])
+    expect(tags.map(&:user)).to match_array([old_user])
+  end
+
+  it "does not use extant tags of a different type with same name for #{type}" do
+    name = "Example Tag"
+    tag = create(:tag, type: 'NonexistentTag', name: name)
+    taggable.send(type + '_ids=', ['_' + name])
+    taggable.save
+    taggable.reload
+    tags = taggable.send(type + 's')
+    tag_ids = taggable.send(type + '_ids')
+    expect(tags.map(&:name)).to match_array([name])
+    expect(tags.map(&:user)).to match_array([taggable.user])
+    expect(tags).not_to include(tag)
+    expect(tag_ids).to match_array(tags.map(&:id))
+  end
+
+  it "uses extant #{type} tags by id" do
+    tag = create(type)
+    old_user = tag.user
+    taggable.send(type + '_ids=', [tag.id.to_s])
+    taggable.save
+    taggable.reload
+    tags = taggable.send(type + 's')
+    tag_ids = taggable.send(type + '_ids')
+    expect(tags).to match_array([tag])
+    expect(tags.map(&:user)).to match_array([old_user])
+    expect(tag_ids).to match_array([tag.id])
+  end
+
+  it "removes #{type} tags when not in list given" do
+    tag = create(type)
+    taggable.send(type + 's=', [tag])
+    taggable.save
+    taggable.reload
+    expect(taggable.send(type + 's')).to match_array([tag])
+    taggable.send(type + '_ids=', [])
+    taggable.save
+    taggable.reload
+    expect(taggable.send(type + 's')).to eq([])
+    expect(taggable.send(type + '_ids')).to eq([])
+  end
+
+  it "only adds #{type} tags once if given multiple times" do
+    name = 'Example Tag'
+    tag = create(type, name: name)
+    old_user = tag.user
+    taggable.send(type + '_ids=', ['_' + name, '_' + name, tag.id.to_s, tag.id.to_s])
+    taggable.save
+    taggable.reload
+    tags = taggable.send(type + 's')
+    tag_ids = taggable.send(type + '_ids')
+    expect(tags).to match_array([tag])
+    expect(tags.map(&:user)).to match_array([old_user])
+    expect(tag_ids).to match_array([tag.id])
+  end
+
+  it "orders #{type} tag joins by order added to model" do
+    tag1 = create(type)
+    tag2 = create(type)
+    tag3 = create(type)
+    tag4 = create(type)
+
+    taggable.send(type + '_ids=', [tag3.id, '_fake1', '_'+tag1.name, '_fake2', tag4.id])
+    taggable.save
+    taggable.reload
+    tags = taggable.send(type + 's').order(model_name + '_tags.id')
+    expect(tags[0]).to eq(tag3)
+    expect(tags[2]).to eq(tag1)
+    expect(tags[4]).to eq(tag4)
+    expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name])
+
+    taggable.send(type + '_ids=', taggable.send(type + '_ids') + ['_'+tag2.name, '_fake3', '_fake4'])
+    taggable.save
+    taggable.reload
+    tags = taggable.send(type + 's').order(model_name + '_tags.id')
+    tag_ids = taggable.send(type + '_ids')
+    expect(tags[0]).to eq(tag3)
+    expect(tags[2]).to eq(tag1)
+    expect(tags[5]).to eq(tag2)
+    expect(tags.map(&:name)).to eq([tag3.name, 'fake1', tag1.name, 'fake2', tag4.name, tag2.name, 'fake3', 'fake4'])
+  end
+end

--- a/spec/support/shared_examples_for_taggable.rb
+++ b/spec/support/shared_examples_for_taggable.rb
@@ -62,6 +62,17 @@ RSpec.shared_examples "taggable" do |type, model_name|
     expect(taggable.send(type + '_ids')).to eq([])
   end
 
+  it "discards when #{type} tags given with invalid ID" do
+    # specifically when a string ID is used and doesn't have an underscore prefix
+    good_tag1 = create(type)
+    good_tag2 = create(type)
+    taggable.send(type + '_ids=', [good_tag1.id, 'broken', '_'+good_tag2.name])
+    taggable.save
+    taggable.reload
+    tags = taggable.send(type + 's')
+    expect(tags).to match_array([good_tag1, good_tag2])
+  end
+
   it "only adds #{type} tags once if given multiple times" do
     name = 'Example Tag'
     tag = create(type, name: name)


### PR DESCRIPTION
DRY – moves all the shared taggable-related concerns to a shared example that then gets used in each model instead of the whole tests being manually duplicated between them.