### PR TITLE
Clean up search HAML & darken search inputs on dark modes

### DIFF
--- a/app/assets/stylesheets/layouts/dark.scss
+++ b/app/assets/stylesheets/layouts/dark.scss
@@ -103,8 +103,12 @@ $FONT_COLOR: #BBB; /* TODO: standardize font color */
 ::-ms-input-placeholder { color: $INPUT_PLACEHOLDER; }
 ::placeholder { color: $INPUT_PLACEHOLDER; }
 
-/* - account options, post editor */
-#content .form-table input:not([type='submit']), #content .form-table textarea, #icon-table input:not([type='submit']) { background-color: $INPUT_BG; color: $FONT_COLOR; border-color: $INPUT_BORDER; }
+/* - account options, post editor, search */
+#content .form-table, #icon-table, .search-form {
+  input:not([type='submit']), textarea {
+    background-color: $INPUT_BG; color: $FONT_COLOR; border-color: $INPUT_BORDER;
+  }
+}
 /* - select2 */
 .select2-dropdown { background-color: $INPUT_BG; color: $FONT_COLOR; border-color: $INPUT_BORDER; }
 /* -- multiple / tag */

--- a/app/assets/stylesheets/layouts/starrydark.scss
+++ b/app/assets/stylesheets/layouts/starrydark.scss
@@ -116,8 +116,12 @@ $SELECT2_SEARCH: $SELECT2_HIGHLIGHT;
 ::-ms-input-placeholder { color: $INPUT_PLACEHOLDER; }
 ::placeholder { color: $INPUT_PLACEHOLDER; }
 
-/* - account options, post editor */
-#content .form-table input:not([type='submit']), #content .form-table textarea, #icon-table input:not([type='submit']) { background-color: $INPUT_BG; color: $FONT_COLOR; border-color: $INPUT_BORDER; }
+/* - account options, post editor, search */
+#content .form-table, #icon-table, .search-form {
+  input:not([type='submit']), textarea {
+    background-color: $INPUT_BG; color: $FONT_COLOR; border-color: $INPUT_BORDER;
+  }
+}
 /* - select2 */
 .select2-dropdown { background-color: $INPUT_BG; color: $FONT_COLOR; border-color: $INPUT_BORDER; }
 /* -- multiple / tag */

--- a/app/views/characters/search.haml
+++ b/app/views/characters/search.haml
@@ -14,15 +14,15 @@
       %tr
         %td.width-300.padding-10.vtop.dark
           = form_tag search_characters_path, :method => :get do
-            %table#signup
+            %table
               %tr
-                %td Author
+                %td= label_tag :author_id, 'Author'
                 %td= select_tag :author_id, options_from_collection_for_select(@users, :id, :username, params[:author_id]), {class: 'chosen-select', prompt: '— Choose Author —'}
               %tr
-                %td Template
+                %td= label_tag :template_id, 'Template'
                 %td= select_tag :template_id, options_from_collection_for_select(@templates, :id, :name, params[:template_id]), {class: 'chosen-select', prompt: '— Choose Template —'}
               %tr
-                %td Name
+                %td= label_tag :name, 'Name'
                 %td= text_field_tag :name, params[:name], style: 'width: 100%; margin: 5px 0px; box-sizing: border-box;'
               %tr
                 %td
@@ -44,31 +44,31 @@
               - # TODO: setting search, facecast search
               %tr
                 %td.centered{colspan: 2}= submit_tag "Search", class: 'button'
-          %td.vtop
-            - if @search_results.present?
-              %table
-                %thead
+        %td.vtop
+          - if @search_results.present?
+            %table
+              %thead
+                %tr
+                  - klass = cycle('even'.freeze, 'odd'.freeze)
+                  %td.padding-5{class: klass}
+                    %b Name
+                  %td.padding-5{class: klass}
+                    %b Nickname
+                  %td.padding-5{class: klass}
+                    %b Screenname
+                  %td.padding-5{class: klass}
+                    %b Facecast
+                  - if false # TODO once setting is fixed for characters
+                    %td.padding-5{class: klass}
+                      %b Setting
+              %tbody
+                - @search_results.each do |character|
+                  - klass = cycle('even'.freeze, 'odd'.freeze)
                   %tr
