### PR TITLE
Fix alignment of text boxes that have icons

### DIFF
--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -105,6 +105,7 @@ button, .button {
   border-radius: 5px;
   font-weight: normal;
   height: 20px;
+  vertical-align: middle;
 
   img { vertical-align: baseline; }
 }

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -106,7 +106,7 @@ button, .button {
   font-weight: normal;
   height: 20px;
 
-  img { vertical-align: text-top; }
+  img { vertical-align: baseline; }
 }
 .link-box.action-new { background-color: #3f7055; }
 .link-box.action-delete { background-color: #880000; }


### PR DESCRIPTION
Changing this line seems to fix #577 on firefox and not significantly disrupt it on chromium; other browsers should perhaps be tested, since the results of `vertical-align` seems to vary by browser.