### PR TITLE
Various small things

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -45,6 +45,7 @@ class Post < ApplicationRecord
   after_commit :notify_followers, on: :create
 
   NON_EDITED_ATTRS = %w(id created_at updated_at edited_at tagged_at last_user_id last_reply_id section_order)
+  NON_TAGGED_ATTRS = %w(icon_id character_alias_id character_id)
   audited except: NON_EDITED_ATTRS
   has_associated_audits
 
@@ -269,12 +270,17 @@ class Post < ApplicationRecord
   def set_timestamps
     return if skip_edited
     self.edited_at = self.updated_at
+    return if skip_tagged
     return if replies.exists? && !status_changed?
     self.tagged_at = self.updated_at
   end
 
   def skip_edited
     @skip_edited || (changed_attributes.keys - NON_EDITED_ATTRS).empty?
+  end
+
+  def skip_tagged
+    (changed_attributes.keys - NON_TAGGED_ATTRS - NON_EDITED_ATTRS).empty?
   end
 
   def ordered_attributes

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -49,7 +49,7 @@ class Reply < ApplicationRecord
 
   def update_post
     return if post.last_reply_id != id || skip_post_update
-    return if (changed_attributes.keys - Post::NON_TAGGED_ATTRS - ['updated_at']).empty?
+    return if (saved_changes.keys - Post::NON_TAGGED_ATTRS - ['updated_at']).empty?
     post.tagged_at = updated_at
     post.status = Post::STATUS_ACTIVE if post.on_hiatus?
     post.save

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -49,6 +49,7 @@ class Reply < ApplicationRecord
 
   def update_post
     return if post.last_reply_id != id || skip_post_update
+    return if (changed_attributes.keys - Post::NON_TAGGED_ATTRS - ['updated_at']).empty?
     post.tagged_at = updated_at
     post.status = Post::STATUS_ACTIVE if post.on_hiatus?
     post.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
   validates_confirmation_of :password, if: :validate_password?
   validates_presence_of :password, :password_confirmation, if: :validate_password?
 
-  before_validation :encrypt_password
+  before_validation :encrypt_password, :strip_spaces
   after_save :clear_password
 
   nilify_blanks
@@ -66,6 +66,10 @@ class User < ApplicationRecord
   end
 
   private
+
+  def strip_spaces
+    self.username = self.username.strip if self.username.present?
+  end
 
   def encrypt_password
     if password.present?

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -22,6 +22,9 @@
 - if @template && @template.description.present?
   %tr
     %td.single-description.written-content{colspan: 6}= sanitize_written_content(@template.description).html_safe
+- elsif @template.nil? && name.present? && name.is_a?(::Template) && name.description.present?
+  %tr
+    %td.single-description.written-content{colspan: 6}= sanitize_written_content(name.description).html_safe
 %tr
   %td.icons-box.left-align
     .character-icon-list

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -24,6 +24,9 @@
 - if @template && @template.description.present?
   %tr
     %td.single-description.written-content{colspan: col_count}= sanitize_written_content(@template.description).html_safe
+- elsif @template.nil? && name.present? && name.is_a?(::Template) && name.description.present?
+  %tr
+    %td.single-description.written-content{colspan: col_count}= sanitize_written_content(name.description).html_safe
 - if characters.empty?
   %tr
     %td.centered.padding-5{class: cycle('even', 'odd'), colspan: col_count} — No characters yet —

--- a/app/views/characters/search.haml
+++ b/app/views/characters/search.haml
@@ -58,6 +58,8 @@
                     %b Screenname
                   %td.padding-5{class: klass}
                     %b Facecast
+                  %td.padding-5{class: klass}
+                    %b User
                   - if false # TODO once setting is fixed for characters
                     %td.padding-5{class: klass}
                       %b Setting
@@ -66,9 +68,10 @@
                   - klass = cycle('even'.freeze, 'odd'.freeze)
                   %tr
                     %td.padding-5{class: klass}= link_to character.name, character_path(character)
-                    %td.padding-5{class: klass, style:'width:20%'}= character.template_name
-                    %td.padding-5{class: klass, style:'width:20%'}= breakable_text(character.screenname)
+                    %td.padding-5{class: klass, style:'width:15%'}= character.template_name
+                    %td.padding-5{class: klass, style:'width:15%'}= breakable_text(character.screenname)
                     %td.padding-5{class: klass, style:'width:25%'}= character.pb
+                    %td.padding-5{class: klass, style:'width:15%'}= link_to character.user.username, user_path(character.user)
 
     - if @search_results && @search_results.total_pages > 1
       %tfoot

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -25,7 +25,7 @@
 
     %div{title: 'If a post is locked, it doesn\'t accept new authors. Current or invited authors can still reply.'}
       = f.label :authors_locked, 'Lock post to authors?'
