### PR TITLE
Fix Dreamwidth scraping if a broken-depth comment is encountered

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -329,7 +329,9 @@ class PostsController < WritableController
 
   def missing_usernames(url)
     require "#{Rails.root}/lib/post_scraper"
-    doc = Nokogiri::HTML(HTTParty.get(url).body)
+    data = HTTParty.get(url).body
+    logger.debug "Downloaded #{url} for scraping"
+    doc = Nokogiri::HTML(data)
     usernames = doc.css('.poster span.ljuser b').map(&:text).uniq
     usernames -= PostScraper::BASE_ACCOUNTS.keys
     poster_names = doc.css('.entry-poster span.ljuser b')

--- a/app/jobs/scrape_post_job.rb
+++ b/app/jobs/scrape_post_job.rb
@@ -4,14 +4,16 @@ class ScrapePostJob < ApplicationJob
   queue_as :low
 
   def perform(url, board_id, section_id, status, threaded, importer_id)
+    Resque.logger.debug "Starting scrape for #{url}"
     scraper = PostScraper.new(url, board_id, section_id, status, threaded)
     scraped_post = scraper.scrape!
     Message.send_site_message(importer_id, 'Post import succeeded', "Your post was successfully imported! #{self.class.view_post(scraped_post.id)}")
   end
 
   def self.notify_exception(exception, url, board_id, section_id, status, threaded, importer_id)
+    Resque.logger.warn "Failed to import #{url}: #{exception.message}"
     if User.find_by_id(importer_id)
-      message = "The url #{url} could not be successfully scraped. "
+      message = "The url <a href='#{url}'>#{url}</a> could not be successfully scraped. "
       message += exception.message if exception.is_a?(UnrecognizedUsernameError)
       message += "Your post was already imported! #{view_post(exception.post_id)}" if exception.is_a?(AlreadyImportedError)
       Message.send_site_message(importer_id, 'Post import failed', message)

--- a/spec/lib/post_scraper_spec.rb
+++ b/spec/lib/post_scraper_spec.rb
@@ -97,6 +97,18 @@ RSpec.describe PostScraper do
     ])
   end
 
+  it "should detect all threaded pages even if there's a broken-depth comment at the 25-per-page boundary" do
+    url = 'https://alicornutopia.dreamwidth.org/22671.html?thread=14691983#cmt14691983'
+    stub_fixture(url, 'scrape_threaded_broken_boundary_depth')
+    scraper = PostScraper.new(url, nil, nil, nil, true)
+    scraper.instance_variable_set('@html_doc', scraper.send(:doc_from_url, url))
+    expect(scraper.send(:page_links)).to eq([
+      'https://alicornutopia.dreamwidth.org/22671.html?thread=14698383&style=site#cmt14698383',
+      'https://alicornutopia.dreamwidth.org/22671.html?thread=14698639&style=site#cmt14698639',
+      'https://alicornutopia.dreamwidth.org/22671.html?thread=14705551&style=site#cmt14705551'
+    ])
+  end
+
   it "should raise an error when an unexpected character is found" do
     url = 'http://wild-pegasus-appeared.dreamwidth.org/403.html?style=site&view=flat'
     stub_fixture(url, 'scrape_no_replies')

