### PR TITLE
Icon handling improvements

### DIFF
--- a/app/assets/javascripts/galleries/expander.js
+++ b/app/assets/javascripts/galleries/expander.js
@@ -1,47 +1,12 @@
 /* global gon */
 $(document).ready(function() {
+  var anchor = window.location.hash;
+  if (anchor.length > 0 && /^#gallery-[0-9]{1,}$/.test(anchor)) {
+    displayGallery($(anchor + " .gallery-box"));
+  }
+
   $(".gallery-box").click(function() {
-    // Update toggle +/-
-    var elem = $(this);
-    var toggleBox = elem.children('.view-button').first();
-    var wasVisible = toggleBox.children('img.up-arrow').is(':visible');
-    toggleBox.children('img.down-arrow').first().toggle();
-    toggleBox.children('img.up-arrow').first().toggle();
-
-    // Toggle display
-    var galleryId = elem.data('id');
-    $("#icons-" + galleryId).toggle();
-
-    // Nothing more necessary if collapsing or already loaded
-    if (wasVisible) return;
-    if (elem.data('loading') || elem.data('loaded')) return;
-
-    // Load and bind icons if they have not already been loaded
-    elem.data('loading', true);
-    $.ajax({
-      url: "/api/v1/galleries/" + galleryId,
-      data: {user_id: gon.user_id}
-    }).done(function(resp) {
-      $.each(resp.icons, function(index, icon) {
-        var iconDiv = $("<div>").attr({class: 'gallery-icon'});
-        var iconLink = $("<a>").attr({href: "/icons/" + icon.id});
-        var iconImg = $("<img>").attr({src: icon.url, alt: icon.keyword, title: icon.keyword, 'class': 'icon'});
-        iconLink.append(iconImg).append("<br>").append($("<span>").attr({class: 'icon-keyword'}).append(icon.keyword));
-        iconDiv.append(iconLink);
-
-        // Add control buttons for the owner
-        if ($("#icons-" + galleryId + " .icons-remove").length > 0) {
-          var iconCheckbox = $("<input>").attr({id: 'marked_ids_'+icon.id, name: 'marked_ids[]', type: 'checkbox'}).val(icon.id);
-          iconDiv.append($("<div>").attr({class: 'select-button'}).append(iconCheckbox));
-        }
-
-        $("#icons-" + galleryId + " .gallery").append(iconDiv);
-      });
-      elem.data('loading', false).data('loaded', true);
-    }).fail(function() {
-      elem.data('loading', false).trigger('click');
-      // TODO: notify user?
-    });
+    displayGallery($(this));
   });
 
   $(".tag-item").hover(function mouseIn() {
@@ -82,3 +47,46 @@ $(document).ready(function() {
     });
   });
 });
+
+function displayGallery(elem) {
+  // Update toggle +/-
+  var toggleBox = elem.children('.view-button').first();
+  var wasVisible = toggleBox.children('img.up-arrow').is(':visible');
+  toggleBox.children('img.down-arrow').first().toggle();
+  toggleBox.children('img.up-arrow').first().toggle();
+
+  // Toggle display
+  var galleryId = elem.data('id');
+  $("#icons-" + galleryId).toggle();
+
+  // Nothing more necessary if collapsing or already loaded
+  if (wasVisible) return;
+  if (elem.data('loading') || elem.data('loaded')) return;
+
+  // Load and bind icons if they have not already been loaded
+  elem.data('loading', true);
+  $.ajax({
+    url: "/api/v1/galleries/" + galleryId,
+    data: {user_id: gon.user_id}
+  }).done(function(resp) {
+    $.each(resp.icons, function(index, icon) {
+      var iconDiv = $("<div>").attr({class: 'gallery-icon'});
+      var iconLink = $("<a>").attr({href: "/icons/" + icon.id});
+      var iconImg = $("<img>").attr({src: icon.url, alt: icon.keyword, title: icon.keyword, 'class': 'icon'});
+      iconLink.append(iconImg).append("<br>").append($("<span>").attr({class: 'icon-keyword'}).append(icon.keyword));
+      iconDiv.append(iconLink);
+
+      // Add control buttons for the owner
+      if ($("#icons-" + galleryId + " .icons-remove").length > 0) {
+        var iconCheckbox = $("<input>").attr({id: 'marked_ids_'+icon.id, name: 'marked_ids[]', type: 'checkbox'}).val(icon.id);
+        iconDiv.append($("<div>").attr({class: 'select-button'}).append(iconCheckbox));
+      }
+
+      $("#icons-" + galleryId + " .gallery").append(iconDiv);
+    });
+    elem.data('loading', false).data('loaded', true);
+  }).fail(function() {
+    elem.data('loading', false).trigger('click');
+    // TODO: notify user?
+  });
+}

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -29,6 +29,7 @@ class IconsController < UploadingController
         gallery.icons.destroy(icon)
       end
       flash[:success] = "Icons removed from gallery."
