### PR TITLE
Add rubocop as a development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
+  gem 'rubocop'
   gem 'web-console', '~> 3.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     apipie-rails (0.5.6)
       rails (>= 4.1)
     arel (8.0.0)
+    ast (2.3.0)
     audited (4.5.0)
       activerecord (>= 4.0, < 5.2)
     aws-partitions (1.52.0)
@@ -186,12 +187,16 @@ GEM
       mini_portile2 (~> 2.3.0)
     nokogumbo (1.4.13)
       nokogiri
+    parallel (1.12.1)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     pg (0.21.0)
     pg_search (2.1.2)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
       arel (>= 6)
     power_assert (1.1.1)
+    powerpack (0.1.1)
     public_suffix (3.0.1)
     puma (3.11.0)
     rack (2.0.3)
@@ -236,6 +241,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
@@ -303,6 +309,14 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
+    rubocop (0.52.1)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     ruby_parser (3.10.1)
       sexp_processor (~> 4.9)
@@ -370,6 +384,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.0.2)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.3.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
     web-console (3.5.1)
@@ -438,6 +453,7 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails
+  rubocop
   sanitize
   sass-rails
   seed_dump (~> 3.2)


### PR DESCRIPTION
I'm not sure if this is necessary, but it looks like I keep forgetting to keep it (and .rubocop.yml) up to date. Having it as a development dependency may well fix that by forcing it to update every so often.