### PR TITLE
Tags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,7 +2,7 @@
 class TagsController < ApplicationController
   before_action :login_required, except: [:index, :show]
   before_action :find_tag, except: :index
-  before_action :permission_required, except: [:index, :show]
+  before_action :permission_required, except: [:index, :show, :destroy]
 
   def index
     @page_title = "Tags"
@@ -52,6 +52,11 @@ class TagsController < ApplicationController
   end
 
   def destroy
+    unless @tag.deletable_by?(current_user)
+      flash[:error] = "You do not have permission to edit this tag."
+      redirect_to tag_path(@tag)
+    end
+
     @tag.destroy
     flash[:success] = "Tag deleted."
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -86,8 +86,7 @@ class TagsController < ApplicationController
 
   def tag_params
     permitted = [:type, :description, :owned, parent_setting_ids: []]
-    permitted.insert(0, :name) if current_user.admin?
-    permitted.insert(0, :user_id) if current_user.admin? || @tag.user == current_user
+    permitted.insert(0, :name, :user_id) if current_user.admin? || @tag.user == current_user
     params.fetch(:tag, {}).permit(permitted)
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -54,7 +54,7 @@ class TagsController < ApplicationController
   def destroy
     unless @tag.deletable_by?(current_user)
       flash[:error] = "You do not have permission to edit this tag."
-      redirect_to tag_path(@tag)
+      redirect_to tag_path(@tag) and return
     end
 
     @tag.destroy

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -19,7 +19,7 @@ class TagsController < ApplicationController
     if @view.present?
       @tags = @tags.where(type: @view)
     else
-      @tags = @tags.where.not(type: ['GalleryGroup', 'Canon'])
+      @tags = @tags.where.not(type: 'GalleryGroup')
     end
     @tags = @tags.with_item_counts.paginate(per_page: 25, page: page)
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -54,7 +54,11 @@ class TagsController < ApplicationController
   def destroy
     @tag.destroy
     flash[:success] = "Tag deleted."
-    redirect_to tags_path
+
+    url_params = {}
+    url_params[:page] = page if params[:page].present?
+    url_params[:view] = params[:view] if params[:view].present?
+    redirect_to tags_path(url_params)
   end
 
   private

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -1,0 +1,8 @@
+module TagHelper
+  def delete_path(tag)
+    url_params = {}
+    url_params[:page] = page if params[:page].present?
+    url_params[:view] = @view if @view.present?
+    tag_path(tag, url_params)
+  end
+end

--- a/app/models/canon.rb
+++ b/app/models/canon.rb
@@ -1,2 +1,0 @@
-class Canon < Tag
-end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -18,7 +18,6 @@ class Character < ApplicationRecord
   has_many :character_tags, inverse_of: :character, dependent: :destroy
   has_many :labels, through: :character_tags, source: :label
   has_many :settings, through: :character_tags, source: :setting
-  has_many :canons, through: :character_tags, source: :canon
   has_many :gallery_groups, through: :character_tags, source: :gallery_group, dependent: :destroy
 
   validates_presence_of :name, :user
@@ -30,7 +29,7 @@ class Character < ApplicationRecord
 
   accepts_nested_attributes_for :template, reject_if: :all_blank
 
-  acts_as_tag :label, :setting, :gallery_group, :canon
+  acts_as_tag :label, :setting, :gallery_group
 
   nilify_blanks types: [:string, :text, :citext] # nilify_blanks does not touch citext by default
 

--- a/app/models/character_tag.rb
+++ b/app/models/character_tag.rb
@@ -4,7 +4,6 @@ class CharacterTag < ApplicationRecord
   belongs_to :label, foreign_key: :tag_id
   belongs_to :setting, foreign_key: :tag_id
   belongs_to :gallery_group, foreign_key: :tag_id
-  belongs_to :canon, foreign_key: :tag_id
   validates_presence_of :character
 
   after_create :add_galleries_to_character

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,8 +1,8 @@
 class Setting < Tag
   include Taggable
 
-  has_many :parent_setting_tags, class_name: TagTag, foreign_key: :tag_id, inverse_of: :child_setting
-  has_many :child_setting_tags, class_name: TagTag, foreign_key: :tagged_id, inverse_of: :parent_setting
+  has_many :parent_setting_tags, class_name: TagTag, foreign_key: :tag_id, inverse_of: :child_setting, dependent: :destroy
+  has_many :child_setting_tags, class_name: TagTag, foreign_key: :tagged_id, inverse_of: :parent_setting, dependent: :destroy
 
   has_many :parent_settings, class_name: Setting, through: :child_setting_tags, source: :parent_setting
   has_many :child_settings, class_name: Setting, through: :parent_setting_tags, source: :child_setting

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -65,13 +65,17 @@ class Tag < ApplicationRecord
   end
 
   def merge_with(other_tag)
