### PR TITLE
Fix moderator note being lost on reply preview

### DIFF
--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -244,7 +244,7 @@ class RepliesController < WritableController
   def preview(written)
     @written = written
     @post = @written.post
-    @written.user = current_user
+    @written.user = current_user unless @written.user
 
     @page_title = @post.subject
 

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -563,8 +563,10 @@ RSpec.describe RepliesController do
       end
 
       it "takes correct actions for moderators" do
-        reply_post = create(:post)
-        reply = create(:reply, post: reply_post, user: reply_post.user)
+        user = create(:user)
+        reply_post = create(:post, user: user)
+        reply = create(:reply, post: reply_post, user: user)
+        char = create(:template_character, user: user)
         login_as(create(:mod_user))
 
         newcontent = reply.content + 'new'
@@ -582,6 +584,9 @@ RSpec.describe RepliesController do
         expect(assigns(:written).user).to eq(reply.user)
         expect(assigns(:written).audit_comment).to eq('note')
         expect(assigns(:written).content).to eq(newcontent)
+
+        expect(controller.gon.editor_user[:username]).to eq(user.username)
+        expect(assigns(:templates)).to eq([char.template])
       end
 
       skip

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -562,6 +562,28 @@ RSpec.describe RepliesController do
         expect(templateless.plucked_characters).to eq([[char.id, char.name]])
       end
 
+      it "takes correct actions for moderators" do
+        reply_post = create(:post)
+        reply = create(:reply, post: reply_post, user: reply_post.user)
+        login_as(create(:mod_user))
+
+        newcontent = reply.content + 'new'
+
+        post :update, params: {
+          id: reply.id,
+          button_preview: true,
+          reply: {
+            content: newcontent,
+            audit_comment: 'note'
+          }
+        }
+
+        expect(response).to render_template(:preview)
+        expect(assigns(:written).user).to eq(reply.user)
+        expect(assigns(:written).audit_comment).to eq('note')
+        expect(assigns(:written).content).to eq(newcontent)
+      end
+
       skip
     end
   end

--- a/spec/features/posts/edit_spec.rb
+++ b/spec/features/posts/edit_spec.rb
@@ -127,4 +127,45 @@ RSpec.feature "Editing posts", :type => :feature do
       expect(page).to have_selector('.post-author', exact_text: user.username)
     end
   end
+
+  scenario "Moderator edits a post with preview" do
+    user = create(:user, password: 'known')
+    post = create(:post, user: user, subject: 'test subject')
+
+    login(create(:mod_user, password: 'known'), 'known')
+
+    visit post_path(post)
+    expect(page).to have_selector('.post-container', count: 1)
+    within('.post-container') do
+      click_link 'Edit'
+    end
+
+    # first changes, then preview
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.content-header', text: 'Edit post')
+    expect(page).to have_no_selector('.post-container')
+    within('#post-editor') do
+      fill_in 'Subject', with: 'other subject'
+      fill_in 'Moderator note', with: 'example edit'
+      click_button 'Preview'
+    end
+
+    # verify preview, change again
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.content-header', text: 'other subject')
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_selector('#post-editor')
+    within('#post-editor') do
+      expect(page).to have_field('Subject', with: 'other subject')
+      expect(page).to have_field('Moderator note', with: 'example edit')
+      fill_in 'Subject', with: 'third subject'
+      fill_in 'Moderator note', with: 'another edit'
+      click_button 'Save'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.success', text: 'has been updated.')
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_selector('#post-title', exact_text: 'third subject')
+  end
 end

--- a/spec/features/posts/edit_spec.rb
+++ b/spec/features/posts/edit_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Editing posts", :type => :feature do
     end
 
     expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', text: 'Edit post')
+    expect(page).to have_selector('.content-header', exact_text: 'Edit post')
     expect(page).to have_no_selector('.post-container')
     within('#post-editor') do
       fill_in 'Subject', with: 'other subject'
@@ -57,7 +57,7 @@ RSpec.feature "Editing posts", :type => :feature do
 
     # first changes, then preview
     expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', text: 'Edit post')
+    expect(page).to have_selector('.content-header', exact_text: 'Edit post')
     expect(page).to have_no_selector('.post-container')
     within('#post-editor') do
       fill_in 'Subject', with: 'other subject'
@@ -66,7 +66,7 @@ RSpec.feature "Editing posts", :type => :feature do
 
     # verify preview, change again
     expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', text: 'other subject')
+    expect(page).to have_selector('.content-header', exact_text: 'other subject')
     expect(page).to have_selector('.post-container', count: 1)
     expect(page).to have_selector('#post-editor')
     within('#post-editor') do
@@ -110,7 +110,7 @@ RSpec.feature "Editing posts", :type => :feature do
     end
 
     expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', text: 'Edit post')
+    expect(page).to have_selector('.content-header', exact_text: 'Edit post')
     expect(page).to have_no_selector('.post-container')
     within('#post-editor') do
       fill_in 'Subject', with: 'other subject'
@@ -142,7 +142,7 @@ RSpec.feature "Editing posts", :type => :feature do
 
     # first changes, then preview
     expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', text: 'Edit post')
+    expect(page).to have_selector('.content-header', exact_text: 'Edit post')
     expect(page).to have_no_selector('.post-container')
     within('#post-editor') do
       fill_in 'Subject', with: 'other subject'
@@ -152,7 +152,7 @@ RSpec.feature "Editing posts", :type => :feature do
 
     # verify preview, change again
     expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', text: 'other subject')
+    expect(page).to have_selector('.content-header', exact_text: 'other subject')
     expect(page).to have_selector('.post-container', count: 1)
     expect(page).to have_selector('#post-editor')
     within('#post-editor') do

--- a/spec/features/replies/new_spec.rb
+++ b/spec/features/replies/new_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Creating replies", :type => :feature do
     end
 
     expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.success', text: 'Posted!')
+    expect(page).to have_selector('.success', exact_text: 'Posted!')
     expect(page).to have_selector('.post-container', count: 2)
     within('.post-reply') do
       expect(page).to have_selector('.post-author', exact_text: user.username)
@@ -56,7 +56,7 @@ RSpec.feature "Creating replies", :type => :feature do
     end
 
     expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.success', text: 'Posted!')
+    expect(page).to have_selector('.success', exact_text: 'Posted!')
     expect(page).to have_selector('.post-container', count: 2)
     within('.post-reply') do
       expect(page).to have_selector('.post-author', exact_text: user.username)


### PR DESCRIPTION
Fixes #657 and adds a test for preview on updating replies.