### PR TITLE
Tag improvements

### DIFF
--- a/app/concerns/taggable.rb
+++ b/app/concerns/taggable.rb
@@ -33,7 +33,7 @@ module Taggable
           tag_ids -= fakes # remove them from proper list
           old_tags = klass.where(id: tag_ids)
 
-          fakes.map! { |name| name[1..-1] } # trim names
+          fakes.map! { |name| name[1..-1].strip } # trim names
 
           # find existing tags by same name
           existing_tags = klass.where(name: fakes)

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -44,6 +44,6 @@ class Api::V1::TagsController < Api::ApiController
 
   def find_type(type_string=nil)
     type_string ||= params[:t]
-    Tag::TYPES.detect {|x| x == type_string }
+    Tag::TYPES.detect {|x| x == type_string }.constantize
   end
 end

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -1,8 +1,6 @@
 class Api::V1::TagsController < Api::ApiController
   before_action :find_tag, except: :index
 
-  TYPES = [Setting, Label, ContentWarning, GalleryGroup, Canon]
-
   resource_description do
     description 'Viewing tags'
   end
@@ -10,7 +8,7 @@ class Api::V1::TagsController < Api::ApiController
   api :GET, '/tags', 'Load all the tags of the specified type that match the given query, results ordered by name'
   param :q, String, required: false, desc: "Query string"
   param :page, :number, required: false, desc: 'Page in results (25 per page)'
-  param :t, TYPES.map(&:name), required: true, desc: 'Type of the tag to search'
+  param :t, Tag::TYPES, required: true, desc: 'Type of the tag to search'
   error 422, "Invalid parameters provided"
   def index
     type = find_type
@@ -46,6 +44,6 @@ class Api::V1::TagsController < Api::ApiController
 
   def find_type(type_string=nil)
     type_string ||= params[:t]
-    TYPES.detect {|x| x.name == type_string }
+    Tag::TYPES.detect {|x| x == type_string }
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -6,7 +6,22 @@ class TagsController < ApplicationController
 
   def index
     @page_title = "Tags"
-    @tags = Tag.where.not(type: 'GalleryGroup').order('type desc, LOWER(name) asc').select('tags.*').with_item_counts.paginate(per_page: 25, page: page)
+
+    if params[:view].present?
+      unless Tag::TYPES.include?(params[:view])
+        flash[:error] = "Invalid filter"
+        redirect_to tags_path and return
+      end
+      @view = params[:view]
+    end
+
+    @tags = Tag.order('type desc, LOWER(name) asc').select('tags.*')
+    if @view.present?
+      @tags = @tags.where(type: @view)
+    else
+      @tags = @tags.where.not(type: 'GalleryGroup')
+    end
+    @tags = @tags.with_item_counts.paginate(per_page: 25, page: page)
   end
 
   def show

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -7,6 +7,8 @@ class Tag < ApplicationRecord
   has_many :gallery_tags, dependent: :destroy
   has_many :galleries, through: :gallery_tags
 
+  TYPES = %w(Setting Label ContentWarning GalleryGroup Canon)
+
   validates_presence_of :user, :name, :type
   validates :name, uniqueness: { scope: :type }
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -18,6 +18,7 @@ class Tag < ApplicationRecord
   def editable_by?(user)
     return false unless user
     return true if user.admin?
+    return true unless owned?
     user.id == user_id
   end
 

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -85,6 +85,7 @@
             %li= link_to 'Unread', unread_posts_path
             %li= link_to 'Tags Owed', owed_posts_path
           %li= link_to 'Contribute', contribute_path
+          %li= link_to 'Tags', tags_path
           - if (day = DailyReport.unread_date_for(current_user)).present?
             %li
               = link_to report_path(id: :daily, day: day), style: 'text-shadow: 0 0 0.8em #F87, 0 0 0.8em #F87' do

--- a/app/views/tags/edit.haml
+++ b/app/views/tags/edit.haml
@@ -9,5 +9,5 @@
   - f.object = @tag.becomes(@tag.class) # handles the STI with Tag/Setting/ContentWarning properly
   %table.form-table
     %tr
-      %th.centered{colspan: 2} Edit Tag
+      %th.centered{colspan: 2} Edit #{@tag.type.titlecase}
     = render partial: 'editor', locals: {f: f}

--- a/app/views/tags/edit.haml
+++ b/app/views/tags/edit.haml
@@ -1,6 +1,8 @@
 - content_for :breadcrumbs do
   = link_to "Tags", tags_path
   &raquo;
+  = link_to @tag.type.pluralize.titlecase, tags_path(view: @tag.type)
+  &raquo;
   = link_to @tag.name, tag_path(@tag)
   &raquo;
   %b Edit

--- a/app/views/tags/index.haml
+++ b/app/views/tags/index.haml
@@ -1,12 +1,19 @@
+- if @view.present?
+  - content_for :breadcrumbs do
+    = link_to "Tags", tags_path
+    &raquo;
+    %b= @view.pluralize.titlecase
+
 %table
   %thead
     %tr
       %th{colspan: 5}
