### PR TITLE
Mods

### DIFF
--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -163,6 +163,7 @@ function displayGallery(newId) {
 }
 
 function bindIcons(obj) {
+  if(gon.mod_editing) return; // Mods can't change icons, so don't present the UI
   obj = obj || window.body;
   $(".character-icon", obj).click(function() {
     if ($(this).hasClass('selected-icon')) {

--- a/app/concerns/permissible.rb
+++ b/app/concerns/permissible.rb
@@ -5,7 +5,7 @@ module Permissible
   MOD_PERMS = [
     :edit_posts,
     :edit_replies,
-    # :edit_characters,
+    :edit_characters,
     # :edit_tags,
     # :delete_tags,
     # :edit_continuities

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -41,6 +41,12 @@ class Character < ApplicationRecord
     user.has_permission?(:edit_characters)
   end
 
+  def deletable_by?(user)
+    return false unless user
+    return true if user_id == user.id
+    user.has_permission?(:delete_characters)
+  end
+
   def recent_posts
     return @recent unless @recent.nil?
     reply_ids = replies.group(:post_id).pluck(:post_id)

--- a/app/views/characters/_editor.haml
+++ b/app/views/characters/_editor.haml
@@ -15,19 +15,21 @@
   %th.sub.vtop Template
   %td{class: klass}
     = f.collection_select :template_id, @templates, :id, :name, {include_blank: '— Choose Template —'}, {class: 'text chosen-select', disabled: params[:new_template].present?}
-    %br
-    = check_box_tag :new_template, '1', params[:new_template].present?
-    = label_tag :new_template, 'Create New Template'
-%tr#create_template{class: ('hidden' unless params[:new_template])}
-  %th.sub &#8627; Name
-  = f.fields_for :template do |ff|
-    %td{class: klass}= ff.text_field :name, placeholder: "Template Name", class: 'text'
-- if current_user.galleries.present?
+    - if @character.user == current_user
+      %br
+      = check_box_tag :new_template, '1', params[:new_template].present?
+      = label_tag :new_template, 'Create New Template'
+- if @character.user == current_user
+  %tr#create_template{class: ('hidden' unless params[:new_template])}
+    %th.sub &#8627; Name
+    = f.fields_for :template do |ff|
+      %td{class: klass}= ff.text_field :name, placeholder: "Template Name", class: 'text'
+- if @character.user.galleries.present?
   %tr
     %th.sub Galleries
     %td{class: cycle('even', 'odd')}
       = f.collection_select(:ungrouped_gallery_ids,
-      current_user.galleries.order('name asc'),
+      @character.user.galleries.order('name asc'),
       :id, :name, {selected: @character.ungrouped_gallery_ids}, {multiple: true})
   %tr
     %th.sub Gallery Groups
@@ -39,6 +41,10 @@
 %tr
   %th.sub.vtop Description
   %td{class: cycle('even', 'odd')}= f.text_area :description, placeholder: 'Description', class: 'text', cols: 35
+- if current_user.id != @character.user_id
+  %tr
+    %th.sub.vtop Moderator Note
+    %td{class: cycle('even', 'odd')}= f.text_area :audit_comment, placeholder: 'Explain reason for moderation here', class: 'text', cols: 35
 %tr
   %th.form-table-ender{colspan: 2}= submit_tag "Save", class: 'button'
 
@@ -48,7 +54,7 @@
   Pick default icon (optional):
   %br
   .character-galleries-simple
-    - galleries = @character.galleries.present? ? @character.galleries.ordered : [Struct.new(:id, :name, :icons).new(0, 'Galleryless', current_user.galleryless_icons || [])]
+    - galleries = @character.galleries.present? ? @character.galleries.ordered : [Struct.new(:id, :name, :icons).new(0, 'Galleryless', @character.user.galleryless_icons || [])]
     - if galleries.present?
       - galleries.each do |gallery|
         %div{id: "gallery#{gallery.id}", :'data-id' => gallery.id }

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -32,7 +32,7 @@
             .character-name= character.name
             - if character.screenname
               .character-screenname= surround('(', ')') { breakable_text(character.screenname) }
-          - if character.user_id == current_user.try(:id)
+          - if character.deletable_by?(current_user)
             .delete-button{ id: character.id }
               = link_to '×', character_path(character), :method => :delete, data: { confirm: 'Are you sure you want to delete '+character.name+'?' }
       - unless characters.present?

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -64,9 +64,10 @@
 
       %td.width-70.right-align{class: klass}
         - unless local_assigns[:hide_buttons]
-          - if @user.id == current_user.try(:id)
+          - if character.editable_by?(current_user)
             = link_to edit_character_path(character) do
               = image_tag "icons/pencil.png"
+          - if character.deletable_by?(current_user)
             = link_to character_path(character), :method => :delete, data: { confirm: 'Are you sure you want to delete '+character.name+'?' } do
               = image_tag "icons/cross.png"
             &nbsp;

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -47,12 +47,13 @@
         = link_to character_path(@character, view: 'posts') do
           = image_tag "icons/book_open.png"
           Posts
-    - if logged_in? && current_user.id == @character.user_id
+    - if @character.editable_by?(current_user)
       %tr
         %td.centered{class: cycle('even', 'odd')}
           = link_to edit_character_path(@character), class: 'character-edit' do
             = image_tag "icons/pencil.png"
             Edit Character
+    - if logged_in? && @character.user_id == current_user.id
       %tr
         %td.centered{class: cycle('even', 'odd')}
           = link_to duplicate_character_path(@character), method: :post, class: 'character-duplicate', data: { confirm: 'Are you sure you want to duplicate this character?' } do
@@ -63,6 +64,7 @@
           = link_to replace_character_path(@character), class: 'character-replace' do
             = image_tag "icons/swap.png", style: 'width: 16px;'
             Replace Character
+    - if @character.deletable_by?(current_user)
       %tr
         %td.centered{class: cycle('even', 'odd')}
           = link_to character_path(@character), method: :delete, data: { confirm: 'Are you sure you want to delete this character?' } do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ marri = User.create(username: 'Marri', password: 'nikari', email: "dummy1@exampl
 alicorn = User.create(username: 'Alicorn', password: 'alicorn', email: "dummy2@example.com")
 kappa = User.create(username: 'Kappa', password: 'pythbox', email: "dummy3@example.com")
 aestrix = User.create(username: 'Aestrix', password: 'aestrix', email: "dummy4@example.com")
-throne = User.create(username: 'Throne3d', password: 'throne3d', email: "dummy5@example.com")
+throne = User.create(username: 'Throne3d', password: 'throne3d', email: "dummy5@example.com", role_id: 2)
 
 puts "Creating avatars..."
 Icon.create!([

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -306,6 +306,26 @@ RSpec.describe CharactersController do
       expect(character.reload.name).not_to eq(new_name)
     end
 
+    it "requires notes from moderators" do
+      character = create(:character)
+      login_as(create(:mod_user))
+      put :update, params: { id: character.id }
+      expect(response).to render_template(:edit)
+      expect(flash[:error]).to eq('You must provide a reason for your moderator edit.')
+    end
+
+    it "stores note from moderators" do
+      Character.auditing_enabled = true
+      character = create(:character, name: 'a')
+      admin = create(:admin_user)
+      login_as(admin)
+      put :update, params: { id: character.id, character: { name: 'b', audit_comment: 'note' } }
+      expect(flash[:success]).to eq("Character saved successfully.")
+      expect(character.reload.name).to eq('b')
+      expect(character.audits.last.comment).to eq('note')
+      Character.auditing_enabled = false
+    end
+
     it "succeeds when valid" do
       character = create(:character)
       user = character.user


### PR DESCRIPTION
Next round: editing characters!
- Turn off the UI for default character icon and creating templates if the editor is not the owner
- Character editor uses correct templates/galleries rather than defaulting to current user's
- Correct edit/delete permissions
- Requires audit comment when editing a character you don't own
- Incidentally give Throne's seed user mod permissions while I'm in here