+      redirect_to galleries_path(anchor: "gallery-#{gallery.id}") and return if params[:return_to] == 'index'
       redirect_to gallery_path(gallery) and return
     end
 

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -6,6 +6,7 @@ class IconsController < UploadingController
   before_action :set_s3_url, only: :edit
 
   def delete_multiple
+    gallery = Gallery.find_by_id(params[:gallery_id])
     icon_ids = (params[:marked_ids] || []).map(&:to_i).reject(&:zero?)
     if icon_ids.empty? || (icons = Icon.where(id: icon_ids)).empty?
       flash[:error] = "No icons selected."
@@ -13,7 +14,6 @@ class IconsController < UploadingController
     end
 
     if params[:gallery_delete]
-      gallery = Gallery.find_by_id(params[:gallery_id])
       unless gallery
         flash[:error] = "Gallery could not be found."
         redirect_to galleries_path and return
@@ -28,9 +28,9 @@ class IconsController < UploadingController
         next unless icon.user_id == current_user.id
         gallery.icons.destroy(icon)
       end
+
       flash[:success] = "Icons removed from gallery."
-      redirect_to galleries_path(anchor: "gallery-#{gallery.id}") and return if params[:return_to] == 'index'
-      redirect_to gallery_path(gallery) and return
+      icon_redirect(gallery) and return
     end
 
     icons.each do |icon|
@@ -38,7 +38,7 @@ class IconsController < UploadingController
       icon.destroy
     end
     flash[:success] = "Icons deleted."
-    redirect_to gallery_path(id: params[:gallery_id] || 0)
+    icon_redirect(gallery) and return
   end
 
   def show
@@ -142,6 +142,16 @@ class IconsController < UploadingController
     if @icon.user_id != current_user.id
       flash[:error] = "That is not your icon."
       redirect_to galleries_path
+    end
+  end
+
+  def icon_redirect(gallery)
+    if params[:return_to] == 'index'
+      redirect_to galleries_path(anchor: "gallery-#{gallery.id}")
+    elsif params[:return_tag].present? && (tag = Tag.find_by_id(params[:return_tag]))
+      redirect_to tag_path(tag, anchor: "gallery-#{gallery.id}")
+    else
+      redirect_to gallery_path(id: gallery.try(:id) || 0)
     end
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -12,8 +12,9 @@ class TagsController < ApplicationController
   def show
     @posts = posts_from_relation(@tag.posts)
     @characters = @tag.characters.includes(:user)
-    @galleries = @tag.galleries
+    @galleries = @tag.galleries.with_icon_count.order('name asc')
     @page_title = @tag.name.to_s
+    use_javascript('galleries/expander') if @tag.is_a?(GalleryGroup)
   end
 
   def edit

--- a/app/views/galleries/_expandable.haml
+++ b/app/views/galleries/_expandable.haml
@@ -1,0 +1,34 @@
+%tr{id: "gallery-#{gallery.id}"}
+  - klass = cycle('even', 'odd')
+  %td.gallery-name{class: klass}
+    = link_to gallery.name, gallery_path(gallery)
+    .tag-box
+      - gallery.gallery_groups_data.each do |group|
+        - next if group == @tag
+        = link_to tag_path(group.id), class: 'tag-item-link' do
+          %span.tag-item.semiplusopaque
+            = group.name
+  %td.width-150.centered.gallery-icon-count{class: klass}= gallery.icon_count
+  %td.width-70.gallery-buttons{class: klass}
+    - if gallery.user_id == current_user.try(:id)
+      = link_to add_gallery_path(gallery), title: "Add Icons", class: 'gallery-add' do
+        = image_tag "icons/add.png"
+      = link_to edit_gallery_path(gallery), title: "Edit Gallery", class: 'gallery-edit' do
+        = image_tag "icons/pencil.png"
+      = link_to gallery_path(gallery), title: "Delete Gallery", method: :delete, data: { confirm: "Are you sure you want to delete #{gallery.name}?" }, class: 'gallery-delete' do
+        = image_tag "icons/cross.png"
+  %td.centered.width-70{class: klass}
+    .gallery-box.vmid{id: "minmax-#{gallery.id}", style: 'display: inline-block;', data: {id: gallery.id}}
+      .view-button{style: 'padding: 5px 7px;'}
+        = image_tag "icons/bullet_arrow_down.png", class: 'vmid down-arrow'
+        = image_tag "icons/bullet_arrow_up.png", class: 'vmid hidden up-arrow'
+%tr
+  %td.padding-5.hidden{class: klass, id: "icons-#{gallery.id}", colspan: 4}
+    = form_tag delete_multiple_icons_path, method: :delete do
+      .gallery{style: 'padding: 0px;'}
+      - if gallery.user_id == current_user.try(:id)
+        .clear.centered.icons-remove
+          = hidden_field_tag :gallery_id, gallery.id
+          = hidden_field_tag :return_to, 'index' # TODO not on gallery group page
+          = submit_tag "- Remove selected icons from gallery", name: 'gallery_delete'
+          = submit_tag "x Delete selected icons permanently", data: { confirm: "Are you sure? These icons will be gone from the site!" }