--- a/spec/support/fixtures/scrape_threaded_broken_boundary_depth.html
+++ b/spec/support/fixtures/scrape_threaded_broken_boundary_depth.html
@@ -1,0 +1,1578 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+    <title>alicornutopia | i wasn't looking for this</title>
+
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+
+            <script type="text/javascript">
+                var Site;
+                if (!Site)
+                    Site = {};
+
+                var site_p = {"ctx_popup_userhead": 1,
+"iconprefix": "https://v.dreamwidth.org",
+"imgprefix": "https://www.dreamwidth.org/img",
+"statprefix": "https://www.dreamwidth.org/stc",
+"ctx_popup_icons": 1,
+"has_remote": 0,
+"siteroot": "https://www.dreamwidth.org",
+"user_domain": "dreamwidth.org",
+"inbox_update_poll": 1,
+"currentJournal": "alicornutopia",
+"media_embed_enabled": 1,
+"ctx_popup": 1,
+"esn_async": 1,
+"currentJournalBase": "https://alicornutopia.dreamwidth.org"};
+                var site_k = ["ctx_popup_userhead", "iconprefix", "imgprefix", "statprefix", "ctx_popup_icons", "has_remote", "siteroot", "user_domain", "inbox_update_poll", "currentJournal", "media_embed_enabled", "ctx_popup", "esn_async", "currentJournalBase"];
+                for (var i = 0; site_k.length > i; i++) {
+                    Site[site_k[i]] = site_p[site_k[i]];
+                }
+           </script>
+        <link rel="stylesheet" type="text/css" href="https://www.dreamwidth.org/stc/??lj_base.css,esn.css,jquery/jquery.ui.core.css,jquery/jquery.ui.tooltip.css,jquery.contextualhover.css,lj_base-app.css,base-colors-light.css,reset.css,tropo/tropo-base.css,tropo/tropo-red.css?v=1493607634">
+<link rel="stylesheet" type="text/css" href="https://www.dreamwidth.org/stc/??jquery/jquery.ui.button.css,jquery/jquery.ui.dialog.css,jquery.commentmanage.css,jquery/jquery.ui.theme.smoothness.css,entrypage.css,siteviews/tropo-red.css?v=1426479404">
+<script type="text/javascript" src="https://www.dreamwidth.org/js/??jquery/jquery-1.8.3.js,dw/dw-core.js,jquery/jquery.ui.core.js,jquery/jquery.ui.widget.js,jquery/jquery.ui.tooltip.js,jquery.ajaxtip.js,jquery/jquery.ui.position.js,jquery.hoverIntent.js,jquery.contextualhover.js,nav-jquery.js?v=1493607634"></script>
+<script type="text/javascript" src="https://www.dreamwidth.org/js/??jquery.quickreply.js,jquery.threadexpander.js,jquery/jquery.ui.button.js,jquery/jquery.ui.dialog.js,jquery.commentmanage.js,jquery.esn.js,jquery.poll.js,journals/jquery.tag-nav.js,jquery.mediaplaceholder.js,md5.js,login-jquery.js?v=1460259022"></script>
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<link rel="meta" type="application/rdf+xml" title="FOAF" href="https://alicornutopia.dreamwidth.org/data/foaf">
+<link rel="help" href="https://www.dreamwidth.org/support/faq">
+<link rel="apple-touch-icon" href="//www.dreamwidth.org/apple-touch-icon.png">
+<meta property="og:image:width" content="363">
+<meta property="og:image:height" content="363">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<link rel="prev" href="https://www.dreamwidth.org/go?dir=prev&amp;itemid=22671&amp;journal=alicornutopia">
+<link rel="next" href="https://www.dreamwidth.org/go?dir=next&amp;itemid=22671&amp;journal=alicornutopia">
+<link rel="canonical" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14691983#cmt14691983">
+<style></style>
+
+    <!--[if lte IE 8]>
+    <script src="https://www.dreamwidth.org/js/html5.js" type="text/javascript"></script>
+    <![endif]-->
+</head>
+    <body>
+        <div id="canvas">
+            <div id="page">
+<div id="skip">
+     <a href="#content" tabindex="1">Skip to Main Content</a>
+</div>
+
+                <div id="masthead" role="banner">
+                    <span id="logo">
+                        <a href="https://www.dreamwidth.org/"><img alt="Dreamwidth Studios" src="https://www.dreamwidth.org/img/tropo-red/dw_logo.png"></a>
+                    </span>
+                </div>
+
+                <div id="content" role="main">
+                <h1></h1>
+                <div class="entry-wrapper entry-wrapper-odd security-public restrictions-none journal-type-C poster-from_scratch journal-alicornutopia has-userpic  has-subject" id="entry-wrapper-22671">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="entry" id="entry-22671">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865290/2258301" title="from_scratch: (Default)" alt="from_scratch: (Default)" height="100" width="100"></a></div>
+<div class="poster-info">
+<span class="poster entry-poster ">Campbell Mark Swan (<span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span>) wrote in <span lj:user="alicornutopia" style="white-space: nowrap;" class="ljuser"><a href="https://alicornutopia.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/community.png" alt="[community profile] " width="16" height="16" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://alicornutopia.dreamwidth.org/"><b>alicornutopia</b></a></span></span><span class="datetime"><span class="date"><a href="/2015/">2015</a>-<a href="/2015/10/">10</a>-<a href="/2015/10/28/">28</a></span> <span class="time">06:04 pm</span></span></div>
+</div>
+<div class="action-box">
+<div class="inner">
+<ul class="entry-management-links icon-links"><li class="link link_prev first-item"> <a href="https://www.dreamwidth.org/go?dir=prev&amp;itemid=22671&amp;journal=alicornutopia"><img border="0" width="16" height="16" alt="Previous Entry" title="Previous Entry" src="//www.dreamwidth.org/img/silk/entry/previous.png"></a></li>
+<li class="link mem_add"><a href="https://www.dreamwidth.org/tools/memadd?journal=alicornutopia&amp;itemid=22671"><img border="0" width="16" height="16" alt="Add Memory" title="Add Memory" src="//www.dreamwidth.org/img/silk/entry/memories_add.png"></a></li>
+<li class="link tell_friend"><a href="https://www.dreamwidth.org/tools/tellafriend?journal=alicornutopia&amp;itemid=22671"><img border="0" width="16" height="16" alt="Share This Entry" title="Share This Entry" src="//www.dreamwidth.org/img/silk/entry/tellafriend.png"></a></li>
+<li class="link link_next"> <a href="https://www.dreamwidth.org/go?dir=next&amp;itemid=22671&amp;journal=alicornutopia"><img border="0" width="16" height="16" alt="Next Entry" title="Next Entry" src="//www.dreamwidth.org/img/silk/entry/next.png"></a></li>
+</ul></div>
+</div>
+</div>
+<div class="currents">
+<div class="tag"><span class="tag-text" data-journal="alicornutopia" data-ditemid="22671">Entry tags:</span><ul>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/form:+sandbox">form: sandbox</a>,</li>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/form:+tree">form: tree</a>,</li>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/person:+erinflight">person: erinflight</a>,</li>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/person:+maggie">person: maggie</a>,</li>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/person:+rockeye">person: rockeye</a>,</li>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/pup:+incandescence">pup: incandescence</a></li>
+</ul></div></div>
+<div>
+<div class="contents usercontent">
+<div class="inner">
+<h3 class="entry-title"><a title="i wasn't looking for this" href="https://alicornutopia.dreamwidth.org/22671.html">i wasn't looking for this</a></h3><div class="entry-content"><em>This is a successor to <a href="http://alicornutopia.dreamwidth.org/6744.html?style=site&amp;view=top-only#comments">call me maybe</a> and <a href="http://alicornutopia.dreamwidth.org/11460.html?style=site&amp;view=top-only#comments">trade my soul for a wish</a>, which were getting crowded.<br><br><a href="http://alicornutopia.dreamwidth.org/22671.html?thread=11261839#cmt11261839">with Emily</a> (Maggie)<br><br><a href="http://alicornutopia.dreamwidth.org/22671.html?thread=12068239#cmt12068239">with Alex</a> (ErinFlight)<br><br><a href="http://alicornutopia.dreamwidth.org/22671.html?thread=12307599#cmt12307599">with Destin</a> (Rockeye)<br><br><a href="http://alicornutopia.dreamwidth.org/22671.html?thread=14264719#cmt14264719">with Nick</a> (Rockeye)</em></div></div>
+</div>
+</div>
+<div class="footer">
+<div class="inner">
+<hr class="above-entry-interaction-links">
+    <div class="comment-pages-wrapper"></div><ul class="entry-interaction-links text-links"><li class="entry-readlink first-item"><a href="https://alicornutopia.dreamwidth.org/22671.html#comments" data-sing="1 comment" data-dual="2 comments" data-plur="3 comments">75 comments</a></li>
+<li class="entry-replylink"><a onclick="return function(that) {return quickreply(&quot;topcomment&quot;, 0, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?mode=reply">Post a new comment</a></li>
+</ul></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+<div id="comments"><div class="inner"><div class="comment-pages toppages"><span class="view-flat"><a href="https://alicornutopia.dreamwidth.org/22671.html?view=flat#comments">Flat</a></span> | <span class="view-top-only"><a href="https://alicornutopia.dreamwidth.org/22671.html?view=top-only#comments">Top-Level Comments Only</a></span></div><div id="ljqrttopcomment" data-quickreply-container="topcomment" style="display: none;"></div><div class="comment-thread comment-depth-odd comment-depth-1">
+<div id="cmt14691983" class="dwexpcomment" style="margin-left: 0px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14691983">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 08:31 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14691983#cmt14691983">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content"> "Perhaps you do. Would you like to come in?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14691983#cmt14691983">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14691983&quot;, 57390, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14691983">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14691983">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14675343#cmt14675343">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14691983#cmt14691983">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14691983_hide"><a href="#cmt14691983" onclick="Expander.hideComments(this, '14691983'); return false;">Hide 1585 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14691983_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14691983#cmt14691983" onclick="Expander.unhideComments(this, '14691983'); return false;">Show 1585 comments</a></li>
+</ul><div id="ljqrt14691983" data-quickreply-container="14691983" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-2">
+<div id="cmt14692239" class="dwexpcomment" style="margin-left: 25px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14692239">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7950829/2258301" title="from_scratch: h ~ put on wings" alt="from_scratch: (h ~ put on wings)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 08:31 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692239#cmt14692239">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Sure."  In Cam goes.</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692239#cmt14692239">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14692239&quot;, 57391, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14692239">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14692239">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14691983#cmt14691983">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692239#cmt14692239">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14692239_hide"><a href="#cmt14692239" onclick="Expander.hideComments(this, '14692239'); return false;">Hide 1584 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14692239_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692239#cmt14692239" onclick="Expander.unhideComments(this, '14692239'); return false;">Show 1584 comments</a></li>
+</ul><div id="ljqrt14692239" data-quickreply-container="14692239" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-3">
+<div id="cmt14692495" class="dwexpcomment" style="margin-left: 50px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14692495">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 08:36 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692495#cmt14692495">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">Collins leads them to the door of his living room.<br>"Wait here for a moment."<br>He takes down several large tapestries hanging from the walls and begins rolling up the rug. </div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692495#cmt14692495">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14692495&quot;, 57392, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14692495">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14692495">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692239#cmt14692239">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692495#cmt14692495">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14692495_hide"><a href="#cmt14692495" onclick="Expander.hideComments(this, '14692495'); return false;">Hide 1583 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14692495_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692495#cmt14692495" onclick="Expander.unhideComments(this, '14692495'); return false;">Show 1583 comments</a></li>
+</ul><div id="ljqrt14692495" data-quickreply-container="14692495" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-4">
+<div id="cmt14692751" class="dwexpcomment" style="margin-left: 75px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14692751">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865289/2258301" title="from_scratch: f ~ real sun" alt="from_scratch: (f ~ real sun)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 08:36 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692751#cmt14692751">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Why the redecoration?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692751#cmt14692751">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14692751&quot;, 57393, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14692751">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14692751">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692495#cmt14692495">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692751#cmt14692751">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14692751_hide"><a href="#cmt14692751" onclick="Expander.hideComments(this, '14692751'); return false;">Hide 1582 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14692751_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692751#cmt14692751" onclick="Expander.unhideComments(this, '14692751'); return false;">Show 1582 comments</a></li>
+</ul><div id="ljqrt14692751" data-quickreply-container="14692751" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-5">
+<div id="cmt14693007" class="dwexpcomment" style="margin-left: 100px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14693007">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 08:43 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693007#cmt14693007">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"I'm removing the silver. These were woven with thin silver threads. I don't usually have guests."<br>Collins finishes rolling up the rug and awkwardly begins carrying it into the hall. </div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693007#cmt14693007">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14693007&quot;, 57394, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14693007">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14693007">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14692751#cmt14692751">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693007#cmt14693007">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14693007_hide"><a href="#cmt14693007" onclick="Expander.hideComments(this, '14693007'); return false;">Hide 1581 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14693007_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693007#cmt14693007" onclick="Expander.unhideComments(this, '14693007'); return false;">Show 1581 comments</a></li>
+</ul><div id="ljqrt14693007" data-quickreply-container="14693007" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-6">
+<div id="cmt14693263" class="dwexpcomment" style="margin-left: 125px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14693263">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865291/2258301" title="from_scratch: g ~ pinhole" alt="from_scratch: (g ~ pinhole)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 08:44 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693263#cmt14693263">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"We could meet somewhere else if that would be more convenient."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693263#cmt14693263">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14693263&quot;, 57395, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14693263">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14693263">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693007#cmt14693007">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693263#cmt14693263">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14693263_hide"><a href="#cmt14693263" onclick="Expander.hideComments(this, '14693263'); return false;">Hide 1580 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14693263_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693263#cmt14693263" onclick="Expander.unhideComments(this, '14693263'); return false;">Show 1580 comments</a></li>
+</ul><div id="ljqrt14693263" data-quickreply-container="14693263" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-7">
+<div id="cmt14693519" class="dwexpcomment" style="margin-left: 150px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14693519">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 08:45 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693519#cmt14693519">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"You're here. It's fine. I don't think you're going to try to kill me. Actually, I was meaning to ask you for help with my defense."<br><br></div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693519#cmt14693519">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14693519&quot;, 57396, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14693519">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14693519">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693263#cmt14693263">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693519#cmt14693519">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14693519_hide"><a href="#cmt14693519" onclick="Expander.hideComments(this, '14693519'); return false;">Hide 1579 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14693519_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693519#cmt14693519" onclick="Expander.unhideComments(this, '14693519'); return false;">Show 1579 comments</a></li>
+</ul><div id="ljqrt14693519" data-quickreply-container="14693519" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-8">
+<div id="cmt14693775" class="dwexpcomment" style="margin-left: 175px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14693775">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865289/2258301" title="from_scratch: f ~ real sun" alt="from_scratch: (f ~ real sun)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 08:53 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693775#cmt14693775">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Well, I'd want the friendly demons out of the way first."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693775#cmt14693775">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14693775&quot;, 57397, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14693775">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14693775">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693519#cmt14693519">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693775#cmt14693775">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14693775_hide"><a href="#cmt14693775" onclick="Expander.hideComments(this, '14693775'); return false;">Hide 1578 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14693775_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693775#cmt14693775" onclick="Expander.unhideComments(this, '14693775'); return false;">Show 1578 comments</a></li>
+</ul><div id="ljqrt14693775" data-quickreply-container="14693775" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-9">
+<div id="cmt14694031" class="dwexpcomment" style="margin-left: 200px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14694031">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 08:59 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694031#cmt14694031">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"It's not particularly urgent. The word hasn't spread yet and I won't be most of my enemies' first target."<br>Cam looks around the room and then at Glen. <br>"I think that's all the silver?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694031#cmt14694031">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14694031&quot;, 57398, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14694031">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14694031">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14693775#cmt14693775">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694031#cmt14694031">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14694031_hide"><a href="#cmt14694031" onclick="Expander.hideComments(this, '14694031'); return false;">Hide 1577 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14694031_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694031#cmt14694031" onclick="Expander.unhideComments(this, '14694031'); return false;">Show 1577 comments</a></li>
+</ul><div id="ljqrt14694031" data-quickreply-container="14694031" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-10">
+<div id="cmt14694287" class="dwexpcomment" style="margin-left: 225px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-intricate_engineer  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14694287">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://intricate-engineer.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9145812/2408323" title="intricate_engineer: Glen looking" alt="intricate_engineer: (Glen looking)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 08:59 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694287#cmt14694287">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Yea. Everything in the room anyways."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694287#cmt14694287">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14694287&quot;, 57399, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14694287">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14694287">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694031#cmt14694031">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694287#cmt14694287">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14694287_hide"><a href="#cmt14694287" onclick="Expander.hideComments(this, '14694287'); return false;">Hide 1576 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14694287_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694287#cmt14694287" onclick="Expander.unhideComments(this, '14694287'); return false;">Show 1576 comments</a></li>
+</ul><div id="ljqrt14694287" data-quickreply-container="14694287" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-11">
+<div id="cmt14694543" class="dwexpcomment" style="margin-left: 250px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14694543">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865285/2258301" title="from_scratch: e ~ making" alt="from_scratch: (e ~ making)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:02 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694543#cmt14694543">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Good, then we can all have this conversation comfortably."  Cam sits.</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694543#cmt14694543">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14694543&quot;, 57400, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14694543">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14694543">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694287#cmt14694287">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694543#cmt14694543">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14694543_hide"><a href="#cmt14694543" onclick="Expander.hideComments(this, '14694543'); return false;">Hide 1575 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14694543_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694543#cmt14694543" onclick="Expander.unhideComments(this, '14694543'); return false;">Show 1575 comments</a></li>
+</ul><div id="ljqrt14694543" data-quickreply-container="14694543" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-12">
+<div id="cmt14694799" class="dwexpcomment" style="margin-left: 275px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-intricate_engineer  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14694799">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://intricate-engineer.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9236250/2408323" title="intricate_engineer: Glen open" alt="intricate_engineer: (Glen open)" height="74" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:03 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694799#cmt14694799">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">Glen sits down next him. </div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694799#cmt14694799">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14694799&quot;, 57401, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14694799">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14694799">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694543#cmt14694543">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694799#cmt14694799">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14694799_hide"><a href="#cmt14694799" onclick="Expander.hideComments(this, '14694799'); return false;">Hide 1574 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14694799_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694799#cmt14694799" onclick="Expander.unhideComments(this, '14694799'); return false;">Show 1574 comments</a></li>
+</ul><div id="ljqrt14694799" data-quickreply-container="14694799" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-13">
+<div id="cmt14695055" class="dwexpcomment" style="margin-left: 300px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14695055">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9919487/2474063" title="magicians_of_london: Uraziel" alt="magicians_of_london: (Uraziel)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:03 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695055#cmt14695055">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">Uraziel remains continues to stand in the doorway, watching.</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695055#cmt14695055">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14695055&quot;, 57402, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14695055">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14695055">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14694799#cmt14694799">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695055#cmt14695055">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14695055_hide"><a href="#cmt14695055" onclick="Expander.hideComments(this, '14695055'); return false;">Hide 1573 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14695055_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695055#cmt14695055" onclick="Expander.unhideComments(this, '14695055'); return false;">Show 1573 comments</a></li>
+</ul><div id="ljqrt14695055" data-quickreply-container="14695055" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-14">
+<div id="cmt14695311" class="dwexpcomment" style="margin-left: 325px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14695311">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865282/2258301" title="from_scratch: c ~ list of books" alt="from_scratch: (c ~ list of books)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:04 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695311#cmt14695311">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">That's very creepy of you, Uraziel.<br><br>"So, what's the story?" Cam asks.<div class="edittime"><em>Edited <span class="datetime"><span class="comment-date-text"> </span> <span title="">2016-02-16 21:05 (UTC)</span></span></em></div></div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695311#cmt14695311">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14695311&quot;, 57403, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14695311">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14695311">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695055#cmt14695055">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695311#cmt14695311">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14695311_hide"><a href="#cmt14695311" onclick="Expander.hideComments(this, '14695311'); return false;">Hide 1572 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14695311_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695311#cmt14695311" onclick="Expander.unhideComments(this, '14695311'); return false;">Show 1572 comments</a></li>
+</ul><div id="ljqrt14695311" data-quickreply-container="14695311" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-15">
+<div id="cmt14695567" class="dwexpcomment" style="margin-left: 350px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14695567">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:12 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695567#cmt14695567">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Many magicians have as little regard for the common people as they do for demons. Magicians and commoners rarely mix. so the problem has not been forced out into the open. However, if a commoner does manage to anger a magician or even happens to accidentally stand in their way, there is no recourse. The magician can do anything, <i>anything</i>, and face no consequences."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695567#cmt14695567">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14695567&quot;, 57404, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14695567">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14695567">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695311#cmt14695311">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695567#cmt14695567">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14695567_hide"><a href="#cmt14695567" onclick="Expander.hideComments(this, '14695567'); return false;">Hide 1571 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14695567_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695567#cmt14695567" onclick="Expander.unhideComments(this, '14695567'); return false;">Show 1571 comments</a></li>
+</ul><div id="ljqrt14695567" data-quickreply-container="14695567" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-16">
+<div id="cmt14695823" class="dwexpcomment" style="margin-left: 375px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14695823">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865287/2258301" title="from_scratch: n ~ offended by that" alt="from_scratch: (n ~ offended by that)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:14 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695823#cmt14695823">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"No legal consequences, or if you literally just seized some commoner and tortured them to death their friends and family would be scared enough of you to keep their heads down about it?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695823#cmt14695823">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14695823&quot;, 57405, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14695823">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14695823">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695567#cmt14695567">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695823#cmt14695823">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14695823_hide"><a href="#cmt14695823" onclick="Expander.hideComments(this, '14695823'); return false;">Hide 1570 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14695823_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695823#cmt14695823" onclick="Expander.unhideComments(this, '14695823'); return false;">Show 1570 comments</a></li>
+</ul><div id="ljqrt14695823" data-quickreply-container="14695823" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-17">
+<div id="cmt14696079" class="dwexpcomment" style="margin-left: 400px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14696079">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:21 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696079#cmt14696079">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Last year two children were playing in a park and accidentally sent a ball through the windshield of a magician's car. He ordered a demon to attack the boy. The boy was badly burned and will be permanently disfigured. His friend was young enough to still believe in justice and tried to take this magician to court. She was fined, more than she could possibly afford, and the magician faced no consequences."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696079#cmt14696079">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14696079&quot;, 57406, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14696079">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14696079">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14695823#cmt14695823">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696079#cmt14696079">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14696079_hide"><a href="#cmt14696079" onclick="Expander.hideComments(this, '14696079'); return false;">Hide 1569 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14696079_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696079#cmt14696079" onclick="Expander.unhideComments(this, '14696079'); return false;">Show 1569 comments</a></li>
+</ul><div id="ljqrt14696079" data-quickreply-container="14696079" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-18">
+<div id="cmt14696335" class="dwexpcomment" style="margin-left: 425px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14696335">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865293/2258301" title="from_scratch: i ~ shirtless" alt="from_scratch: (i ~ shirtless)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:21 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696335#cmt14696335">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"And their parents?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696335#cmt14696335">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14696335&quot;, 57407, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14696335">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14696335">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696079#cmt14696079">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696335#cmt14696335">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14696335_hide"><a href="#cmt14696335" onclick="Expander.hideComments(this, '14696335'); return false;">Hide 1568 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14696335_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696335#cmt14696335" onclick="Expander.unhideComments(this, '14696335'); return false;">Show 1568 comments</a></li>
+</ul><div id="ljqrt14696335" data-quickreply-container="14696335" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-19">
+<div id="cmt14696591" class="dwexpcomment" style="margin-left: 450px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14696591">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:23 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696591#cmt14696591">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"They did not attend the hearing. I believe they were afraid."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696591#cmt14696591">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14696591&quot;, 57408, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14696591">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14696591">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696335#cmt14696335">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696591#cmt14696591">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14696591_hide"><a href="#cmt14696591" onclick="Expander.hideComments(this, '14696591'); return false;">Hide 1567 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14696591_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696591#cmt14696591" onclick="Expander.unhideComments(this, '14696591'); return false;">Show 1567 comments</a></li>
+</ul><div id="ljqrt14696591" data-quickreply-container="14696591" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-20">
+<div id="cmt14696847" class="dwexpcomment" style="margin-left: 475px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14696847">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865280/2258301" title="from_scratch: k ~ indestructible" alt="from_scratch: (k ~ indestructible)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:24 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696847#cmt14696847">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"And the reason that magicians are not just occasionally shot in the head by vengeful victims is...?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696847#cmt14696847">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14696847&quot;, 57409, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14696847">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14696847">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696591#cmt14696591">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696847#cmt14696847">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14696847_hide"><a href="#cmt14696847" onclick="Expander.hideComments(this, '14696847'); return false;">Hide 1566 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14696847_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696847#cmt14696847" onclick="Expander.unhideComments(this, '14696847'); return false;">Show 1566 comments</a></li>
+</ul><div id="ljqrt14696847" data-quickreply-container="14696847" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-21">
+<div id="cmt14697103" class="dwexpcomment" style="margin-left: 500px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14697103">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:33 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697103#cmt14697103">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Fear. Most commoners do not know about demons. They believe the magic is the magician's own. They have no reason to believe a gun would be more effective if the magician was taken by surprise. Our government was not always this way. The magicians usurped the previous government in 1860. Several rebellions occurred, but they were brutally crushed. For most commoners now, rebellion isn't worth it. An unlucky few have their lives ruined, but most will never speak directly to a magician."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697103#cmt14697103">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14697103&quot;, 57410, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14697103">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14697103">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14696847#cmt14696847">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697103#cmt14697103">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14697103_hide"><a href="#cmt14697103" onclick="Expander.hideComments(this, '14697103'); return false;">Hide 1565 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14697103_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697103#cmt14697103" onclick="Expander.unhideComments(this, '14697103'); return false;">Show 1565 comments</a></li>
+</ul><div id="ljqrt14697103" data-quickreply-container="14697103" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-22">
+<div id="cmt14697359" class="dwexpcomment" style="margin-left: 525px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14697359">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865291/2258301" title="from_scratch: g ~ pinhole" alt="from_scratch: (g ~ pinhole)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:33 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697359#cmt14697359">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Okay.  So, phasing out the use of demons will fix the problem indirectly, but I'm guessing you have another solution in mind."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697359#cmt14697359">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14697359&quot;, 57411, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14697359">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14697359">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697103#cmt14697103">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697359#cmt14697359">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14697359_hide"><a href="#cmt14697359" onclick="Expander.hideComments(this, '14697359'); return false;">Hide 1564 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14697359_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697359#cmt14697359" onclick="Expander.unhideComments(this, '14697359'); return false;">Show 1564 comments</a></li>
+</ul><div id="ljqrt14697359" data-quickreply-container="14697359" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-23">
+<div id="cmt14697615" class="dwexpcomment" style="margin-left: 550px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14697615">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:38 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697615#cmt14697615">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"If you phase out the demons, the magicians will still remain in power. They control the government. They have the wealth. They'll grow more careful, as they don't want to ignite a rebellion, but nothing will really change. If you plan to pay them off as an incentive to release the demons, that will only worsen the problem. They'll have control over all of the new knowledge and technology and they aren't going to share."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697615#cmt14697615">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14697615&quot;, 57412, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14697615">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14697615">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697359#cmt14697359">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697615#cmt14697615">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14697615_hide"><a href="#cmt14697615" onclick="Expander.hideComments(this, '14697615'); return false;">Hide 1563 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14697615_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697615#cmt14697615" onclick="Expander.unhideComments(this, '14697615'); return false;">Show 1563 comments</a></li>
+</ul><div id="ljqrt14697615" data-quickreply-container="14697615" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-24">
+<div id="cmt14697871" class="dwexpcomment" style="margin-left: 575px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14697871">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865289/2258301" title="from_scratch: f ~ real sun" alt="from_scratch: (f ~ real sun)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:40 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697871#cmt14697871">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"The magicians will no longer have <em>magic</em>.  I was imagining someone might notice.  I suppose the state of ignorance about what magic actually is might be bad enough that no one would.  What was the <em>formal</em> reason to fine the girl for bringing her case to court?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697871#cmt14697871">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14697871&quot;, 57413, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14697871">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14697871">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697615#cmt14697615">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697871#cmt14697871">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14697871_hide"><a href="#cmt14697871" onclick="Expander.hideComments(this, '14697871'); return false;">Hide 1562 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14697871_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697871#cmt14697871" onclick="Expander.unhideComments(this, '14697871'); return false;">Show 1562 comments</a></li>
+</ul><div id="ljqrt14697871" data-quickreply-container="14697871" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-25">
+<div id="cmt14698127" class="dwexpcomment" style="margin-left: 600px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14698127">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 09:48 pm (UTC)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127#cmt14698127">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"I believe it was defamation. Yes, people will notice, but they won't be sure. Magicians rarely use flashy magic. It will take time before everyone truly believes their power is gone. But even if you made a public announcement, I'm not sure anything would change. Most people's lives aren't terrible, and this might make them optimistic enough to wait for the status quo to change. It might be possible to start a rebellion, but guess who has all the guns? More death isn't the solution to this."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127#cmt14698127">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14698127&quot;, 57414, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14698127">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14698127">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697871#cmt14697871">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127#cmt14698127">Thread</a></li>
+<li class="link expand"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127#cmt14698127" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14698127#cmt14698127','14698127'); return false;">Expand</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="display:none;" id="cmt14698127_hide"><a href="#cmt14698127" onclick="Expander.hideComments(this, '14698127'); return false;">Hide 1561 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14698127_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127#cmt14698127" onclick="Expander.unhideComments(this, '14698127'); return false;">Show 1561 comments</a></li>
+</ul><div id="ljqrt14698127" data-quickreply-container="14698127" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-26">
+<div id="cmt14698383" class="dwexpcomment" style="margin-left: 625px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14698383">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698383#cmt14698383">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 21:48 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698383#cmt14698383" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14698383#cmt14698383','14698383'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-26">
+<div id="cmt14698639" class="dwexpcomment" style="margin-left: 625px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14698639">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698639#cmt14698639">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 21:58 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698639#cmt14698639" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14698639#cmt14698639','14698639'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-27">
+<div id="cmt14698895" class="dwexpcomment" style="margin-left: 650px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14698895">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698895#cmt14698895">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 21:59 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698895#cmt14698895" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14698895#cmt14698895','14698895'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-28">
+<div id="cmt14699151" class="dwexpcomment" style="margin-left: 675px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14699151">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699151#cmt14699151">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 22:01 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699151#cmt14699151" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14699151#cmt14699151','14699151'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-29">
+<div id="cmt14699407" class="dwexpcomment" style="margin-left: 700px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14699407">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699407#cmt14699407">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 22:04 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699407#cmt14699407" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14699407#cmt14699407','14699407'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-30">
+<div id="cmt14700175" class="dwexpcomment" style="margin-left: 725px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14700175">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700175#cmt14700175">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:32 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700175#cmt14700175" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14700175#cmt14700175','14700175'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-31">
+<div id="cmt14700431" class="dwexpcomment" style="margin-left: 750px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14700431">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700431#cmt14700431">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:33 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700431#cmt14700431" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14700431#cmt14700431','14700431'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-32">
+<div id="cmt14700687" class="dwexpcomment" style="margin-left: 775px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14700687">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700687#cmt14700687">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:37 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700687#cmt14700687" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14700687#cmt14700687','14700687'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-33">
+<div id="cmt14700943" class="dwexpcomment" style="margin-left: 800px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14700943">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700943#cmt14700943">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:40 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700943#cmt14700943" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14700943#cmt14700943','14700943'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-34">
+<div id="cmt14701199" class="dwexpcomment" style="margin-left: 825px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14701199">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701199#cmt14701199">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:44 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701199#cmt14701199" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14701199#cmt14701199','14701199'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-35">
+<div id="cmt14701455" class="dwexpcomment" style="margin-left: 850px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14701455">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701455#cmt14701455">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:45 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701455#cmt14701455" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14701455#cmt14701455','14701455'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-36">
+<div id="cmt14701711" class="dwexpcomment" style="margin-left: 875px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14701711">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701711#cmt14701711">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:52 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701711#cmt14701711" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14701711#cmt14701711','14701711'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-37">
+<div id="cmt14701967" class="dwexpcomment" style="margin-left: 900px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14701967">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701967#cmt14701967">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:53 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701967#cmt14701967" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14701967#cmt14701967','14701967'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-38">
+<div id="cmt14702223" class="dwexpcomment" style="margin-left: 925px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14702223">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702223#cmt14702223">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:07 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702223#cmt14702223" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14702223#cmt14702223','14702223'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-39">
+<div id="cmt14702479" class="dwexpcomment" style="margin-left: 950px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14702479">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702479#cmt14702479">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:09 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702479#cmt14702479" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14702479#cmt14702479','14702479'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-40">
+<div id="cmt14702735" class="dwexpcomment" style="margin-left: 975px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14702735">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702735#cmt14702735">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:11 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702735#cmt14702735" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14702735#cmt14702735','14702735'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-41">
+<div id="cmt14702991" class="dwexpcomment" style="margin-left: 1000px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14702991">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702991#cmt14702991">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:11 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702991#cmt14702991" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14702991#cmt14702991','14702991'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-42">
+<div id="cmt14703247" class="dwexpcomment" style="margin-left: 1025px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14703247">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703247#cmt14703247">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:16 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703247#cmt14703247" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14703247#cmt14703247','14703247'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-43">
+<div id="cmt14703503" class="dwexpcomment" style="margin-left: 1050px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14703503">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703503#cmt14703503">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:18 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703503#cmt14703503" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14703503#cmt14703503','14703503'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-44">
+<div id="cmt14703759" class="dwexpcomment" style="margin-left: 1075px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14703759">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703759#cmt14703759">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:23 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703759#cmt14703759" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14703759#cmt14703759','14703759'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-45">
+<div id="cmt14704015" class="dwexpcomment" style="margin-left: 1100px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14704015">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704015#cmt14704015">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:23 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704015#cmt14704015" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14704015#cmt14704015','14704015'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-46">
+<div id="cmt14704271" class="dwexpcomment" style="margin-left: 1125px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14704271">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704271#cmt14704271">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:28 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704271#cmt14704271" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14704271#cmt14704271','14704271'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-47">
+<div id="cmt14704527" class="dwexpcomment" style="margin-left: 1150px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14704527">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704527#cmt14704527">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:32 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704527#cmt14704527" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14704527#cmt14704527','14704527'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-48">
+<div id="cmt14704783" class="dwexpcomment" style="margin-left: 1175px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14704783">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704783#cmt14704783">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:33 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704783#cmt14704783" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14704783#cmt14704783','14704783'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-49">
+<div id="cmt14705039" class="dwexpcomment" style="margin-left: 1200px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14705039">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705039#cmt14705039">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:34 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705039#cmt14705039" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14705039#cmt14705039','14705039'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-50">
+<div id="cmt14705295" class="dwexpcomment" style="margin-left: 1225px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14705295">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705295#cmt14705295">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:35 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705295#cmt14705295" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14705295#cmt14705295','14705295'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-51">
+<div id="cmt14705551" class="dwexpcomment" style="margin-left: 1250px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14705551">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705551#cmt14705551">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:37 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705551#cmt14705551" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14705551#cmt14705551','14705551'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-52">
+<div id="cmt14705807" class="dwexpcomment" style="margin-left: 1275px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14705807">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705807#cmt14705807">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:38 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705807#cmt14705807" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14705807#cmt14705807','14705807'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-53">
+<div id="cmt14706063" class="dwexpcomment" style="margin-left: 1300px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14706063">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706063#cmt14706063">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:40 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706063#cmt14706063" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14706063#cmt14706063','14706063'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-54">
+<div id="cmt14706319" class="dwexpcomment" style="margin-left: 1325px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14706319">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706319#cmt14706319">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:42 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706319#cmt14706319" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14706319#cmt14706319','14706319'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-55">
+<div id="cmt14706575" class="dwexpcomment" style="margin-left: 1350px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14706575">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706575#cmt14706575">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:43 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706575#cmt14706575" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14706575#cmt14706575','14706575'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-56">
+<div id="cmt14706831" class="dwexpcomment" style="margin-left: 1375px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14706831">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706831#cmt14706831">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:45 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706831#cmt14706831" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14706831#cmt14706831','14706831'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-57">
+<div id="cmt14707087" class="dwexpcomment" style="margin-left: 1400px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14707087">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707087#cmt14707087">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:47 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707087#cmt14707087" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14707087#cmt14707087','14707087'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-58">
+<div id="cmt14707599" class="dwexpcomment" style="margin-left: 1425px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14707599">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707599#cmt14707599">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:54 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707599#cmt14707599" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14707599#cmt14707599','14707599'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-59">
+<div id="cmt14707855" class="dwexpcomment" style="margin-left: 1450px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14707855">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707855#cmt14707855">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:55 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707855#cmt14707855" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14707855#cmt14707855','14707855'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-60">
+<div id="cmt14708111" class="dwexpcomment" style="margin-left: 1475px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14708111">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708111#cmt14708111">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:59 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708111#cmt14708111" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14708111#cmt14708111','14708111'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-61">
+<div id="cmt14708367" class="dwexpcomment" style="margin-left: 1500px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14708367">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708367#cmt14708367">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 01:01 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708367#cmt14708367" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14708367#cmt14708367','14708367'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-62">
+<div id="cmt14708623" class="dwexpcomment" style="margin-left: 1525px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14708623">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708623#cmt14708623">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 01:02 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708623#cmt14708623" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14708623#cmt14708623','14708623'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-63">
+<div id="cmt14708879" class="dwexpcomment" style="margin-left: 1550px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14708879">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708879#cmt14708879">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 01:03 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708879#cmt14708879" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14708879#cmt14708879','14708879'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-64">
+<div id="cmt14709135" class="dwexpcomment" style="margin-left: 1575px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14709135">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709135#cmt14709135">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 01:03 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709135#cmt14709135" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14709135#cmt14709135','14709135'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-65">
+<div id="cmt14709391" class="dwexpcomment" style="margin-left: 1600px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14709391">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709391#cmt14709391">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:07 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709391#cmt14709391" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14709391#cmt14709391','14709391'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-66">
+<div id="cmt14709647" class="dwexpcomment" style="margin-left: 1625px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14709647">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709647#cmt14709647">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:10 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709647#cmt14709647" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14709647#cmt14709647','14709647'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-67">
+<div id="cmt14709903" class="dwexpcomment" style="margin-left: 1650px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14709903">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709903#cmt14709903">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:13 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709903#cmt14709903" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14709903#cmt14709903','14709903'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-68">
+<div id="cmt14710159" class="dwexpcomment" style="margin-left: 1675px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14710159">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710159#cmt14710159">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:14 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710159#cmt14710159" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14710159#cmt14710159','14710159'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-69">
+<div id="cmt14710415" class="dwexpcomment" style="margin-left: 1700px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14710415">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710415#cmt14710415">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:15 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710415#cmt14710415" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14710415#cmt14710415','14710415'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-70">
+<div id="cmt14710671" class="dwexpcomment" style="margin-left: 1725px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14710671">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710671#cmt14710671">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:22 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710671#cmt14710671" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14710671#cmt14710671','14710671'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-71">
+<div id="cmt14710927" class="dwexpcomment" style="margin-left: 1750px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14710927">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710927#cmt14710927">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:23 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710927#cmt14710927" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14710927#cmt14710927','14710927'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-72">
+<div id="cmt14711183" class="dwexpcomment" style="margin-left: 1775px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14711183">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711183#cmt14711183">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:27 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711183#cmt14711183" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14711183#cmt14711183','14711183'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-73">
+<div id="cmt14711439" class="dwexpcomment" style="margin-left: 1800px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14711439">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711439#cmt14711439">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:29 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711439#cmt14711439" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14711439#cmt14711439','14711439'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-74">
+<div id="cmt14711695" class="dwexpcomment" style="margin-left: 1825px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14711695">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711695#cmt14711695">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:33 (UTC)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711695#cmt14711695" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14711695#cmt14711695','14711695'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="bottomcomment"><hr class="below-entry-interaction-links"><ul class="entry-interaction-links text-links"><li class="entry-readlink first-item"><a href="https://alicornutopia.dreamwidth.org/22671.html#comments" data-sing="1 comment" data-dual="2 comments" data-plur="3 comments">75 comments</a></li>
+<li class="entry-replylink"><a onclick="return function(that) {return quickreply(&quot;bottomcomment&quot;, 0, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?mode=reply">Post a new comment</a></li>
+</ul></div><div class="comment-pages bottompages"><span class="view-flat"><a href="https://alicornutopia.dreamwidth.org/22671.html?view=flat#comments">Flat</a></span> | <span class="view-top-only"><a href="https://alicornutopia.dreamwidth.org/22671.html?view=top-only#comments">Top-Level Comments Only</a></span></div><div id="ljqrtbottomcomment" data-quickreply-container="bottomcomment" style="display: none;"></div><div class="commment-pages-wrapper"></div></div></div>
+                </div>
+
+                <div id="account-links" role="navigation" aria-label="Account Links"><form action="https://www.dreamwidth.org/login?ret=1" method="post" class="lj_login_form"><input type="hidden" name="returnto" value=""><input type="hidden" name="chal" class="lj_login_chal" value="c0:1513990800:87:300:lduPfjXMMaB7XYqkgLT9:faafe95f18b717b118fdce5549fb116e">
+    <input type="hidden" name="response" class="lj_login_response" value="">
+    <table summary="" id="login-table"><tbody><tr><td><label for="login_user">Account name:</label></td><td class="input-cell" colspan="2"><input name="user" id="login_user" size="20" maxlength="27" tabindex="1" aria-required="true"> <a href="https://www.dreamwidth.org/openid/" tabindex="5">Log in with OpenID?</a></td></tr><tr><td><label for="login_password">Password:</label></td><td class="input-cell" colspan="2"><input type="password" name="password" id="login_password" size="20" tabindex="2" aria-required="true" class="lj_login_password"> <a href="https://www.dreamwidth.org/lostinfo" tabindex="6">Forget your password?</a></td></tr><tr><td>&nbsp;</td><td class="remember-me-cell"><input type="checkbox" name="remember_me" id="login_remember_me" value="1" tabindex="3"> <label for="login_remember_me">Remember me</label></td><td><input type="submit" name="login" value="Log in" tabindex="4"></td></tr></tbody></table></form></div>
+
+                <nav role="navigation" aria-label="Site Navigation">
+                    <ul class="left"><li id="create_topnav" class="topnav has-dropdown"><a href="https://www.dreamwidth.org/nav/create">Create</a>
+<ul id="create_subnav" class="subnav_container dropdown">
+                <li class="subnav"><a href="https://www.dreamwidth.org/create">Create Account</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/manage/settings/?cat=display">Display Preferences</a></li>
+</ul>
+</li><li id="explore_topnav" class="topnav has-dropdown"><a href="https://www.dreamwidth.org/nav/explore">Explore</a>
+<ul id="explore_subnav" class="subnav_container dropdown">
+                <li class="subnav"><a href="https://www.dreamwidth.org/interests">Interests</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/directorysearch">Directory Search</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/search">Site and Journal Search</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/latest">Latest Things</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/random">Random Journal</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/community/random">Random Community</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/support/faq">FAQ</a></li>
+</ul>
+</li><li id="shop_topnav" class="topnav has-dropdown"><a href="https://www.dreamwidth.org/nav/shop">Shop</a>
+<ul id="shop_subnav" class="subnav_container dropdown">
+                <li class="subnav"><a href="https://www.dreamwidth.org/shop">Buy Dreamwidth Services</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/shop/randomgift">Gift a Random User</a></li>
+                <li class="subnav"><a href="https://www.zazzle.com/dreamwidth*">DW Merchandise</a></li>
+</ul>
+</li>
+</ul>
+                    <div role="search">
+                    <div class="appwidget appwidget-search" id="LJWidget_48">
+<form action="https://www.dreamwidth.org/multisearch" method="post">
+<input type="text" size="20" class="text" title="Search" id="search" name="q"> <select name="type" class="select">
+<option value="int" selected="selected">Interest</option>
+<option value="region">Region</option>
+<option value="nav_and_user">Site and Account</option>
+<option value="faq">FAQ</option>
+<option value="email">Email</option>
+<option value="im">IM Info</option>
+</select> <input type="submit" value="Go"></form></div><!-- end .appwidget-search -->
+
+                    </div>
+                </nav>
+                <footer role="contentinfo">
+                    <ul>
+    <li><a href="https://www.dreamwidth.org/legal/privacy">Privacy Policy</a> • </li>
+    <li><a href="https://www.dreamwidth.org/legal/tos">Terms of Service</a> • </li>
+    <li><a href="https://www.dreamwidth.org/legal/diversity">Diversity Statement</a> • </li>
+    <li><a href="https://www.dreamwidth.org/legal/principles">Guiding Principles</a> • </li>
+    <li><a href="https://www.dreamwidth.org/site/">Site Map</a> • </li>
+    <li><a href="https://www.dreamwidth.org/site/suggest">Make a Suggestion</a> • </li>
+    <li><a href="https://www.dreamwidth.org/site/opensource">Open Source</a> • </li>
+    <li><a href="https://www.dreamwidth.org/support">Help/Support</a></li>
+</ul>
+<p>Copyright © 2009-2017 Dreamwidth Studios, LLC. <a href="//www.dreamwidth.org/site/opensource">Some</a> rights reserved.</p>
+                </footer>
+            </div>
+        </div>
+        <div id="statistics" style="text-align: left; font-size:0; line-height:0; height:0; overflow:hidden;"></div>
+     <div id="shim-alpha"> </div>
+
+</body></html>

