### PR TITLE
Fix android favicon asset paths

### DIFF
--- a/app/assets/images/favicons/manifest.json.erb
+++ b/app/assets/images/favicons/manifest.json.erb
@@ -2,12 +2,12 @@
 	"name": "",
 	"icons": [
 		{
-			"src": "<%= asset_path 'favicon/android-chrome-192x192.png' %>",
+			"src": "<%= asset_path 'favicons/android-chrome-192x192.png' %>",
 			"sizes": "192x192",
 			"type": "image\/png"
 		},
 		{
-			"src": "<%= asset_path 'favicon/android-chrome-256x256.png' %>",
+			"src": "<%= asset_path 'favicons/android-chrome-256x256.png' %>",
 			"sizes": "256x256",
 			"type": "image\/png"
 		}


### PR DESCRIPTION
Previously the path was incorrect, so the assets weren't being served with their digests and failed to match their paths.