### PR TITLE
Remove duplicate after_* logic on Gallery/GalleryTag

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -18,7 +18,7 @@ class Character < ApplicationRecord
   has_many :character_tags, inverse_of: :character, dependent: :destroy
   has_many :labels, through: :character_tags, source: :label
   has_many :settings, through: :character_tags, source: :setting
-  has_many :gallery_groups, through: :character_tags, source: :gallery_group, after_remove: :remove_galleries_from_character
+  has_many :gallery_groups, through: :character_tags, source: :gallery_group, dependent: :destroy
 
   validates_presence_of :name, :user
   validate :valid_group, :valid_galleries, :valid_default_icon
@@ -106,14 +106,6 @@ class Character < ApplicationRecord
         self.assign_attributes(characters_galleries: new_chargals)
       end
     end
-  end
-
-  def remove_galleries_from_character(gallery_group)
-    galleries = gallery_group.galleries.where(user_id: user_id)
-    joined_group_galleries = gallery_groups.joins(:galleries).where(galleries: {user_id: user_id}).pluck(:gallery_id)
-    galleries = galleries.where.not(id: joined_group_galleries)
-    to_delete = characters_galleries.where(gallery: galleries, added_by_group: true).destroy_all
-    characters_galleries.reload
   end
 
   private

--- a/app/models/character_tag.rb
+++ b/app/models/character_tag.rb
@@ -20,6 +20,10 @@ class CharacterTag < ApplicationRecord
 
   def remove_galleries_from_character
     return if gallery_group.nil? # skip non-gallery_groups
-    character.remove_galleries_from_character(gallery_group)
+    galleries = gallery_group.galleries.where(user_id: character.user_id)
+    joined_group_galleries = character.gallery_groups.joins(:galleries).where(galleries: {user_id: character.user_id}).pluck(:gallery_id)
+    galleries = galleries.where.not(id: joined_group_galleries)
+    character.characters_galleries.where(gallery: galleries, added_by_group: true).destroy_all
+    character.characters_galleries.reload
   end
 end

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -10,7 +10,7 @@ class Gallery < ApplicationRecord
   has_many :characters, through: :characters_galleries
 
   has_many :gallery_tags, inverse_of: :gallery, dependent: :destroy
-  has_many :gallery_groups, through: :gallery_tags, source: :gallery_group, after_remove: :remove_gallery_from_characters
+  has_many :gallery_groups, through: :gallery_tags, source: :gallery_group, dependent: :destroy
 
   validates_presence_of :user, :name
 
@@ -47,10 +47,5 @@ class Gallery < ApplicationRecord
 
   def character_gallery_for(character)
     characters_galleries.where(character_id: character).first
-  end
-
-  def remove_gallery_from_characters(gallery_group)
-    characters = gallery_group.characters.where(user_id: user_id)
-    CharactersGallery.where(character: characters, gallery: self, added_by_group: true).destroy_all
   end
 end

--- a/app/models/gallery_tag.rb
+++ b/app/models/gallery_tag.rb
@@ -17,6 +17,7 @@ class GalleryTag < ApplicationRecord
 
   def remove_gallery_from_characters
     return if gallery_group.nil? # skip non-gallery_groups
-    gallery.remove_gallery_from_characters(gallery_group)
+    characters = gallery_group.characters.where(user_id: gallery.user_id)
+    CharactersGallery.where(character: gallery.characters, gallery: gallery, added_by_group: true).destroy_all
   end
 end

--- a/spec/models/gallery_tag_spec.rb
+++ b/spec/models/gallery_tag_spec.rb
@@ -72,6 +72,17 @@ RSpec.describe GalleryTag do
         expect(gallery.characters).to match_array([other_character, character_both])
         expect(gallery.characters_galleries.find_by(character_id: character_both.id)).not_to be_added_by_group
       end
+
+      it "does not destroy galleries when destroyed" do
+        group = create(:gallery_group)
+        gallery = create(:gallery)
+        gallery.gallery_groups << group
+        gallery.save
+        gallery.reload
+        expect(gallery.gallery_groups.count).to eq(1)
+        gallery.destroy
+        group.reload
+      end
     end
   end
 end


### PR DESCRIPTION
dependent is safer than after_remove because it maps to actual save actions better