### PR TITLE
Escape screennames better when adding underscore wrap, apply more

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -190,6 +190,7 @@ module ApplicationHelper
   end
 
   def breakable_text(text)
+    return text if text.nil?
     h(text).gsub('_', '_<wbr>').html_safe
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -189,6 +189,10 @@ module ApplicationHelper
     short_msg[0...73] + '…' # make the absolute max length 75 characters
   end
 
+  def breakable_text(text)
+    h(text).gsub('_', '_<wbr>').html_safe
+  end
+
   def post_privacy_settings
     { 'Public'              => Post::PRIVACY_PUBLIC,
       'Constellation Users' => Post::PRIVACY_REGISTERED,

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -30,8 +30,8 @@
             - else
               .icon.character-no-icon &nbsp;
             .character-name= character.name
-            - if character.screenname.present?
-              .character-screenname= surround('(', ')') { sanitize(character.screenname).gsub('_', '_<wbr>') }
+            - if character.screenname
+              .character-screenname= surround('(', ')') { breakable_text(character.screenname) }
           - if character.user_id == current_user.try(:id)
             .delete-button{ id: character.id }
               = link_to '×', character_path(character), :method => :delete, data: { confirm: 'Are you sure you want to delete '+character.name+'?' }

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -42,7 +42,7 @@
       %td.padding-5{class: klass}
         = link_to character.name, character_path(character)
       %td.padding-5{class: klass, style:'width:15%'}= character.template_name
-      %td.padding-5{class: klass, style:'width:15%'}= character.screenname
+      %td.padding-5{class: klass, style:'width:15%'}= breakable_text(character.screenname)
       %td.padding-5{class: klass, style:'width:20%'}= character.pb
       %td.padding-5{class: klass, style:'width:15%'}= character.setting
 

--- a/app/views/characters/search.haml
+++ b/app/views/characters/search.haml
@@ -41,7 +41,7 @@
                     %br
                     = check_box_tag :search_aliases, true, params[:commit] ? params[:search_aliases] : true, {class: 'vmid no-margin', style: 'margin-bottom: 3px;'}
                     = label_tag :search_aliases, "Aliases"
-              - # TODO: setting search, facecast search  
+              - # TODO: setting search, facecast search
               %tr
                 %td.centered{colspan: 2}= submit_tag "Search", class: 'button'
           %td.vtop
@@ -67,7 +67,7 @@
                     %tr
                       %td.padding-5{class: klass}= link_to character.name, character_path(character)
                       %td.padding-5{class: klass, style:'width:20%'}= character.template_name
-                      %td.padding-5{class: klass, style:'width:20%'}= character.screenname
+                      %td.padding-5{class: klass, style:'width:20%'}= breakable_text(character.screenname)
                       %td.padding-5{class: klass, style:'width:25%'}= character.pb
 
     - if @search_results && @search_results.total_pages > 1

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -25,7 +25,7 @@
         %span.character-name= @character.name
         - if @character.screenname
           %br
-          %span.character-screenname= @character.screenname
+          %span.character-screenname= breakable_text(@character.screenname)
   %tbody
     - if @character.default_icon
       %tr

--- a/app/views/posts/_generate_flat.haml
+++ b/app/views/posts/_generate_flat.haml
@@ -11,7 +11,7 @@
             - if reply.character_id
               .post-character= reply.name
               - if reply.screenname
-                .post-screenname= reply.screenname
+                .post-screenname= breakable_text(reply.screenname)
             - else
               .dark.spacer
             .post-author= reply.username

--- a/app/views/posts/flat.haml
+++ b/app/views/posts/flat.haml
@@ -31,7 +31,7 @@
               - if @post.character
                 .post-character= @post.name
                 - if @post.character.screenname
-                  .post-screenname= @post.character.screenname
+                  .post-screenname= breakable_text(@post.character.screenname)
               - else
                 .dark.spacer
               .post-author= @post.user.username

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -15,7 +15,7 @@
           .post-character
             = link_to reply.name, character_path(reply.character_id)
           - if reply.screenname
-            .post-screenname= reply.screenname
+            .post-screenname= breakable_text(reply.screenname)
         - else
           .dark.spacer
         .post-author

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -154,4 +154,44 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe "#breakable_text" do
+    it "leaves blank strings intact" do
+      expect(helper.send(:breakable_text, nil)).to eq(nil)
+      expect(helper.send(:breakable_text, '')).to eq('')
+    end
+
+    it "does not do anything special to linebreaks" do
+      expect(helper.send(:breakable_text, "text\ntext")).to eq("text\ntext")
+      expect(helper.send(:breakable_text, "text\r\ntext")).to eq("text\r\ntext")
+    end
+
+    it "escapes HTML elements" do
+      text = "screenname <b>text</b> &amp; more text"
+      expected = "screenname &lt;b&gt;text&lt;/b&gt; &amp;amp; more text"
+      expect(helper.send(:breakable_text, text)).to eq(expected)
+    end
+
+    it "leaves simple text intact" do
+      text = "screenname"
+      expected = text
+      expect(helper.send(:breakable_text, text)).to eq(expected)
+    end
+
+    it "leaves hyphenated text intact" do
+      text = "screen-name"
+      expected = text
+      expect(helper.send(:breakable_text, text)).to eq(expected)
+
+      text = "-screen-name-"
+      expected = text
+      expect(helper.send(:breakable_text, text)).to eq(expected)
+    end
+
+    it "adds wordbreak opportunities after underscores" do
+      text = "screen_name"
+      expected = "screen_<wbr>name"
+      expect(helper.send(:breakable_text, text)).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #482 and also adds the wrap-on-underscore thing more places.

Tests incoming.