### PR TITLE
Feature spec replies#new, replies#edit, posts#edit, and improve posts#new

### DIFF
--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -39,7 +39,7 @@
       #post-form-wrapper
         = f.text_area :content, class: 'tinymce'
         - unless current_user.id == post.user_id
-          %b Moderator note
+          %b= f.label :audit_comment, 'Moderator note'
           %br
           = f.text_area :audit_comment, placeholder: 'Explain reason for moderation here', class: 'mod'
           %br

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -21,7 +21,7 @@
         %td.post-subheader{colspan: 2, style: 'width: unset;'}= sanitize_post_description(@post.description).html_safe
   %tbody
     %tr
-      %td.sub.width-150 Status
+      %th.sub.width-150 Status
       %td{class: cycle('odd', 'even')}
         - case @post.status
         - when Post::STATUS_ACTIVE
@@ -37,7 +37,7 @@
           = image_tag "icons/book_grey.png", class: 'vmid', title: "In Progress"
           Abandoned
     %tr
-      %td.sub.width-150 Audience
+      %th.sub.width-150 Audience
       %td{class: cycle('odd', 'even')}
         = privacy_state(@post.privacy)
         - if @post.access_list?
@@ -49,10 +49,10 @@
             - else
               = link_to viewer.user.username, user_path(viewer.user)
     %tr
-      %td.sub.width-150 Authors
+      %th.sub.width-150 Authors
       %td{class: cycle('odd', 'even')}= @post.authors.sort_by { |author| author.username.downcase }.map { |author| link_to author.username, user_path(author) }.join(', ').html_safe
     %tr
-      %td.sub.width-150.vtop Characters
+      %th.sub.width-150.vtop Characters
       %td{class: cycle('odd', 'even')}
         %ul
           - @post.character_appearance_counts.each do |character, count|
@@ -63,18 +63,18 @@
 
     - if @post.settings.present?
       %tr
-        %td.sub.width-150 Setting
+        %th.sub.width-150 Setting
         %td{class: cycle('odd', 'even')}= @post.settings.order('post_tags.id asc').map { |tag| link_to tag.name, tag_path(tag) }.join(', ').html_safe
     - if @post.content_warnings.present?
       %tr
-        %td.sub.width-150 Content Warnings
+        %th.sub.width-150 Content Warnings
         %td{class: cycle('odd', 'even')}= @post.content_warnings.order('post_tags.id asc').map { |tag| link_to tag.name, tag_path(tag) }.join(', ').html_safe
     - if @post.labels.present?
       %tr
-        %td.sub.width-150 Labels
+        %th.sub.width-150 Labels
         %td{class: cycle('odd', 'even')}= @post.labels.order('post_tags.id asc').map { |tag| link_to tag.name, tag_path(tag) }.join(', ').html_safe
     %tr
-      %td.sub.width-150.vtop Word Count
+      %th.sub.width-150.vtop Word Count
       %td{class: cycle('odd', 'even')}
         = number_with_delimiter(@post.total_word_count)
         - if @post.authors.count > 1
@@ -84,8 +84,8 @@
                 = username + ':'
                 = number_with_delimiter(count)
     %tr
-      %td.sub.width-150 Time Begun
+      %th.sub.width-150 Time Begun
       %td{class: cycle('odd', 'even')}= pretty_time(@post.created_at)
     %tr
-      %td.sub.width-150 Time Last Updated
+      %th.sub.width-150 Time Last Updated
       %td{class: cycle('odd', 'even')}= pretty_time(@post.tagged_at)

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -29,13 +29,13 @@
           = image_tag "icons/link.png".freeze, title: 'Permalink'.freeze, alt: 'Permalink'.freeze
       - if reply.id.present? && (reply.editable_by?(current_user) || (reply.is_a?(Post) && reply.metadata_editable_by?(current_user)))
         = link_to path_for(reply, 'edit_%s') do
-          = image_tag "icons/pencil.png".freeze
+          = image_tag "icons/pencil.png".freeze, title: 'Edit'.freeze, alt: 'Edit'.freeze
       - if reply.id.present? && reply.deletable_by?(current_user)
         = link_to path_for(reply, '%s'), method: :delete, data: { confirm: "Are you sure you wish to delete this #{reply.class.to_s.downcase}?" } do
