### PR TITLE
Make belongs_to associations explicitly state optional / required

### DIFF
--- a/app/concerns/writable.rb
+++ b/app/concerns/writable.rb
@@ -2,12 +2,11 @@ module Writable
   extend ActiveSupport::Concern
 
   included do
-    belongs_to :character
-    belongs_to :icon
-    belongs_to :user
-    belongs_to :character_alias
+    belongs_to :character, optional: true
+    belongs_to :icon, optional: true
+    belongs_to :user, optional: false
+    belongs_to :character_alias, optional: true
 
-    validates_presence_of :user
     validate :character_ownership, :icon_ownership
 
     def has_icons?

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -9,10 +9,10 @@ class Board < ApplicationRecord
   has_many :favorites, as: :favorite, dependent: :destroy
   belongs_to :creator, class_name: User, optional: false
 
-  has_many :board_authors
-  has_many :board_coauthors, -> { where(cameo: false) }, class_name: BoardAuthor
+  has_many :board_authors, inverse_of: :board
+  has_many :board_coauthors, -> { where(cameo: false) }, class_name: BoardAuthor, inverse_of: :board
   has_many :coauthors, class_name: User, through: :board_coauthors, source: :user
-  has_many :board_cameos, -> { where(cameo: true) }, class_name: BoardAuthor
+  has_many :board_cameos, -> { where(cameo: true) }, class_name: BoardAuthor, inverse_of: :board
   has_many :cameos, class_name: User, through: :board_cameos, source: :user
 
   validates_presence_of :name

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -7,7 +7,7 @@ class Board < ApplicationRecord
   has_many :posts
   has_many :board_sections, dependent: :destroy
   has_many :favorites, as: :favorite, dependent: :destroy
-  belongs_to :creator, class_name: User
+  belongs_to :creator, class_name: User, optional: false
 
   has_many :board_authors
   has_many :board_coauthors, -> { where(cameo: false) }, class_name: BoardAuthor
@@ -15,7 +15,7 @@ class Board < ApplicationRecord
   has_many :board_cameos, -> { where(cameo: true) }, class_name: BoardAuthor
   has_many :cameos, class_name: User, through: :board_cameos, source: :user
 
-  validates_presence_of :name, :creator
+  validates_presence_of :name
 
   after_destroy :move_posts_to_sandbox
 

--- a/app/models/board_author.rb
+++ b/app/models/board_author.rb
@@ -1,6 +1,6 @@
 class BoardAuthor < ApplicationRecord
-  belongs_to :board
-  belongs_to :user
+  belongs_to :board, optional: false
+  belongs_to :user, optional: false
 
   validates :user_id, uniqueness: { scope: :board_id }
 end

--- a/app/models/board_section.rb
+++ b/app/models/board_section.rb
@@ -2,10 +2,10 @@ class BoardSection < ApplicationRecord
   include Orderable
   include Presentable
 
-  belongs_to :board, inverse_of: :board_sections
+  belongs_to :board, inverse_of: :board_sections, optional: false
   has_many :posts, inverse_of: :section, foreign_key: :section_id
 
-  validates_presence_of :name, :board
+  validates_presence_of :name
 
   after_destroy :clear_post_values
 

--- a/app/models/board_view.rb
+++ b/app/models/board_view.rb
@@ -1,7 +1,6 @@
 class BoardView < ApplicationRecord
-  belongs_to :board
-  belongs_to :user
+  belongs_to :board, optional: false
+  belongs_to :user, optional: false
 
-  validates_presence_of :user, :board
   validates :board, uniqueness: { scope: :user }
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -2,10 +2,10 @@ class Character < ApplicationRecord
   include Presentable
   include Taggable
 
