### PR TITLE
Tests handle missing environment variables without issue

### DIFF
--- a/spec/controllers/api/v1/icons_controller_spec.rb
+++ b/spec/controllers/api/v1/icons_controller_spec.rb
@@ -1,8 +1,10 @@
 require "spec_helper"
+require "support/s3_bucket_helper"
 
 RSpec.describe Api::V1::IconsController do
   describe "POST s3_delete", show_in_doc: true do
     it "should require login" do
+      handle_s3_bucket
       expect(S3_BUCKET).not_to receive(:delete_objects)
       post :s3_delete
       expect(response).to have_http_status(401)
@@ -10,6 +12,7 @@ RSpec.describe Api::V1::IconsController do
     end
 
     it "should require s3_key param" do
+      handle_s3_bucket
       expect(S3_BUCKET).not_to receive(:delete_objects)
       login
       post :s3_delete
@@ -18,6 +21,7 @@ RSpec.describe Api::V1::IconsController do
     end
 
     it "should require your own icon" do
+      handle_s3_bucket
       user = create(:user)
       login_as(user)
 
@@ -29,6 +33,7 @@ RSpec.describe Api::V1::IconsController do
     end
 
     it "should not allow deleting a URL in use" do
+      handle_s3_bucket
       icon = create(:uploaded_icon)
       login_as(icon.user)
       expect(S3_BUCKET).not_to receive(:delete_objects)
@@ -38,6 +43,7 @@ RSpec.describe Api::V1::IconsController do
     end
 
     it "should delete the URL" do
+      handle_s3_bucket
       icon = build(:uploaded_icon)
       login_as(icon.user)
       delete_key = {delete: {objects: [{key: icon.s3_key}], quiet: true}}

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "support/s3_bucket_helper"
 
 RSpec.describe GalleriesController do
   describe "GET index" do
@@ -417,17 +418,6 @@ RSpec.describe GalleriesController do
   end
 
   describe "GET add" do
-    def handle_s3_bucket
-      # compensates for developers not having S3 buckets set up locally
-      return unless S3_BUCKET.nil?
-      struct = Struct.new(:url) do
-        def presigned_post(_args)
-          1
-        end
-      end
-      stub_const("S3_BUCKET", struct.new(''))
-    end
-
     it "requires login" do
       get :add, params: { id: -1 }
       expect(response).to redirect_to(root_url)

--- a/spec/jobs/delete_icon_from_s3_job_spec.rb
+++ b/spec/jobs/delete_icon_from_s3_job_spec.rb
@@ -1,9 +1,11 @@
 require "spec_helper"
+require "support/s3_bucket_helper"
 
 RSpec.describe DeleteIconFromS3Job do
   before(:each) { ResqueSpec.reset! }
 
   it "deletes the given key" do
+    handle_s3_bucket
     key = 'arbitrary'
     delete_key = {delete: {objects: [{key: key}]}}
     expect(S3_BUCKET).to receive(:delete_objects).with(delete_key)

--- a/spec/support/s3_bucket_helper.rb
+++ b/spec/support/s3_bucket_helper.rb
@@ -1,0 +1,14 @@
+def handle_s3_bucket
+  # compensates for developers not having S3 buckets set up locally
+  return unless S3_BUCKET.nil?
+  struct = Struct.new(:url) do
+    def delete_objects(_args)
+      1
+    end
+
+    def presigned_post(_args)
+      1
+    end
+  end
+  stub_const("S3_BUCKET", struct.new(''))
+end


### PR DESCRIPTION
Specifically, when S3_BUCKET was nil, we would see warnings about issuing expectations on a nil object

Fixes #550 