-          = image_tag "icons/cross.png".freeze
+          = image_tag "icons/cross.png".freeze, title: 'Delete'.freeze, alt: 'Delete'.freeze
       - if reply.id.present? && reply.is_a?(Reply) && logged_in?
         = link_to post_path(@post, unread: true, at_id: reply.id), method: :put do
-          = image_tag "icons/eye.png".freeze, title: 'Mark Unread Here'.freeze, alt: 'Eye'.freeze
+          = image_tag "icons/eye.png".freeze, title: 'Mark Unread Here'.freeze, alt: 'Mark Unread Here'.freeze
     .post-content= sanitize_written_content(reply.content.to_s).html_safe
   .post-footer
     - unless local_assigns[:hide_footer]

--- a/app/views/replies/_write.haml
+++ b/app/views/replies/_write.haml
@@ -18,7 +18,7 @@
     #post-form-wrapper
       = f.text_area :content, class: 'tinymce'
       - unless current_user.id == reply.user_id
-        %b Moderator note
+        %b= f.label :audit_comment, 'Moderator note'
         %br
         = f.text_area :audit_comment, placeholder: 'Explain reason for moderation here', class: 'mod'
         %br

--- a/spec/features/posts/edit_spec.rb
+++ b/spec/features/posts/edit_spec.rb
@@ -1,0 +1,130 @@
+require "spec_helper"
+
+RSpec.feature "Editing posts", :type => :feature do
+  scenario "Logged-out user tries to edit a post" do
+    post = create(:post, subject: 'test subject')
+
+    visit post_path(post)
+    expect(page).to have_selector('#post-title', exact_text: 'test subject')
+    expect(page).to have_selector('.post-container', count: 1)
+    within('.post-container') do
+      expect(page).to have_no_link('Edit')
+    end
+
+    visit edit_post_path(post)
+    expect(page).to have_selector('.error', text: 'You must be logged in to view that page.')
+    expect(page).to have_current_path(root_path)
+    expect(page).to have_no_selector('#post-editor')
+  end
+
+  scenario "User edits a post" do
+    user = create(:user, password: 'known')
+    post = create(:post, user: user, subject: 'test subject')
+
+    login(user, 'known')
+
+    visit post_path(post)
+    expect(page).to have_selector('.post-container', count: 1)
+    within('.post-container') do
+      click_link 'Edit'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.content-header', text: 'Edit post')
+    expect(page).to have_no_selector('.post-container')
+    within('#post-editor') do
+      fill_in 'Subject', with: 'other subject'
+      click_button 'Save'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.success', text: 'has been updated.')
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_selector('#post-title', exact_text: 'other subject')
+  end
+
+  scenario "User edits a post with preview" do
+    user = create(:user, password: 'known')
+    post = create(:post, user: user, subject: 'test subject')
+
+    login(user, 'known')
+
+    visit post_path(post)
+    expect(page).to have_selector('.post-container', count: 1)
+    within('.post-container') do
+      click_link 'Edit'
+    end
+
+    # first changes, then preview
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.content-header', text: 'Edit post')
+    expect(page).to have_no_selector('.post-container')
+    within('#post-editor') do
+      fill_in 'Subject', with: 'other subject'
+      click_button 'Preview'
+    end
+
+    # verify preview, change again
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.content-header', text: 'other subject')
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_selector('#post-editor')
+    within('#post-editor') do
+      expect(page).to have_field('Subject', with: 'other subject')
+      fill_in 'Subject', with: 'third subject'
+      click_button 'Save'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.success', text: 'has been updated.')
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_selector('#post-title', exact_text: 'third subject')
+  end
+
+  scenario "User tries to edit someone else's post" do
+    post = create(:post, subject: 'test subject')
+
+    login
+    visit post_path(post)
+    expect(page).to have_selector('#post-title', exact_text: 'test subject')
+    expect(page).to have_selector('.post-container', count: 1)
+    within('.post-container') do
+      expect(page).to have_no_link('Edit')
+    end
+
+    visit edit_post_path(post)
+    expect(page).to have_selector('.error', text: 'You do not have permission to modify this post.')
+    expect(page).to have_current_path(post_path(post))
+  end
+
+  scenario "Moderator edits a post" do
+    user = create(:user, password: 'known')
+    post = create(:post, user: user, subject: 'test subject')
+
+    login(create(:mod_user, password: 'known'), 'known')
+
+    visit post_path(post)
+    expect(page).to have_selector('.post-container', count: 1)
+    within('.post-container') do
+      click_link 'Edit'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.content-header', text: 'Edit post')
+    expect(page).to have_no_selector('.post-container')
+    within('#post-editor') do
+      fill_in 'Subject', with: 'other subject'
+      fill_in 'Moderator note', with: 'example edit'
+      click_button 'Save'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.success', text: 'has been updated.')
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_selector('#post-title', exact_text: 'other subject')
+    within('.post-container') do
+      # must not change post's user
+      expect(page).to have_selector('.post-author', exact_text: user.username)
+    end
+  end
+end