-    transaction do # TODO tagtag for setting/canon
+    transaction do
       PostTag.where(tag_id: other_tag.id).where(post_id: post_tags.pluck('distinct post_id')).delete_all
       PostTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
       CharacterTag.where(tag_id: other_tag.id).where(character_id: character_tags.pluck('distinct character_id')).delete_all
       CharacterTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
       GalleryTag.where(tag_id: other_tag.id).where(gallery_id: gallery_tags.pluck('distinct gallery_id')).delete_all
       GalleryTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
+      TagTag.where(tag_id: other_tag.id, tagged_id: self.id).delete_all
+      TagTag.where(tag_id: self.id, tagged_id: other_tag.id).delete_all
+      TagTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
+      TagTag.where(tagged_id: other_tag.id).update_all(tagged_id: self.id)
       other_tag.destroy
     end
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,8 +19,14 @@ class Tag < ApplicationRecord
 
   def editable_by?(user)
     return false unless user
+    return true if deletable_by?(user)
+    return false unless is_a?(Setting)
+    !owned?
+  end
+
+  def deletable_by?(user)
+    return false unless user
     return true if user.admin?
-    return true unless owned?
     user.id == user_id
   end
 

--- a/app/views/tags/_editor.haml
+++ b/app/views/tags/_editor.haml
@@ -1,7 +1,7 @@
 %tr
   %th.sub Name
   %td{class: cycle('even', 'odd')}
-    - if current_user.admin? # TODO or owned owner
+    - if current_user.admin? || f.object.user_id == current_user.id
       = f.text_field :name, placeholder: "Tag Name", class: 'text'
     - else
       = f.object.name

--- a/app/views/tags/index.haml
+++ b/app/views/tags/index.haml
@@ -29,6 +29,7 @@
           - if tag.editable_by?(current_user)
             = link_to edit_tag_path(tag) do
               = image_tag "icons/pencil.png"
+          - if tag.deletable_by?(current_user)
             = link_to tag_path(tag), method: :delete, data: { confirm: 'Are you sure you want to delete '+tag.name+'?' } do # TODO takes you back to the same view/page
               = image_tag "icons/cross.png"
             &nbsp;

--- a/app/views/tags/index.haml
+++ b/app/views/tags/index.haml
@@ -29,7 +29,7 @@
           - if tag.editable_by?(current_user)
             = link_to edit_tag_path(tag) do
               = image_tag "icons/pencil.png"
-            = link_to tag_path(tag), method: :delete, confirm: 'Are you sure you want to delete '+tag.name+'?' do # TODO takes you back to the same view/page
+            = link_to tag_path(tag), method: :delete, data: { confirm: 'Are you sure you want to delete '+tag.name+'?' } do # TODO takes you back to the same view/page
               = image_tag "icons/cross.png"
             &nbsp;
   - if @tags.total_pages > 1

--- a/app/views/tags/index.haml
+++ b/app/views/tags/index.haml
@@ -30,7 +30,7 @@
             = link_to edit_tag_path(tag) do
               = image_tag "icons/pencil.png"
           - if tag.deletable_by?(current_user)
-            = link_to tag_path(tag), method: :delete, data: { confirm: 'Are you sure you want to delete '+tag.name+'?' } do # TODO takes you back to the same view/page
+            = link_to delete_path(tag), method: :delete, data: { confirm: 'Are you sure you want to delete '+tag.name+'?' } do
               = image_tag "icons/cross.png"
             &nbsp;
   - if @tags.total_pages > 1

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -58,6 +58,7 @@
         %th{colspan: 6} Characters Tagged: #{@tag.name}
     %tbody
       = render partial: 'characters/list_section', locals: {name: nil, characters: @characters.order('name asc'), hide_buttons: true, show_user: true}
+  %br
 
 - if @tag.is_a?(Setting)
   - reset_cycle

--- a/db/migrate/20171111163658_canon_refactor.rb
+++ b/db/migrate/20171111163658_canon_refactor.rb
@@ -1,6 +1,6 @@
 class CanonRefactor < ActiveRecord::Migration[5.0]
   def up
-    Canon.all.each do |canon|
+    Tag.where(type: "Canon").each do |canon|
       # find or create a setting with the same name
       setting = Setting.where(name: canon.name.strip).first
       setting ||= Setting.create!(

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe TagsController do
 
       it "succeeds when logged in" do
         tags = create_tags
-        login
+        login_as(tags.first.user)
         get :index
         expect(response.status).to eq(200)
         tags.reject! { |tag| tag.is_a?(GalleryGroup) }


### PR DESCRIPTION
- Removes remaining Canon code
- Deletes Setting<>Setting joins when a Setting is deleted
- Spaces the sections in Tag#show properly
- Fixes the confirmation prompt upon deleting a Tag
- Locks deletion privileges to only owners and admins
- Preserves view and filters on tags#index page when deleting a tag
- Allow owners to rename tags
- Tag#merge_with admin method now updates Setting<>Setting joins correctly