### PR TITLE
Add inverse_of

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -7,7 +7,7 @@ class Board < ApplicationRecord
   has_many :posts, dependent: false # This is handled in callbacks
   has_many :board_sections, dependent: :destroy
   has_many :favorites, as: :favorite, dependent: :destroy
-  belongs_to :creator, class_name: 'User', optional: false
+  belongs_to :creator, class_name: 'User', inverse_of: false, optional: false
 
   has_many :board_authors, inverse_of: :board, dependent: :destroy
   has_many :board_coauthors, -> { where(cameo: false) }, class_name: 'BoardAuthor', inverse_of: :board

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -6,7 +6,7 @@ class Board < ApplicationRecord
 
   has_many :posts, dependent: false # This is handled in callbacks
   has_many :board_sections, dependent: :destroy
-  has_many :favorites, as: :favorite, dependent: :destroy
+  has_many :favorites, as: :favorite, inverse_of: :favorite, dependent: :destroy
   belongs_to :creator, class_name: 'User', inverse_of: false, optional: false
 
   has_many :board_authors, inverse_of: :board, dependent: :destroy

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -3,7 +3,7 @@ class Character < ApplicationRecord
 
   belongs_to :user, optional: false
   belongs_to :template, inverse_of: :characters, optional: true
-  belongs_to :default_icon, class_name: 'Icon', optional: true
+  belongs_to :default_icon, class_name: 'Icon', inverse_of: false, optional: true
   belongs_to :character_group, optional: true
   has_many :replies, dependent: false
   has_many :posts, dependent: false # These are handled in callbacks

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -7,7 +7,7 @@ class Character < ApplicationRecord
   belongs_to :character_group, optional: true
   has_many :replies, dependent: false
   has_many :posts, dependent: false # These are handled in callbacks
-  has_many :aliases, class_name: 'CharacterAlias', dependent: :destroy
+  has_many :aliases, class_name: 'CharacterAlias', inverse_of: :character, dependent: :destroy
 
   has_many :characters_galleries, inverse_of: :character, dependent: :destroy
   accepts_nested_attributes_for :characters_galleries, allow_destroy: true

--- a/app/models/character_tag.rb
+++ b/app/models/character_tag.rb
@@ -1,8 +1,8 @@
 class CharacterTag < ApplicationRecord
   belongs_to :character, inverse_of: :character_tags, optional: false
   belongs_to :tag, inverse_of: :character_tags, optional: true # TODO: This is required, fix bug around validation if it is set as such
-  belongs_to :setting, foreign_key: :tag_id, optional: true
-  belongs_to :gallery_group, foreign_key: :tag_id, optional: true
+  belongs_to :setting, foreign_key: :tag_id, inverse_of: :character_tags, optional: true
+  belongs_to :gallery_group, foreign_key: :tag_id, inverse_of: :character_tags, optional: true
 
   after_create :add_galleries_to_character
   after_destroy :remove_galleries_from_character

--- a/app/models/gallery_tag.rb
+++ b/app/models/gallery_tag.rb
@@ -1,7 +1,7 @@
 class GalleryTag < ApplicationRecord
   belongs_to :gallery, inverse_of: :gallery_tags, optional: false
   belongs_to :tag, inverse_of: :gallery_tags, optional: true # TODO: This is required, fix bug around validation if it is set as such
-  belongs_to :gallery_group, foreign_key: :tag_id, optional: false # This is currently required but may not continue to be
+  belongs_to :gallery_group, foreign_key: :tag_id, inverse_of: :gallery_tags, optional: false # This is currently required but may not continue to be
 
   after_create :add_gallery_to_characters
   after_destroy :remove_gallery_from_characters

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,8 +2,8 @@ class Message < ApplicationRecord
   # TODO drop marked_*
   belongs_to :sender, class_name: 'User', inverse_of: :sent_messages, optional: true
   belongs_to :recipient, class_name: 'User', inverse_of: :messages, optional: false