-        Tags
+        = @view ? @view.titlecase.pluralize : 'Tags'
   %tbody
     %tr
-      %th.sub Tag
-      %th.sub Type
+      %th.sub= @view ? @view.titlecase : 'Tag'
+      - unless @view.present?
+        %th.sub Type
       %th.sub Posts
       %th.sub Characters
       %th.sub
@@ -14,7 +21,8 @@
       - klass = cycle('even', 'odd')
       %tr
         %td{class: klass}= link_to tag.name, tag_path(tag)
-        %td{class: klass}= (tag.type || 'Tag').titlecase
+        - unless @view.present?
+          %td{class: klass}= link_to tag.type.titlecase, tags_path(view: tag.type)
         %td{class: klass}= tag.post_count
         %td{class: klass}= tag.character_count
         %td.width-70.right-align{class: klass}

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -9,7 +9,7 @@
   %thead
     %tr
       %th{colspan: 2}
-        #{@tag.type}: #{@tag.name}
+        #{@tag.type.titlecase}: #{@tag.name}
         - if @tag.editable_by?(current_user)
           = link_to edit_tag_path(@tag) do
             .link-box.blue

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
   = link_to "Tags", tags_path
   &raquo;
-  = @tag.type.pluralize.titlecase
+  = link_to @tag.type.pluralize.titlecase, tags_path(view: @tag.type)
   &raquo;
   %b= @tag.name
 

--- a/db/migrate/20171109031527_add_ownership_to_tags.rb
+++ b/db/migrate/20171109031527_add_ownership_to_tags.rb
@@ -1,0 +1,5 @@
+class AddOwnershipToTags < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tags, :owned, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1086,7 +1086,8 @@ CREATE TABLE tags (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     type character varying,
-    description text
+    description text,
+    owned boolean DEFAULT false
 );
 
 
@@ -2230,6 +2231,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170914191425'),
 ('20171001035221'),
 ('20171027225408'),
-('20171104140915');
+('20171104140915'),
+('20171109031527');
 
 

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -9,18 +9,12 @@ RSpec.describe TagsController do
         empty_tag = create(:label)
         tag = create(:label)
         create(:post, labels: [tag])
+        setting = create(:setting)
 
         empty_group = create(:gallery_group)
         group1 = create(:gallery_group)
         create(:gallery, gallery_groups: [group1])
-
-        group2 = create(:gallery_group)
-        create(:gallery, gallery_groups: [group2])
-        create(:character, gallery_groups: [group2])
-
-        group3 = create(:gallery_group)
-        create(:character, gallery_groups: [group3])
-        [empty_tag, tag, empty_group, group1, group2, group3]
+        [empty_tag, tag, empty_group, group1, setting]
       end
 
       it "succeeds when logged out" do
@@ -29,6 +23,13 @@ RSpec.describe TagsController do
         expect(response.status).to eq(200)
         tags.reject! { |tag| tag.is_a?(GalleryGroup) }
         expect(assigns(:tags)).to match_array(tags)
+      end
+
+      it "succeeds with filter" do
+        tags = create_tags
+        get :index, params: { view: 'Setting' }
+        expect(response).to have_http_status(200)
+        expect(assigns(:tags).size).to eq(1)
       end
 
       it "succeeds when logged in" do
@@ -164,7 +165,7 @@ RSpec.describe TagsController do
     end
 
     it "requires valid params" do
-      tag = create(:label)
+      tag = create(:setting)
       login_as(create(:admin_user))
       put :update, params: { id: tag.id, tag: {name: nil} }
       expect(response.status).to eq(200)

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe TagsController do
     end
 
     it "requires permission" do
-      tag = create(:label)
+      tag = create(:label, owned: true)
       login
       get :edit, params: { id: tag.id }
       expect(response).to redirect_to(tag_url(tag))
@@ -157,7 +157,7 @@ RSpec.describe TagsController do
 
     it "requires permission" do
       login
-      tag = create(:label)
+      tag = create(:label, owned: true)
       put :update, params: { id: tag.id }
       expect(response).to redirect_to(tag_url(tag))
       expect(flash[:error]).to eq("You do not have permission to edit this tag.")
@@ -197,7 +197,7 @@ RSpec.describe TagsController do
     end
 
     it "requires permission" do
-      tag = create(:label)
+      tag = create(:label, owned: true)
       login
       delete :destroy, params: { id: tag.id }
       expect(response).to redirect_to(tag_url(tag))


### PR DESCRIPTION
Tag improvements, somewhat hacky for the benefit of speed.

[As requested here](https://docs.google.com/document/d/1Hzz8U8adCkCd9e9DWsCaYUoayGRAjsKGGddOWO7g4Yc/edit) by Mori.

Covers:
- Link to Tags in the top menu
- Tags filtered by Tag type, with breadcrumbs
- Publicly owned tags
- Stripping end spaces off tags, since we've seen a bunch of them
- See what type of tag you're editing from the edit tag page, with breadcrumbs
- Added a titlecase and breadcrumbs to tag#show