-                    - klass = cycle('even'.freeze, 'odd'.freeze)
-                    %td.padding-5{class: klass}
-                      %b Name
-                    %td.padding-5{class: klass}
-                      %b Nickname
-                    %td.padding-5{class: klass}
-                      %b Screenname
-                    %td.padding-5{class: klass}
-                      %b Facecast
-                    - if false # TODO once setting is fixed for characters
-                      %td.padding-5{class: klass}
-                        %b Setting
-                %tbody
-                  - @search_results.each do |character|
-                    - klass = cycle('even'.freeze, 'odd'.freeze)
-                    %tr
-                      %td.padding-5{class: klass}= link_to character.name, character_path(character)
-                      %td.padding-5{class: klass, style:'width:20%'}= character.template_name
-                      %td.padding-5{class: klass, style:'width:20%'}= breakable_text(character.screenname)
-                      %td.padding-5{class: klass, style:'width:25%'}= character.pb
+                    %td.padding-5{class: klass}= link_to character.name, character_path(character)
+                    %td.padding-5{class: klass, style:'width:20%'}= character.template_name
+                    %td.padding-5{class: klass, style:'width:20%'}= breakable_text(character.screenname)
+                    %td.padding-5{class: klass, style:'width:25%'}= character.pb
 
     - if @search_results && @search_results.total_pages > 1
       %tfoot

--- a/app/views/characters/search.haml
+++ b/app/views/characters/search.haml
@@ -14,7 +14,7 @@
       %tr
         %td.width-300.padding-10.vtop.dark
           = form_tag search_characters_path, :method => :get do
-            %table
+            %table.search-form
               %tr
                 %td= label_tag :author_id, 'Author'
                 %td= select_tag :author_id, options_from_collection_for_select(@users, :id, :username, params[:author_id]), {class: 'chosen-select', prompt: '— Choose Author —'}

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -39,7 +39,7 @@
               = image_tag current_user.avatar.url, class: 'icon', id: 'user-icon'
             - else
               .no-img
-            #username= current_user.username
+            #user-username= current_user.username
       #header-right
         #logo
           - unless logged_in?

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -14,7 +14,7 @@
     %tr
       %td.width-300.padding-10.vtop.dark#search_form
         = form_tag search_posts_path, :method => :get do
-          %table#signup
+          %table
             %tr
               %td.width-70= label_tag :board_id, 'Continuity'
               %td= select_tag :board_id, options_from_collection_for_select(@board || [], :id, :name, params[:board_id]), {class: 'chosen-select', prompt: '— Choose Continuity —'}

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -12,23 +12,23 @@
           = render partial: 'paginator', locals: {paginated: @search_results}
   %tbody
     %tr
-      %td.width-300.padding-10.vtop.dark
+      %td.width-300.padding-10.vtop.dark#search_form
         = form_tag search_posts_path, :method => :get do
           %table#signup
             %tr
-              %td.width-70 Continuity
+              %td.width-70= label_tag :board_id, 'Continuity'
               %td= select_tag :board_id, options_from_collection_for_select(@board || [], :id, :name, params[:board_id]), {class: 'chosen-select', prompt: '— Choose Continuity —'}
             %tr
-              %td Author
+              %td= label_tag :author_id, 'Author'
               %td= select_tag :author_id, options_from_collection_for_select(@user || [], :id, :username, params[:author_id]), {class: 'chosen-select', prompt: '— Choose Author —', multiple: true}
             %tr
-              %td Character
+              %td= label_tag :character_id, 'Character'
               %td= select_tag :character_id, options_from_collection_for_select(@character || [], :id, :selector_name, params[:character_id]), {prompt: '— Choose Character —'}
             %tr
