### PR TITLE
Helper method to regenerate flat posts

### DIFF
--- a/app/models/flat_post.rb
+++ b/app/models/flat_post.rb
@@ -1,3 +1,18 @@
 class FlatPost < ApplicationRecord
   belongs_to :post, inverse_of: :flat_post, optional: false
+
+  def self.regenerate_all(before=nil, override=true)
+    # uses Post instead of FlatPost in case any are missing
+    Post.includes(:flat_post).find_each do |post|
+      unless post.flat_post
+        # ignore arguments because posts should always have a flat post object and this is Bad
+        GenerateFlatPostJob.enqueue(post.id)
+        next
+      end
+
+      next if before.present? && post.flat_post.updated_at >= before
+      next if !override && post.flat_post.updated_at >= post.tagged_at
+      GenerateFlatPostJob.enqueue(post.id)
+    end
+  end
 end

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -93,12 +93,6 @@ class Reply < ApplicationRecord
 
   def update_flat_post
     return if skip_regenerate
-
-    # frequent tag check
-    lock_key = GenerateFlatPostJob.lock_key(post_id)
-    return if $redis.get(lock_key)
-    $redis.set(lock_key, true)
-
-    GenerateFlatPostJob.perform_later(post_id)
+    GenerateFlatPostJob.enqueue(post_id)
   end
 end

--- a/spec/models/flat_post_spec.rb
+++ b/spec/models/flat_post_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+RSpec.describe FlatPost do
+  include ActiveJob::TestHelper
+
+  describe ".regenerate_all" do
+    def delete_lock(post)
+      lock_key = GenerateFlatPostJob.lock_key(post.id)
+      $redis.del(lock_key)
+    end
+
+    it "regenerates all flat posts" do
+      post = create(:post)
+      delete_lock(post)
+      FlatPost.regenerate_all
+      expect(GenerateFlatPostJob).to have_been_enqueued.with(post.id).on_queue('high')
+    end
+
+    it "regenerates only old flat posts with argument" do
+      post = create(:post)
+      nonpost = Timecop.freeze(post.tagged_at + 2.hours) { create(:post) }
+      delete_lock(post)
+      delete_lock(nonpost)
+      FlatPost.regenerate_all(post.tagged_at + 1.hours)
+      expect(GenerateFlatPostJob).to have_been_enqueued.with(post.id).on_queue('high')
+      expect(GenerateFlatPostJob).not_to have_been_enqueued.with(nonpost.id).on_queue('high')
+    end
+
+    it "regenerates only matching flat posts with arguments" do
+      post = create(:post)
+      nonpost = create(:post)
+
+      reply = build(:reply, post: post)
+      reply.skip_regenerate = true
+      reply.save
+
+      delete_lock(post)
+      delete_lock(nonpost)
+      FlatPost.regenerate_all(nil, false)
+      expect(GenerateFlatPostJob).to have_been_enqueued.with(post.id).on_queue('high')
+      expect(GenerateFlatPostJob).not_to have_been_enqueued.with(nonpost.id).on_queue('high')
+    end
+
+    it "handles missing flat posts" do
+      post = create(:post)
+      post.flat_post.delete
+      delete_lock(post)
+      FlatPost.regenerate_all
+      expect(GenerateFlatPostJob).to have_been_enqueued.with(post.id).on_queue('high')
+    end
+  end
+end


### PR DESCRIPTION
Takes an optional argument to only regenerate flat posts older than a certain date
Takes an optional argument to skip flat posts that don't require updating (we may in some cases wish to update anyway; for example, our icon URLs changed when we moved to the asset pipeline and they're now broken on many flat views.)