-  belongs_to :user
-  belongs_to :template, inverse_of: :characters
-  belongs_to :default_icon, class_name: Icon
-  belongs_to :character_group
+  belongs_to :user, optional: false
+  belongs_to :template, inverse_of: :characters, optional: true
+  belongs_to :default_icon, class_name: Icon, optional: true
+  belongs_to :character_group, optional: true
   has_many :replies
   has_many :posts
   has_many :aliases, class_name: CharacterAlias, dependent: :destroy
@@ -20,7 +20,7 @@ class Character < ApplicationRecord
   has_many :settings, through: :character_tags, source: :setting
   has_many :gallery_groups, through: :character_tags, source: :gallery_group, dependent: :destroy
 
-  validates_presence_of :name, :user
+  validates_presence_of :name
   validate :valid_group, :valid_galleries, :valid_default_icon
 
   attr_accessor :group_name

--- a/app/models/character_alias.rb
+++ b/app/models/character_alias.rb
@@ -1,6 +1,6 @@
 class CharacterAlias < ApplicationRecord
-  belongs_to :character
-  validates_presence_of :character, :name
+  belongs_to :character, optional: false
+  validates_presence_of :name
   after_destroy :clear_alias_ids
 
   def as_json(_options={})

--- a/app/models/character_group.rb
+++ b/app/models/character_group.rb
@@ -1,6 +1,6 @@
 class CharacterGroup < ApplicationRecord
   has_many :characters
   has_many :templates
-  belongs_to :user
-  validates_presence_of :name, :user
+  belongs_to :user, optional: false
+  validates_presence_of :name
 end

--- a/app/models/character_tag.rb
+++ b/app/models/character_tag.rb
@@ -1,10 +1,9 @@
 class CharacterTag < ApplicationRecord
-  belongs_to :character, inverse_of: :character_tags
-  belongs_to :tag
-  belongs_to :label, foreign_key: :tag_id
-  belongs_to :setting, foreign_key: :tag_id
-  belongs_to :gallery_group, foreign_key: :tag_id
-  validates_presence_of :character
+  belongs_to :character, inverse_of: :character_tags, optional: false
+  belongs_to :tag, optional: false
+  belongs_to :label, foreign_key: :tag_id, optional: true
+  belongs_to :setting, foreign_key: :tag_id, optional: true
+  belongs_to :gallery_group, foreign_key: :tag_id, optional: true
 
   after_create :add_galleries_to_character
   after_destroy :remove_galleries_from_character

--- a/app/models/character_tag.rb
+++ b/app/models/character_tag.rb
@@ -1,6 +1,6 @@
 class CharacterTag < ApplicationRecord
   belongs_to :character, inverse_of: :character_tags, optional: false
-  belongs_to :tag, inverse_of: :character_tags, optional: true
+  belongs_to :tag, inverse_of: :character_tags, optional: true # TODO: This is required, fix bug around validation if it is set as such
   belongs_to :label, foreign_key: :tag_id, optional: true
   belongs_to :setting, foreign_key: :tag_id, optional: true
   belongs_to :gallery_group, foreign_key: :tag_id, optional: true

--- a/app/models/character_tag.rb
+++ b/app/models/character_tag.rb
@@ -1,6 +1,6 @@
 class CharacterTag < ApplicationRecord
   belongs_to :character, inverse_of: :character_tags, optional: false
-  belongs_to :tag, optional: false
+  belongs_to :tag, inverse_of: :character_tags, optional: true
   belongs_to :label, foreign_key: :tag_id, optional: true
   belongs_to :setting, foreign_key: :tag_id, optional: true
   belongs_to :gallery_group, foreign_key: :tag_id, optional: true

--- a/app/models/characters_gallery.rb
+++ b/app/models/characters_gallery.rb
@@ -1,7 +1,6 @@
 class CharactersGallery < ApplicationRecord
-  belongs_to :character, inverse_of: :characters_galleries
-  belongs_to :gallery, inverse_of: :characters_galleries
-  validates_presence_of :character, :gallery
+  belongs_to :character, inverse_of: :characters_galleries, optional: false
+  belongs_to :gallery, inverse_of: :characters_galleries, optional: false
 
   before_create :autofill_order
   after_destroy :reorder_others

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,8 +1,7 @@
 class Favorite < ApplicationRecord