--- a/spec/features/posts/new_spec.rb
+++ b/spec/features/posts/new_spec.rb
@@ -13,13 +13,20 @@ RSpec.feature "Creating posts", :type => :feature do
     expect(page).to have_selector(".content-header", text: "Create a new post")
 
     click_button "Post"
-    within(".error") { expect(page).to have_text("Subject can't be blank") }
+    expect(page).to have_selector('.error', text: "Subject can't be blank")
     expect(page).to have_selector(".content-header", text: "Create a new post")
 
     fill_in "post_subject", with: "test subject"
     click_button "Post"
     expect(page).to have_no_selector(".error")
-    within(".success") { expect(page).to have_text("successfully posted.") }
+    expect(page).to have_selector('.success', text: 'successfully posted.')
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_selector('#post-title', exact_text: 'test subject')
+
+    within('.post-container') do
+      expect(page).to have_selector('.post-author', exact_text: user.username)
+      expect(page).to have_selector('.post-content', exact_text: '')
+    end
   end
 
   scenario "User sees different editor settings" do
@@ -28,14 +35,14 @@ RSpec.feature "Creating posts", :type => :feature do
 
     visit new_post_path
     within("#current-icon-holder") do
-      expect(page).to have_xpath("//img[contains(@src, 'no-icon')]")
+      expect(page).to have_xpath(".//img[contains(@src, 'no-icon')]")
     end
 
     icon = create(:icon, user: user)
     user.update_attributes(avatar: icon)
     visit new_post_path
     within("#current-icon-holder") do
-      expect(page).to have_xpath("//img[contains(@src, '#{icon.url}')]")
+      expect(page).to have_xpath(".//img[contains(@src, '#{icon.url}')]")
     end
 
     icon2 = create(:icon, user: user)
@@ -43,7 +50,7 @@ RSpec.feature "Creating posts", :type => :feature do
     user.update_attributes(active_character: character)
     visit new_post_path
     within("#current-icon-holder") do
-      expect(page).to have_xpath("//img[contains(@src, '#{icon2.url}')]")
+      expect(page).to have_xpath(".//img[contains(@src, '#{icon2.url}')]")
     end
   end
 end

