### PR TITLE
Convert import permissions to use Permissible

### DIFF
--- a/app/concerns/permissible.rb
+++ b/app/concerns/permissible.rb
@@ -1,11 +1,13 @@
 module Permissible
   ADMIN = 1
   MOD = 2
+  IMPORTER = 3
 
   MOD_PERMS = [
     :edit_posts,
     :edit_replies,
     :edit_characters,
+    :import_posts,
     # :edit_tags,
     # :delete_tags,
     # :edit_continuities
@@ -14,6 +16,7 @@ module Permissible
   def has_permission?(permission)
     return false unless role_id
     return true if admin?
+    return true if importer? && permission == :import_posts
     return false unless mod?
     MOD_PERMS.include?(permission)
   end
@@ -24,5 +27,9 @@ module Permissible
 
   def mod?
     role_id == MOD
+  end
+
+  def importer?
+    role_id == IMPORTER
   end
 end

--- a/app/views/posts/new.haml
+++ b/app/views/posts/new.haml
@@ -3,7 +3,7 @@
 - else
   .content-header
     Create a new post
-    - if PostsController::SCRAPE_USERS.include?(current_user.id)
+    - if current_user.has_permission?(:import_posts)
       = link_to new_post_path(view: :import) do
         .view-button Import &raquo;
   = render partial: 'write', locals: { post: @post, url: posts_path, method: :post }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
     factory :mod_user do
       role_id 2
     end
+
+    factory :importing_user do
+      role_id 3
+    end
   end
 
   factory :board do


### PR DESCRIPTION
We'll need to manually:

```ruby
User.where(id: [1, 2, 3, 8, 19, 24, 31], role_id: nil).update_attributes(role_id: Permissible::IMPORTER)
```

This should be neater than the current hardcoding method.