### PR TITLE
Improve post stats page

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -201,10 +201,6 @@ class Post < ApplicationRecord
     author_ids.include?(user.id)
   end
 
-  def characters
-    @chars ||= Character.where(id: ([character_id] + replies.group(:character_id).pluck(:character_id)).compact).sort_by(&:name)
-  end
-
   def taggable_by?(user)
     return false unless user
     return false if completed? || abandoned?
@@ -232,6 +228,12 @@ class Post < ApplicationRecord
 
   def author_word_counts
     authors.map { |author| [author.username, word_count_for(author)] }.sort_by{|a| -a[1] }
+  end
+
+  def character_appearance_counts
+    reply_counts = replies.joins(:character).group(:character_id).count
+    reply_counts[character_id] = reply_counts[character_id].to_i + 1
+    Character.where(id: reply_counts.keys).map { |c| [c, reply_counts[c.id]]}.sort_by{|a| -a[1] }
   end
 
   def has_content_warnings?

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -64,12 +64,13 @@
     %tr
       %td.sub.width-150.vtop Characters
       %td{class: cycle('odd', 'even')}
-        - if @post.characters.count > 2
-          %ul
-            - @post.characters.each do |character|
-              %li= link_to character.name, character_path(character)
-        - else
-          = @post.characters.map { |character| link_to character.name, character_path(character) }.join(', ').html_safe
+        %ul
+          - @post.character_appearance_counts.each do |character, count|
+            %li
+              = link_to character.name, character_path(character)
+              = surround '(', ')' do
+                = link_to "#{count} times", search_replies_path(post_id: @post.id, character_id: character.id, commit: true)
+
     - if @post.settings.present?
       %tr
         %td.sub.width-150 Setting
@@ -86,11 +87,12 @@
       %td.sub.width-150.vtop Word Count
       %td{class: cycle('odd', 'even')}
         = number_with_delimiter(@post.total_word_count)
-        %ul
-          - @post.author_word_counts.each do |username, count|
-            %li
-              = username + ':'
-              = number_with_delimiter(count)
+        - if @post.authors.count > 1
+          %ul
+            - @post.author_word_counts.each do |username, count|
+              %li
+                = username + ':'
+                = number_with_delimiter(count)
     %tr
       %td.sub.width-150 Time Begun
       %td{class: cycle('odd', 'even')}= pretty_time(@post.created_at)

--- a/spec/features/post_stats_spec.rb
+++ b/spec/features/post_stats_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.feature "Post stats", :type => :feature do
+  scenario "User views a stats page" do
+    post = create(:post, subject: "stats post test")
+    character = create(:character, user: post.user, name: "statchar")
+    3.times { create(:reply, post: post, user: post.user, character: character) }
+
+    visit stats_post_path(post)
+
+    expect(page).to have_text("Metadata: stats post test")
+    expect(page).to have_text("statchar (3 times)")
+  end
+end


### PR DESCRIPTION
Makes the following small changes:
- We no longer display word count by author if there is only one author
- Characters are now displayed with "(x times)" after their profile link counting thread appearances
- Characters are displayed ordered by this count rather than alphabetically
- The appearance count links to the reply search page
- There are now view tests for the page. (Not, like, comprehensive ones. But before there were literally none, so literally one is still an improvement!)