### PR TITLE
Test character destroy does not delete gallery groups

### DIFF
--- a/spec/models/character_tag_spec.rb
+++ b/spec/models/character_tag_spec.rb
@@ -72,6 +72,20 @@ RSpec.describe CharacterTag do
         expect(character.galleries).to match_array([other_gallery, gallery_both])
         expect(character.characters_galleries.find_by(gallery_id: gallery_both.id)).not_to be_added_by_group
       end
+
+      it "does not destroy gallery groups when destroyed" do
+        group = create(:gallery_group)
+        character = create(:character, gallery_groups: [group])
+        other = create(:character, gallery_groups: [group])
+        character.reload
+        other.reload
+        expect(character.gallery_groups).to match_array([group])
+        expect(other.gallery_groups).to match_array([group])
+
+        character.destroy
+        group.reload
+        expect(other.reload.gallery_groups).to match_array([group])
+      end
     end
   end
 end

--- a/spec/models/gallery_tag_spec.rb
+++ b/spec/models/gallery_tag_spec.rb
@@ -73,15 +73,18 @@ RSpec.describe GalleryTag do
         expect(gallery.characters_galleries.find_by(character_id: character_both.id)).not_to be_added_by_group
       end
 
-      it "does not destroy galleries when destroyed" do
+      it "does not destroy gallery groups when destroyed" do
         group = create(:gallery_group)
-        gallery = create(:gallery)
-        gallery.gallery_groups << group
-        gallery.save
+        gallery = create(:gallery, gallery_groups: [group])
+        other = create(:gallery, gallery_groups: [group])
         gallery.reload
-        expect(gallery.gallery_groups.count).to eq(1)
+        other.reload
+        expect(gallery.gallery_groups).to match_array([group])
+        expect(other.gallery_groups).to match_array([group])
+
         gallery.destroy
         group.reload
+        expect(other.reload.gallery_groups).to match_array([group])
       end
     end
   end


### PR DESCRIPTION
In response to #472, also test CharacterTag doesn't destroy groups when character destroyed, and make both check that other characters/galleries don't have the group removed.