-      = f.check_box :authors_locked, class: 'vmid', checked: @authors_from_board
+      = f.check_box :authors_locked, class: 'vmid', checked: @authors_from_board || @post.authors_locked
 
     = f.label :setting_ids, 'Setting:'
     = tag_select(post, f, :settings)

--- a/app/views/templates/_editor.haml
+++ b/app/views/templates/_editor.haml
@@ -8,6 +8,9 @@
   %tr
     %th.sub.vtop Characters
     %td.even
-      = collection_check_boxes :template, :character_ids, @selectable_characters, :id, :name, selected: @character_ids
+      = collection_check_boxes :template, :character_ids, @selectable_characters, :id, :name, selected: @character_ids do |box|
+        = box.check_box
+        = box.label
+        %br
 %tr
   %th.form-table-ender{colspan: 2}= submit_tag "Save", class: 'button'

--- a/lib/post_scraper.rb
+++ b/lib/post_scraper.rb
@@ -15,7 +15,8 @@ class PostScraper < Object
     'rockeye-stonetoe' => 'Rockeye',
     'rockeye_stonetoe' => 'Rockeye',
     'maggie-of-the-owls' => 'MaggieoftheOwls',
-    'maggie_of_the_owls' => 'MaggieoftheOwls' # have both - and _ versions cause Dreamwidth supports both
+    'maggie_of_the_owls' => 'MaggieoftheOwls', # have both - and _ versions cause Dreamwidth supports both
+    'nemoconsequentiae' => 'Nemo',
   }
 
   attr_accessor :url, :post, :html_doc

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -109,6 +109,14 @@ RSpec.describe UsersController do
       expect(assigns(:current_user).username).to eq(user['username'])
       expect(assigns(:current_user).authenticate(pass)).to eq(true)
     end
+
+    it "strips spaces" do
+      user = build(:user, username: 'withspace ').attributes
+      user = user.with_indifferent_access.merge(password: 'password', password_confirmation: 'password')
+      post :create, params: { secret: 'ALLHAILTHECOIN' }.merge(user: user)
+      expect(flash[:success]).to eq("User created! You have been logged in.")
+      expect(assigns(:current_user).username).to eq('withspace')
+    end
   end
 
   describe "GET show" do

--- a/spec/jobs/update_model_job_spec.rb
+++ b/spec/jobs/update_model_job_spec.rb
@@ -21,4 +21,14 @@ RSpec.describe UpdateModelJob do
       UpdateModelJob.perform_now('Reply', {id: reply.id}, {board_id: 2})
     }.to raise_error(ActiveModel::UnknownAttributeError)
   end
+
+  it "does not update tagged_at" do
+    reply = create(:reply)
+    old_tag = reply.post.tagged_at
+    new_char = create(:character, user: reply.user)
+    expect(reply.character).to be_nil
+    UpdateModelJob.perform_now('Reply', {id: reply.id}, {character_id: new_char.id})
+    expect(reply.reload.character).to eq(new_char)
+    expect(reply.post.reload.tagged_at).to be_the_same_time_as(old_tag)
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -138,6 +138,21 @@ RSpec.describe Post do
       create(:reply, post: post, user: post.user)
       expect(post.edited_at).to eq(post.created_at)
     end
+
+    it 'should update correctly when characters are edited' do
+      post = create(:post)
+      old_tag = post.tagged_at
+      expect(post.edited_at).to eq(post.created_at)
+      expect(post.audits.count).to eq(1)
+
+      post.character = create(:character, user: post.user)
+      post.save
+
+      # editing a post's character changes edit and makes audit but does not tag
+      expect(post.edited_at).not_to be_the_same_time_as(post.created_at)
+      expect(post.audits.count).to eq(2)
+      expect(post.tagged_at).to be_the_same_time_as(old_tag)
+    end
   end
 
   describe "#section_order" do

--- a/spec/models/reply_spec.rb
+++ b/spec/models/reply_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe Reply do
     shared_examples 'has_edit_audits' do |get_has_edit_audits|
       let(:user) { create(:user) }
       before(:each) { Reply.auditing_enabled = true }
+      after(:each) { Reply.auditing_enabled = false }
       it "is false if reply has never been edited" do
         reply = nil
         Audited.audit_class.as_user(user) do


### PR DESCRIPTION
- Add Nemo to scraper authors
- Automatically strip whitespace from the beginning/end of usernames to prevent login issues
- Don't tag a post when updating character/icon/alias, especially because character replace now uses callbacks
- Add line breaks to the untemplated character list on template editor
- Add template descriptions in relevant places
- Display author of a character in the search page
- Fix misbehaving Authors Locked checkbox on post editor