-              %td Setting
+              %td= label_tag :setting_id, 'Setting'
               %td= select_tag :setting_id, options_from_collection_for_select(@setting || [], :id, :name, params[:setting_id]), {prompt: '— Choose Setting —'}
             %tr
-              %td Subject
+              %td= label_tag :subject, 'Subject'
               %td= text_field_tag :subject, params[:subject], style: 'width: 100%; margin: 5px 0px; box-sizing: border-box;'
             %tr
               %td Completed
@@ -37,20 +37,20 @@
                 = label_tag :completed, "Completed Only"
             %tr
               %td.centered{colspan: 2}= submit_tag "Search", class: 'button'
-        %td.vtop
-          - if @search_results.present?
-            %table
-              %thead
-                %tr
-                  %th.sub
-                  %th.sub Thread
-                  %th.sub Continuity
-                  %th.sub Authors
-                  %th.sub Replies
-                  %th.sub Last Updated
-              %tbody
-                - visible_posts = @search_results.select { |post| post.visible_to?(current_user) }
-                = render partial: 'posts/list_item', collection: visible_posts, as: :post
+      %td.vtop#search_results
+        - if @search_results.present?
+          %table
+            %thead
+              %tr
+                %th.sub
+                %th.sub Thread
+                %th.sub Continuity
+                %th.sub Authors
+                %th.sub Replies
+                %th.sub Last Updated
+            %tbody
+              - visible_posts = @search_results.select { |post| post.visible_to?(current_user) }
+              = render partial: 'posts/list_item', collection: visible_posts, as: :post
 
   - if @search_results && @search_results.total_pages > 1
     %tfoot

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -14,7 +14,7 @@
     %tr
       %td.width-300.padding-10.vtop.dark#search_form
         = form_tag search_posts_path, :method => :get do
-          %table
+          %table.search-form
             %tr
               %td.width-70= label_tag :board_id, 'Continuity'
               %td= select_tag :board_id, options_from_collection_for_select(@board || [], :id, :name, params[:board_id]), {class: 'chosen-select', prompt: '— Choose Continuity —'}

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -49,7 +49,8 @@
                   %th.sub Replies
                   %th.sub Last Updated
               %tbody
-                = render partial: 'posts/list_item', collection: @search_results, as: :post
+                - visible_posts = @search_results.select { |post| post.visible_to?(current_user) }
+                = render partial: 'posts/list_item', collection: visible_posts, as: :post
 
   - if @search_results && @search_results.total_pages > 1
     %tfoot

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -14,7 +14,7 @@
     %tr
       %td.width-300.padding-10.vtop.dark
         = form_tag search_replies_path, :method => :get do
-          %table
+          %table.search-form
             %tr
               %td.width-70= label_tag :board_id, 'Continuity'
               %td

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -14,25 +14,25 @@
     %tr
       %td.width-300.padding-10.vtop.dark
         = form_tag search_replies_path, :method => :get do
-          %table#signup
+          %table
             %tr
-              %td.width-70 Continuity
+              %td.width-70= label_tag :board_id, 'Continuity'
               %td
                 - if @post
                   %b= @post.board.name
                 - else
                   = select_tag :board_id, options_from_collection_for_select(@boards || [], :id, :name, params[:board_id]), {class: 'chosen-select', prompt: '— Choose Continuity —'}
             %tr
-              %td Author
+              %td= label_tag :author_id, 'Author'
               %td= select_tag :author_id, options_from_collection_for_select(@users || [], :id, :username, params[:author_id]), {class: 'chosen-select', prompt: '— Choose Author —'}
             %tr
-              %td Template
+              %td= label_tag :template_id, 'Template'
               %td= select_tag :template_id, options_from_collection_for_select(@templates, :id, :name, params[:template_id]), {class: 'chosen-select', prompt: '— Choose Template —'}
             %tr
-              %td Character
+              %td= label_tag :character_id, 'Character'
               %td= select_tag :character_id, options_from_collection_for_select(@characters || [], :id, :selector_name, params[:character_id]), {prompt: '— Choose Character —'}
             %tr