--- a/app/views/galleries/_expandable.haml
+++ b/app/views/galleries/_expandable.haml
@@ -29,6 +29,9 @@
       - if gallery.user_id == current_user.try(:id)
         .clear.centered.icons-remove
           = hidden_field_tag :gallery_id, gallery.id
-          = hidden_field_tag :return_to, 'index' # TODO not on gallery group page
+          - if local_assigns[:tag]
+            = hidden_field_tag :return_tag, local_assigns[:tag].id
+          - else
+            = hidden_field_tag :return_to, 'index'
           = submit_tag "- Remove selected icons from gallery", name: 'gallery_delete'
           = submit_tag "x Delete selected icons permanently", data: { confirm: "Are you sure? These icons will be gone from the site!" }

--- a/app/views/galleries/index.haml
+++ b/app/views/galleries/index.haml
@@ -43,37 +43,4 @@
           - if @user.id == current_user.try(:id)
             .clear.centered.icons-remove
               = submit_tag "x Delete selected icons permanently", data: { confirm: "Are you sure? These icons will be gone from the site!" }
-    - @user.galleries.with_icon_count.with_gallery_groups.order('name asc').each do |gallery|
-      %tr{id: "gallery-#{gallery.id}"}
-        - klass = cycle('even', 'odd')
-        %td.gallery-name{class: klass}
-          = link_to gallery.name, gallery_path(gallery)
-          .tag-box
-            - gallery.gallery_groups_data.each do |group|
-              = link_to tag_path(group.id), class: 'tag-item-link' do
-                %span.tag-item.semiplusopaque
-                  = group.name
-        %td.width-150.centered.gallery-icon-count{class: klass}= gallery.icon_count
-        %td.width-70.gallery-buttons{class: klass}
-          - if @user.id == current_user.try(:id)
-            = link_to add_gallery_path(gallery), title: "Add Icons", class: 'gallery-add' do
-              = image_tag "icons/add.png"
-            = link_to edit_gallery_path(gallery), title: "Edit Gallery", class: 'gallery-edit' do
-              = image_tag "icons/pencil.png"
-            = link_to gallery_path(gallery), title: "Delete Gallery", method: :delete, data: { confirm: "Are you sure you want to delete #{gallery.name}?" }, class: 'gallery-delete' do
-              = image_tag "icons/cross.png"
-        %td.centered.width-70{class: klass}
-          .gallery-box.vmid{id: "minmax-#{gallery.id}", style: 'display: inline-block;', data: {id: gallery.id}}
-            .view-button{style: 'padding: 5px 7px;'}
-              = image_tag "icons/bullet_arrow_down.png", class: 'vmid down-arrow'
-              = image_tag "icons/bullet_arrow_up.png", class: 'vmid hidden up-arrow'
-      %tr
-        %td.padding-5.hidden{class: klass, id: "icons-#{gallery.id}", colspan: 4}
-          = form_tag delete_multiple_icons_path, method: :delete do
-            .gallery{style: 'padding: 0px;'}
-            - if @user.id == current_user.try(:id)
-              .clear.centered.icons-remove
-                = hidden_field_tag :gallery_id, gallery.id
-                = hidden_field_tag :return_to, 'index'
-                = submit_tag "- Remove selected icons from gallery", name: 'gallery_delete'
-                = submit_tag "x Delete selected icons permanently", data: { confirm: "Are you sure? These icons will be gone from the site!" }
+    = render partial: 'galleries/expandable', collection: @user.galleries.with_icon_count.with_gallery_groups.order('name asc'), as: :gallery

--- a/app/views/galleries/index.haml
+++ b/app/views/galleries/index.haml
@@ -44,7 +44,7 @@
             .clear.centered.icons-remove
               = submit_tag "x Delete selected icons permanently", data: { confirm: "Are you sure? These icons will be gone from the site!" }
     - @user.galleries.with_icon_count.with_gallery_groups.order('name asc').each do |gallery|
-      %tr
+      %tr{id: "gallery-#{gallery.id}"}
         - klass = cycle('even', 'odd')
         %td.gallery-name{class: klass}
           = link_to gallery.name, gallery_path(gallery)