-  belongs_to :user, inverse_of: :favorites
-  belongs_to :favorite, polymorphic: true
+  belongs_to :user, inverse_of: :favorites, optional: false
+  belongs_to :favorite, polymorphic: true, optional: false
 
-  validates_presence_of :user, :favorite
   validates :user_id, uniqueness: { scope: [:favorite_id, :favorite_type] }
   validate :not_yourself
 

--- a/app/models/flat_post.rb
+++ b/app/models/flat_post.rb
@@ -1,5 +1,3 @@
 class FlatPost < ApplicationRecord
-  belongs_to :post, inverse_of: :flat_post
-
-  validates_presence_of :post
+  belongs_to :post, inverse_of: :flat_post, optional: false
 end

--- a/app/models/galleries_icon.rb
+++ b/app/models/galleries_icon.rb
@@ -1,5 +1,5 @@
 class GalleriesIcon < ApplicationRecord
-  belongs_to :icon, optional: false
+  belongs_to :icon, optional: true  # TODO: This is required, fix bug around validation if it is set as such
   belongs_to :gallery, optional: false
   accepts_nested_attributes_for :icon, allow_destroy: true
 

--- a/app/models/galleries_icon.rb
+++ b/app/models/galleries_icon.rb
@@ -1,6 +1,6 @@
 class GalleriesIcon < ApplicationRecord
-  belongs_to :icon
-  belongs_to :gallery
+  belongs_to :icon, optional: false
+  belongs_to :gallery, optional: false
   accepts_nested_attributes_for :icon, allow_destroy: true
 
   after_create :set_has_gallery

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -2,7 +2,7 @@ class Gallery < ApplicationRecord
   include Taggable
   belongs_to :user, optional: false
 
-  has_many :galleries_icons, dependent: :destroy
+  has_many :galleries_icons, dependent: :destroy, inverse_of: :gallery
   accepts_nested_attributes_for :galleries_icons, allow_destroy: true
   has_many :icons, -> { order('LOWER(keyword)') }, through: :galleries_icons
 

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -1,6 +1,6 @@
 class Gallery < ApplicationRecord
   include Taggable
-  belongs_to :user
+  belongs_to :user, optional: false
 
   has_many :galleries_icons, dependent: :destroy
   accepts_nested_attributes_for :galleries_icons, allow_destroy: true
@@ -12,7 +12,7 @@ class Gallery < ApplicationRecord
   has_many :gallery_tags, inverse_of: :gallery, dependent: :destroy
   has_many :gallery_groups, through: :gallery_tags, source: :gallery_group, dependent: :destroy
 
-  validates_presence_of :user, :name
+  validates_presence_of :name
 
   acts_as_tag :gallery_group
 

--- a/app/models/gallery_tag.rb
+++ b/app/models/gallery_tag.rb
@@ -1,7 +1,7 @@
 class GalleryTag < ApplicationRecord
-  belongs_to :gallery, inverse_of: :gallery_tags
-  belongs_to :tag
-  belongs_to :gallery_group, foreign_key: :tag_id
+  belongs_to :gallery, inverse_of: :gallery_tags, optional: false
+  belongs_to :tag, optional: false
+  belongs_to :gallery_group, foreign_key: :tag_id, optional: false # This is currently required but may not continue to be
 
   after_create :add_gallery_to_characters
   after_destroy :remove_gallery_from_characters

--- a/app/models/gallery_tag.rb
+++ b/app/models/gallery_tag.rb
@@ -1,6 +1,6 @@
 class GalleryTag < ApplicationRecord
   belongs_to :gallery, inverse_of: :gallery_tags, optional: false