-              %td Content
+              %td= label_tag :subj_content, 'Content'
               %td= text_field_tag :subj_content, params[:subj_content], style: 'width: 100%; margin: 5px 0px; box-sizing: border-box;'
             - if @post.present?
               %tr
@@ -42,30 +42,30 @@
                   = hidden_field_tag :post_id, @post.id
             %tr
               %td.centered{colspan: 2}= submit_tag "Search", class: 'button'
-        %td.vtop
-          - if @search_results.present?
-            %table
-              %tbody
-                - @search_results.each do |reply|
-                  - next unless reply.post.visible_to?(current_user)
-                  - klass = cycle('even'.freeze, 'odd'.freeze)
-                  %tr
-                    %td.vtop{class: klass}
-                      .post-info-box
-                        .post-info-text
-                          - if reply.name.present?
-                            .post-character= link_to reply.name, character_path(reply.character_id)
-                          .post-author= link_to reply.username, user_path(reply.user_id)
-                    %td.vtop{class: klass}
-                      %b= link_to reply.subject, reply_path(reply, anchor: "reply-#{reply.id}")
-                      %br
-                      - if params[:subj_content].present?
-                        = reply.pg_search_highlight.html_safe
-                      - else
-                        = sanitize_written_content(reply.content).html_safe
-                    %td.vtop{class: klass}
-                      = link_to reply_path(reply, anchor: "reply-#{reply.id}") do
-                        = image_tag "icons/link.png".freeze, title: 'Permalink'.freeze, alt: 'Permalink'.freeze
+      %td.vtop
+        - if @search_results.present?
+          %table
+            %tbody
+              - @search_results.each do |reply|
+                - next unless reply.post.visible_to?(current_user)
+                - klass = cycle('even'.freeze, 'odd'.freeze)
+                %tr
+                  %td.vtop{class: klass}
+                    .post-info-box
+                      .post-info-text
+                        - if reply.name.present?
+                          .post-character= link_to reply.name, character_path(reply.character_id)
+                        .post-author= link_to reply.username, user_path(reply.user_id)
+                  %td.vtop{class: klass}
+                    %b= link_to reply.subject, reply_path(reply, anchor: "reply-#{reply.id}")
+                    %br
+                    - if params[:subj_content].present?
+                      = reply.pg_search_highlight.html_safe
+                    - else
+                      = sanitize_written_content(reply.content).html_safe
+                  %td.vtop{class: klass}
+                    = link_to reply_path(reply, anchor: "reply-#{reply.id}") do
+                      = image_tag "icons/link.png".freeze, title: 'Permalink'.freeze, alt: 'Permalink'.freeze
 
   - if @search_results && @search_results.total_pages > 1
     %tfoot

--- a/app/views/users/search.haml
+++ b/app/views/users/search.haml
@@ -14,7 +14,7 @@
     %tr
       %td.width-300.padding-10.vtop.dark
         = form_tag search_users_path, method: :get do
-          %table
+          %table.search-form
             %tr
               %td.width-70= label_tag :username, 'Username'
               %td= text_field_tag :username, params[:username], style: 'width: 100%; margin: 5px 0px; box-sizing: border-box;'

--- a/app/views/users/search.haml
+++ b/app/views/users/search.haml
@@ -14,27 +14,27 @@
     %tr
       %td.width-300.padding-10.vtop.dark
         = form_tag search_users_path, method: :get do
-          %table#signup
+          %table
             %tr
-              %td.width-70 Username
+              %td.width-70= label_tag :username, 'Username'
               %td= text_field_tag :username, params[:username], style: 'width: 100%; margin: 5px 0px; box-sizing: border-box;'
             %tr
               %td.centered{colspan: 2}= submit_tag "Search", class: 'button'