@@ -74,5 +74,6 @@
             - if @user.id == current_user.try(:id)
               .clear.centered.icons-remove
                 = hidden_field_tag :gallery_id, gallery.id
+                = hidden_field_tag :return_to, 'index'
                 = submit_tag "- Remove selected icons from gallery", name: 'gallery_delete'
                 = submit_tag "x Delete selected icons permanently", data: { confirm: "Are you sure? These icons will be gone from the site!" }

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -32,7 +32,7 @@
           Galleries Tagged: #{@tag.name}
           - content_for :edit_box
     %tbody
-      = render partial: 'galleries/expandable', collection: @galleries, as: :gallery
+      = render partial: 'galleries/expandable', collection: @galleries, as: :gallery, locals: {tag: @tag}
   %br
 
 - if @characters.present?

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -28,18 +28,11 @@
   %table
     %thead
       %tr
-        %th.padding-10{colspan: 2}
+        %th.padding-10{colspan: 4}
           Galleries Tagged: #{@tag.name}
           - content_for :edit_box
     %tbody
-      %tr
-        %th.sub Name
-        %th.sub # of Icons
-      - @galleries.with_icon_count.order('name asc').each do |gallery|
-        %tr
-          - klass = cycle('even', 'odd')
-          %td.gallery-name{class: klass}= link_to gallery.name, gallery_path(gallery)
-          %td.width-150.centered.gallery-icon-count{class: klass}= gallery.icon_count
+      = render partial: 'galleries/expandable', collection: @galleries, as: :gallery
   %br
 
 - if @characters.present?

--- a/spec/controllers/icons_controller_spec.rb
+++ b/spec/controllers/icons_controller_spec.rb
@@ -75,6 +75,28 @@ RSpec.describe IconsController do
         expect(response).to redirect_to(gallery_url(gallery))
         expect(flash[:success]).to eq("Icons removed from gallery.")
       end
+
+      it "goes back to index page if given" do
+        icon = create(:icon, user: user)
+        gallery = create(:gallery, user: user)
+        gallery.icons << icon
+        expect(icon.galleries.count).to eq(1)
+        delete :delete_multiple, params: { marked_ids: [icon.id.to_s], gallery_id: gallery.id, gallery_delete: true, return_to: 'index' }
+        expect(icon.galleries.count).to eq(0)
+        expect(response).to redirect_to(galleries_url(anchor: "gallery-#{gallery.id}"))
+      end
+
+      it "goes back to index page if given" do
+        icon = create(:icon, user: user)
+        gallery = create(:gallery, user: user)
+        group = create(:gallery_group, user: user)
+        group.galleries << gallery
+        gallery.icons << icon
+        expect(icon.galleries.count).to eq(1)
+        delete :delete_multiple, params: { marked_ids: [icon.id.to_s], gallery_id: gallery.id, gallery_delete: true, return_tag: group.id }
+        expect(icon.galleries.count).to eq(0)
+        expect(response).to redirect_to(tag_url(group, anchor: "gallery-#{gallery.id}"))
+      end
     end
 
     context "deleting icons from the site" do
@@ -99,6 +121,27 @@ RSpec.describe IconsController do
         delete :delete_multiple, params: { marked_ids: [icon.id.to_s, icon2.id.to_s] }
         expect(Icon.find_by_id(icon.id)).to be_nil
         expect(Icon.find_by_id(icon2.id)).to be_nil
+        expect(response).to redirect_to(gallery_url(id: 0))
+      end
+
+      it "goes back to index page if given" do
+        icon = create(:icon, user: user)
+        gallery = create(:gallery, user: user)
+        gallery.icons << icon
+        delete :delete_multiple, params: { marked_ids: [icon.id], gallery_id: gallery.id, return_to: 'index' }
+        expect(Icon.find_by_id(icon.id)).to be_nil
+        expect(response).to redirect_to(galleries_url(anchor: "gallery-#{gallery.id}"))
+      end
+
+      it "goes back to index page if given" do
+        icon = create(:icon, user: user)
+        gallery = create(:gallery, user: user)
+        group = create(:gallery_group, user: user)
+        group.galleries << gallery
+        gallery.icons << icon
+        delete :delete_multiple, params: { marked_ids: [icon.id], gallery_id: gallery.id, return_tag: group.id }
+        expect(Icon.find_by_id(icon.id)).to be_nil
+        expect(response).to redirect_to(tag_url(group, anchor: "gallery-#{gallery.id}"))
       end
     end
   end


### PR DESCRIPTION
- You can now expand or manage galleries from the GalleryGroup page
- When you remove an icon from a gallery or delete from the site, you are now returned back to the page you took the action from (galleries#index, galleries#show or gallery_group#show)
- When you navigate to an anchored gallery on a gallery list page (galleries or gallery group list), it will now auto-expand the gallery