--- a/spec/support/fixtures/scrape_threaded_broken_depth.html
+++ b/spec/support/fixtures/scrape_threaded_broken_depth.html
@@ -1,0 +1,1681 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+    <title>alicornutopia | i wasn't looking for this</title>
+
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+
+            <script type="text/javascript">
+                var Site;
+                if (!Site)
+                    Site = {};
+
+                var site_p = {"media_embed_enabled": 1,
+"ctx_popup": 0,
+"esn_async": 1,
+"currentJournalBase": "https://alicornutopia.dreamwidth.org",
+"inbox_update_poll": 1,
+"user_domain": "dreamwidth.org",
+"currentJournal": "alicornutopia",
+"siteroot": "https://www.dreamwidth.org",
+"has_remote": 1,
+"statprefix": "https://www.dreamwidth.org/stc",
+"ctx_popup_icons": 0,
+"iconprefix": "https://v.dreamwidth.org",
+"ctx_popup_userhead": 0,
+"imgprefix": "https://www.dreamwidth.org/img"};
+                var site_k = ["media_embed_enabled", "ctx_popup", "esn_async", "currentJournalBase", "inbox_update_poll", "user_domain", "currentJournal", "siteroot", "has_remote", "statprefix", "ctx_popup_icons", "iconprefix", "ctx_popup_userhead", "imgprefix"];
+                for (var i = 0; site_k.length > i; i++) {
+                    Site[site_k[i]] = site_p[site_k[i]];
+                }
+           </script>
+        <link rel="stylesheet" type="text/css" href="https://www.dreamwidth.org/stc/??lj_base.css,esn.css,jquery/jquery.ui.core.css,jquery/jquery.ui.tooltip.css,jquery.contextualhover.css,reset.css,jquery/jquery.ui.theme.dark-hive.css,lj_base-app.css,base-colors-dark.css,gradation/gradation.css?v=1493607634">
+<link rel="stylesheet" type="text/css" href="https://www.dreamwidth.org/stc/??jquery/jquery.ui.button.css,jquery/jquery.ui.dialog.css,jquery.commentmanage.css,jquery/jquery.ui.theme.smoothness.css,entrypage.css,siteviews/gradation.css?v=1426479404">
+<script type="text/javascript" src="https://www.dreamwidth.org/js/??jquery/jquery-1.8.3.js,dw/dw-core.js,jquery/jquery.ui.core.js,jquery/jquery.ui.widget.js,jquery/jquery.ui.tooltip.js,jquery.ajaxtip.js,jquery/jquery.ui.position.js,jquery.hoverIntent.js,jquery.contextualhover.js,nav-jquery.js?v=1493607634"></script>
+<script type="text/javascript" src="https://www.dreamwidth.org/js/??jquery.quickreply.js,jquery.threadexpander.js,jquery/jquery.ui.button.js,jquery/jquery.ui.dialog.js,jquery.commentmanage.js,jquery.esn.js,jquery.poll.js,journals/jquery.tag-nav.js,jquery.mediaplaceholder.js,md5.js,login-jquery.js?v=1460259022"></script>
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<link rel="meta" type="application/rdf+xml" title="FOAF" href="https://alicornutopia.dreamwidth.org/data/foaf">
+<link rel="help" href="https://www.dreamwidth.org/support/faq">
+<link rel="apple-touch-icon" href="//www.dreamwidth.org/apple-touch-icon.png">
+<meta property="og:image:width" content="363">
+<meta property="og:image:height" content="363">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<link rel="prev" href="https://www.dreamwidth.org/go?dir=prev&amp;itemid=22671&amp;journal=alicornutopia&amp;style=site">
+<link rel="next" href="https://www.dreamwidth.org/go?dir=next&amp;itemid=22671&amp;journal=alicornutopia&amp;style=site">
+<link rel="canonical" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127#cmt14698127">
+
+    <!--[if lte IE 8]>
+    <script src="https://www.dreamwidth.org/js/html5.js" type="text/javascript"></script>
+    <![endif]-->
+</head>
+    <body>
+        <div id="canvas" class="horizontal-nav">
+            <div id="page">
+
+<div id="skip">
+     <a href="#content" tabindex="1">Skip to Main Content</a>
+</div>
+
+
+    <div id="masthead" role="banner">
+        <span id="logo">
+            <a href="https://www.dreamwidth.org/"><img alt="Dreamwidth Studios" src="https://www.dreamwidth.org/img/gradation/dw_logo_gradation.png"></a>
+        </span>
+    </div>
+
+    <div id="content" role="main">
+    <h1></h1>
+    <div class="entry-wrapper entry-wrapper-odd security-public restrictions-none journal-type-C poster-from_scratch journal-alicornutopia has-userpic  has-subject" id="entry-wrapper-22671">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="entry" id="entry-22671">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865290/2258301" title="from_scratch: (Default)" alt="from_scratch: (Default)" height="100" width="100"></a></div>
+<div class="poster-info">
+<span class="poster entry-poster ">Campbell Mark Swan (<span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span>) wrote in <span lj:user="alicornutopia" style="white-space: nowrap;" class="ljuser"><a href="https://alicornutopia.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/community.png" alt="[community profile] " width="16" height="16" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://alicornutopia.dreamwidth.org/"><b>alicornutopia</b></a></span></span><span class="datetime"><span class="date"><a href="/2015/">2015</a>-<a href="/2015/10/">10</a>-<a href="/2015/10/28/">28</a></span> <span class="time">18:04</span></span></div>
+</div>
+<div class="action-box">
+<div class="inner">
+<ul class="entry-management-links icon-links"><li class="link link_prev first-item"> <a href="https://www.dreamwidth.org/go?dir=prev&amp;itemid=22671&amp;journal=alicornutopia&amp;style=site"><img border="0" width="16" height="16" alt="Previous Entry" title="Previous Entry" src="//www.dreamwidth.org/img/silk/entry/previous.png"></a></li>
+<li class="link mem_add"><a href="https://www.dreamwidth.org/tools/memadd?journal=alicornutopia&amp;itemid=22671"><img border="0" width="16" height="16" alt="Add Memory" title="Add Memory" src="//www.dreamwidth.org/img/silk/entry/memories_add.png"></a></li>
+<li class="link tell_friend"><a href="https://www.dreamwidth.org/tools/tellafriend?journal=alicornutopia&amp;itemid=22671"><img border="0" width="16" height="16" alt="Share This Entry" title="Share This Entry" src="//www.dreamwidth.org/img/silk/entry/tellafriend.png"></a></li>
+<li class="link watch_comments"><a href="https://www.dreamwidth.org/manage/tracking/entry?journal=alicornutopia&amp;itemid=22671" lj_journalid="2146354" lj_auth_token="ajax:1513987200:2451705:26:/__rpc_esn_subs:addsub&amp;22671&amp;3&amp;2146354:319e1da3730d4ed54632a6290f5d5c60c64b75e7" lj_newentry_etypeid="1" js_swapname="Untrack This" lj_newentry_subid="13" lj_etypeid="3" lj_arg1="22671" lj_newentry_token="ajax:1513987200:2451705:26:/__rpc_esn_subs:delsub&amp;13:8255329653e2b0e6f0e6014f4ec6690eac406f8f" lj_subid="0" class="TrackButton" journal="alicornutopia"><img border="0" width="16" height="16" alt="Track This" title="Track This" src="//www.dreamwidth.org/img/silk/entry/track.png"></a></li>
+<li class="link link_next"> <a href="https://www.dreamwidth.org/go?dir=next&amp;itemid=22671&amp;journal=alicornutopia&amp;style=site"><img border="0" width="16" height="16" alt="Next Entry" title="Next Entry" src="//www.dreamwidth.org/img/silk/entry/next.png"></a></li>
+</ul></div>
+</div>
+</div>
+<div class="currents">
+<div class="tag"><span class="tag-text" data-journal="alicornutopia" data-ditemid="22671">Entry tags:</span><input class="tag-nav-trigger" type="image" aria-expanded="false" alt="Show tag navigation" title="Tag navigation: Select this button, then a tag, then use the arrows displayed to navigate through entries with that tag." src="https://www.dreamwidth.org/img/silk/site/add.png"><ul>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/form:+sandbox">form: sandbox</a>,</li>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/form:+tree">form: tree</a>,</li>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/person:+erinflight">person: erinflight</a>,</li>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/person:+maggie">person: maggie</a>,</li>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/person:+rockeye">person: rockeye</a>,</li>
+<li><a rel="tag" href="https://alicornutopia.dreamwidth.org/tag/pup:+incandescence">pup: incandescence</a></li>
+</ul></div></div>
+<div>
+<div class="contents usercontent">
+<div class="inner">
+<h3 class="entry-title"><a title="i wasn't looking for this" href="https://alicornutopia.dreamwidth.org/22671.html">i wasn't looking for this</a></h3><div class="entry-content"><em>This is a successor to <a href="http://alicornutopia.dreamwidth.org/6744.html?style=site&amp;view=top-only#comments">call me maybe</a> and <a href="http://alicornutopia.dreamwidth.org/11460.html?style=site&amp;view=top-only#comments">trade my soul for a wish</a>, which were getting crowded.<br><br><a href="http://alicornutopia.dreamwidth.org/22671.html?thread=11261839#cmt11261839">with Emily</a> (Maggie)<br><br><a href="http://alicornutopia.dreamwidth.org/22671.html?thread=12068239#cmt12068239">with Alex</a> (ErinFlight)<br><br><a href="http://alicornutopia.dreamwidth.org/22671.html?thread=12307599#cmt12307599">with Destin</a> (Rockeye)<br><br><a href="http://alicornutopia.dreamwidth.org/22671.html?thread=14264719#cmt14264719">with Nick</a> (Rockeye)</em></div></div>
+</div>
+</div>
+<div class="footer">
+<div class="inner">
+<hr class="above-entry-interaction-links">
+    <div class="comment-pages-wrapper"></div><ul class="entry-interaction-links text-links"><li class="entry-readlink first-item"><a href="https://alicornutopia.dreamwidth.org/22671.html?style=site#comments" data-sing="1 comment" data-dual="2 comments" data-plur="3 comments">75 comments</a></li>
+<li class="entry-replylink"><a onclick="return function(that) {return quickreply(&quot;topcomment&quot;, 0, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?mode=reply&amp;style=site">Post a new comment</a></li>
+</ul></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+<div id="comments"><div class="inner"><div class="comment-pages toppages"><span class="view-flat"><a href="https://alicornutopia.dreamwidth.org/22671.html?style=site&amp;view=flat#comments">Flat</a></span> | <span class="view-top-only"><a href="https://alicornutopia.dreamwidth.org/22671.html?style=site&amp;view=top-only#comments">Top-Level Comments Only</a></span></div><div id="ljqrttopcomment" data-quickreply-container="topcomment" style="display: none;"></div>
+
+<script type="text/javascript">
+jQuery(function(jQ){
+  jQ("body").append(jQ("<div id='qrdiv'></div>").html("<div id=\'qrformdiv\'><form id=\'qrform\' name=\'qrform\' method=\'POST\' action=\'https://www.dreamwidth.org/talkpost_do\'><input type=\'hidden\' name=\"lj_form_auth\" value=\"c0:1513987200:1492:86400:AhYOCPfnTz-2451705-26:1296ead9f1dad0cafc0d41102a03a558\" /><input type=\'hidden\' name=\"replyto\" value=\"\" id=\"replyto\" /><input type=\'hidden\' name=\"parenttalkid\" value=\"\" id=\"parenttalkid\" /><input type=\'hidden\' name=\"journal\" value=\"alicornutopia\" id=\"journal\" /><input type=\'hidden\' name=\"itemid\" value=\"22671\" id=\"itemid\" /><input type=\'hidden\' name=\"usertype\" value=\"cookieuser\" id=\"usertype\" /><input type=\'hidden\' name=\"qr\" value=\"1\" id=\"qr\" /><input type=\'hidden\' name=\"cookieuser\" value=\"throne3d\" id=\"cookieuser\" /><input type=\'hidden\' name=\"dtid\" value=\"\" id=\"dtid\" /><input type=\'hidden\' name=\"basepath\" value=\"https://alicornutopia.dreamwidth.org/22671.html?style=site&amp;\" id=\"basepath\" /><input type=\'hidden\' name=\"viewing_thread\" value=\"14698127\" id=\"viewing_thread\" /><input type=\'hidden\' name=\"style\" value=\"site\" id=\"style\" /><input type=\'hidden\' name=\"chrp1\" value=\"22671-2146354-1513987200-4MLsxQNElnGMO9UR1KZs-cd8a16218e6e85d8a307ea120ecb5830\" />\n<table>\n  <tr valign=\'center\'>\n    <td align=\'right\'><b>From:</b></td>\n    <td align=\'left\'><span lj:user=\'throne3d\' style=\'white-space: nowrap;\' class=\'ljuser\'><a href=\'https://throne3d.dreamwidth.org/profile\'><img src=\'https://www.dreamwidth.org/img/silk/identity/user.png\' alt=\'[personal profile] \' width=\'17\' height=\'17\' style=\'vertical-align: text-bottom; border: 0; padding-right: 1px;\' /></a><a href=\'https://throne3d.dreamwidth.org/\'><b>throne3d</b></a></span></td>\n    <td align=\'center\'>\n      <label for=\'prop_picture_keyword\'><a href=\'https://throne3d.dreamwidth.org/icons\'>Icon</a> to use:</label><select class=\"select\" id=\"prop_picture_keyword\" name=\"prop_picture_keyword\">\n<option value=\"\" selected=\'selected\' data-url=\'https://v.dreamwidth.org/10163618/2451705\'>(default)</option>\n<option value=\"avatar\" data-url=\'https://v.dreamwidth.org/10163618/2451705\'>avatar</option>\n</select>\n      <input type=\'button\' id=\'randomicon\' value=\'Random icon\' />\n\n      <span id=\'quotebuttonspan\'></span>\n    </td>\n  </tr>\n\n  <tr>\n    <td align=\'right\'><label for=\'subject\'><b>Subject:</b></label></td>\n    <td colspan=\'2\' align=\'left\'><input class=\'textbox\' type=\'text\' size=\'50\' maxlength=\'100\' name=\'subject\' id=\'subject\' value=\'\' /></td>\n  </tr>\n\n  <tr valign=\'top\'>\n    <td align=\'right\'><label for=\'body\'><b>Message:</b></td>\n    <td colspan=\'3\' style=\'width: 90%\'>\n      <textarea class=\'textbox\' rows=\'10\' cols=\'50\' wrap=\'soft\' name=\'body\' id=\'body\' style=\'width: 99%; height: 99%\'></textarea>\n    </td>\n  </tr>\n\n  <tr>\n    <td>&nbsp;</td>\n    <td colspan=\'3\' align=\'left\'><input type=\'submit\' name=\"submitpost\" value=\"Post Comment\" class=\"submit\" id=\"submitpost\" />      &nbsp;<input type=\'submit\' name=\"submitpview\" value=\"Preview\" id=\"submitpview\" class=\"submit\" /><input type=\'hidden\' name=\"submitpreview\" value=\"0\" />      &nbsp;<input type=\'submit\' name=\"submitmoreopts\" value=\"More Options\" id=\"submitmoreopts\" class=\"submit\" />        &nbsp;<input type=\'checkbox\' class=\"checkbox\" id=\"do_spellcheck\" name=\"do_spellcheck\" />\n        <label for=\"do_spellcheck\" class=\"checkboxlabel\">\n            Check spelling\n        </label>\n                <br><span class=\'de\'><strong>Notice:</strong> This account is set to log the IP addresses of everyone who comments.</span>    </td>\n  </tr>\n</table>\n</form></div>").hide());
+});jQuery(function(jQ){
+        var helped = 0; var pasted = 0;
+    function quote(e) {
+        var text = '';
+
+        if (document.getSelection) {
+            text = document.getSelection();
+        } else if (document.selection) {
+            text = document.selection.createRange().text;
+        } else if (window.getSelection) {
+            text = window.getSelection();
+        }
+
+        text = text.toString().replace(/^\s+/, '').replace(/\s+$/, '');
+
+        if (text == '') {
+            if (helped != 1 && pasted != 1) {
+                helped = 1;
+                alert("If you'd like to quote a portion of the original message, highlight it then press 'Quote'.");
+            }
+        } else {
+            pasted = 1;
+        }
+
+        var element = text.search(/\n/) == -1 ? 'q' : 'blockquote';
+        var textarea = document.getElementById('body');
+        textarea.focus();
+        textarea.value = textarea.value + "<" + element + ">" + text + "</" + element + ">";
+        textarea.caretPos = textarea.value;
+        textarea.focus();
+    }
+
+
+    jQ("<input type='button' value='Quote' />")
+        .appendTo("#quotebuttonspan")
+        .click(quote);
+    });
+</script><div class="comment-thread comment-depth-odd comment-depth-1">
+<div id="cmt14698127" class="dwexpcomment" style="margin-left: 0px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14698127">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 21:48 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127#cmt14698127">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"I believe it was defamation. Yes, people will notice, but they won't be sure. Magicians rarely use flashy magic. It will take time before everyone truly believes their power is gone. But even if you made a public announcement, I'm not sure anything would change. Most people's lives aren't terrible, and this might make them optimistic enough to wait for the status quo to change. It might be possible to start a rebellion, but guess who has all the guns? More death isn't the solution to this."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127#cmt14698127">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14698127&quot;, 57414, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14698127&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14698127&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14697871&amp;style=site#cmt14697871">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127&amp;style=site#cmt14698127">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14698127_hide"><a href="#cmt14698127" onclick="Expander.hideComments(this, '14698127'); return false;">Hide 1561 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14698127_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127&amp;style=site#cmt14698127" onclick="Expander.unhideComments(this, '14698127'); return false;">Show 1561 comments</a></li>
+</ul><div id="ljqrt14698127" data-quickreply-container="14698127" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-2">
+<div id="cmt14698383" class="dwexpcomment" style="margin-left: 25px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14698383">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865291/2258301" title="from_scratch: g ~ pinhole" alt="from_scratch: (g ~ pinhole)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 21:48 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698383#cmt14698383">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"If the situation's so recent, is the situation different in other countries?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698383#cmt14698383">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14698383&quot;, 57415, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14698383&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14698383&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127&amp;style=site#cmt14698127">Parent</a></li>
+</ul><div id="ljqrt14698383" data-quickreply-container="14698383" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-2">
+<div id="cmt14698639" class="dwexpcomment" style="margin-left: 25px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14698639">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 21:58 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698639#cmt14698639">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Yes. Many countries have magicians pulling the string, but we are one of the few where they are so blatantly in power. The history is complicated, but essentially magicians can only seize power when they've managed to create artifacts like that ring on your hand. Individually, magicians can't summon demons powerful enough to take control, however, if they manage to bind a powerful demon into an artifact, they can use its power at will. The Staff of Gladstone was used in 1860."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698639#cmt14698639">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14698639&quot;, 57416, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14698639&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14698639&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698127&amp;style=site#cmt14698127">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698639&amp;style=site#cmt14698639">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14698639_hide"><a href="#cmt14698639" onclick="Expander.hideComments(this, '14698639'); return false;">Hide 1559 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14698639_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698639&amp;style=site#cmt14698639" onclick="Expander.unhideComments(this, '14698639'); return false;">Show 1559 comments</a></li>
+</ul><div id="ljqrt14698639" data-quickreply-container="14698639" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-3">
+<div id="cmt14698895" class="dwexpcomment" style="margin-left: 50px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14698895">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865289/2258301" title="from_scratch: f ~ real sun" alt="from_scratch: (f ~ real sun)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 21:59 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698895#cmt14698895">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"What'd the Staff do?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698895#cmt14698895">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14698895&quot;, 57417, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14698895&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14698895&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698639&amp;style=site#cmt14698639">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698895&amp;style=site#cmt14698895">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14698895_hide"><a href="#cmt14698895" onclick="Expander.hideComments(this, '14698895'); return false;">Hide 1558 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14698895_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698895&amp;style=site#cmt14698895" onclick="Expander.unhideComments(this, '14698895'); return false;">Show 1558 comments</a></li>
+</ul><div id="ljqrt14698895" data-quickreply-container="14698895" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-4">
+<div id="cmt14699151" class="dwexpcomment" style="margin-left: 75px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14699151">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 22:01 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699151#cmt14699151">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"It summoned a destructive lightning from the sky. It was strong enough to lay waste to Prague."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699151#cmt14699151">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14699151&quot;, 57418, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14699151&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14699151&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14698895&amp;style=site#cmt14698895">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699151&amp;style=site#cmt14699151">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14699151_hide"><a href="#cmt14699151" onclick="Expander.hideComments(this, '14699151'); return false;">Hide 1557 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14699151_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699151&amp;style=site#cmt14699151" onclick="Expander.unhideComments(this, '14699151'); return false;">Show 1557 comments</a></li>
+</ul><div id="ljqrt14699151" data-quickreply-container="14699151" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-5">
+<div id="cmt14699407" class="dwexpcomment" style="margin-left: 100px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14699407">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865293/2258301" title="from_scratch: i ~ shirtless" alt="from_scratch: (i ~ shirtless)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 22:04 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699407#cmt14699407">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"And this so thoroughly privileged magicians as a class because?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699407#cmt14699407">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14699407&quot;, 57419, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14699407&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14699407&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699151&amp;style=site#cmt14699151">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699407&amp;style=site#cmt14699407">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14699407_hide"><a href="#cmt14699407" onclick="Expander.hideComments(this, '14699407'); return false;">Hide 1556 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14699407_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699407&amp;style=site#cmt14699407" onclick="Expander.unhideComments(this, '14699407'); return false;">Show 1556 comments</a></li>
+</ul><div id="ljqrt14699407" data-quickreply-container="14699407" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-6">
+<div id="cmt14700175" class="dwexpcomment" style="margin-left: 125px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14700175">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:32 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700175#cmt14700175">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Gladstone didn't only create his staff. He also discovered a new way to trap demons. Almost every magician carries two or three magical artifacts and may own a dozen more. Previously, this was unheard of. The creation of artifacts used to be extremely dangerous. Most magicians who attempted it were killed."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700175#cmt14700175">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14700175&quot;, 57422, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14700175&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14700175&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14699407&amp;style=site#cmt14699407">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700175&amp;style=site#cmt14700175">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14700175_hide"><a href="#cmt14700175" onclick="Expander.hideComments(this, '14700175'); return false;">Hide 1555 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14700175_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700175&amp;style=site#cmt14700175" onclick="Expander.unhideComments(this, '14700175'); return false;">Show 1555 comments</a></li>
+</ul><div id="ljqrt14700175" data-quickreply-container="14700175" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-7">
+<div id="cmt14700431" class="dwexpcomment" style="margin-left: 150px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14700431">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865280/2258301" title="from_scratch: k ~ indestructible" alt="from_scratch: (k ~ indestructible)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:33 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700431#cmt14700431">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Oh boy.  What a thoroughly unpleasant character."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700431#cmt14700431">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14700431&quot;, 57423, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14700431&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14700431&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700175&amp;style=site#cmt14700175">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700431&amp;style=site#cmt14700431">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14700431_hide"><a href="#cmt14700431" onclick="Expander.hideComments(this, '14700431'); return false;">Hide 1554 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14700431_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700431&amp;style=site#cmt14700431" onclick="Expander.unhideComments(this, '14700431'); return false;">Show 1554 comments</a></li>
+</ul><div id="ljqrt14700431" data-quickreply-container="14700431" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-8">
+<div id="cmt14700687" class="dwexpcomment" style="margin-left: 175px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14700687">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:37 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700687#cmt14700687">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">Collins inclines his head.<br>"Yes, though he is quite well loved. He is painted as a hero in history books and the magicians revere him. You've probably seen the statues."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700687#cmt14700687">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14700687&quot;, 57424, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14700687&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14700687&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700431&amp;style=site#cmt14700431">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700687&amp;style=site#cmt14700687">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14700687_hide"><a href="#cmt14700687" onclick="Expander.hideComments(this, '14700687'); return false;">Hide 1553 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14700687_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700687&amp;style=site#cmt14700687" onclick="Expander.unhideComments(this, '14700687'); return false;">Show 1553 comments</a></li>
+</ul><div id="ljqrt14700687" data-quickreply-container="14700687" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-9">
+<div id="cmt14700943" class="dwexpcomment" style="margin-left: 200px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14700943">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865293/2258301" title="from_scratch: i ~ shirtless" alt="from_scratch: (i ~ shirtless)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:40 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700943#cmt14700943">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"I have, yes.  So how did laying waste to Prague put him on top, do people just love a war hero that much?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700943#cmt14700943">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14700943&quot;, 57425, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14700943&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14700943&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700687&amp;style=site#cmt14700687">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700943&amp;style=site#cmt14700943">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14700943_hide"><a href="#cmt14700943" onclick="Expander.hideComments(this, '14700943'); return false;">Hide 1552 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14700943_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700943&amp;style=site#cmt14700943" onclick="Expander.unhideComments(this, '14700943'); return false;">Show 1552 comments</a></li>
+</ul><div id="ljqrt14700943" data-quickreply-container="14700943" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-10">
+<div id="cmt14701199" class="dwexpcomment" style="margin-left: 225px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14701199">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:44 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701199#cmt14701199">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"He 'saved us from the darkness' and 'defended our liberty' apparently. The magicians love him for obvious reasons."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701199#cmt14701199">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14701199&quot;, 57426, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14701199&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14701199&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14700943&amp;style=site#cmt14700943">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701199&amp;style=site#cmt14701199">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14701199_hide"><a href="#cmt14701199" onclick="Expander.hideComments(this, '14701199'); return false;">Hide 1551 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14701199_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701199&amp;style=site#cmt14701199" onclick="Expander.unhideComments(this, '14701199'); return false;">Show 1551 comments</a></li>
+</ul><div id="ljqrt14701199" data-quickreply-container="14701199" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-11">
+<div id="cmt14701455" class="dwexpcomment" style="margin-left: 250px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14701455">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865290/2258301" title="from_scratch: (Default)" alt="from_scratch: (Default)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:45 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701455#cmt14701455">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"All right, so what was your strategy before I came along?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701455#cmt14701455">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14701455&quot;, 57427, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14701455&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14701455&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701199&amp;style=site#cmt14701199">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701455&amp;style=site#cmt14701455">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14701455_hide"><a href="#cmt14701455" onclick="Expander.hideComments(this, '14701455'); return false;">Hide 1550 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14701455_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701455&amp;style=site#cmt14701455" onclick="Expander.unhideComments(this, '14701455'); return false;">Show 1550 comments</a></li>
+</ul><div id="ljqrt14701455" data-quickreply-container="14701455" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-12">
+<div id="cmt14701711" class="dwexpcomment" style="margin-left: 275px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14701711">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:52 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701711#cmt14701711">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"There isn't one, or at least not a particularly good one. I've been trying to change things from the inside, but so far I haven't made much progress. We've been keeping an eye out for magical artifacts and ways to protect ourselves from demon attacks. We've been trying to understand how demons work, to see if there is a way to prevent magicians from using them. We've been recording the magicians various crimes. Some want to incite an uprising, but that's not a very popular idea. No one really believes it would work."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701711#cmt14701711">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14701711&quot;, 57428, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14701711&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14701711&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701455&amp;style=site#cmt14701455">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701711&amp;style=site#cmt14701711">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14701711_hide"><a href="#cmt14701711" onclick="Expander.hideComments(this, '14701711'); return false;">Hide 1549 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14701711_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701711&amp;style=site#cmt14701711" onclick="Expander.unhideComments(this, '14701711'); return false;">Show 1549 comments</a></li>
+</ul><div id="ljqrt14701711" data-quickreply-container="14701711" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-13">
+<div id="cmt14701967" class="dwexpcomment" style="margin-left: 300px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14701967">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865291/2258301" title="from_scratch: g ~ pinhole" alt="from_scratch: (g ~ pinhole)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-16 23:53 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701967#cmt14701967">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"It's not a simple problem.  Do you have a clever idea for how to deploy <em>me</em> here?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701967#cmt14701967">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14701967&quot;, 57429, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14701967&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14701967&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701711&amp;style=site#cmt14701711">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701967&amp;style=site#cmt14701967">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14701967_hide"><a href="#cmt14701967" onclick="Expander.hideComments(this, '14701967'); return false;">Hide 1548 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14701967_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701967&amp;style=site#cmt14701967" onclick="Expander.unhideComments(this, '14701967'); return false;">Show 1548 comments</a></li>
+</ul><div id="ljqrt14701967" data-quickreply-container="14701967" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-14">
+<div id="cmt14702223" class="dwexpcomment" style="margin-left: 325px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14702223">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:07 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702223#cmt14702223">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Destroy the magical artifacts <i>now</i>. Don't wait until you have permission. Then, help us make this public. Tell everyone where the magicians' power comes from and how it works. If you share knowledge, make it public. Right now the magicians seem omnipotent. Knowing they're not could shift the balance enough so that they don't remain in power once their magic is gone."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702223#cmt14702223">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14702223&quot;, 57430, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14702223&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14702223&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14701967&amp;style=site#cmt14701967">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702223&amp;style=site#cmt14702223">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14702223_hide"><a href="#cmt14702223" onclick="Expander.hideComments(this, '14702223'); return false;">Hide 1547 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14702223_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702223&amp;style=site#cmt14702223" onclick="Expander.unhideComments(this, '14702223'); return false;">Show 1547 comments</a></li>
+</ul><div id="ljqrt14702223" data-quickreply-container="14702223" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-15">
+<div id="cmt14702479" class="dwexpcomment" style="margin-left: 350px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14702479">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865289/2258301" title="from_scratch: f ~ real sun" alt="from_scratch: (f ~ real sun)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:09 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702479#cmt14702479">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"This has many appealing features as a principled stand, but means I have nothing to bribe the magicians with and they'll fight the change as hard as they can.  With demons."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702479#cmt14702479">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14702479&quot;, 57431, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14702479&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14702479&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702223&amp;style=site#cmt14702223">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702479&amp;style=site#cmt14702479">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14702479_hide"><a href="#cmt14702479" onclick="Expander.hideComments(this, '14702479'); return false;">Hide 1546 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14702479_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702479&amp;style=site#cmt14702479" onclick="Expander.unhideComments(this, '14702479'); return false;">Show 1546 comments</a></li>
+</ul><div id="ljqrt14702479" data-quickreply-container="14702479" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-16">
+<div id="cmt14702735" class="dwexpcomment" style="margin-left: 375px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14702735">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:11 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702735#cmt14702735">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Can your magic change people?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702735#cmt14702735">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14702735&quot;, 57432, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14702735&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14702735&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702479&amp;style=site#cmt14702479">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702735&amp;style=site#cmt14702735">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14702735_hide"><a href="#cmt14702735" onclick="Expander.hideComments(this, '14702735'); return false;">Hide 1545 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14702735_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702735&amp;style=site#cmt14702735" onclick="Expander.unhideComments(this, '14702735'); return false;">Show 1545 comments</a></li>
+</ul><div id="ljqrt14702735" data-quickreply-container="14702735" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-17">
+<div id="cmt14702991" class="dwexpcomment" style="margin-left: 400px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14702991">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865290/2258301" title="from_scratch: j ~ didn't change much" alt="from_scratch: (j ~ didn't change much)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:11 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702991#cmt14702991">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Change them how?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702991#cmt14702991">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14702991&quot;, 57433, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14702991&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14702991&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702735&amp;style=site#cmt14702735">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702991&amp;style=site#cmt14702991">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14702991_hide"><a href="#cmt14702991" onclick="Expander.hideComments(this, '14702991'); return false;">Hide 1544 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14702991_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702991&amp;style=site#cmt14702991" onclick="Expander.unhideComments(this, '14702991'); return false;">Show 1544 comments</a></li>
+</ul><div id="ljqrt14702991" data-quickreply-container="14702991" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-18">
+<div id="cmt14703247" class="dwexpcomment" style="margin-left: 425px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14703247">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:16 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703247#cmt14703247">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"Could you give someone an inborn ability they didn't already have?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703247#cmt14703247">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14703247&quot;, 57434, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14703247&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14703247&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14702991&amp;style=site#cmt14702991">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703247&amp;style=site#cmt14703247">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14703247_hide"><a href="#cmt14703247" onclick="Expander.hideComments(this, '14703247'); return false;">Hide 1543 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14703247_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703247&amp;style=site#cmt14703247" onclick="Expander.unhideComments(this, '14703247'); return false;">Show 1543 comments</a></li>
+</ul><div id="ljqrt14703247" data-quickreply-container="14703247" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-19">
+<div id="cmt14703503" class="dwexpcomment" style="margin-left: 450px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14703503">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865289/2258301" title="from_scratch: f ~ real sun" alt="from_scratch: (f ~ real sun)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:18 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703503#cmt14703503">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"...I could give people wings, but given how I've been advised on going around with a set of my own I'm not sure that would go over well.  And they'd have to learn to fly the long way.  With ten minutes and someone who's willing to let me perform eye surgery I can get somebody's vision above human baseline acuity.  I'm not sure if that's the sort of thing you had in mind."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703503#cmt14703503">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14703503&quot;, 57435, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14703503&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14703503&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703247&amp;style=site#cmt14703247">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703503&amp;style=site#cmt14703503">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14703503_hide"><a href="#cmt14703503" onclick="Expander.hideComments(this, '14703503'); return false;">Hide 1542 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14703503_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703503&amp;style=site#cmt14703503" onclick="Expander.unhideComments(this, '14703503'); return false;">Show 1542 comments</a></li>
+</ul><div id="ljqrt14703503" data-quickreply-container="14703503" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-20">
+<div id="cmt14703759" class="dwexpcomment" style="margin-left: 475px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14703759">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:23 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703759#cmt14703759">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">Collins shakes his head. <br>"Would you be willing to inform the population after you have the magicians' agreement?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703759#cmt14703759">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14703759&quot;, 57436, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14703759&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14703759&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703503&amp;style=site#cmt14703503">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703759&amp;style=site#cmt14703759">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14703759_hide"><a href="#cmt14703759" onclick="Expander.hideComments(this, '14703759'); return false;">Hide 1541 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14703759_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703759&amp;style=site#cmt14703759" onclick="Expander.unhideComments(this, '14703759'); return false;">Show 1541 comments</a></li>
+</ul><div id="ljqrt14703759" data-quickreply-container="14703759" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-21">
+<div id="cmt14704015" class="dwexpcomment" style="margin-left: 500px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14704015">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865293/2258301" title="from_scratch: i ~ shirtless" alt="from_scratch: (i ~ shirtless)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:23 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704015#cmt14704015">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"In what scenario would this not lead to the magicians reneging?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704015#cmt14704015">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14704015&quot;, 57437, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14704015&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14704015&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14703759&amp;style=site#cmt14703759">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704015&amp;style=site#cmt14704015">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14704015_hide"><a href="#cmt14704015" onclick="Expander.hideComments(this, '14704015'); return false;">Hide 1540 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14704015_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704015&amp;style=site#cmt14704015" onclick="Expander.unhideComments(this, '14704015'); return false;">Show 1540 comments</a></li>
+</ul><div id="ljqrt14704015" data-quickreply-container="14704015" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-22">
+<div id="cmt14704271" class="dwexpcomment" style="margin-left: 525px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14704271">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:28 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704271#cmt14704271">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"If the magicians already agreed to stop summoning demons, they wouldn't be nearly as bothered by you sharing the basics of how it worked. They might be angry if you publicly shared specific knowledge you'd used as a bargaining chip with them, but you could make it clear you planned to share a large amount of information once the agreement was in place. That could even be an incentive. You wouldn't want to discredit them, but in the aftermath someone else could and would be believed in a way they wouldn't be now."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704271#cmt14704271">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14704271&quot;, 57438, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14704271&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14704271&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704015&amp;style=site#cmt14704015">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704271&amp;style=site#cmt14704271">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14704271_hide"><a href="#cmt14704271" onclick="Expander.hideComments(this, '14704271'); return false;">Hide 1539 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14704271_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704271&amp;style=site#cmt14704271" onclick="Expander.unhideComments(this, '14704271'); return false;">Show 1539 comments</a></li>
+</ul><div id="ljqrt14704271" data-quickreply-container="14704271" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-23">
+<div id="cmt14704527" class="dwexpcomment" style="margin-left: 550px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14704527">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://from-scratch.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/7865289/2258301" title="from_scratch: f ~ real sun" alt="from_scratch: (f ~ real sun)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:32 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704527#cmt14704527">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"What if commoners decide summoning demons sounds like great fun?"</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704527#cmt14704527">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14704527&quot;, 57439, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14704527&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14704527&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704271&amp;style=site#cmt14704271">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704527&amp;style=site#cmt14704527">Thread</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14704527_hide"><a href="#cmt14704527" onclick="Expander.hideComments(this, '14704527'); return false;">Hide 1538 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14704527_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704527&amp;style=site#cmt14704527" onclick="Expander.unhideComments(this, '14704527'); return false;">Show 1538 comments</a></li>
+</ul><div id="ljqrt14704527" data-quickreply-container="14704527" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-24">
+<div id="cmt14704783" class="dwexpcomment" style="margin-left: 575px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  full has-userpic  no-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14704783">
+<div class="inner">
+<div class="header">
+<div class="inner">
+<div class="userpic"><a href="https://magicians-of-london.dreamwidth.org/icons"><img src="https://v.dreamwidth.org/9847661/2474063" title="magicians_of_london: Bruce Collins" alt="magicians_of_london: (Bruce Collins)" height="100" width="100"></a></div>
+<div class="comment-info">
+<h4 class="comment-title"><span class=" invisible">no subject</span></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+<span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:33 (local)</span></span><span class="commentpermalink">(<a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704783#cmt14704783">link</a>)</span>
+</div>
+</div>
+</div>
+<div class="contents usercontent">
+<div class="inner">
+<div class="comment-content">"I'm not suggesting you share any of the mechanics, just the very general concepts."</div></div>
+</div>
+<div class="footer">
+<div class="inner">
+<ul class="comment-interaction-links text-links"><li class="link commentpermalink"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704783#cmt14704783">Thread</a></li>
+<li class="link reply first-item"><a onclick="return function(that) {return quickreply(&quot;14704783&quot;, 57440, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?replyto=14704783&amp;style=site">Reply to this</a></li>
+<li class="link threadroot"><a href="https://www.dreamwidth.org/go?redir_type=threadroot&amp;journal=alicornutopia&amp;talkid=14704783&amp;style=site">Thread from start</a></li>
+<li class="link commentparent"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704527&amp;style=site#cmt14704527">Parent</a></li>
+<li class="link thread"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704783&amp;style=site#cmt14704783">Thread</a></li>
+<li class="link expand"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704783&amp;style=site#cmt14704783" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14704783&amp;style=site#cmt14704783','14704783'); return false;">Expand</a></li>
+<li class="link cmt_hide cmt_show_hide_default" style="" id="cmt14704783_hide"><a href="#cmt14704783" onclick="Expander.hideComments(this, '14704783'); return false;">Hide 1537 comments</a></li>
+<li class="link cmt_unhide" style="display: none;" id="cmt14704783_unhide"><a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14704783&amp;style=site#cmt14704783" onclick="Expander.unhideComments(this, '14704783'); return false;">Show 1537 comments</a></li>
+</ul><div id="ljqrt14704783" data-quickreply-container="14704783" style="display: none;"></div></div>
+</div>
+</div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-25">
+<div id="cmt14705039" class="dwexpcomment" style="margin-left: 600px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14705039">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705039#cmt14705039">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:34 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705039&amp;style=site#cmt14705039" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14705039&amp;style=site#cmt14705039','14705039'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-26">
+<div id="cmt14705295" class="dwexpcomment" style="margin-left: 625px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14705295">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705295#cmt14705295">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:35 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705295&amp;style=site#cmt14705295" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14705295&amp;style=site#cmt14705295','14705295'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-27">
+<div id="cmt14705551" class="dwexpcomment" style="margin-left: 650px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14705551">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705551#cmt14705551">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:37 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705551&amp;style=site#cmt14705551" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14705551&amp;style=site#cmt14705551','14705551'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-28">
+<div id="cmt14705807" class="dwexpcomment" style="margin-left: 675px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14705807">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705807#cmt14705807">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:38 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14705807&amp;style=site#cmt14705807" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14705807&amp;style=site#cmt14705807','14705807'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-29">
+<div id="cmt14706063" class="dwexpcomment" style="margin-left: 700px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14706063">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706063#cmt14706063">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:40 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706063&amp;style=site#cmt14706063" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14706063&amp;style=site#cmt14706063','14706063'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-30">
+<div id="cmt14706319" class="dwexpcomment" style="margin-left: 725px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14706319">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706319#cmt14706319">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:42 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706319&amp;style=site#cmt14706319" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14706319&amp;style=site#cmt14706319','14706319'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-31">
+<div id="cmt14706575" class="dwexpcomment" style="margin-left: 750px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14706575">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706575#cmt14706575">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:43 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706575&amp;style=site#cmt14706575" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14706575&amp;style=site#cmt14706575','14706575'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-32">
+<div id="cmt14706831" class="dwexpcomment" style="margin-left: 775px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14706831">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706831#cmt14706831">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:45 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14706831&amp;style=site#cmt14706831" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14706831&amp;style=site#cmt14706831','14706831'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-33">
+<div id="cmt14707087" class="dwexpcomment" style="margin-left: 800px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14707087">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707087#cmt14707087">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:47 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707087&amp;style=site#cmt14707087" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14707087&amp;style=site#cmt14707087','14707087'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-34">
+<div id="cmt14707599" class="dwexpcomment" style="margin-left: 825px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14707599">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707599#cmt14707599">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:54 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707599&amp;style=site#cmt14707599" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14707599&amp;style=site#cmt14707599','14707599'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-35">
+<div id="cmt14707855" class="dwexpcomment" style="margin-left: 850px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14707855">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707855#cmt14707855">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:55 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14707855&amp;style=site#cmt14707855" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14707855&amp;style=site#cmt14707855','14707855'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-36">
+<div id="cmt14708111" class="dwexpcomment" style="margin-left: 875px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14708111">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708111#cmt14708111">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 00:59 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708111&amp;style=site#cmt14708111" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14708111&amp;style=site#cmt14708111','14708111'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-37">
+<div id="cmt14708367" class="dwexpcomment" style="margin-left: 900px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14708367">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708367#cmt14708367">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 01:01 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708367&amp;style=site#cmt14708367" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14708367&amp;style=site#cmt14708367','14708367'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-38">
+<div id="cmt14708623" class="dwexpcomment" style="margin-left: 925px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14708623">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708623#cmt14708623">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 01:02 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708623&amp;style=site#cmt14708623" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14708623&amp;style=site#cmt14708623','14708623'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-39">
+<div id="cmt14708879" class="dwexpcomment" style="margin-left: 950px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14708879">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708879#cmt14708879">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 01:03 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14708879&amp;style=site#cmt14708879" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14708879&amp;style=site#cmt14708879','14708879'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-40">
+<div id="cmt14709135" class="dwexpcomment" style="margin-left: 975px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14709135">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709135#cmt14709135">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="110 days after journal entry">2016-02-17 01:03 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709135&amp;style=site#cmt14709135" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14709135&amp;style=site#cmt14709135','14709135'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-41">
+<div id="cmt14709391" class="dwexpcomment" style="margin-left: 1000px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14709391">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709391#cmt14709391">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:07 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709391&amp;style=site#cmt14709391" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14709391&amp;style=site#cmt14709391','14709391'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-42">
+<div id="cmt14709647" class="dwexpcomment" style="margin-left: 1025px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14709647">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709647#cmt14709647">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:10 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709647&amp;style=site#cmt14709647" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14709647&amp;style=site#cmt14709647','14709647'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-43">
+<div id="cmt14709903" class="dwexpcomment" style="margin-left: 1050px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14709903">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709903#cmt14709903">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:13 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14709903&amp;style=site#cmt14709903" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14709903&amp;style=site#cmt14709903','14709903'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-44">
+<div id="cmt14710159" class="dwexpcomment" style="margin-left: 1075px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14710159">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710159#cmt14710159">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:14 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710159&amp;style=site#cmt14710159" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14710159&amp;style=site#cmt14710159','14710159'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-45">
+<div id="cmt14710415" class="dwexpcomment" style="margin-left: 1100px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14710415">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710415#cmt14710415">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:15 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710415&amp;style=site#cmt14710415" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14710415&amp;style=site#cmt14710415','14710415'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-46">
+<div id="cmt14710671" class="dwexpcomment" style="margin-left: 1125px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-intricate_engineer  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14710671">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710671#cmt14710671">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="intricate_engineer" style="white-space: nowrap;" class="ljuser"><a href="https://intricate-engineer.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://intricate-engineer.dreamwidth.org/"><b>intricate_engineer</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:22 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710671&amp;style=site#cmt14710671" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14710671&amp;style=site#cmt14710671','14710671'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-47">
+<div id="cmt14710927" class="dwexpcomment" style="margin-left: 1150px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14710927">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710927#cmt14710927">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:23 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14710927&amp;style=site#cmt14710927" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14710927&amp;style=site#cmt14710927','14710927'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-48">
+<div id="cmt14711183" class="dwexpcomment" style="margin-left: 1175px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14711183">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711183#cmt14711183">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:27 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711183&amp;style=site#cmt14711183" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14711183&amp;style=site#cmt14711183','14711183'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-49">
+<div id="cmt14711439" class="dwexpcomment" style="margin-left: 1200px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14711439">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711439#cmt14711439">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:29 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711439&amp;style=site#cmt14711439" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14711439&amp;style=site#cmt14711439','14711439'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-50">
+<div id="cmt14711695" class="dwexpcomment" style="margin-left: 1225px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14711695">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711695#cmt14711695">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:33 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711695&amp;style=site#cmt14711695" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14711695&amp;style=site#cmt14711695','14711695'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-51">
+<div id="cmt14711951" class="dwexpcomment" style="margin-left: 1250px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14711951">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711951#cmt14711951">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:35 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14711951&amp;style=site#cmt14711951" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14711951&amp;style=site#cmt14711951','14711951'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-52">
+<div id="cmt14712207" class="dwexpcomment" style="margin-left: 1275px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14712207">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14712207#cmt14712207">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:37 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14712207&amp;style=site#cmt14712207" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14712207&amp;style=site#cmt14712207','14712207'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-53">
+<div id="cmt14712463" class="dwexpcomment" style="margin-left: 1300px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14712463">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14712463#cmt14712463">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:38 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14712463&amp;style=site#cmt14712463" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14712463&amp;style=site#cmt14712463','14712463'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-54">
+<div id="cmt14712719" class="dwexpcomment" style="margin-left: 1325px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14712719">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14712719#cmt14712719">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:41 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14712719&amp;style=site#cmt14712719" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14712719&amp;style=site#cmt14712719','14712719'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-55">
+<div id="cmt14712975" class="dwexpcomment" style="margin-left: 1350px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14712975">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14712975#cmt14712975">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:42 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14712975&amp;style=site#cmt14712975" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14712975&amp;style=site#cmt14712975','14712975'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-56">
+<div id="cmt14713231" class="dwexpcomment" style="margin-left: 1375px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14713231">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14713231#cmt14713231">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:44 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14713231&amp;style=site#cmt14713231" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14713231&amp;style=site#cmt14713231','14713231'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-57">
+<div id="cmt14713487" class="dwexpcomment" style="margin-left: 1400px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14713487">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14713487#cmt14713487">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:45 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14713487&amp;style=site#cmt14713487" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14713487&amp;style=site#cmt14713487','14713487'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-58">
+<div id="cmt14713743" class="dwexpcomment" style="margin-left: 1425px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14713743">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14713743#cmt14713743">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:48 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14713743&amp;style=site#cmt14713743" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14713743&amp;style=site#cmt14713743','14713743'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-59">
+<div id="cmt14713999" class="dwexpcomment" style="margin-left: 1450px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14713999">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14713999#cmt14713999">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:49 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14713999&amp;style=site#cmt14713999" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14713999&amp;style=site#cmt14713999','14713999'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-60">
+<div id="cmt14714255" class="dwexpcomment" style="margin-left: 1475px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14714255">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14714255#cmt14714255">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:50 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14714255&amp;style=site#cmt14714255" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14714255&amp;style=site#cmt14714255','14714255'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-61">
+<div id="cmt14714511" class="dwexpcomment" style="margin-left: 1500px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14714511">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14714511#cmt14714511">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:51 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14714511&amp;style=site#cmt14714511" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14714511&amp;style=site#cmt14714511','14714511'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-62">
+<div id="cmt14714767" class="dwexpcomment" style="margin-left: 1525px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14714767">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14714767#cmt14714767">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 01:53 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14714767&amp;style=site#cmt14714767" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14714767&amp;style=site#cmt14714767','14714767'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-63">
+<div id="cmt14715023" class="dwexpcomment" style="margin-left: 1550px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14715023">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14715023#cmt14715023">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 02:12 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14715023&amp;style=site#cmt14715023" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14715023&amp;style=site#cmt14715023','14715023'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-64">
+<div id="cmt14715279" class="dwexpcomment" style="margin-left: 1575px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14715279">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14715279#cmt14715279">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 02:33 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14715279&amp;style=site#cmt14715279" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14715279&amp;style=site#cmt14715279','14715279'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-65">
+<div id="cmt14715535" class="dwexpcomment" style="margin-left: 1600px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14715535">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14715535#cmt14715535">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 02:33 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14715535&amp;style=site#cmt14715535" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14715535&amp;style=site#cmt14715535','14715535'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-66">
+<div id="cmt14715791" class="dwexpcomment" style="margin-left: 1625px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14715791">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14715791#cmt14715791">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 02:39 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14715791&amp;style=site#cmt14715791" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14715791&amp;style=site#cmt14715791','14715791'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-67">
+<div id="cmt14716047" class="dwexpcomment" style="margin-left: 1650px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14716047">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14716047#cmt14716047">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 05:14 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14716047&amp;style=site#cmt14716047" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14716047&amp;style=site#cmt14716047','14716047'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-68">
+<div id="cmt14716303" class="dwexpcomment" style="margin-left: 1675px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14716303">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14716303#cmt14716303">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 05:17 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14716303&amp;style=site#cmt14716303" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14716303&amp;style=site#cmt14716303','14716303'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-69">
+<div id="cmt14716559" class="dwexpcomment" style="margin-left: 1700px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14716559">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14716559#cmt14716559">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 05:17 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14716559&amp;style=site#cmt14716559" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14716559&amp;style=site#cmt14716559','14716559'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-70">
+<div id="cmt14716815" class="dwexpcomment" style="margin-left: 1725px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14716815">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14716815#cmt14716815">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 05:23 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14716815&amp;style=site#cmt14716815" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14716815&amp;style=site#cmt14716815','14716815'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-71">
+<div id="cmt14717071" class="dwexpcomment" style="margin-left: 1750px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14717071">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14717071#cmt14717071">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 05:24 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14717071&amp;style=site#cmt14717071" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14717071&amp;style=site#cmt14717071','14717071'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-72">
+<div id="cmt14717327" class="dwexpcomment" style="margin-left: 1775px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14717327">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14717327#cmt14717327">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 05:26 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14717327&amp;style=site#cmt14717327" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14717327&amp;style=site#cmt14717327','14717327'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-odd comment-depth-73">
+<div id="cmt14717583" class="dwexpcomment" style="margin-left: 1800px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-even visible    poster-from_scratch entry-author partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14717583">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14717583#cmt14717583">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="from_scratch" style="white-space: nowrap;" class="ljuser"><a href="https://from-scratch.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://from-scratch.dreamwidth.org/"><b>from_scratch</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 05:27 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14717583&amp;style=site#cmt14717583" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14717583&amp;style=site#cmt14717583','14717583'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="comment-thread comment-depth-even comment-depth-74">
+<div id="cmt14717839" class="dwexpcomment" style="margin-left: 1825px; margin-top: 5px;">
+<div class="comment-wrapper comment-wrapper-odd visible    poster-magicians_of_london  partial no-userpic  has-subject">
+<div class="separator separator-before"><div class="inner"></div></div>
+<div class="comment" id="comment-cmt14717839">
+<div class="inner">
+<h4 class="comment-title"><a title="(no subject)" href="https://alicornutopia.dreamwidth.org/22671.html?thread=14717839#cmt14717839">(no subject)</a></h4><span class="poster comment-poster"> <span lj:user="magicians_of_london" style="white-space: nowrap;" class="ljuser"><a href="https://magicians-of-london.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://magicians-of-london.dreamwidth.org/"><b>magicians_of_london</b></a></span></span>
+ - <span class="datetime"><span class="comment-date-text"> </span> <span title="111 days after journal entry">2016-02-17 05:31 (local)</span></span> - <a href="https://alicornutopia.dreamwidth.org/22671.html?thread=14717839&amp;style=site#cmt14717839" onclick="Expander.make(this,'https://alicornutopia.dreamwidth.org/22671.html?thread=14717839&amp;style=site#cmt14717839','14717839'); return false;">Expand</a></div>
+</div>
+<div class="separator separator-after"><div class="inner"></div></div>
+</div>
+</div></div><div class="bottomcomment"><hr class="below-entry-interaction-links"><ul class="entry-interaction-links text-links"><li class="entry-readlink first-item"><a href="https://alicornutopia.dreamwidth.org/22671.html?style=site#comments" data-sing="1 comment" data-dual="2 comments" data-plur="3 comments">75 comments</a></li>
+<li class="entry-replylink"><a onclick="return function(that) {return quickreply(&quot;bottomcomment&quot;, 0, &quot;&quot;,that)}(this)" href="https://alicornutopia.dreamwidth.org/22671.html?mode=reply&amp;style=site">Post a new comment</a></li>
+</ul></div><div class="comment-pages bottompages"><span class="view-flat"><a href="https://alicornutopia.dreamwidth.org/22671.html?style=site&amp;view=flat#comments">Flat</a></span> | <span class="view-top-only"><a href="https://alicornutopia.dreamwidth.org/22671.html?style=site&amp;view=top-only#comments">Top-Level Comments Only</a></span></div><div id="ljqrtbottomcomment" data-quickreply-container="bottomcomment" style="display: none;"></div><div class="commment-pages-wrapper"></div></div></div>
+    </div>
+    <div id="account-links" role="navigation" aria-label="Account Links"><div id="account-links-userpic"><a href="https://www.dreamwidth.org/manage/icons">            <img src="https://v.dreamwidth.org/10163618/2451705" height="80" width="80" alt="Manage Icons"></a></div><div id="account-links-text"><form action="https://www.dreamwidth.org/logout?ret=1" method="post"><span lj:user="throne3d" style="white-space: nowrap;" class="ljuser"><a href="https://throne3d.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://throne3d.dreamwidth.org/"><b>throne3d</b></a></span><input type="hidden" name="user" value="throne3d"><input type="hidden" name="sessid" value="26"><input type="submit" value="Log out"></form><ul><li><a href="https://www.dreamwidth.org/update">Post</a></li><li><a href="https://throne3d.dreamwidth.org/read">Reading Page</a></li><li><a href="https://www.dreamwidth.org/inbox/">Inbox <span id="Inbox_Unread_Count">(1)</span></a></li></ul><ul><li><a href="https://www.dreamwidth.org/manage/settings/">Account Settings</a></li><li><a href="https://www.dreamwidth.org/support/">Help/Support</a></li></ul></div></div>
+    <nav role="navigation" aria-label="Site Navigation">
+        <ul class="left"><li id="create_topnav" class="topnav has-dropdown"><a href="https://www.dreamwidth.org/nav/create">Create</a>
+<ul id="create_subnav" class="subnav_container dropdown">
+                <li class="subnav"><a href="https://www.dreamwidth.org/update">Post Entry</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/editjournal">Edit Entries</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/manage/profile/">Edit Profile</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/manage/icons">Upload Icons (1 of 15)</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/file/new">Upload Images</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/communities/new">Create Community</a></li>
+</ul>
+</li><li id="organize_topnav" class="topnav has-dropdown"><a href="https://www.dreamwidth.org/nav/organize">Organize</a>
+<ul id="organize_subnav" class="subnav_container dropdown">
+                <li class="subnav"><a href="https://www.dreamwidth.org/manage/settings/">Manage Account</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/manage/circle/edit">Manage Circle</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/manage/subscriptions/filters">Manage Filters</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/manage/tags">Manage Tags</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/communities/list">Manage Communities</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/file/edit">Manage Images</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/tools/importer">Import Content</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/customize/">Select Style</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/customize/options">Customize Style</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/beta">Test Beta Features</a></li>
+</ul>
+</li><li id="read_topnav" class="topnav has-dropdown"><a href="https://www.dreamwidth.org/nav/read">Read</a>
+<ul id="read_subnav" class="subnav_container dropdown">
+                <li class="subnav"><a href="https://throne3d.dreamwidth.org/read">Reading Page</a></li>
+                <li class="subnav"><a href="https://throne3d.dreamwidth.org/profile">Profile</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/feeds/">Feeds</a></li>
+                <li class="subnav"><a href="https://throne3d.dreamwidth.org/tag">Tags</a></li>
+                <li class="subnav"><a href="https://throne3d.dreamwidth.org/archive">Archive</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/comments/recent">Recent Comments</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/inbox/">Inbox <span id="Inbox_Unread_Count_Menu"> (1)</span></a></li>
+</ul>
+</li><li id="explore_topnav" class="topnav has-dropdown"><a href="https://www.dreamwidth.org/nav/explore">Explore</a>
+<ul id="explore_subnav" class="subnav_container dropdown">
+                <li class="subnav"><a href="https://www.dreamwidth.org/interests">Interests</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/directorysearch">Directory Search</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/search">Site and Journal Search</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/latest">Latest Things</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/random">Random Journal</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/community/random">Random Community</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/support/faq">FAQ</a></li>
+</ul>
+</li><li id="shop_topnav" class="topnav has-dropdown"><a href="https://www.dreamwidth.org/nav/shop">Shop</a>
+<ul id="shop_subnav" class="subnav_container dropdown">
+                <li class="subnav"><a href="https://www.dreamwidth.org/shop">Buy Dreamwidth Services</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/shop/history">Payment History</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/shop/gifts">Circle Gifts</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/shop/randomgift">Gift a Random User</a></li>
+                <li class="subnav"><a href="https://www.dreamwidth.org/shop/transferpoints">Send Shop Points</a></li>
+                <li class="subnav"><a href="https://www.zazzle.com/dreamwidth*">DW Merchandise</a></li>
+</ul>
+</li>
+</ul>
+    </nav>
+    <div id="header-search" role="search">
+        <div class="appwidget appwidget-search" id="LJWidget_107">
+<form action="https://www.dreamwidth.org/multisearch" method="post">
+<input type="text" size="20" class="text" title="Search" id="search" name="q"> <select name="type" class="select">
+<option value="int" selected="selected">Interest</option>
+<option value="region">Region</option>
+<option value="nav_and_user">Site and Account</option>
+<option value="faq">FAQ</option>
+<option value="email">Email</option>
+<option value="im">IM Info</option>
+</select> <input type="submit" value="Go"></form></div><!-- end .appwidget-search -->
+
+    </div>
+    <footer role="contentinfo">
+        <ul>
+    <li><a href="https://www.dreamwidth.org/legal/privacy">Privacy Policy</a> • </li>
+    <li><a href="https://www.dreamwidth.org/legal/tos">Terms of Service</a> • </li>
+    <li><a href="https://www.dreamwidth.org/legal/diversity">Diversity Statement</a> • </li>
+    <li><a href="https://www.dreamwidth.org/legal/principles">Guiding Principles</a> • </li>
+    <li><a href="https://www.dreamwidth.org/site/">Site Map</a> • </li>
+    <li><a href="https://www.dreamwidth.org/site/suggest">Make a Suggestion</a> • </li>
+    <li><a href="https://www.dreamwidth.org/site/opensource">Open Source</a> • </li>
+    <li><a href="https://www.dreamwidth.org/support">Help/Support</a></li>
+</ul>
+<p>Copyright © 2009-2017 Dreamwidth Studios, LLC. <a href="//www.dreamwidth.org/site/opensource">Some</a> rights reserved.</p>
+    </footer>
+</div>
+        </div>
+        <div id="statistics" style="text-align: left; font-size:0; line-height:0; height:0; overflow:hidden;"></div>
+
+<div id="qrdiv" style="display: none;"><div id="qrformdiv"><form id="qrform" name="qrform" method="POST" action="https://www.dreamwidth.org/talkpost_do"><input type="hidden" name="lj_form_auth" value="c0:1513987200:1492:86400:AhYOCPfnTz-2451705-26:1296ead9f1dad0cafc0d41102a03a558"><input type="hidden" name="replyto" value="" id="replyto"><input type="hidden" name="parenttalkid" value="" id="parenttalkid"><input type="hidden" name="journal" value="alicornutopia" id="journal"><input type="hidden" name="itemid" value="22671" id="itemid"><input type="hidden" name="usertype" value="cookieuser" id="usertype"><input type="hidden" name="qr" value="1" id="qr"><input type="hidden" name="cookieuser" value="throne3d" id="cookieuser"><input type="hidden" name="dtid" value="" id="dtid"><input type="hidden" name="basepath" value="https://alicornutopia.dreamwidth.org/22671.html?style=site&amp;" id="basepath"><input type="hidden" name="viewing_thread" value="14698127" id="viewing_thread"><input type="hidden" name="style" value="site" id="style"><input type="hidden" name="chrp1" value="22671-2146354-1513987200-4MLsxQNElnGMO9UR1KZs-cd8a16218e6e85d8a307ea120ecb5830">
+<table>
+  <tbody><tr valign="center">
+    <td align="right"><b>From:</b></td>
+    <td align="left"><span lj:user="throne3d" style="white-space: nowrap;" class="ljuser"><a href="https://throne3d.dreamwidth.org/profile"><img src="https://www.dreamwidth.org/img/silk/identity/user.png" alt="[personal profile] " width="17" height="17" style="vertical-align: text-bottom; border: 0; padding-right: 1px;"></a><a href="https://throne3d.dreamwidth.org/"><b>throne3d</b></a></span></td>
+    <td align="center">
+      <label for="prop_picture_keyword"><a href="https://throne3d.dreamwidth.org/icons">Icon</a> to use:</label><select class="select" id="prop_picture_keyword" name="prop_picture_keyword">
+<option value="" selected="selected" data-url="https://v.dreamwidth.org/10163618/2451705">(default)</option>
+<option value="avatar" data-url="https://v.dreamwidth.org/10163618/2451705">avatar</option>
+</select>
+      <input type="button" id="randomicon" value="Random icon">
+
+      <span id="quotebuttonspan"><input type="button" value="Quote"></span>
+    </td>
+  </tr>
+
+  <tr>
+    <td align="right"><label for="subject"><b>Subject:</b></label></td>
+    <td colspan="2" align="left"><input class="textbox" type="text" size="50" maxlength="100" name="subject" id="subject" value=""></td>
+  </tr>
+
+  <tr valign="top">
+    <td align="right"><label for="body"><b>Message:</b></label></td>
+    <td colspan="3" style="width: 90%">
+      <textarea class="textbox" rows="10" cols="50" wrap="soft" name="body" id="body" style="width: 99%; height: 99%"></textarea>
+    </td>
+  </tr>
+
+  <tr>
+    <td>&nbsp;</td>
+    <td colspan="3" align="left"><input type="submit" name="submitpost" value="Post Comment" class="submit" id="submitpost">      &nbsp;<input type="submit" name="submitpview" value="Preview" id="submitpview" class="submit"><input type="hidden" name="submitpreview" value="0">      &nbsp;<input type="submit" name="submitmoreopts" value="More Options" id="submitmoreopts" class="submit">        &nbsp;<input type="checkbox" class="checkbox" id="do_spellcheck" name="do_spellcheck">
+        <label for="do_spellcheck" class="checkboxlabel">
+            Check spelling
+        </label>
+                <br><span class="de"><strong>Notice:</strong> This account is set to log the IP addresses of everyone who comments.</span>    </td>
+  </tr>
+</tbody></table>
+</form></div></div></body></html>


### PR DESCRIPTION
The first commit fixes this when the broken-depth comment isn't on the page boundary, by counting every 25th reply instead of every 25th comment depth.

See an example of the problem here:
https://alicornutopia.dreamwidth.org/22671.html?thread=14698127&style=site#cmt14698127

(The second and third comments are on the same depth, and accordingly break the old way of figuring out the pages of the thread.)

The second commit fixes this on the boundary. If there's a comment for a new page, but it's followed directly by another comment on the same depth, this will store a page for both comments. This means it'll load a page for the single earlier comment on the wrong depth, then a page for the rest of the comments.

The third commit adds retry functionality to the PostScraper, which really I should split out from this PR.