--- a/spec/features/replies/edit_spec.rb
+++ b/spec/features/replies/edit_spec.rb
@@ -1,0 +1,137 @@
+require "spec_helper"
+
+RSpec.feature "Creating replies", :type => :feature do
+  def find_reply_on_page(reply)
+    find('.post-reply') { |x| x.has_selector?('a', id: "reply-#{reply.id}") }
+  end
+
+  scenario "Logged-out user tries to edit a reply" do
+    reply = create(:reply)
+
+    visit reply_path(reply)
+    within(find_reply_on_page(reply)) do
+      expect(page).to have_no_link('Edit')
+    end
+
+    visit edit_reply_path(reply)
+    expect(page).to have_selector('.error', text: 'You must be logged in to view that page.')
+    expect(page).to have_current_path(root_path)
+    expect(page).to have_no_selector('#post-editor')
+  end
+
+  scenario "User edits a reply" do
+    user = create(:user, password: 'known')
+    reply = create(:reply, user: user, content: 'example text')
+
+    login(user, 'known')
+
+    visit reply_path(reply)
+    expect(page).to have_selector('.post-container', count: 2)
+    within(find_reply_on_page(reply)) do
+      click_link 'Edit'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.content-header', exact_text: 'Edit post')
+    expect(page).to have_no_selector('.post-container')
+    within('#post-editor') do
+      fill_in 'reply_content', with: 'other text'
+      click_button 'Save'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.success', exact_text: 'Post updated')
+    expect(page).to have_selector('.post-container', count: 2)
+    within(find_reply_on_page(reply)) do
+      expect(page).to have_selector('.post-content', exact_text: 'other text')
+    end
+  end
+
+  scenario "User edits a reply with preview" do
+    user = create(:user, password: 'known')
+    reply = create(:reply, user: user, content: 'example text')
+
+    login(user, 'known')
+
+    visit reply_path(reply)
+    expect(page).to have_selector('.post-container', count: 2)
+    within(find_reply_on_page(reply)) do
+      click_link 'Edit'
+    end
+
+    # first changes, then preview
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.content-header', exact_text: 'Edit post')
+    expect(page).to have_no_selector('.post-container')
+    within('#post-editor') do
+      fill_in 'reply_content', with: 'other text'
+      click_button 'Preview'
+    end
+
+    # verify preview, change again
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_no_selector('.success')
+    expect(page).to have_selector('.content-header', exact_text: reply.post.subject)
+    expect(page).to have_selector('.post-container', count: 1)
+    within('.post-container') do
+      expect(page).to have_selector('.post-content', exact_text: 'other text')
+    end
+
+    within('#post-editor') do
+      expect(page).to have_field('reply_content', with: 'other text')
+      fill_in 'reply_content', with: 'third text'
+      click_button 'Save'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.success', exact_text: 'Post updated')
+    expect(page).to have_selector('.post-container', count: 2)
+    within(find_reply_on_page(reply)) do
+      expect(page).to have_selector('.post-content', exact_text: 'third text')
+    end
+  end
+
+  scenario "User tries to edit someone else's reply" do
+    reply = create(:reply, content: 'example text')
+
+    login
+    visit reply_path(reply)
+    within(find_reply_on_page(reply)) do
+      expect(page).to have_no_link('Edit')
+    end
+
+    visit edit_reply_path(reply)
+    expect(page).to have_selector('.error', text: 'You do not have permission to modify this post.')
+    expect(page).to have_current_path(post_path(reply.post))
+  end
+
+  scenario "Moderator edits a reply" do
+    user = create(:user, password: 'known')
+    reply = create(:reply, user: user, content: 'example text')
+
+    login(create(:mod_user, password: 'known'), 'known')
+
+    visit reply_path(reply)
+    expect(page).to have_selector('.post-container', count: 2)
+    within(find_reply_on_page(reply)) do
+      click_link 'Edit'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.content-header', exact_text: 'Edit post')
+    expect(page).to have_no_selector('.post-container')
+    within('#post-editor') do
+      fill_in 'reply_content', with: 'other text'
+      fill_in 'Moderator note', with: 'example edit'
+      click_button 'Save'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.success', exact_text: 'Post updated')
+    expect(page).to have_selector('.post-container', count: 2)
+    within(find_reply_on_page(reply)) do
+      expect(page).to have_selector('.post-content', exact_text: 'other text')
+      expect(page).to have_selector('.post-author', exact_text: user.username)
+    end
+  end
+end

