### PR TITLE
Some updates to history and auditing for consistency

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -8,7 +8,7 @@ class Character < ApplicationRecord
   belongs_to :character_group
   has_many :replies
   has_many :posts
-  has_many :aliases, class_name: CharacterAlias
+  has_many :aliases, class_name: CharacterAlias, dependent: :destroy
 
   has_many :characters_galleries, inverse_of: :character
   accepts_nested_attributes_for :characters_galleries, allow_destroy: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,8 +12,6 @@ class Post < ApplicationRecord
   STATUS_HIATUS = 2
   STATUS_ABANDONED = 3
 
-  EDITED_ATTRS = %w(subject content icon_id character_id)
-
   belongs_to :board, inverse_of: :posts
   belongs_to :section, class_name: BoardSection, inverse_of: :posts
   belongs_to :last_user, class_name: User
@@ -44,7 +42,8 @@ class Post < ApplicationRecord
 
   acts_as_tag :label, :content_warning, :setting
 
-  audited except: [:last_reply_id, :last_user_id, :edited_at, :tagged_at, :section_id, :section_order]
+  NON_EDITED_ATTRS = %w(id created_at updated_at edited_at tagged_at last_user_id last_reply_id section_order)
+  audited except: NON_EDITED_ATTRS
   has_associated_audits
 
   pg_search_scope(
@@ -276,7 +275,7 @@ class Post < ApplicationRecord
   end
 
   def skip_edited
-    @skip_edited || EDITED_ATTRS.none? { |edit| send(edit + "_changed?") }
+    @skip_edited || (changed_attributes.keys - NON_EDITED_ATTRS).empty?
   end
 
   def timestamp_attributes_for_create

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -6,14 +6,17 @@
       %a#unread.unread-marker First unread marker
   .padding-10
     .post-info-box
-      - if reply.icon_id
+      - if reply.icon_id && reply.keyword
         .post-icon
           = link_to icon_path(reply.icon_id) do
             = icon_mem_tag reply.url, reply.keyword
       .post-info-text
         - if reply.character_id
           .post-character
-            = link_to reply.name, character_path(reply.character_id)
+            - if reply.name
+              = link_to reply.name, character_path(reply.character_id)
+            - else
+              [Deleted]
           - if reply.screenname
             .post-screenname= breakable_text(reply.screenname)
         - else

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -44,7 +44,7 @@
           - if reply.created_at
             = precede 'Posted '.freeze do
               %span.post-posted=pretty_time(reply.created_at)
-          - if reply.id.present? && reply.created_at.to_i != reply.last_updated.to_i
+          - if reply.id.present? && reply.audits.count > 0
             = surround ' | Updated '.freeze, ' | '.freeze do
               %span.post-updated=pretty_time(reply.last_updated)
             = link_to 'See History'.freeze, path_for(reply, 'history_%s'), class: 'post-history'.freeze

--- a/app/views/writable/_history.haml
+++ b/app/views/writable/_history.haml
@@ -37,9 +37,15 @@
           %th.sub Continuity
           %td{class: cycle('even', 'odd')}
             Changed from
-            %b= link_to Board.find_by_id(audit.audited_changes['board_id'][0]).try(:name) || '(deleted)', board_path(id: audit.audited_changes['board_id'][0])
+            - if (board = Board.find_by_id(audit.audited_changes['board_id'][0]))
+              %b= link_to board.name, board_path(board)
+            - else
+              %b [Deleted]
             to
-            %b= link_to cur.board.try(:name) || '(deleted)', board_path(cur.board)
+            - if cur.board
+              %b= link_to cur.board.name, board_path(cur.board)
+            - else
+              %b [Deleted]
       - if audit.version > 1 && audit.audited_changes.keys.include?('privacy')
         %tr
           %th.sub Privacy


### PR DESCRIPTION
- Destroy CharacterAliases when a Character is deleted
- Display [Deleted] for deleted characters rather than the URL "/characters/:id"
- Display [Deleted] for deleted continuities rather than crashing
- Do not display an empty box for deleted icons
- Make audits and edited_at consistent for Posts