### PR TITLE
Fix various layout lints

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -78,10 +78,8 @@ class CharactersController < ApplicationController
         @character.gallery_groups = process_tags(GalleryGroup, :character, :gallery_group_ids)
         @character.save!
       end
-
       flash[:success] = "Character saved successfully."
       redirect_to character_path(@character)
-
     rescue ActiveRecord::RecordInvalid
       @page_title = "Edit Character: " + @character.name
       flash.now[:error] = {}

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -95,10 +95,8 @@ class GalleriesController < UploadingController
         @gallery.gallery_groups = process_tags(GalleryGroup, :gallery, :gallery_group_ids)
         @gallery.save!
       end
-
       flash[:success] = "Gallery saved."
       redirect_to edit_gallery_path(@gallery)
-
     rescue ActiveRecord::RecordInvalid
       flash.now[:error] = {}
       flash.now[:error][:message] = "Gallery could not be saved."

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -417,7 +417,8 @@ class PostsController < WritableController
       :icon_id,
       :character_alias_id,
       :authors_locked,
-      :audit_comment]
+      :audit_comment
+    ]
 
     # prevents us from setting (and saving) associations on preview()
     if include_associations

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -49,10 +49,8 @@ class TagsController < ApplicationController
         @tag.parent_settings = process_tags(Setting, :tag, :parent_setting_ids) if @tag.is_a?(Setting)
         @tag.save!
       end
-
       flash[:success] = "Tag saved!"
       redirect_to tag_path(@tag)
-
     rescue ActiveRecord::RecordInvalid
       flash.now[:error] = {}
       flash.now[:error][:message] = "Tag could not be saved because of the following problems:"

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -17,10 +17,10 @@ module WritableHelper
 
     if item.character
       icons = if galleries.present?
-                galleries.map(&:icons).flatten
-              else
-                item.character.icons
-              end
+        galleries.map(&:icons).flatten
+      else
+        item.character.icons
+      end
       icons |= [item.character.default_icon] if item.character.default_icon
       icons |= [item.icon] if item.icon
       selected_id = item.icon_id

--- a/app/models/galleries_icon.rb
+++ b/app/models/galleries_icon.rb
@@ -1,5 +1,5 @@
 class GalleriesIcon < ApplicationRecord
-  belongs_to :icon, optional: true  # TODO: This is required, fix bug around validation if it is set as such
+  belongs_to :icon, optional: true # TODO: This is required, fix bug around validation if it is set as such
   belongs_to :gallery, optional: false
   accepts_nested_attributes_for :icon, allow_destroy: true
 

--- a/db/migrate/20171001035221_move_setting_to_tags.rb
+++ b/db/migrate/20171001035221_move_setting_to_tags.rb
@@ -14,7 +14,7 @@ class MoveSettingToTags < ActiveRecord::Migration[5.0]
     print "\nDone!\n\n"
     remove_column :characters, :setting
   end
-  
+
   def down
     add_column :characters, :setting, :text
     Setting.all.each do |setting|

--- a/lib/memorylogic.rb
+++ b/lib/memorylogic.rb
@@ -16,9 +16,9 @@ module Memorylogic
 
   private
 
-    def log_memory_usage
-      if logger
-        logger.warn("Memory usage in #{params[:controller]}\##{params[:action]}: #{Memorylogic.memory_usage} | PID: #{Process.pid}")
-      end
+  def log_memory_usage
+    if logger
+      logger.warn("Memory usage in #{params[:controller]}\##{params[:action]}: #{Memorylogic.memory_usage} | PID: #{Process.pid}")
     end
+  end
 end

--- a/lib/memorylogic.rb
+++ b/lib/memorylogic.rb
@@ -15,6 +15,7 @@ module Memorylogic
   end
 
   private
+
     def log_memory_usage
       if logger
         logger.warn("Memory usage in #{params[:controller]}\##{params[:action]}: #{Memorylogic.memory_usage} | PID: #{Process.pid}")

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -70,14 +70,13 @@ RSpec.describe Api::V1::PostsController do
   end
 
   describe "POST reorder" do
-  describe "GET show" do
     it "requires login", :show_in_doc do
       post :reorder
       expect(response).to have_http_status(401)
       expect(response.json['errors'][0]['message']).to eq("You must be logged in to view that page.")
     end
 
-    context "without section_id"
+    context "without section_id" do
       it "requires a board you have access to" do
         board = create(:board)
         board_post1 = create(:post, board_id: board.id)

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe Api::V1::PostsController do
     end
   end
 
-  describe "POST reorder" do  describe "GET show" do
+  describe "POST reorder" do
+  describe "GET show" do
     it "requires login", :show_in_doc do
       post :reorder
       expect(response).to have_http_status(401)

--- a/spec/features/boards/show_spec.rb
+++ b/spec/features/boards/show_spec.rb
@@ -4,22 +4,22 @@ RSpec.feature "Show a single continuity", :type => :feature do
   scenario "View a standard continuity" do
     board = create(:board, name: "Test board")
     5.times do create(:post, board: board, user: board.creator) end
-    
+
     visit board_path(board)
-    
+
     expect(page).to have_text("Test board")
     expect(page).to have_selector('.post-subject', count: 5)
   end
-  
+
   scenario "View a continuity with many authors in a post" do
     board = create(:board, name: "Author board")
     post1 = create(:post, board: board, user: board.creator)
     reply = create(:reply, post: post1)
     post2 = create(:post, board: board, user: board.creator)
     4.times do create(:reply, post: post2) end
-    
+
     visit board_path(board)
-    
+
     expect(page).to have_text("Author board")
     expect(page).to have_selector('.post-subject', count: 2)
     within("tbody tr:nth-child(2)") do

--- a/spec/features/messages/show_spec.rb
+++ b/spec/features/messages/show_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Message threads", :type => :feature do
     expect(table_rows[0]).to have_text('second')
     expect(table_rows[1]).to have_text('first')
 
-    third = create(:message, thread_id: first.id, recipient:user, sender: first.sender)
+    third = create(:message, thread_id: first.id, recipient: user, sender: first.sender)
     visit messages_path(view: 'inbox')
     expect(page).to have_selector('tr.message-row', count: 2)
     table_rows = page.all(:css, 'tr.message-row')

--- a/spec/features/seed_spec.rb
+++ b/spec/features/seed_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 RSpec.feature "Seeding database", :type => :feature do
   scenario "Loading seed data throws no errors" do
-  	allow(STDOUT).to receive(:puts)
-  	DatabaseCleaner.clean_with(:truncation)
-  	Rails.application.load_seed
+    allow(STDOUT).to receive(:puts)
+    DatabaseCleaner.clean_with(:truncation)
+    Rails.application.load_seed
   end
 end


### PR DESCRIPTION
* Fixes alignment/indentation in a bunch of places
* Adds empty lines around declarations of `private` and rescue statements
* Removes stray spaces
* Adds a space after a semicolon
* Replaces tabs with spaces
* Removes trailing whitespace