### PR TITLE
Improve the paginator display (mainly CSS & Javascript)

### DIFF
--- a/app/assets/javascripts/posts/show.js
+++ b/app/assets/javascripts/posts/show.js
@@ -54,10 +54,10 @@ $(document).ready(function() {
   paginators.each(function() { reflowPaginator(this); });
   var resizeDebounce = null;
   $(window).resize(function() {
-    clearTimeout(resizeDebounce);
-    resizeDebounce = setTimeout(function() {
+    window.cancelAnimationFrame(resizeDebounce);
+    resizeDebounce = window.requestAnimationFrame(function() {
       paginators.each(function() { reflowPaginator(this); });
-    }, 100);
+    });
   });
 
   // Now that we've finished the scripts that change page locations, scroll to #unread
@@ -71,7 +71,93 @@ function reflowPaginator(paginator) {
   var narrowClear = paginator.find('.narrow-clear');
 
   narrowClear.css('clear', 'none');
+
+  var innerWindow = 4;
+  var outerBoundary = 2;
+  hidePaginatorLinks(paginator, innerWindow, outerBoundary);
   if (paginator.height() < 60) return;
 
   narrowClear.css('clear', 'both');
+
+  if (paginator.height() < 100) return;
+  while (paginator.height() >= 100 && innerWindow > 0) {
+    hidePaginatorLinks(paginator, innerWindow, outerBoundary);
+    innerWindow -= 1;
+  }
+}
+
+function pageAsNumber(page) {
+  return parseInt(page.html().trim(), 10);
+}
+
+function newInsertedEllipsis() {
+  return $('<span class="gap inserted-ellipsis">').append('…');
+}
+
+function range(lower, upper) {
+  // [lower .. upper] (inclusive)
+  var list = [];
+  for (var i=lower; i<=upper; i++) {
+    list.push(i);
+  }
+  return list;
+}
+
+function calculateVisiblePages(innerWindow, outerBoundary, totalPages, currentNum) {
+  var windowFrom = currentNum - innerWindow;
+  var windowTo = currentNum + innerWindow;
+  if (windowTo > totalPages) {
+    windowFrom -= windowTo - totalPages;
+    windowTo = totalPages;
+  }
+  if (windowFrom < 1) {
+    windowTo += 1 - windowFrom;
+    windowFrom = 1;
+    if (windowTo > totalPages) windowTo = totalPages;
+  }
+
+  var middle = range(windowFrom, windowTo);
+
+  var left;
+  if (outerBoundary + 3 < middle[0]) {
+    left = range(1, outerBoundary+1);
+    left.push('gap');
+  } else {
+    left = range(1, middle[0]);
+  }
+
+  var right;
+  if (totalPages - outerBoundary - 2 > middle[middle.length-1]) {
+    right = range(totalPages - outerBoundary, totalPages);
+  } else {
+    right = range(middle[middle.length-1] + 1, totalPages);
+    right.unshift('gap');
+  }
+
+  return left.concat(middle).concat(right);
+}
+
+function hidePaginatorLinks(paginator, innerWindow, outerBoundary) {
+  paginator.find('.inserted-ellipsis').remove();
+  var links = paginator.find('a:not(.previous_page):not(.next_page)');
+  links.show();
+
+  // logic for page numbers from will_paginate
+  var lastLink = paginator.find('.next_page').prev('a,.current');
+  var current = paginator.find('.current');
+  var currentNum = pageAsNumber(current);
+  var totalPages = pageAsNumber(lastLink);
+  var pages = calculateVisiblePages(innerWindow, outerBoundary, totalPages, currentNum);
+
+  var linksToHide = links;
+  links.each(function() {
+    var link = $(this);
+    var num = pageAsNumber(link);
+    var index = pages.indexOf(num);
+    if (index < 0) return;
+    linksToHide = linksToHide.not(link);
+    if (pages[index + 1] === 'gap' && !link.next('.gap')) link.after(newInsertedEllipsis());
+  });
+
+  linksToHide.hide();
 }

--- a/app/assets/javascripts/posts/show.js
+++ b/app/assets/javascripts/posts/show.js
@@ -48,8 +48,30 @@ $(document).ready(function() {
     resizeScreenname(this);
   });
 
+  // horrible hack to make the paginator center-aligned when it's forced to a second line
+  // the timeout in the resize event acts as a debounce so we don't re-render on each pixel change of the resize
+  var paginators = $('.paginator');
+  paginators.each(function() { reflowPaginator(this); });
+  var resizeDebounce = null;
+  $(window).resize(function() {
+    clearTimeout(resizeDebounce);
+    resizeDebounce = setTimeout(function() {
+      paginators.each(function() { reflowPaginator(this); });
+    }, 100);
+  });
+
   // Now that we've finished the scripts that change page locations, scroll to #unread
   // if we determined on page load that we should.
   if (shouldScrollToUnread)
     $(window).scrollTop(unreadElem.offset().top);
 });
