### PR TITLE
Clean up css classes named by color

### DIFF
--- a/app/assets/stylesheets/characters.scss
+++ b/app/assets/stylesheets/characters.scss
@@ -17,7 +17,7 @@
 
 // character icon view
 .character-icon-list { padding: 10px; }
-.character-icon { width: 100px; height: 100px; }
+.character-icon { width: 100px; height: 100px; text-align: center; }
 .character-icon-item .icon { margin: 5px; }
 .character-no-icon {
   @extend .character-icon;

--- a/app/assets/stylesheets/galleries.scss
+++ b/app/assets/stylesheets/galleries.scss
@@ -72,3 +72,21 @@
   margin: 0;
 }
 .loading-icon { width: 16px; height: 16px; }
+
+/* Various tables with icons in previously styled with .green */
+.icons-box {
+  background-color: #B0BBA9;
+}
+
+/* Icon credit, previously styled with .green */
+.icon-credit {
+  background-color: #B0BBA9;
+  text-align: center;
+}
+
+/* The preview icon boxes on replace icon and replace character */
+.replace-icon {
+  @extend .icons-box;
+  width: 150px;
+  text-align: center;
+}

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -83,7 +83,6 @@ button, .button {
 
 /* Displaying forum threads */
 .green { background-color: #B0BBA9; }
-.dark { background-color: #8B8687; }
 .even, .odd, .post-post, .post-reply, #post-editor {
   padding: 5px;
 }

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -82,7 +82,6 @@ button, .button {
 }
 
 /* Displaying forum threads */
-.green { background-color: #B0BBA9; }
 .even, .odd, .post-post, .post-reply, #post-editor {
   padding: 5px;
 }

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -109,10 +109,12 @@ button, .button {
 
   img { vertical-align: text-top; }
 }
-.link-box.green { background-color: #3f7055; }
-.link-box.red { background-color: #880000; }
-.link-box.blue { background-color: #4455AA;}
-.link-box.orange { background-color: #EA8A40;}
+.link-box.action-new { background-color: #3f7055; }
+.link-box.action-delete { background-color: #880000; }
+.link-box.action-edit { background-color: #4455AA;}
+.link-box.orange { background-color: #EA8A40;} // TODO: This does not appear to be used anywhere
+.link-box.action-favorite { background-color: #4455AA;}
+.link-box.action-dismiss { background-color: #880000; }
 #post-form-wrapper { margin-top: 5px; }
 
 /* Inline lists */

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -56,7 +56,8 @@ button, .button {
 .width-150 { width: 150px; }
 .width-250 { width: 250px; }
 .width-300 { width: 300px; }
-.spacer { height: 2px; padding: 0; }
+.spacer, .space-alt { height: 2px; padding: 0; }
+.spacer-alt { background-color: #8B8687; }
 .centered { text-align: center !important; }
 .left-align { text-align: left; }
 .right-align { text-align: right; }

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -56,7 +56,7 @@ button, .button {
 .width-150 { width: 150px; }
 .width-250 { width: 250px; }
 .width-300 { width: 300px; }
-.spacer, .space-alt { height: 2px; padding: 0; }
+.spacer, .spacer-alt { height: 2px; padding: 0; }
 .spacer-alt { background-color: #8B8687; }
 .centered { text-align: center !important; }
 .left-align { text-align: left; }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -302,6 +302,7 @@ td, .table-list li { font-size: 14px; }
 .user-right-content-box { width: calc(100% - 200px); }
 .icon-right-content-box { width: calc(100% - 150px); }
 .character-right-content-box { width: calc(100% - 175px); }
+#user-avatar { text-align: center; }
 
 /* Not yet deserving of its own CSS file */
 #stats ul { margin-top: 0; margin-bottom: 0; padding-left: 15px; }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -329,5 +329,13 @@ td, .table-list li { font-size: 14px; }
 #homepage-content {
   padding: 20px;
 }
+
+/* Search Input */
+.search-box {
+  width: 300px;
+  padding: 10px;
+  vertical-align: top;
+  background-color: #8B8687;
+}
 .search-icon-preview { vertical-align: middle; }
 .search-icon-keyword { padding-left: 5px; }

--- a/app/assets/stylesheets/layouts/dark.scss
+++ b/app/assets/stylesheets/layouts/dark.scss
@@ -2,6 +2,7 @@
 html, body, #content { background-color: #212121; color: #A2A2A2; }
 .selector-popup, .single-description { background-color: #565656; }
 #content .dark { background-color: #333333; }
+.spacer-alt { background-color: #333333; }
 table { border-color: #555; }
 .sub {
   background-color: #383838;

--- a/app/assets/stylesheets/layouts/dark.scss
+++ b/app/assets/stylesheets/layouts/dark.scss
@@ -1,7 +1,7 @@
 @import 'variables';
 html, body, #content { background-color: #212121; color: #A2A2A2; }
 .selector-popup, .single-description { background-color: #565656; }
-#content .dark { background-color: #333333; }
+.search-box { background-color: #333333; }
 .spacer-alt { background-color: #333333; }
 table { border-color: #555; }
 .sub {

--- a/app/assets/stylesheets/layouts/dark.scss
+++ b/app/assets/stylesheets/layouts/dark.scss
@@ -37,7 +37,7 @@ $ODD_COLOR: #474747;
   }
 }
 
-.green { background-color: #444D3F; }
+#reply-icon-selector, .replace-icon, .icons-box, .icon-credit { background-color: #444D3F; }
 .subber, .flash.breadcrumbs, .form-table-ender {
   background-color: #464646;
   color: #DDDDDD;

--- a/app/assets/stylesheets/layouts/monochrome.scss
+++ b/app/assets/stylesheets/layouts/monochrome.scss
@@ -9,7 +9,7 @@ a:visited { color: #484848; }
 .post-expander { background-color: #A0A0A0; }
 .post-icon, #current-icon-dropdown { background-color: #BDBDBD; }
 .post-navheader { background-color: #BDBDBD; }
-.green { background-color: #BDBDBD; }
+#reply-icon-selector, .replace-icon, .icons-box, .icon-credit { background-color: #BDBDBD; }
 .link-box.action-new { background-color: #5A5A5A; }
 .link-box.action-edit { background-color: #545A79; }
 .link-box.action-delete { background-color: #503636; }

--- a/app/assets/stylesheets/layouts/monochrome.scss
+++ b/app/assets/stylesheets/layouts/monochrome.scss
@@ -10,9 +10,11 @@ a:visited { color: #484848; }
 .post-icon, #current-icon-dropdown { background-color: #BDBDBD; }
 .post-navheader { background-color: #BDBDBD; }
 .green { background-color: #BDBDBD; }
-.link-box.green { background-color: #5A5A5A; }
-.link-box.blue { background-color: #545A79; }
-.link-box.red { background-color: #503636; }
+.link-box.action-new { background-color: #5A5A5A; }
+.link-box.action-edit { background-color: #545A79; }
+.link-box.action-delete { background-color: #503636; }
+.link-box.action-favorite { background-color: #545A79;}
+.link-box.action-dismiss { background-color: #503636; }
 .subber, .flash.breadcrumbs, .form-table-ender { background-color: #ADADAD; }
 .post-character { background-color: #929292; }
 .post-screenname { background-color: #A5A5A5; }

--- a/app/assets/stylesheets/layouts/river.scss
+++ b/app/assets/stylesheets/layouts/river.scss
@@ -20,7 +20,7 @@ body { background-color: #E0E0E0; }
 #header, #nav-bottom { background-color: #ADB5B9; }
 .post-expander { background-color: #A4B0BD; }
 .pagination .current { background: #718EB9; }
-.post-icon, #current-icon-dropdown, .green { background-color: #A9B4BB; }
+.post-icon, #current-icon-dropdown, #reply-icon-selector, .replace-icon, .icons-box, .icon-credit { background-color: #A9B4BB; }
 a { color: #3F5970; }
 a:visited { color: #284150; }
 .flash.breadcrumbs, .form-table-ender { background-color: #A3A8A9; }

--- a/app/assets/stylesheets/layouts/river.scss
+++ b/app/assets/stylesheets/layouts/river.scss
@@ -4,8 +4,11 @@ body { background-color: #E0E0E0; }
 .flash.success, .flash.inbox { background-color: #ECECEC; }
 .pagination a:visited { color: #3A3A3A; }
 .post-navheader { background-color: #BDBDBD; }
-.link-box.blue { background-color: #545A79; }
-.link-box.red { background-color: #503636; }
+.link-box.action-new { background-color: #3F5370; }
+.link-box.action-edit { background-color: #545A79; }
+.link-box.action-delete { background-color: #503636; }
+.link-box.action-favorite { background-color: #545A79; }
+.link-box.action-dismiss { background-color: #503636; }
 .post-character { background-color: #929292; }
 .post-screenname { background-color: #A5A5A5; }
 .post-author { background-color: #BBBBBB; }
@@ -22,7 +25,6 @@ a { color: #3F5970; }
 a:visited { color: #284150; }
 .flash.breadcrumbs, .form-table-ender { background-color: #A3A8A9; }
 .subber { background-color: #B9B6AD; }
-.link-box.green { background-color: #3F5370; }
 .post-edit-box img { width: 1em; height: 1em; }
 .post-character a, .post-character a:visited { color: #B3D3FF; }
 .post-footer { color: #717171; }

--- a/app/assets/stylesheets/layouts/starry.scss
+++ b/app/assets/stylesheets/layouts/starry.scss
@@ -70,7 +70,7 @@ $ODD_COLOR: #D8D8D8;
 .post-screenname, .post-screenname a, .post-screenname a:visited { color: #9C9AA4; }
 .post-character, .post-character a, .post-character a:visited, .post-author, .post-author a, .post-author a:visited { color: #F3F3F3; }
 
-#content .dark { background-color: #182152; color: #FEFEFE; }
+.search-box { background-color: #182152; color: #FEFEFE; }
 .spacer-alt { background-color: #182152; color: #FEFEFE; }
 
 tr.gallery-tags .tag-item { background-color: #2C2C5D; color: #F7F7F7; }

--- a/app/assets/stylesheets/layouts/starry.scss
+++ b/app/assets/stylesheets/layouts/starry.scss
@@ -71,6 +71,7 @@ $ODD_COLOR: #D8D8D8;
 .post-character, .post-character a, .post-character a:visited, .post-author, .post-author a, .post-author a:visited { color: #F3F3F3; }
 
 #content .dark { background-color: #182152; color: #FEFEFE; }
+.spacer-alt { background-color: #182152; color: #FEFEFE; }
 
 tr.gallery-tags .tag-item { background-color: #2C2C5D; color: #F7F7F7; }
 .tag-item { color: #444158; }

--- a/app/assets/stylesheets/layouts/starry.scss
+++ b/app/assets/stylesheets/layouts/starry.scss
@@ -51,7 +51,7 @@ $ODD_COLOR: #D8D8D8;
   }
 }
 
-.post-navheader .view-button, .view-button.selected, .view-button, .link-box.green, .link-box.blue, .link-box.red { background-color: #463C65; }
+.post-navheader .view-button, .view-button.selected, .view-button, .link-box.action-new, .link-box.action-edit, .link-box.action-favorite, .link-box.action-delete, .link-box.action-dismiss { background-color: #463C65; }
 .flash.breadcrumbs .link-box, .subber .link-box { background-color: #66608B; }
 .green { background-color: #D8D8D8; }
 #post-editor .green { background-color: #484357; color: #DADADA; }

--- a/app/assets/stylesheets/layouts/starry.scss
+++ b/app/assets/stylesheets/layouts/starry.scss
@@ -53,8 +53,8 @@ $ODD_COLOR: #D8D8D8;
 
 .post-navheader .view-button, .view-button.selected, .view-button, .link-box.action-new, .link-box.action-edit, .link-box.action-favorite, .link-box.action-delete, .link-box.action-dismiss { background-color: #463C65; }
 .flash.breadcrumbs .link-box, .subber .link-box { background-color: #66608B; }
-.green { background-color: #D8D8D8; }
-#post-editor .green { background-color: #484357; color: #DADADA; }
+.replace-icon, .icons-box, .icon-credit { background-color: #D8D8D8; }
+#reply-icon-selector { background-color: #484357; color: #DADADA; }
 .post-subheader { background-color: #484357; color: #F3F3F3; }
 
 .subber, .flash.breadcrumbs {

--- a/app/assets/stylesheets/layouts/starrydark.scss
+++ b/app/assets/stylesheets/layouts/starrydark.scss
@@ -70,6 +70,7 @@ $ODD_COLOR: #25262E;
 .selected-icon { border-color: #B9BBEB; }
 
 #content .dark { background-color: #131937; color: #FEFEFE; }
+.spacer-alt { background-color: #131937; color: #FEFEFE; }
 
 .pagination .current { background-color: #484357; }
 .pagination a { color: #F3F3F3; }

--- a/app/assets/stylesheets/layouts/starrydark.scss
+++ b/app/assets/stylesheets/layouts/starrydark.scss
@@ -49,7 +49,7 @@ $ODD_COLOR: #25262E;
   }
 }
 
-.post-navheader .view-button, .view-button.selected, .view-button, .link-box.green, .link-box.blue, .link-box.red, .tag-item { background-color: #463C65; }
+.post-navheader .view-button, .view-button.selected, .view-button, .link-box.action-new, .link-box.action-edit, .link-box.action-favorite, .link-box.action-delete, .link-box.action-dismiss, .tag-item { background-color: #463C65; }
 .flash.breadcrumbs .link-box, .subber .link-box { background-color: #5C5778; }
 #post-editor .green { background-color: #484357; color: $FONT_COLOR; }
 .post-subheader { background-color: #484357; color: #F3F3F3; }

--- a/app/assets/stylesheets/layouts/starrydark.scss
+++ b/app/assets/stylesheets/layouts/starrydark.scss
@@ -69,7 +69,7 @@ $ODD_COLOR: #25262E;
 
 .selected-icon { border-color: #B9BBEB; }
 
-#content .dark { background-color: #131937; color: #FEFEFE; }
+.search-box { background-color: #131937; color: #FEFEFE; }
 .spacer-alt { background-color: #131937; color: #FEFEFE; }
 
 .pagination .current { background-color: #484357; }

--- a/app/assets/stylesheets/layouts/starrydark.scss
+++ b/app/assets/stylesheets/layouts/starrydark.scss
@@ -51,7 +51,7 @@ $ODD_COLOR: #25262E;
 
 .post-navheader .view-button, .view-button.selected, .view-button, .link-box.action-new, .link-box.action-edit, .link-box.action-favorite, .link-box.action-delete, .link-box.action-dismiss, .tag-item { background-color: #463C65; }
 .flash.breadcrumbs .link-box, .subber .link-box { background-color: #5C5778; }
-#post-editor .green { background-color: #484357; color: $FONT_COLOR; }
+#reply-icon-selector { background-color: #484357; color: $FONT_COLOR; }
 .post-subheader { background-color: #484357; color: #F3F3F3; }
 
 .subber, .flash.breadcrumbs {
@@ -84,7 +84,7 @@ $ODD_COLOR: #25262E;
 
 #post-menu-box, #content .even, #content .odd, .post-post, .post-reply { color: $FONT_COLOR; }
 
-.green { background-color: #323232; }
+.replace-icon, .icons-box, .icon-credit { background-color: #323232; }
 
 .tag-item { background-color: #241F4E; }
 .even .tag-item { background-color: #24252D; }

--- a/app/assets/stylesheets/layouts/starrylight.scss
+++ b/app/assets/stylesheets/layouts/starrylight.scss
@@ -50,8 +50,8 @@ $ODD_COLOR: #D8D8D8;
 
 .post-navheader .view-button, .view-button.selected, .view-button, .link-box.action-new, .link-box.action-edit, .link-box.action-favorite, .link-box.action-delete, .link-box.action-dismiss { background-color: #6565AE; }
 .flash.breadcrumbs .link-box, .subber .link-box { background-color: #8689B7; }
-.green { background-color: #D8D8D8; }
-#post-editor .green { background-color: #9692A8; color: #DADADA; }
+.replace-icon, .icons-box, .icon-credit { background-color: #D8D8D8; }
+#reply-icon-selector { background-color: #9692A8; color: #DADADA; }
 .post-subheader { background-color: #9692A8; color: #F3F3F3; }
 
 .subber, .flash.breadcrumbs {

--- a/app/assets/stylesheets/layouts/starrylight.scss
+++ b/app/assets/stylesheets/layouts/starrylight.scss
@@ -70,7 +70,7 @@ $ODD_COLOR: #D8D8D8;
 
 /*.selected-icon { border-color: #409CFF; }*/
 
-#content .dark { background-color: #645F8A; color: #FEFEFE; }
+.search-box { background-color: #645F8A; color: #FEFEFE; }
 .spacer-alt { background-color: #645F8A; color: #FEFEFE; }
 
 tr.gallery-tags .tag-item { background-color: #968BB4; color: #F7F7F7; }

--- a/app/assets/stylesheets/layouts/starrylight.scss
+++ b/app/assets/stylesheets/layouts/starrylight.scss
@@ -71,6 +71,7 @@ $ODD_COLOR: #D8D8D8;
 /*.selected-icon { border-color: #409CFF; }*/
 
 #content .dark { background-color: #645F8A; color: #FEFEFE; }
+.spacer-alt { background-color: #645F8A; color: #FEFEFE; }
 
 tr.gallery-tags .tag-item { background-color: #968BB4; color: #F7F7F7; }
 .tag-item { color: #444158; }

--- a/app/assets/stylesheets/layouts/starrylight.scss
+++ b/app/assets/stylesheets/layouts/starrylight.scss
@@ -48,7 +48,7 @@ $ODD_COLOR: #D8D8D8;
   }
 }
 
-.post-navheader .view-button, .view-button.selected, .view-button, .link-box.green, .link-box.blue, .link-box.red { background-color: #6565AE; }
+.post-navheader .view-button, .view-button.selected, .view-button, .link-box.action-new, .link-box.action-edit, .link-box.action-favorite, .link-box.action-delete, .link-box.action-dismiss { background-color: #6565AE; }
 .flash.breadcrumbs .link-box, .subber .link-box { background-color: #8689B7; }
 .green { background-color: #D8D8D8; }
 #post-editor .green { background-color: #9692A8; color: #DADADA; }

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -52,6 +52,7 @@
   padding: 10px;
   margin: 0;
   z-index: 4;
+  background-color: #B0BBA9;
 
   img { cursor: pointer; }
   .gallery-icon {

--- a/app/views/board_sections/show.haml
+++ b/app/views/board_sections/show.haml
@@ -9,13 +9,13 @@
   = @board_section.name
   - if @board_section.board.open_to?(current_user)
     = link_to new_post_path params: {board_id: @board_section.board.id, section_id: @board_section.id} do
-      .link-box.green + New Post
+      .link-box.action-new + New Post
   - if @board_section.board.editable_by?(current_user)
     = link_to edit_board_section_path(@board_section) do
-      .link-box.blue
+      .link-box.action-edit
         = image_tag "icons/pencil.png"
         Edit
     = link_to board_section_path(@board_section), :method => :delete, data: { confirm: 'Are you sure you want to delete this section?' } do
-      .link-box.red x Delete
+      .link-box.action-delete x Delete
 
 = render partial: 'posts/list', locals: {posts: @posts, hide_continuity: true}

--- a/app/views/boards/edit.haml
+++ b/app/views/boards/edit.haml
@@ -19,7 +19,7 @@
   .content-header
     Organize Continuity Sections
     = link_to new_board_section_path params: {board_id: @board.id} do
-      .link-box.green + New Section
+      .link-box.action-new + New Section
     #loading.float-right.hidden= loading_tag
     #saveerror.float-right.hidden
       = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: '!'

--- a/app/views/boards/index.haml
+++ b/app/views/boards/index.haml
@@ -13,7 +13,7 @@
         = @page_title
         - if logged_in? && (@user.nil? || @user.id == current_user.id)
           = link_to new_board_path do
-            .link-box.green + New Continuity
+            .link-box.action-new + New Continuity
     %tr
       %th.sub Name
       %th.sub Authors

--- a/app/views/boards/show.haml
+++ b/app/views/boards/show.haml
@@ -8,24 +8,24 @@
   - if logged_in?
     - if @board.open_to?(current_user)
       = link_to new_post_path params: {board_id: @board.id} do
-        .link-box.green + New Post
+        .link-box.action-new + New Post
     - if @board.editable_by?(current_user)
       = link_to new_board_section_path params: {board_id: @board.id} do
-        .link-box.green + New Section
+        .link-box.action-new + New Section
       = link_to edit_board_path(@board) do
-        .link-box.blue
+        .link-box.action-edit
           = image_tag "icons/pencil.png"
           Edit
       = link_to board_path(@board), method: :delete, data: { confirm: 'Are you sure you want to delete this continuity?' } do
-        .link-box.red x Delete
+        .link-box.action-delete x Delete
     - if fav = Favorite.between(current_user, @board)
       = link_to favorite_path(fav), method: :delete do
-        .link-box.blue
+        .link-box.action-edit
           = image_tag "icons/star_delete.png", class: 'vmid'
           Unfavorite
     - else
       = link_to favorites_path(board_id: @board.id), method: :post do
-        .link-box.blue
+        .link-box.action-favorite
           = image_tag "icons/star_add.png", class: 'vmid'
           Favorite
 

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -9,13 +9,13 @@
           = link_to name.name, template_path(name)
         - if current_user.try(:id) == name.user_id
           = link_to new_character_path(template_id: name.id) do
-            .link-box.green{style: 'font-size: 14px'} + New Instance
+            .link-box.action-new{style: 'font-size: 14px'} + New Instance
           = link_to edit_template_path(name) do
-            .link-box.blue{style: 'font-size: 14px'}
+            .link-box.action-edit{style: 'font-size: 14px'}
               = image_tag "icons/pencil.png", class: 'vmid'
               Edit
           = link_to template_path(name), method: :delete, data: { confirm: 'Are you sure you want to delete this template?' } do
-            .link-box.red{style: 'font-size: 14px'} x Delete
+            .link-box.action-delete{style: 'font-size: 14px'} x Delete
 - if @template && @template.description.present?
   %tr
     %td.single-description.written-content{colspan: 6}= sanitize_written_content(@template.description).html_safe

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -20,7 +20,7 @@
   %tr
     %td.single-description.written-content{colspan: 6}= sanitize_written_content(@template.description).html_safe
 %tr
-  %td.green.left-align
+  %td.icons-box.left-align
     .character-icon-list
       - characters.includes(:default_icon).each do |character|
         .character-icon-item

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -9,13 +9,13 @@
           = link_to name.name, template_path(name)
         - if current_user.try(:id) == name.user_id
           = link_to new_character_path(template_id: name.id) do
-            .link-box.green{style: 'font-size: 14px'} + New Instance
+            .link-box.action-new{style: 'font-size: 14px'} + New Instance
           = link_to edit_template_path(name) do
-            .link-box.blue{style: 'font-size: 14px'}
+            .link-box.action-edit{style: 'font-size: 14px'}
               = image_tag "icons/pencil.png", class: 'vmid'
               Edit
           = link_to template_path(name), method: :delete, data: { confirm: 'Are you sure you want to delete this template?' } do
-            .link-box.red{style: 'font-size: 14px'} x Delete
+            .link-box.action-delete{style: 'font-size: 14px'} x Delete
       - else
         %b= name
 - if @template && @template.description.present?

--- a/app/views/characters/edit.haml
+++ b/app/views/characters/edit.haml
@@ -20,7 +20,7 @@
     %th.centered
       Aliases and Pseudonyms
       = link_to new_character_alias_path(@character) do
-        .link-box.green + New Alias
+        .link-box.action-new + New Alias
   - @aliases.each do |calias|
     %tr
       %td.padding-5{class: cycle('even', 'odd')}

--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -14,9 +14,9 @@
         - if @user.id == current_user.try(:id)
           Your Characters
           = link_to new_character_path(character_group_id: @group.try(:id)) do
-            .link-box.green + New Character
+            .link-box.action-new + New Character
           = link_to new_template_path do
-            .link-box.green + New Template
+            .link-box.action-new + New Template
         - else
           = @user.username + "'s Characters"
       = link_to url_for(character_split: character_split, view: 'icons') do

--- a/app/views/characters/replace.haml
+++ b/app/views/characters/replace.haml
@@ -19,13 +19,13 @@
       %th.sub Current
       %th.sub New
     %tr
-      %td.green.width-150.centered.vtop
+      %td.replace-icon.vtop
         = icon_tag @character.default_icon
         %br
         = @character.name
         - if @character.aliases.exists?
           = select_tag :orig_alias, options_for_select({'— Any Alias —': 'all'}, 'all') + options_from_collection_for_select(@character.aliases, :id, :name), prompt: '— No alias —'
-      %td.green.width-150.centered
+      %td.replace-icon
         - if @alts.first.try(:default_icon)
           = icon_tag @alts.first.default_icon, id: 'new_icon'
         - else

--- a/app/views/characters/search.haml
+++ b/app/views/characters/search.haml
@@ -12,7 +12,7 @@
           = render partial: 'posts/paginator', locals: {paginated: @search_results, no_per: true}
     %tbody
       %tr
-        %td.width-300.padding-10.vtop.dark
+        %td.search-box
           = form_tag search_characters_path, :method => :get do
             %table.search-form
               %tr

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -29,7 +29,7 @@
   %tbody
     - if @character.default_icon
       %tr
-        %td.green.centered.character-icon
+        %td.character-icon.icons-box
           = link_to icon_path(@character.default_icon) do
             = icon_tag @character.default_icon
     %tr
@@ -90,7 +90,7 @@
         = render partial: 'galleries/single', locals: {gallery: gallery, klass: 'subber', skip_forms: true, character_gallery: gallery.character_gallery_for(@character)}
       - unless galleries.present?
         %tr
-          %td.green
+          %td.icon-box
             .centered.padding-5 — No galleries yet —
 - elsif params[:view] == 'posts'
   - content_for :posts_title do 'Recent Threads' end

--- a/app/views/galleries/_galleryless.haml
+++ b/app/views/galleries/_galleryless.haml
@@ -3,7 +3,7 @@
     = link_to 'Galleryless icons', user_gallery_path(id: 0, user_id: @user.id), class: 'gallery-title'
     - if @user.id == current_user.try(:id)
       = link_to add_gallery_path(id: 0), class: 'gallery-add' do
-        .link-box.green
+        .link-box.action-new
           + Add Icons
     .gallery-box.float-right.gallery-minmax{id: 0} -
 - if @user.id == current_user.try(:id)

--- a/app/views/galleries/_galleryless.haml
+++ b/app/views/galleries/_galleryless.haml
@@ -10,7 +10,7 @@
   %tr.gallery-subheader
     %th.sub Unsorted icons without a gallery will appear here. They can still be individually assigned to a character with no galleries.
 %tr.gallery-icons
-  %td.green.gallery-title
+  %td.icons-box.gallery-title
     .gallery{id: "gallery0"}
       = form_tag delete_multiple_icons_path, method: :delete do
         - icons = @user.galleryless_icons

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -29,7 +29,7 @@
             %span.tag-item
               = group.name
 %tr.gallery-icons
-  %td.green
+  %td.icons-box
     .gallery{id: "gallery#{gallery.id.to_s}"}
       = form_tag delete_multiple_icons_path, method: :delete do
         - gallery.icons.pluck(:id, :keyword, :url).each do |icon_id, keyword, url|

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -5,13 +5,13 @@
     = link_to gallery.name, gallery_path(gallery), class: 'gallery-title'
     - if gallery.user_id == current_user.try(:id) and not defined? skip_forms
       = link_to add_gallery_path(gallery), class: 'gallery-add' do
-        .link-box.green + Add Icons
+        .link-box.action-new + Add Icons
       = link_to edit_gallery_path(gallery), class: 'gallery-edit' do
-        .link-box.blue
+        .link-box.action-edit
           = image_tag "icons/pencil.png"
           Edit Gallery
       = link_to gallery_path(gallery), method: :delete, data: { confirm: 'Are you sure you want to delete this gallery? (This will not delete the icons.)' }, class: 'gallery-delete' do
-        .link-box.red x Delete Gallery
+        .link-box.action-delete x Delete Gallery
     - unless local_assigns[:hide_minmax]
       .gallery-box.float-right.gallery-minmax{data: {id: gallery.id}} -
     - if local_assigns[:character_gallery] && (gallery.user_id == current_user.try(:id) || current_user.try(:admin?))

--- a/app/views/galleries/edit.haml
+++ b/app/views/galleries/edit.haml
@@ -22,7 +22,7 @@
     = f.fields_for :galleries_icons, @gallery.galleries_icons.joins(:icon).order('LOWER(keyword)') do |gif|
       = gif.fields_for :icon do |i|
         %tr{id: "icon-row-#{i.object.id}"}
-          %td.green.centered{rowspan: 6}
+          %td.icons-box.centered{rowspan: 6}
             = icon_tag i.object, id: "icon-#{i.object.id}"
             = i.hidden_field :id
             = loading_tag class: 'hidden', id: "loading-#{i.object.id}"

--- a/app/views/galleries/index.haml
+++ b/app/views/galleries/index.haml
@@ -11,7 +11,7 @@
         - if @user.id == current_user.try(:id)
           Your Galleries
           = link_to new_gallery_path, class: 'gallery-new' do
-            .link-box.green + New Gallery
+            .link-box.action-new + New Gallery
         - else
           = @user.username + "'s Galleries"
   %tbody

--- a/app/views/icons/edit.haml
+++ b/app/views/icons/edit.haml
@@ -16,7 +16,7 @@
       %th.centered{colspan: 2}
         Edit Icon
     %tr
-      %td.green.centered{colspan: 2}
+      %td.icons-box.centered{colspan: 2}
         = icon_tag @icon, id: 'edit-icon'
         = loading_tag class: 'hidden', id: "loading"
     %tr

--- a/app/views/icons/replace.haml
+++ b/app/views/icons/replace.haml
@@ -13,11 +13,11 @@
       %th.sub Current
       %th.sub New
     %tr
-      %td.green.width-150.centered.vtop
+      %td.replace-icon.vtop
         = icon_tag @icon
         %br
         = @icon.keyword
-      %td.green.width-150.centered
+      %td.replace-icon
         - if @alts.first
           = icon_tag @alts.first, id: 'new_icon'
         - else

--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -24,10 +24,10 @@
   %tr
     %th.centered.icon-keyword= @icon.keyword
   %tr
-    %td.green.centered.icon-icon= icon_tag @icon
+    %td.icons-box.centered.icon-icon= icon_tag @icon
   - if @icon.credit
     %tr
-      %td.green.centered
+      %td.icon-credit
         .details= @icon.credit
   %tr
     %td.centered{class: cycle('even', 'odd')}

--- a/app/views/index_sections/_single.haml
+++ b/app/views/index_sections/_single.haml
@@ -7,13 +7,13 @@
     = link_to section.name, index_section_path(section)
     - if section.index.editable_by?(current_user)
       = link_to new_index_post_path params: {index_id: section.index.id, index_section_id: section.id} do
-        .link-box.green + Add Post to Section
+        .link-box.action-new + Add Post to Section
       = link_to edit_index_section_path(section) do
-        .link-box.blue
+        .link-box.action-edit
           = image_tag "icons/pencil.png"
           Edit
       = link_to index_section_path(section), method: :delete, data: { confirm: 'Are you sure you want to delete this section?' } do # TODO do I nilify or destroy here?
-        .link-box.red x Delete
+        .link-box.action-delete x Delete
 - if section.description.present?
   %tr
     %th.subber.index-description{colspan: 6}= sanitize_written_content(section.description).html_safe

--- a/app/views/indexes/index.haml
+++ b/app/views/indexes/index.haml
@@ -5,7 +5,7 @@
         Indexes
         - if logged_in? && current_user.admin?
           = link_to new_index_path do
-            .link-box.green + New Index
+            .link-box.action-new + New Index
   %tbody
     %tr
       %th.sub Name

--- a/app/views/indexes/show.haml
+++ b/app/views/indexes/show.haml
@@ -7,15 +7,15 @@
   = @index.name
   - if @index.editable_by?(current_user)
     = link_to new_index_post_path params: {index_id: @index.id} do
-      .link-box.green + Add Post to Index
+      .link-box.action-new + Add Post to Index
     = link_to new_index_section_path params: {index_id: @index.id} do
-      .link-box.green + New Section
+      .link-box.action-new + New Section
     = link_to edit_index_path(@index) do
-      .link-box.blue
+      .link-box.action-edit
         = image_tag "icons/pencil.png"
         Edit
     = link_to index_path(@index), method: :delete, data: { confirm: 'Are you sure you want to delete this index?' } do
-      .link-box.red x Delete
+      .link-box.action-delete x Delete
 
 %table
   %thead

--- a/app/views/messages/_inbox.haml
+++ b/app/views/messages/_inbox.haml
@@ -4,4 +4,4 @@
     = link_to messages_path params: {view: 'outbox'} do
       .view-button Outbox &raquo;
     = link_to new_message_path do
-      .link-box.green + Write Message
+      .link-box.action-new + Write Message

--- a/app/views/messages/_outbox.haml
+++ b/app/views/messages/_outbox.haml
@@ -4,4 +4,4 @@
     = link_to messages_path params: {view: 'inbox'} do
       .view-button &laquo; Inbox
     = link_to new_message_path do
-      .link-box.green + Write Message
+      .link-box.action-new + Write Message

--- a/app/views/posts/_editor.haml
+++ b/app/views/posts/_editor.haml
@@ -41,7 +41,7 @@
           - if recent_characters.present?
             - recent_characters.each do |character|
               = character_icon_tag character
-  #reply-icon-selector.green
+  #reply-icon-selector
     - if character_galleries.present?
       - character_galleries.each do |gallery|
         .gallery-group

--- a/app/views/posts/_editor.haml
+++ b/app/views/posts/_editor.haml
@@ -20,7 +20,7 @@
           %h4 Choose Alias
           = select_tag :character_alias, options_from_collection_for_select(item.character.try(:aliases).to_a, :id, :name, item.character_alias_id), prompt: item.character.try(:name), class: 'chosen-select'
       .post-screenname{class: ('hidden' unless item.character.try(:screenname))}= item.character.try(:screenname)
-      #post-author-spacer.dark.spacer{class: ('hidden' if item.character)}
+      #post-author-spacer.spacer-alt{class: ('hidden' if item.character)}
       .post-author
         = item.user.username
         - if current_user.characters.present?

--- a/app/views/posts/_generate_flat.haml
+++ b/app/views/posts/_generate_flat.haml
@@ -12,7 +12,7 @@
               - if reply.screenname
                 .post-screenname= breakable_text(reply.screenname)
             - else
-              .dark.spacer
+              .spacer-alt
             .post-author= reply.username
         .post-edit-box
           = link_to Rails.application.routes.url_helpers.reply_path(reply, anchor: "reply-#{reply.id}"), rel: 'alternate'.freeze do

--- a/app/views/posts/flat.haml
+++ b/app/views/posts/flat.haml
@@ -33,7 +33,7 @@
                 - if @post.character.screenname
                   .post-screenname= breakable_text(@post.character.screenname)
               - else
-                .dark.spacer
+                .spacer-alt
               .post-author= @post.user.username
           .post-edit-box
             = link_to post_path(@post), rel: 'alternate' do

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -12,7 +12,7 @@
           = render partial: 'paginator', locals: {paginated: @search_results}
   %tbody
     %tr
-      %td.width-300.padding-10.vtop.dark
+      %td.search-box
         = form_tag search_posts_path, :method => :get do
           %table.search-form
             %tr

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -12,7 +12,7 @@
           = render partial: 'paginator', locals: {paginated: @search_results}
   %tbody
     %tr
-      %td.width-300.padding-10.vtop.dark#search_form
+      %td.width-300.padding-10.vtop.dark
         = form_tag search_posts_path, :method => :get do
           %table.search-form
             %tr

--- a/app/views/posts/show.haml
+++ b/app/views/posts/show.haml
@@ -15,10 +15,10 @@
     .flash.error
       - if logged_in?
         = link_to warnings_post_path(@post, page: page, per_page: per_page), method: :post do
-          .link-box.red.float-right Dismiss for this post
+          .link-box.action-dismiss.float-right Dismiss for this post
       - else
         = link_to warnings_post_path(@post, page: page, per_page: per_page), method: :post, data: { confirm: 'Are you sure? You will not see content warnings again until you restart your browser!'.freeze } do
-          .link-box.red.float-right Dismiss all content warnings
+          .link-box.action-dismiss.float-right Dismiss all content warnings
       = image_tag "icons/exclamation.png".freeze, class: 'vmid'.freeze
       This post has the following content warnings:
       %ul

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -20,7 +20,7 @@
           - if reply.screenname
             .post-screenname= breakable_text(reply.screenname)
         - else
-          .dark.spacer
+          .spacer-alt
         .post-author
           = link_to reply.username, user_path(reply.user_id)
     .post-edit-box

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -12,7 +12,7 @@
           = render partial: 'posts/paginator', locals: {paginated: @search_results, no_per: true}
   %tbody
     %tr
-      %td.width-300.padding-10.vtop.dark
+      %td.search-box
         = form_tag search_replies_path, :method => :get do
           %table.search-form
             %tr

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -12,11 +12,11 @@
         #{@tag.type.titlecase}: #{@tag.name}
         - if @tag.editable_by?(current_user)
           = link_to edit_tag_path(@tag) do
-            .link-box.blue
+            .link-box.action-edit
               = image_tag "icons/pencil.png"
               Edit
           = link_to tag_path(@tag), method: :delete, data: { confirm: 'Are you sure you want to delete this tag?' } do
-            .link-box.red x Delete
+            .link-box.action-delete x Delete
   %tbody
     - if @tag.is_a?(Setting) && @tag.parent_settings.present?
       %tr

--- a/app/views/templates/show.haml
+++ b/app/views/templates/show.haml
@@ -14,13 +14,13 @@
       Template: #{@template.name}
       - if @template.user_id == current_user.try(:id)
         = link_to new_character_path(template_id: @template.id) do
-          .link-box.green + New Instance
+          .link-box.action-new + New Instance
         = link_to edit_template_path(@template) do
-          .link-box.blue
+          .link-box.action-edit
             = image_tag "icons/pencil.png"
             Edit Template
         = link_to template_path(@template), :method => :delete, data: { confirm: 'Are you sure you want to delete this template?' } do
-          .link-box.red x Delete Template
+          .link-box.action-delete x Delete Template
       = link_to url_for(view: 'icons') do
         .view-button{class: (:selected unless page_view == 'list')}
           = image_tag "icons/grid.png", class:'icon-view', alt: ''

--- a/app/views/users/search.haml
+++ b/app/views/users/search.haml
@@ -12,7 +12,7 @@
           = render partial: 'posts/paginator', locals: {paginated: @search_results, no_per: true}
   %tbody
     %tr
-      %td.width-300.padding-10.vtop.dark
+      %td.search-box
         = form_tag search_users_path, method: :get do
           %table.search-form
             %tr

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -5,7 +5,7 @@
   %tbody
     - if @user.avatar
       %tr
-        %td.green.centered.user-avatar
+        %td.icons-box#user-avatar
           = link_to icon_path(@user.avatar) do
             = icon_tag @user.avatar
     - if logged_in? && @user.id != current_user.id

--- a/spec/features/posts/search_spec.rb
+++ b/spec/features/posts/search_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Searching posts", :type => :feature do
     visit search_posts_path
 
     def perform_search
-      within('#search_form') do
+      within('.search-form') do
         fill_in 'Subject', with: 'post'
       end
       click_button 'Search'


### PR DESCRIPTION
* Makes `.link-box`es use semantic class names
* Splits the two uses of `.dark` unto their own clases
* Folds `.green`'s color styling into a few pre-existing things
* Creates three new semantic classes to cover the rest of `.green`
* Cleans up `#search_form` (unrelated)