### PR TITLE
Modify replies#search UI to use a div layout instead of table

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -344,7 +344,8 @@ td, .table-list li { font-size: 14px; }
 /* Collapsible tables on search pages for mobile view */
 @media (max-width: 600px) {
   .search-collapsible {
-    > thead > tr > th, > tbody > tr > td {
+    .empty { display: none; }
+    > thead > tr > th, > tbody > tr > td, > tfoot > tr > th {
       box-sizing: border-box;
       display: block;
       width: 100%;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -340,3 +340,14 @@ td, .table-list li { font-size: 14px; }
 }
 .search-icon-preview { vertical-align: middle; }
 .search-icon-keyword { padding-left: 5px; }
+
+/* Collapsible tables on search pages for mobile view */
+@media (max-width: 600px) {
+  .search-collapsible {
+    > thead > tr > th, > tbody > tr > td {
+      box-sizing: border-box;
+      display: block;
+      width: 100%;
+    }
+  }
+}

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -364,6 +364,7 @@ div.post-subheader { width: 100%; }
   @include mobile-paginator;
 }
 @media (max-width: 400px) {
+  .paginator-meta { display: none; }
   .paginator {
     @include mobile-paginator;
   }

--- a/app/views/characters/search.haml
+++ b/app/views/characters/search.haml
@@ -1,6 +1,6 @@
 = render partial: 'search/breadcrumbs'
 
-%table
+%table.search-collapsible
   %thead
     %tr
       %th.width-150
@@ -73,5 +73,5 @@
     - if @search_results && @search_results.total_pages > 1
       %tfoot
         %tr
-          %th.width-150
+          %th.width-150.empty
           %th= render partial: 'posts/paginator', locals: {paginated: @search_results, no_per: true}

--- a/app/views/posts/_paginator.haml
+++ b/app/views/posts/_paginator.haml
@@ -1,14 +1,13 @@
 .paginator.centered.sub
-  - unless browser.device.mobile?
-    .paginator-meta
-      .left-align
-        Total:
-        %span.reply-count=paginated.total_entries
-      .right-align
-        - if paginated.klass == Reply && !local_assigns[:no_per]
-          Posts Per Page:
-          = select_tag :per_page, per_page_options, class: 'per-page'
-      .narrow-clear
+  .paginator-meta
+    .left-align
+      Total:
+      %span.reply-count=paginated.total_entries
+    .right-align
+      - if paginated.klass == Reply && !local_assigns[:no_per]
+        Posts Per Page:
+        = select_tag :per_page, per_page_options, class: 'per-page'
+    .narrow-clear
   .pagination
     - if paginated.total_entries > paginated.per_page
       - args = {container: false, params: @paginate_params || {}, first_label: "&laquo; First", last_label: "Last &raquo", summary_label: "%d of %d"}

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -1,6 +1,6 @@
 = render partial: 'search/breadcrumbs'
 
-%table
+%table.search-collapsible
   %thead
     %tr
       %th.width-150
@@ -55,5 +55,5 @@
   - if @search_results && @search_results.total_pages > 1
     %tfoot
       %tr
-        %th.width-150
+        %th.width-150.empty
         %th= render partial: 'paginator', locals: {paginated: @search_results}

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -1,6 +1,6 @@
 = render partial: 'search/breadcrumbs'
 
-%table
+%table.search-collapsible
   %thead
     %tr
       %th.width-150

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -65,7 +65,6 @@
                         - if reply.name.present?
                           .post-character= link_to reply.name, character_path(reply.character_id)
                         .post-author= link_to reply.username, user_path(reply.user_id)
-                        = pretty_time(reply.created_at)
                     .post-edit-box
                       = link_to reply_path(reply, anchor: "reply-#{reply.id}") do
                         = image_tag "icons/link.png".freeze, title: 'Permalink'.freeze, alt: 'Permalink'.freeze
@@ -75,6 +74,15 @@
                         = reply.pg_search_highlight.html_safe
                       - else
                         = sanitize_written_content(reply.content).html_safe
+                    .post-footer
+                      .right-align>
+                        - if reply.created_at
+                          = precede 'Posted '.freeze do
+                            %span.post-posted=pretty_time(reply.created_at)
+                        - if reply.id.present? && reply.audits.count > 1
+                          = surround ' | Updated '.freeze, ' | '.freeze do
+                            %span.post-updated=pretty_time(reply.last_updated)
+                          = link_to 'See History'.freeze, path_for(reply, 'history_%s'), class: 'post-history'.freeze
 
   - if @search_results && @search_results.total_pages > 1
     %tfoot

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -66,16 +66,15 @@
                           .post-character= link_to reply.name, character_path(reply.character_id)
                         .post-author= link_to reply.username, user_path(reply.user_id)
                         = pretty_time(reply.created_at)
-                  %td.vtop{class: klass}
+                    .post-edit-box
+                      = link_to reply_path(reply, anchor: "reply-#{reply.id}") do
+                        = image_tag "icons/link.png".freeze, title: 'Permalink'.freeze, alt: 'Permalink'.freeze
                     %b= link_to reply.post.subject, reply_path(reply, anchor: "reply-#{reply.id}")
-                    %br
-                    - if params[:subj_content].present?
-                      = reply.pg_search_highlight.html_safe
-                    - else
-                      = sanitize_written_content(reply.content).html_safe
-                  %td.vtop{class: klass}
-                    = link_to reply_path(reply, anchor: "reply-#{reply.id}") do
-                      = image_tag "icons/link.png".freeze, title: 'Permalink'.freeze, alt: 'Permalink'.freeze
+                    .post-content
+                      - if params[:subj_content].present?
+                        = reply.pg_search_highlight.html_safe
+                      - else
+                        = sanitize_written_content(reply.content).html_safe
 
   - if @search_results && @search_results.total_pages > 1
     %tfoot

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -87,5 +87,5 @@
   - if @search_results && @search_results.total_pages > 1
     %tfoot
       %tr
-        %th.width-150
+        %th.width-150.empty
         %th= render partial: 'posts/paginator', locals: {paginated: @search_results, no_per: true}

--- a/app/views/users/search.haml
+++ b/app/views/users/search.haml
@@ -1,6 +1,6 @@
 = render partial: 'search/breadcrumbs'
 
-%table
+%table.search-collapsible
   %thead
     %tr
       %th.width-150
@@ -39,5 +39,5 @@
   - if @search_results && @search_results.total_pages > 1
     %tfoot
       %tr
-        %th.width-150
+        %th.width-150.empty
         %th= render partial: 'posts/paginator', locals: {paginated: @search_results, no_per: true}


### PR DESCRIPTION
Also fixes large spacing around first and last paragraphs, and allows
text to flow around post info boxes, as in replies.