### PR TITLE
Fix/rename header links

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,7 +22,7 @@ class PostsController < WritableController
     @posts = posts_from_relation(@posts.order('tagged_at desc'))
     @show_unread = true
     @hide_quicklinks = true
-    @page_title = 'Tags Owed'
+    @page_title = 'Replies Owed'
   end
 
   def unread

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   before_action :require_own_user, only: [:edit, :update, :password]
 
   def index
-    @page_title = 'Glowficcers'
+    @page_title = 'Users'
   end
 
   def show

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -83,7 +83,7 @@
           %li= link_to 'Facecasts', facecasts_characters_path
           - if logged_in?
             %li= link_to 'Unread', unread_posts_path
-            %li= link_to 'Tags Owed', owed_posts_path
+            %li= link_to 'Replies Owed', owed_posts_path
           %li= link_to 'Contribute', contribute_path
           %li= link_to 'Tags', tags_path
           - if (day = DailyReport.unread_date_for(current_user)).present?

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -79,7 +79,7 @@
           %li= link_to 'Continuities', boards_path
           %li= link_to 'Recently Updated', posts_path
           %li= link_to 'Search', search_posts_path
-          %li= link_to 'Glowficcers', users_path
+          %li= link_to 'Users', users_path
           %li= link_to 'Facecasts', facecasts_characters_path
           - if logged_in?
             %li= link_to 'Unread', unread_posts_path

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -74,7 +74,7 @@
         = f.check_box :hide_warnings, class: 'width-15 vmid'
         = f.label :hide_warnings, "Hide content warnings"
     %tr
-      %th.sub Tags Owed
+      %th.sub Replies Owed
       %td{class: cycle('even', 'odd')}
         = f.check_box :hide_hiatused_tags_owed, class: 'width-15 vmid'
         = f.label :hide_hiatused_tags_owed, "Hide hiatused threads"

--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -1,7 +1,7 @@
 %table
   %thead
     %tr
-      %th{colspan: 3} Glowficcers
+      %th{colspan: 3} Users
     %tr
       %th.sub Name
       %th.width-70.sub.centered Moiety

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1503,7 +1503,7 @@ RSpec.describe PostsController do
       login
       get :owed
       expect(response.status).to eq(200)
-      expect(assigns(:page_title)).to eq('Tags Owed')
+      expect(assigns(:page_title)).to eq('Replies Owed')
     end
 
     context "with posts" do


### PR DESCRIPTION
* Convert 'Glowficcers' to 'Users' (fixes #209)
* Convert 'Tags Owed' to 'Replies Owed'