### PR TITLE
Show user in character list instead of setting on settings pages

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -11,7 +11,7 @@ class TagsController < ApplicationController
 
   def show
     @posts = posts_from_relation(@tag.posts)
-    @characters = @tag.characters
+    @characters = @tag.characters.includes(:user)
     @galleries = @tag.galleries
     @page_title = @tag.name.to_s
   end

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -34,7 +34,10 @@
     %td.padding-5{class: klass}
       %b Facecast
     %td.padding-5{class: klass}
-      %b Setting
+      - if local_assigns[:show_user]
+        %b User
+      - else
+        %b Setting
     %td.padding-5{class: klass}
   - characters.order('name asc').each do |character|
     - klass = cycle('even', 'odd')
@@ -44,7 +47,11 @@
       %td.padding-5{class: klass, style:'width:15%'}= character.template_name
       %td.padding-5{class: klass, style:'width:15%'}= breakable_text(character.screenname)
       %td.padding-5{class: klass, style:'width:20%'}= character.pb
-      %td.padding-5{class: klass, style:'width:15%'}= character.settings.map { |setting| link_to(setting.name, tag_path(setting)) }.join(', ').html_safe
+      %td.padding-5{class: klass, style:'width:15%'}
+        - if local_assigns[:show_user]
+          = link_to character.user.username, character.user
+        - else
+          = character.settings.map { |setting| link_to(setting.name, tag_path(setting)) }.join(', ').html_safe
 
       %td.width-70.right-align{class: klass}
         - unless local_assigns[:hide_buttons]

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -51,7 +51,7 @@
           Characters Tagged: #{@tag.name}
           - content_for :edit_box
     %tbody
-      = render partial: 'characters/list_section', locals: {name: nil, characters: @characters.order('name asc'), hide_buttons: true}
+      = render partial: 'characters/list_section', locals: {name: nil, characters: @characters.order('name asc'), hide_buttons: true, show_user: true}
 
 - unless [@posts, @galleries, @characters].any?(&:present?)
   %table


### PR DESCRIPTION
On a setting page you already know the setting and you definitely don't know the owner; vice versa when viewing a user's character list.