-  belongs_to :tag, optional: false
+  belongs_to :tag, inverse_of: :gallery_tags, optional: true
   belongs_to :gallery_group, foreign_key: :tag_id, optional: false # This is currently required but may not continue to be
 
   after_create :add_gallery_to_characters

--- a/app/models/gallery_tag.rb
+++ b/app/models/gallery_tag.rb
@@ -1,6 +1,6 @@
 class GalleryTag < ApplicationRecord
   belongs_to :gallery, inverse_of: :gallery_tags, optional: false
-  belongs_to :tag, inverse_of: :gallery_tags, optional: true
+  belongs_to :tag, inverse_of: :gallery_tags, optional: true # TODO: This is required, fix bug around validation if it is set as such
   belongs_to :gallery_group, foreign_key: :tag_id, optional: false # This is currently required but may not continue to be
 
   after_create :add_gallery_to_characters

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -7,7 +7,8 @@ class Icon < ApplicationRecord
   has_many :posts
   has_many :replies
   has_many :reply_drafts
-  has_and_belongs_to_many :galleries
+  has_many :galleries_icons, dependent: :destroy, inverse_of: :icon
+  has_many :galleries, through: :galleries_icons
 
   validates_presence_of :url, :keyword
   validate :url_is_url

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -3,13 +3,13 @@ class Icon < ApplicationRecord
 
   S3_DOMAIN = '.s3.amazonaws.com'
 
-  belongs_to :user
+  belongs_to :user, optional: false
   has_many :posts
   has_many :replies
   has_many :reply_drafts
   has_and_belongs_to_many :galleries
 
-  validates_presence_of :url, :user, :keyword
+  validates_presence_of :url, :keyword
   validate :url_is_url
   validate :uploaded_url_not_in_use
   nilify_blanks types: [:string, :text, :citext] # nilify_blanks does not touch citext by default

--- a/app/models/index.rb
+++ b/app/models/index.rb
@@ -4,9 +4,9 @@ class Index < ApplicationRecord
   has_many :index_posts, inverse_of: :index, dependent: :destroy
   has_many :posts, through: :index_posts
   has_many :index_sections, inverse_of: :index, dependent: :destroy
-  belongs_to :user, inverse_of: :indexes
+  belongs_to :user, inverse_of: :indexes, optional: false
 
-  validates_presence_of :user, :name
+  validates_presence_of :name
 
   def editable_by?(user)
     return false unless user

--- a/app/models/index_post.rb
+++ b/app/models/index_post.rb
@@ -1,11 +1,10 @@
 class IndexPost < ApplicationRecord
   include Orderable
 
-  belongs_to :post, inverse_of: :index_posts
-  belongs_to :index, inverse_of: :index_posts
-  belongs_to :index_section, inverse_of: :index_posts
+  belongs_to :post, inverse_of: :index_posts, optional: false
+  belongs_to :index, inverse_of: :index_posts, optional: false
+  belongs_to :index_section, inverse_of: :index_posts, optional: true
 
-  validates_presence_of :post, :index
   validate :section_in_index
 
   before_validation :populate_index

--- a/app/models/index_section.rb
+++ b/app/models/index_section.rb
@@ -1,11 +1,11 @@
 class IndexSection < ApplicationRecord
   include Orderable
 
-  belongs_to :index, inverse_of: :index_sections
+  belongs_to :index, inverse_of: :index_sections, optional: false
   has_many :index_posts, inverse_of: :index_section, dependent: :destroy
   has_many :posts, through: :index_posts
 
-  validates_presence_of :name, :index
+  validates_presence_of :name
 
   private
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,11 +1,10 @@
 class Message < ApplicationRecord
   # TODO drop marked_*
-  belongs_to :sender, class_name: User, inverse_of: :sent_messages
-  belongs_to :recipient, class_name: User, inverse_of: :messages
-  belongs_to :parent, class_name: Message
-  belongs_to :first_thread, class_name: Message, foreign_key: :thread_id
+  belongs_to :sender, class_name: User, inverse_of: :sent_messages, optional: true
+  belongs_to :recipient, class_name: User, inverse_of: :messages, optional: false
+  belongs_to :parent, class_name: Message, optional: true
+  belongs_to :first_thread, class_name: Message, foreign_key: :thread_id, optional: false
 