--- a/spec/features/replies/new_spec.rb
+++ b/spec/features/replies/new_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+
+RSpec.feature "Creating replies", :type => :feature do
+  scenario "User replies to own post" do
+    user = login
+    post = create(:post, user: user)
+
+    visit post_path(post)
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_no_selector('.post-expander', text: 'Join Thread')
+    expect(page).to have_selector('#post-editor')
+
+    # preview first:
+    within('#post-editor') do
+      click_button 'Preview'
+    end
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.success', exact_text: 'Draft saved!')
+    expect(page).to have_selector('#post-editor')
+
+    # then save:
+    within('#post-editor') do
+      click_button 'Post'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.success', text: 'Posted!')
+    expect(page).to have_selector('.post-container', count: 2)
+    within('.post-reply') do
+      expect(page).to have_selector('.post-author', exact_text: user.username)
+      expect(page).to have_no_selector('.post-icon')
+      expect(page).to have_no_selector('.post-character')
+      expect(page).to have_no_selector('.post-screenname')
+    end
+
+    # check author list
+    visit stats_post_path(post)
+    within(row_for('Authors')) do
+      expect(page).to have_selector('a', count: 1)
+      expect(page).to have_link(exact_text: user.username, href: user_path(user))
+    end
+  end
+
+  scenario "User replies to open post" do
+    post = create(:post)
+
+    user = login
+    visit post_path(post)
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_selector('.post-expander', text: 'Join Thread')
+    expect(page).to have_selector('.hidden #post-editor')
+
+    # TODO: use javascript to expand post editor
+    within('#post-editor') do
+      click_button 'Post'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.success', text: 'Posted!')
+    expect(page).to have_selector('.post-container', count: 2)
+    within('.post-reply') do
+      expect(page).to have_selector('.post-author', exact_text: user.username)
+      expect(page).to have_no_selector('.post-icon')
+      expect(page).to have_no_selector('.post-character')
+      expect(page).to have_no_selector('.post-screenname')
+    end
+
+    # check author list
+    visit stats_post_path(post)
+    within(row_for('Authors')) do
+      expect(page).to have_selector('a', count: 2)
+      expect(page).to have_link(exact_text: post.user.username, href: user_path(post.user))
+      expect(page).to have_link(exact_text: user.username, href: user_path(user))
+    end
+  end
+
+  scenario "User tries to reply to locked post" do
+    post = create(:post, authors_locked: true)
+
+    login
+    visit post_path(post)
+    expect(page.text).not_to include('Join Thread')
+    expect(page).to have_no_selector('#post-editor')
+  end
+
+  scenario "Logged-out user tries to reply to post" do
+    post = create(:post)
+
+    visit post_path(post)
+    expect(page.text).not_to include('Join Thread')
+    expect(page).to have_no_selector('#post-editor')
+  end
+end

--- a/spec/features/templates/new_spec.rb
+++ b/spec/features/templates/new_spec.rb
@@ -66,8 +66,7 @@ RSpec.feature "Creating a new template", :type => :feature do
     within('.form-table') do
       expect(page).to have_field('Template Name')
       fill_in 'template_description', with: 'Example template description'
-      characters_row = find('tr') { |x| x.has_selector?('th', text: 'Characters') }
-      within(characters_row) do
+      within(row_for('Characters')) do
         check('Character1')
         check('Character5')
       end
@@ -82,8 +81,7 @@ RSpec.feature "Creating a new template", :type => :feature do
     within('.form-table') do
       expect(page).to have_field('Template Name', with: '')
       expect(page).to have_field('template_description', with: 'Example template description')
-      characters_row = find('tr') { |x| x.has_selector?('th', text: 'Characters') }
-      within(characters_row) do
+      within(row_for('Characters')) do
         expect(page).to have_checked_field('Character1')
         expect(page).to have_unchecked_field('Character2')
         expect(page).to have_unchecked_field('Character3')

--- a/spec/support/spec_feature_helper.rb
+++ b/spec/support/spec_feature_helper.rb
@@ -7,4 +7,8 @@ module SpecFeatureHelper
     click_button "Log in"
     user
   end
+
+  def row_for(title)
+    find('tr') { |x| x.has_selector?('th', text: title) }
+  end
 end

--- a/spec/support/spec_feature_helper.rb
+++ b/spec/support/spec_feature_helper.rb
@@ -1,9 +1,12 @@
 module SpecFeatureHelper
-  def login
-    user = create(:user, password: 'known')
+  # if given a user, the password must be 'known' or given as a parameter
+  # otherwise, the helper will create a user with a given password
+  # returns the user it logs in as, navigates to root_path
+  def login(user = nil, password = 'known')
+    user = create(:user, password: password) unless user
     visit root_path
-    fill_in "username", with: user.username
-    fill_in "password", with: 'known'
+    fill_in "Username", with: user.username
+    fill_in "Password", with: password
     click_button "Log in"
     user
   end


### PR DESCRIPTION
As side effects:

- Makes the row headers in posts#stats into `th`s
- Makes the "Moderator note" text into a label for the field
- Amends the button-icons on posts/replies to have sensible alt and title text ("Edit", "Delete" and "Mark Unread Here"); the latter previously had "Eye" as alt text
- In feature specs, lets `login` take an optional user and known password to log into a particular pre-existing user
- In feature specs, creates a new `row_for` helper, which will find the `tr` which contains a `th` with the relevant text (especially useful for forms or table layouts, where inputs and data are identified by the headers on the same row).

This does not test moderator previews, as those are currently broken. See #666 for a fix for that and new specs testing that.