### PR TITLE
Update framework defaults

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -17,3 +17,6 @@ Rails.application.config.action_controller.forgery_protection_origin_check = fal
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
 ActiveSupport.to_time_preserves_timezone = false
+
+# Require `belongs_to` associations by default. Previous versions had false.
+Rails.application.config.active_record.belongs_to_required_by_default = true

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -9,10 +9,10 @@
 Rails.application.config.action_controller.raise_on_unfiltered_parameters = true
 
 # Enable per-form CSRF tokens. Previous versions had false.
-Rails.application.config.action_controller.per_form_csrf_tokens = false
+Rails.application.config.action_controller.per_form_csrf_tokens = true
 
 # Enable origin-checking CSRF mitigation. Previous versions had false.
-Rails.application.config.action_controller.forgery_protection_origin_check = false
+Rails.application.config.action_controller.forgery_protection_origin_check = true
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -16,7 +16,7 @@ Rails.application.config.action_controller.forgery_protection_origin_check = fal
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
-ActiveSupport.to_time_preserves_timezone = false
+ActiveSupport.to_time_preserves_timezone = true
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = true


### PR DESCRIPTION
Per the `new_framework_defaults.rb` file, explicitly alter the defaults so we're on the new behavior. This is in preparation for a Rails 5.1 upgrade.