-  validates_presence_of :recipient
   validates_presence_of :sender, if: Proc.new { |m| m.sender_id != 0 }
 
   after_create :set_thread_id, :notify_recipient

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -7,7 +7,8 @@ class Message < ApplicationRecord
 
   validates_presence_of :sender, if: Proc.new { |m| m.sender_id != 0 }
 
-  after_create :set_thread_id, :notify_recipient
+  before_validation :set_thread_id
+  after_create :notify_recipient
 
   def visible_to?(user)
     user_ids.include?(user.id)
@@ -55,7 +56,7 @@ class Message < ApplicationRecord
 
   def set_thread_id
     return unless thread_id.blank?
-    update_attributes(thread_id: id)
+    self.first_thread = self
   end
 
   def notify_recipient

--- a/app/models/password_reset.rb
+++ b/app/models/password_reset.rb
@@ -1,7 +1,7 @@
 class PasswordReset < ApplicationRecord
-  belongs_to :user, inverse_of: :password_resets
+  belongs_to :user, inverse_of: :password_resets, optional: false
 
-  validates_presence_of :user, :auth_token
+  validates_presence_of :auth_token
   validates_uniqueness_of :auth_token
 
   before_validation :generate_unique_auth_token

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -21,11 +21,13 @@ class Post < ApplicationRecord
   has_many :post_viewers, inverse_of: :post, dependent: :destroy
   has_many :viewers, through: :post_viewers, source: :user
   has_many :reply_drafts, dependent: :destroy
+  has_many :favorites, as: :favorite, dependent: :destroy
+
   has_many :post_tags, inverse_of: :post, dependent: :destroy
   has_many :labels, through: :post_tags, source: :label
   has_many :settings, through: :post_tags, source: :setting
   has_many :content_warnings, through: :post_tags, source: :content_warning, after_add: :reset_warnings
-  has_many :favorites, as: :favorite, dependent: :destroy
+
   has_many :index_posts, inverse_of: :post, dependent: :destroy
   has_many :indexes, inverse_of: :posts, through: :index_posts
   has_many :index_sections, inverse_of: :posts, through: :index_posts

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -39,7 +39,7 @@ class Post < ApplicationRecord
   validate :valid_board, :valid_board_section
 
   before_create :build_initial_flat_post
-  before_create :set_last_user
+  before_validation :set_last_user, on: :create
   after_commit :notify_followers, on: :create
 
   acts_as_tag :label, :content_warning, :setting

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,10 +12,10 @@ class Post < ApplicationRecord
   STATUS_HIATUS = 2
   STATUS_ABANDONED = 3
 
-  belongs_to :board, inverse_of: :posts
-  belongs_to :section, class_name: BoardSection, inverse_of: :posts
-  belongs_to :last_user, class_name: User
-  belongs_to :last_reply, class_name: Reply
+  belongs_to :board, inverse_of: :posts, optional: false
+  belongs_to :section, class_name: BoardSection, inverse_of: :posts, optional: true
+  belongs_to :last_user, class_name: User, optional: false
+  belongs_to :last_reply, class_name: Reply, optional: true
   has_one :flat_post
   has_many :replies, inverse_of: :post, dependent: :destroy
   has_many :post_viewers, inverse_of: :post, dependent: :destroy
@@ -33,7 +33,7 @@ class Post < ApplicationRecord
   attr_accessor :is_import
   attr_writer :skip_edited
 
-  validates_presence_of :board, :subject
+  validates_presence_of :subject
   validate :valid_board, :valid_board_section
 
   before_create :build_initial_flat_post

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,6 +1,6 @@
 class PostTag < ApplicationRecord
   belongs_to :post, inverse_of: :post_tags, optional: false