-  belongs_to :parent, class_name: 'Message', optional: true
-  belongs_to :first_thread, class_name: 'Message', foreign_key: :thread_id, optional: false
+  belongs_to :parent, class_name: 'Message', inverse_of: false, optional: true
+  belongs_to :first_thread, class_name: 'Message', foreign_key: :thread_id, inverse_of: false, optional: false
 
   validates :sender, presence: { if: Proc.new { |m| m.sender_id != 0 } }
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -22,7 +22,7 @@ class Post < ApplicationRecord
 
   has_many :post_viewers, inverse_of: :post, dependent: :destroy
   has_many :viewers, through: :post_viewers, source: :user
-  has_many :favorites, as: :favorite, dependent: :destroy
+  has_many :favorites, as: :favorite, inverse_of: :favorite, dependent: :destroy
 
   has_many :post_tags, inverse_of: :post, dependent: :destroy
   has_many :labels, -> { order('post_tags.id ASC') }, through: :post_tags, source: :label

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,8 +14,8 @@ class Post < ApplicationRecord
 
   belongs_to :board, inverse_of: :posts, optional: false
   belongs_to :section, class_name: 'BoardSection', inverse_of: :posts, optional: true
-  belongs_to :last_user, class_name: 'User', optional: false
-  belongs_to :last_reply, class_name: 'Reply', optional: true
+  belongs_to :last_user, class_name: 'User', inverse_of: false, optional: false
+  belongs_to :last_reply, class_name: 'Reply', inverse_of: false, optional: true
   has_one :flat_post, dependent: :destroy
   has_many :replies, inverse_of: :post, dependent: :destroy
   has_many :reply_drafts, dependent: :destroy

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,7 +1,7 @@
 class PostTag < ApplicationRecord
   belongs_to :post, inverse_of: :post_tags, optional: false
   belongs_to :tag, inverse_of: :post_tags, optional: true # TODO: This is required, fix bug around validation if it is set as such
-  belongs_to :setting, foreign_key: :tag_id, optional: true
-  belongs_to :content_warning, foreign_key: :tag_id, optional: true
-  belongs_to :label, foreign_key: :tag_id, optional: true
+  belongs_to :setting, foreign_key: :tag_id, inverse_of: :post_tags, optional: true
+  belongs_to :content_warning, foreign_key: :tag_id, inverse_of: :post_tags, optional: true
+  belongs_to :label, foreign_key: :tag_id, inverse_of: :post_tags, optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,8 +13,8 @@ class User < ApplicationRecord
   has_many :galleries
   has_many :character_groups
   has_many :templates
-  has_many :sent_messages, class_name: 'Message', foreign_key: 'sender_id'
-  has_many :messages, foreign_key: 'recipient_id'
+  has_many :sent_messages, class_name: 'Message', foreign_key: 'sender_id', inverse_of: :sender
+  has_many :messages, foreign_key: 'recipient_id', inverse_of: :recipient
   has_many :password_resets
   has_many :favorites
   has_many :favoriteds, as: :favorite, class_name: 'Favorite'
@@ -22,8 +22,8 @@ class User < ApplicationRecord
   has_many :replies
   has_many :indexes
   has_one :report_view
-  belongs_to :avatar, class_name: 'Icon', optional: true
-  belongs_to :active_character, class_name: 'Character', optional: true
+  belongs_to :avatar, class_name: 'Icon', inverse_of: :user, optional: true
+  belongs_to :active_character, class_name: 'Character', inverse_of: :user, optional: true
 
   validates :crypted, presence: true
   validates :email,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   has_many :messages, foreign_key: 'recipient_id', inverse_of: :recipient
   has_many :password_resets
   has_many :favorites
-  has_many :favoriteds, as: :favorite, class_name: 'Favorite'
+  has_many :favoriteds, as: :favorite, class_name: 'Favorite', inverse_of: :favorite
   has_many :posts
   has_many :replies
   has_many :indexes


### PR DESCRIPTION
* declares the inverse on things which according to rubocop rails cannot automatically determine the inverse on
* explicitly says there is no inverse on some one-way links that confuse rubocop.