+
+function reflowPaginator(paginator) {
+  paginator = $(paginator);
+  var narrowClear = paginator.find('.narrow-clear');
+
+  narrowClear.css('clear', 'none');
+  if (paginator.height() < 60) return;
+
+  narrowClear.css('clear', 'both');
+}

--- a/app/assets/javascripts/posts/show.js
+++ b/app/assets/javascripts/posts/show.js
@@ -68,22 +68,27 @@ $(document).ready(function() {
 
 function reflowPaginator(paginator) {
   paginator = $(paginator);
+  var pagination = paginator.find('.normal-pagination');
   var narrowClear = paginator.find('.narrow-clear');
 
   narrowClear.css('clear', 'none');
+  paginator.removeClass('mobile-paginator');
 
   var innerWindow = 4;
   var outerBoundary = 2;
-  hidePaginatorLinks(paginator, innerWindow, outerBoundary);
+  hidePaginatorLinks(pagination, innerWindow, outerBoundary);
   if (paginator.height() < 60) return;
 
   narrowClear.css('clear', 'both');
 
   if (paginator.height() < 100) return;
   while (paginator.height() >= 100 && innerWindow > 0) {
-    hidePaginatorLinks(paginator, innerWindow, outerBoundary);
+    hidePaginatorLinks(pagination, innerWindow, outerBoundary);
     innerWindow -= 1;
   }
+
+  if (paginator.height() < 100) return;
+  paginator.addClass('mobile-paginator');
 }
 
 function pageAsNumber(page) {

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -342,15 +342,29 @@
 
     a { color: black; }
   }
+
+  .normal-pagination { display: block; }
+  .mobile-pagination { display: none; }
 }
-@media (max-width: 400px) {
-  .paginator { padding: 0; }
+@mixin mobile-paginator {
+  padding: 0;
+
   .pagination {
-    a, .current, .disabled { padding: 5px; }
+    a, .disabled { padding: 5px; }
     .summary {
       padding-left: 5px;
       padding-right: 5px;
     }
+  }
+  .normal-pagination { display: none; }
+  .mobile-pagination { display: block; }
+}
+.mobile-paginator {
+  @include mobile-paginator;
+}
+@media (max-width: 400px) {
+  .paginator {
+    @include mobile-paginator;
   }
 }
 

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -333,13 +333,11 @@
   color: black;
   .left-align {
     float: left;
-    display: inline-block;
     padding: 10px;
   }
   .right-align {
     padding: 2px;
     padding-right: 10px;
-    display: inline-block;
     float: right;
 
     a { color: black; }

--- a/app/views/posts/_paginator.haml
+++ b/app/views/posts/_paginator.haml
@@ -1,12 +1,14 @@
 .paginator.centered.sub
   - unless browser.device.mobile?
-    .left-align
-      Total:
-      %span.reply-count=paginated.total_entries
-    .right-align
-      - if paginated.klass == Reply && !local_assigns[:no_per]
-        Posts Per Page:
-        = select_tag :per_page, per_page_options, class: 'per-page'
+    .paginator-meta
+      .left-align
+        Total:
+        %span.reply-count=paginated.total_entries
+      .right-align
+        - if paginated.klass == Reply && !local_assigns[:no_per]
+          Posts Per Page:
+          = select_tag :per_page, per_page_options, class: 'per-page'
+      .narrow-clear
   .pagination
     - if paginated.total_entries > paginated.per_page
       - args = {container: false, params: @paginate_params || {}, first_label: "&laquo; First", last_label: "Last &raquo", summary_label: "%d of %d"}

--- a/app/views/posts/_paginator.haml
+++ b/app/views/posts/_paginator.haml
@@ -12,6 +12,8 @@
   .pagination
     - if paginated.total_entries > paginated.per_page
       - args = {container: false, params: @paginate_params || {}, first_label: "&laquo; First", last_label: "Last &raquo", summary_label: "%d of %d"}
-      - args[:mobile_view] = browser.device.mobile?
-      = will_paginate paginated, args
+      .normal-pagination
+        = will_paginate paginated, args
+      .mobile-pagination
+        = will_paginate paginated, args.merge(mobile_view: true)
   .clear


### PR DESCRIPTION
- Center the paginator when it wraps to a new line (as it seems to without the `clear` take into account the position of the left float, even though it's on a separate line; it's weird)
- Hide paginator links when the screen narrows, so the paginator doesn't wrap over several lines
- Use the mobile paginator at the 400px breakpoint, instead of based on browser detection, and relatedly also use it when the paginator wraps over several lines and no more links can be feasibly hidden

Other considered solutions were to modify font sizes or padding, but since there are often upwards of ten links on the single line at any one time (the current page, the four to either side, the two at either end of the paginator – this adds to 13, plus the "‹ Previous" and "Next ›" links, which gets bad especially with three-digit page numbers), I considered that it would not be the best fix; it would likely involve reducing the hitbox of the visible links (making them gradually more and more unuseful), whereas the solution of hiding links is more graceful from a user perspective. (Admittedly it is ugly that we duplicate the logic to calculate visible page links.)