### PR TITLE
Use dynamic loading for unread continuties select

### DIFF
--- a/app/assets/javascripts/posts/unread.js
+++ b/app/assets/javascripts/posts/unread.js
@@ -1,0 +1,19 @@
+/* global processResults, queryTransform */
+$(document).ready(function() {
+  $("#board_id").select2({
+    ajax: {
+      delay: 200,
+      url: '/api/v1/boards',
+      dataType: 'json',
+      data: queryTransform,
+      processResults: function(data, params) {
+        var total = this._request.getResponseHeader('Total');
+        return processResults(data, params, total, 'name');
+      },
+      cache: true
+    },
+    placeholder: '— Choose Continuity —',
+    allowClear: true,
+    width: '100%'
+  });
+});

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -43,6 +43,7 @@ class PostsController < WritableController
     @posts = @posts.paginate(per_page: 25, page: page)
     @hide_quicklinks = true
     @page_title = @started ? 'Opened Threads' : 'Unread Threads'
+    use_javascript('posts/unread')
   end
 
   def mark

--- a/app/views/posts/unread.haml
+++ b/app/views/posts/unread.haml
@@ -30,7 +30,7 @@
     %tr
       %td.even.padding-5.centered
         = select_tag :board_id,
-                     options_from_collection_for_select(Board.order('LOWER(name)'), :id, :name, params[:board_id]),
+                     options_from_collection_for_select(Board.where(id: params[:board_id]), :id, :name, params[:board_id]),
                      {class: 'chosen-select', prompt: '— Choose Continuity —'}
     %tr
       %th.form-table-ender


### PR DESCRIPTION
Posts#unread seems to be using a lot of memory; one possibility is that we provide all continuties in a dropdown for Hide From Unread reasons. Switch to using a dynamically loaded continuity list to save memory.