### PR TITLE
Move S3 icon deletion into a background job

### DIFF
--- a/app/jobs/delete_icon_from_s3_job.rb
+++ b/app/jobs/delete_icon_from_s3_job.rb
@@ -1,0 +1,8 @@
+class DeleteIconFromS3Job < ApplicationJob
+  queue_as :high
+
+  def perform(s3_key)
+    Rails.logger.info("Deleting S3 object: #{s3_key}")
+    S3_BUCKET.delete_objects(delete: {objects: [{key: s3_key}]})
+  end
+end

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -40,8 +40,7 @@ class Icon < ApplicationRecord
   def delete_from_s3
     return unless destroyed? || s3_key_changed?
     return unless s3_key_was.present?
-    Rails.logger.info("Deleting S3 object: #{s3_key_was}")
-    S3_BUCKET.delete_objects(delete: {objects: [{key: s3_key_was}], quiet: true})
+    DeleteIconFromS3Job.perform_later(s3_key_was)
   end
 
   def uploaded_url_not_in_use

--- a/spec/jobs/delete_icon_from_s3_job_spec.rb
+++ b/spec/jobs/delete_icon_from_s3_job_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+RSpec.describe DeleteIconFromS3Job do
+  before(:each) { ResqueSpec.reset! }
+
+  it "deletes the given key" do
+    key = 'arbitrary'
+    delete_key = {delete: {objects: [{key: key}]}}
+    expect(S3_BUCKET).to receive(:delete_objects).with(delete_key)
+    DeleteIconFromS3Job.perform_now(key)
+  end
+end


### PR DESCRIPTION
Much speedier this way, and we can turn off `quiet: true` in the background.