-  belongs_to :tag, inverse_of: :post_tags, optional: true
+  belongs_to :tag, inverse_of: :post_tags, optional: true # TODO: This is required, fix bug around validation if it is set as such
   belongs_to :setting, foreign_key: :tag_id, optional: true
   belongs_to :content_warning, foreign_key: :tag_id, optional: true
   belongs_to :label, foreign_key: :tag_id, optional: true

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,6 +1,5 @@
 class PostTag < ApplicationRecord
   belongs_to :post, inverse_of: :post_tags, optional: false
-  belongs_to :user, optional: false
   belongs_to :tag, optional: false
   belongs_to :setting, foreign_key: :tag_id, optional: true
   belongs_to :content_warning, foreign_key: :tag_id, optional: true

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,8 +1,8 @@
 class PostTag < ApplicationRecord
-  belongs_to :post, inverse_of: :post_tags
-  belongs_to :user
-  belongs_to :tag
-  belongs_to :setting, foreign_key: :tag_id
-  belongs_to :content_warning, foreign_key: :tag_id
-  belongs_to :label, foreign_key: :tag_id
+  belongs_to :post, inverse_of: :post_tags, optional: false
+  belongs_to :user, optional: false
+  belongs_to :tag, optional: false
+  belongs_to :setting, foreign_key: :tag_id, optional: true
+  belongs_to :content_warning, foreign_key: :tag_id, optional: true
+  belongs_to :label, foreign_key: :tag_id, optional: true
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,6 +1,6 @@
 class PostTag < ApplicationRecord
   belongs_to :post, inverse_of: :post_tags, optional: false
-  belongs_to :tag, optional: false
+  belongs_to :tag, inverse_of: :post_tags, optional: true
   belongs_to :setting, foreign_key: :tag_id, optional: true
   belongs_to :content_warning, foreign_key: :tag_id, optional: true
   belongs_to :label, foreign_key: :tag_id, optional: true

--- a/app/models/post_view.rb
+++ b/app/models/post_view.rb
@@ -1,7 +1,6 @@
 class PostView < ApplicationRecord
-  belongs_to :post
-  belongs_to :user
+  belongs_to :post, optional: false
+  belongs_to :user, optional: false
 
-  validates_presence_of :user, :post
   validates :post, uniqueness: { scope: :user }
 end

--- a/app/models/post_viewer.rb
+++ b/app/models/post_viewer.rb
@@ -1,6 +1,4 @@
 class PostViewer < ApplicationRecord
-  belongs_to :post
-  belongs_to :user
-
-  validates_presence_of :user, :post
+  belongs_to :post, optional: false
+  belongs_to :user, optional: false
 end

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -3,8 +3,7 @@ class Reply < ApplicationRecord
   include Writable
   include PgSearch
 
-  belongs_to :post, inverse_of: :replies
-  validates_presence_of :post, :user
+  belongs_to :post, inverse_of: :replies, optional: false
   validate :author_can_write_in_post, on: :create
   audited associated_with: :post
 

--- a/app/models/reply_draft.rb
+++ b/app/models/reply_draft.rb
@@ -1,8 +1,7 @@
 class ReplyDraft < ApplicationRecord
   include Writable
 
-  belongs_to :post, inverse_of: :reply_drafts
-  validates_presence_of :post
+  belongs_to :post, inverse_of: :reply_drafts, optional: false
 
   def self.draft_for(post_id, user_id)
     self.where(post_id: post_id, user_id: user_id).first

--- a/app/models/report_view.rb
+++ b/app/models/report_view.rb
@@ -1,4 +1,3 @@
 class ReportView < ApplicationRecord
-  belongs_to :user
-  validates_presence_of :user
+  belongs_to :user, optional: false
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,10 +1,10 @@
 class Tag < ApplicationRecord
   belongs_to :user, optional: false
