### PR TITLE
Make scraped audits match the actual post/reply user

### DIFF
--- a/app/jobs/scrape_post_job.rb
+++ b/app/jobs/scrape_post_job.rb
@@ -5,9 +5,7 @@ class ScrapePostJob < ApplicationJob
 
   def perform(url, board_id, section_id, status, threaded, importer_id)
     scraper = PostScraper.new(url, board_id, section_id, status, threaded)
-    scraped_post = Audited.audit_class.as_user(User.find_by_id(importer_id)) do
-      scraper.scrape!
-    end
+    scraped_post = scraper.scrape!
     Message.send_site_message(importer_id, 'Post import succeeded', "Your post was successfully imported! #{self.class.view_post(scraped_post.id)}")
   end
 

--- a/lib/post_scraper.rb
+++ b/lib/post_scraper.rb
@@ -136,7 +136,9 @@ class PostScraper < Object
 
     set_from_icon(@post, img_url, img_keyword)
 
-    @post.save!
+    Audited.audit_class.as_user(@post.user) do
+      @post.save!
+    end
   end
 
   def import_replies_from_doc(doc)
@@ -165,7 +167,9 @@ class PostScraper < Object
       @reply.skip_post_update = true
       @reply.skip_regenerate = true
       @reply.is_import = true
-      @reply.save!
+      Audited.audit_class.as_user(@reply.user) do
+        @reply.save!
+      end
     end
   end
 

--- a/spec/jobs/scrape_post_job_spec.rb
+++ b/spec/jobs/scrape_post_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ScrapePostJob do
     expect(Message.first.subject).to eq("Post import succeeded")
     expect(Post.count).to eq(1)
     expect(Audited::Audit.count).to eq(1)
-    expect(Audited::Audit.last.user_id).to eq(board.creator_id)
+    expect(Audited::Audit.last.user_id).to eq(Post.last.user_id)
     Post.auditing_enabled = false
   end
 


### PR DESCRIPTION
Last change made all imports use the importing user as the creator of the audit. This makes it, more accurately, use the post/reply's user as the audit's user.