-        %td.vtop
-          - if @search_results.present?
-            %table
-              %thead
+      %td.vtop
+        - if @search_results.present?
+          %table
+            %thead
+              %tr
+                %th.sub Name
+                %th.width-70.sub.centered Moiety
+                %th.sub Date Joined
+            %tbody
+              - @search_results.each do |user|
                 %tr
-                  %th.sub Name
-                  %th.width-70.sub.centered Moiety
-                  %th.sub Date Joined
-              %tbody
-                - @search_results.each do |user|
-                  %tr
-                    - klass = cycle('even','odd')
-                    %td.padding-10.username{class: klass}= link_to user.username, user_path(user)
-                    %td.padding-10.user-moiety.centered.width-70{class: klass}= color_block(user)
-                    %td.padding-10.user-date{class: klass}= pretty_time(user.created_at)
+                  - klass = cycle('even','odd')
+                  %td.padding-10.username{class: klass}= link_to user.username, user_path(user)
+                  %td.padding-10.user-moiety.centered.width-70{class: klass}= color_block(user)
+                  %td.padding-10.user-date{class: klass}= pretty_time(user.created_at)
 
   - if @search_results && @search_results.total_pages > 1
     %tfoot

--- a/spec/features/posts/search_spec.rb
+++ b/spec/features/posts/search_spec.rb
@@ -4,8 +4,9 @@ RSpec.feature "Searching posts", :type => :feature do
   scenario "Searching a mixture of posts" do
     post = create(:post, subject: 'First post')
 
+    visit search_posts_path
+
     def perform_search
-      visit search_posts_path
       within('#search_form') do
         fill_in 'Subject', with: 'post'
       end
@@ -22,17 +23,16 @@ RSpec.feature "Searching posts", :type => :feature do
 
     # check the post is hidden when private
     post.update_attributes(privacy: Concealable::PRIVATE)
-
     perform_search
     within('#search_results') do
-      expect(page).not_to have_selector('.post-subject', text: 'First post')
+      expect(page).to have_no_selector('.post-subject', text: 'First post')
     end
 
     # check the post is still hidden when there are two pages of results
     2.upto(26) { |i| create(:post, subject: 'post ' + i.to_s, privacy: Concealable::PRIVATE) }
     perform_search
     within('#search_results') do
-      expect(page).not_to have_selector('.post-subject')
+      expect(page).to have_no_selector('.post-subject')
     end
 
     # check a new post shows up

--- a/spec/features/posts/search_spec.rb
+++ b/spec/features/posts/search_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+RSpec.feature "Searching posts", :type => :feature do
+  scenario "Searching a mixture of posts" do
+    post = create(:post, subject: 'First post')
+
+    def perform_search
+      visit search_posts_path
+      within('#search_form') do
+        fill_in 'Subject', with: 'post'
+      end
+      click_button 'Search'
+
+      expect(page).to have_no_selector('.error')
+    end
+
+    # check post shows when public
+    perform_search
+    within('#search_results') do
+      expect(page).to have_selector('.post-subject', text: 'First post')
+    end
+
+    # check the post is hidden when private
+    post.update_attributes(privacy: Concealable::PRIVATE)
+
+    perform_search
+    within('#search_results') do
+      expect(page).not_to have_selector('.post-subject', text: 'First post')
+    end
+
+    # check the post is still hidden when there are two pages of results
+    2.upto(26) { |i| create(:post, subject: 'post ' + i.to_s, privacy: Concealable::PRIVATE) }
+    perform_search
+    within('#search_results') do
+      expect(page).not_to have_selector('.post-subject')
+    end
+
+    # check a new post shows up
+    post2 = create(:post, subject: 'Last post')
+    perform_search
+    within('#search_results') do
+      expect(page).to have_selector('.post-subject', count: 1)
+      expect(page).to have_selector('.post-subject', text: 'Last post')
+    end
+  end
+end


### PR DESCRIPTION
Builds on #561.

- Search table should not have ID "signup"
- TD should not be nested inside another TD
- Input labels should be labels
- `username` should not be an ambiguous element ID