-  has_many :post_tags, dependent: :destroy
+  has_many :post_tags, dependent: :destroy, inverse_of: :tag
   has_many :posts, through: :post_tags
-  has_many :character_tags, dependent: :destroy
+  has_many :character_tags, dependent: :destroy, inverse_of: :tag
   has_many :characters, through: :character_tags
-  has_many :gallery_tags, dependent: :destroy
+  has_many :gallery_tags, dependent: :destroy, inverse_of: :tag
   has_many :galleries, through: :gallery_tags
 
   TYPES = %w(Setting Label ContentWarning GalleryGroup)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,5 @@
 class Tag < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: false
   has_many :post_tags, dependent: :destroy
   has_many :posts, through: :post_tags
   has_many :character_tags, dependent: :destroy
@@ -9,7 +9,7 @@ class Tag < ApplicationRecord
 
   TYPES = %w(Setting Label ContentWarning GalleryGroup)
 
-  validates_presence_of :user, :name, :type
+  validates_presence_of :name, :type
   validates :name, uniqueness: { scope: :type }
 
   scope :with_item_counts, -> {

--- a/app/models/tag_tag.rb
+++ b/app/models/tag_tag.rb
@@ -1,4 +1,5 @@
 class TagTag < ApplicationRecord
-  belongs_to :child_setting, class_name: Setting, foreign_key: :tagged_id, inverse_of: :child_setting_tags
-  belongs_to :parent_setting, class_name: Setting, foreign_key: :tag_id, inverse_of: :parent_setting_tags
+  belongs_to :child_setting, class_name: Setting, foreign_key: :tagged_id, inverse_of: :child_setting_tags, optional: false
+  belongs_to :parent_setting, class_name: Setting, foreign_key: :tag_id, inverse_of: :parent_setting_tags, optional: false
+  # These are currently required
 end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -1,10 +1,10 @@
 class Template < ApplicationRecord
   include Presentable
 
-  belongs_to :user, inverse_of: :templates
+  belongs_to :user, inverse_of: :templates, optional: false
   has_many :characters, -> { order('LOWER(name) ASC') }, inverse_of: :template
 
-  validates_presence_of :name, :user
+  validates_presence_of :name
 
   after_destroy :clear_character_templates
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,8 +22,8 @@ class User < ApplicationRecord
   has_many :replies
   has_many :indexes
   has_one :report_view
-  belongs_to :avatar, :class_name => Icon
-  belongs_to :active_character, :class_name => Character
+  belongs_to :avatar, :class_name => Icon, optional: true
+  belongs_to :active_character, :class_name => Character, optional: true
 
   validates_presence_of :username, :crypted
   validates_presence_of :email, on: :create

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -17,6 +17,3 @@ Rails.application.config.action_controller.forgery_protection_origin_check = fal
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
 ActiveSupport.to_time_preserves_timezone = false
-
-# Require `belongs_to` associations by default. Previous versions had false.
-Rails.application.config.active_record.belongs_to_required_by_default = false


### PR DESCRIPTION
Update `belongs_to` as per #476

**Edit by throne**: managed to make fewer tests fail (<https://travis-ci.org/Marri/glowfic/builds/304084617> → <https://travis-ci.org/Marri/glowfic/builds/304093736>) by way of making, for each of `character_tag`, `gallery_tag` and `post_tag`, the `belongs_to :tag…` association `optional: true`; this is a hack and should be fixed at some point:

> Setting the join `*_tag` lines that refer to `:tag` to have `optional:
false` fails.
> 
> I am not sure why Rails knows the post has content_warnings, and it has
post_tags to match, but the post_tag for the new content warning has no
tag attached and so it errors. It seems like it should know it's the new
one. I cannot find a relevant place to add `inverse_of` to fix it.

Relatedly, `galleries_icon` should require an icon, but doing this breaks the ability to delete icons from a gallery using nested parameters, for some reason.