### PR TITLE
Fix modly characters#edit for an untemplated character

### DIFF
--- a/app/views/characters/edit.haml
+++ b/app/views/characters/edit.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
   = link_to "Characters", characters_path
   &raquo;
-  - if @character.template.persisted?
+  - if @character.template.try(:persisted?)
     = link_to @character.template.name, template_path(@character.template)
     &raquo;
   = link_to @character.name, character_path(@character)

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -264,6 +264,34 @@ RSpec.describe CharactersController do
         expect(assigns(:templates).map(&:name)).to match_array(templates.map(&:name))
         expect(assigns(:aliases)).to match_array([calias])
       end
+
+      it "works for moderator with untemplated character" do
+        user = create(:mod_user)
+        login_as(user)
+        character = create(:character)
+        template = create(:template, user: character.user)
+
+        get :edit, params: { id: character.id }
+
+        expect(assigns(:page_title)).to eq("Edit Character: #{character.name}")
+        expect(controller.gon.character_id).to eq(character.id)
+        expect(controller.gon.user_id).to eq(character.user.id)
+        expect(assigns(:templates)).to match_array([template])
+      end
+
+      it "works for moderator with templated character" do
+        user = create(:mod_user)
+        login_as(user)
+        character = create(:template_character)
+        template = create(:template, user: character.user)
+
+        get :edit, params: { id: character.id }
+
+        expect(assigns(:page_title)).to eq("Edit Character: #{character.name}")
+        expect(controller.gon.character_id).to eq(character.id)
+        expect(controller.gon.user_id).to eq(character.user.id)
+        expect(assigns(:templates)).to match_array([character.template, template])
+      end
     end
   end
 


### PR DESCRIPTION
Previously, the view failed to render with an untemplated character if a
moderator tried editing it, since the template didn't exist.