### PR TITLE
Update/Improve Rubocop Config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -201,11 +201,6 @@ Rails/HasManyOrHasOneDependent:
 Rails/SaveBang:
   Enabled: true
 
-Rails/TimeZone:
-  Enabled: true
-  Exclude:
-    - 'spec/**/*'
-
 ################## Style #################################
 
 Style/Alias:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,12 +117,28 @@ Layout/TrailingBlankLines:
 
 #################### Lint ################################
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*'
+
 Lint/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: 'variable'
 
+Lint/HandleExceptions:
+  Exclude:
+    - 'spec/jobs/application_job_spec.rb'
+    - 'spec/jobs/generate_flat_post_job_spec.rb'
+
 Lint/ParenthesesAsGroupedExpression:
   Enabled: false
+
+Lint/RescueException:
+  Exclude:
+    - 'app/jobs/application_job.rb'
+    - 'app/jobs/generate_flat_post_job.rb'
+    - 'spec/jobs/application_job_spec.rb'
+    - 'spec/jobs/generate_flat_post_job_spec.rb'
 
 ###################### Metrics ####################################
 
@@ -183,6 +199,10 @@ Rails/DynamicFindBy:
   Whitelist:
     - find_by_sql
     - find_by_id
+
+Rails/HasManyOrHasOneDependent:
+  Exclude:
+    - 'app/models/user.rb'
 
 Rails/SaveBang:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,17 +5,11 @@ AllCops:
   Exclude:
     - 'bin/*'
     - 'config/environments/*'
-    - 'config/initializers/audited.rb'
-    - 'config/initializers/aws.rb'
-    - 'config/initializers/resque.rb'
-    - 'config/initializers/rack_cors.rb'
-    - 'config/initializers/will_paginate.rb'
+    - 'config/initializers/*'
     - 'db/migrate/2015*'
     - 'db/migrate/2016*'
     - 'db/migrate/2017*'
     - 'db/seeds.rb'
-    - 'features/support/env.rb'
-    - 'lib/tasks/cucumber.rake'
     - 'spec/spec_helper.rb'
 
 Rails:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,12 +3,19 @@ AllCops:
   TargetRailsVersion: 5.1
   DisabledByDefault: false
   Exclude:
+    - 'bin/*'
+    - 'config/environments/*'
+    - 'config/initializers/audited.rb'
+    - 'config/initializers/aws.rb'
     - 'config/initializers/resque.rb'
     - 'config/initializers/rack_cors.rb'
     - 'config/initializers/will_paginate.rb'
+    - 'db/migrate/2015*'
+    - 'db/migrate/2016*'
+    - 'db/migrate/2017*'
     - 'db/seeds.rb'
-    - 'lib/tasks/cucumber.rake'
     - 'features/support/env.rb'
+    - 'lib/tasks/cucumber.rake'
     - 'spec/spec_helper.rb'
 
 Rails:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,72 +24,49 @@ Rails:
 #################### Layout ##############################
 
 Layout/AlignHash:
-  Description: >-
-                 Align the elements of a hash literal if they span more than
-                 one line.
   Enabled: false
 
 Layout/AlignParameters:
-  Description: >-
-                 Align the parameters of a method call if they span more
-                 than one line.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
   Enabled: false
 
 Layout/CaseIndentation:
-  Description: 'Indentation of when in a case/when/[else/]end.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-when-to-case'
   Enabled: true
   EnforcedStyle: 'end'
   IndentOneStep: true
 
 Layout/ClosingParenthesisIndentation:
-  Description: 'Checks the indentation of hanging closing parentheses.'
   Enabled: false
 
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 
 Layout/EmptyLineBetweenDefs:
-  Description: 'Use empty lines between defs.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods'
   Enabled: false
 
 Layout/EmptyLines:
-  Description: "Don't use several empty lines in a row."
   Enabled: false
 
 Layout/EmptyLinesAroundAccessModifier:
-  Description: "Keep blank lines around access modifiers."
   Enabled: true
 
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
   Enabled: true
 
 Layout/EndOfLine:
-  Description: 'Use Unix-style line endings.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#crlf'
   Enabled: false
 
 Layout/FirstParameterIndentation:
-  Description: 'Checks the indentation of the first parameter in a method call.'
   Enabled: false
 
 Layout/IndentationWidth:
-  Description: 'Use 2 spaces for indentation.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
   Enabled: true
   Width: 2
 
 Layout/IndentArray:
-  Description: >-
-                 Checks the indentation of the first element in an array
-                 literal.
   Enabled: true
   EnforcedStyle: 'consistent'
 
 Layout/IndentHash:
-  Description: 'Checks the indentation of the first key in a hash literal.'
   Enabled: true
   EnforcedStyle: 'consistent'
 
@@ -106,83 +83,50 @@ Layout/MultilineMethodDefinitionBraceLayout:
   Enabled: false
 
 Layout/MultilineOperationIndentation:
-  Description: >-
-                 Checks indentation of binary operations that span more than
-                 one line.
   Enabled: false
 
 Layout/SpaceAroundBlockParameters:
-  Description: 'Checks the spacing inside and after block parameters pipes.'
   Enabled: false
 
 Layout/SpaceAroundEqualsInParameterDefault:
-  Description: >-
-                 Checks that the equals signs in parameter default assignments
-                 have or don't have surrounding space depending on
-                 configuration.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-around-equals'
   Enabled: false
 
 Layout/SpaceAroundOperators:
-  Description: 'Use a single space around operators.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: false
 
 Layout/SpaceBeforeBlockBraces:
-  Description: >-
-                 Checks that the left block brace has or doesn't have space
-                 before it.
   Enabled: false
 
 Layout/SpaceInLambdaLiteral:
   Enabled: false
 
 Layout/SpaceInsideBlockBraces:
-  Description: >-
-                 Checks that block braces have or don't have surrounding space.
-                 For blocks taking parameters, checks that the left brace has
-                 or doesn't have trailing space.
   Enabled: false
 
 Layout/SpaceInsideHashLiteralBraces:
-  Description: "Use spaces inside hash literal braces - or don't."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: false
 
 Layout/SpaceInsidePercentLiteralDelimiters:
   Enabled: false
 
 Layout/SpaceInsideRangeLiteral:
-  Description: 'No spaces inside range literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals'
   Enabled: false
 
 Layout/TrailingBlankLines:
-  Description: 'Checks trailing blank lines and final newline.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#newline-eof'
   Enabled: false
 
 #################### Lint ################################
 
 Lint/EndAlignment:
-  Description: 'Align ends correctly.'
   Enabled: true
   EnforcedStyleAlignWith: 'variable'
 
 Lint/ParenthesesAsGroupedExpression:
-  Description: >-
-                 Checks for method calls with a space before the opening
-                 parenthesis.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
   Enabled: false
 
 ###################### Metrics ####################################
 
 Metrics/AbcSize:
-  Description: >-
-                 A calculated magnitude based on number of assignments,
-                 branches, and conditions.
-  Reference: 'http://c2.com/cgi/wiki?AbcMetric'
   Enabled: false
   Max: 20
 
@@ -190,60 +134,39 @@ Metrics/BlockLength:
   Enabled: false
 
 Metrics/BlockNesting:
-  Description: 'Avoid excessive block nesting'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
   Enabled: true
   Max: 4
 
 Metrics/ClassLength:
-  Description: 'Avoid classes longer than 250 lines of code.'
   Enabled: false
 
 Metrics/CyclomaticComplexity:
-  Description: >-
-                 A complexity metric that is strongly correlated to the number
-                 of test cases needed to validate a method.
   Enabled: false
 
 Metrics/LineLength:
-  Description: 'Limit lines to 80 characters.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
   Enabled: false
 
 Metrics/MethodLength:
-  Description: 'Avoid methods longer than 30 lines of code.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#short-methods'
   Enabled: false
 
 Metrics/ModuleLength:
-  Description: 'Avoid modules longer than 250 lines of code.'
   Enabled: false
 
 Metrics/ParameterLists:
-  Description: 'Avoid parameter lists longer than three or four parameters.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
   Enabled: false
 
 Metrics/PerceivedComplexity:
-  Description: >-
-                 A complexity metric geared towards measuring complexity for a
-                 human reader.
   Enabled: false
 
 ####################### Naming ################################
 
 Naming/AccessorMethodName:
-  Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
 
 Naming/AsciiIdentifiers:
-  Description: 'Use only ascii symbols in identifiers.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-identifiers'
   Enabled: false
 
 Naming/PredicateName:
-  Description: 'Check the names of predicate methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
   Enabled: false
 
 Naming/VariableNumber:
@@ -265,13 +188,9 @@ Rails/SaveBang:
   Enabled: true
 
 Rails/ScopeArgs:
-  Description: 'Checks the arguments of ActiveRecord scopes.'
   Enabled: false
 
 Rails/TimeZone:
-  Description: 'Checks the correct usage of time zone aware methods.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
-  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: true
   Exclude:
     - 'spec/**/*'
@@ -279,73 +198,45 @@ Rails/TimeZone:
 ################## Style #################################
 
 Style/Alias:
-  Description: 'Use alias_method instead of alias.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#alias-method'
   Enabled: false
 
 Style/AndOr:
-  Description: 'Use &&/|| instead of and/or.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-and-or-or'
   Enabled: false
 
 Style/ArrayJoin:
-  Description: 'Use Array#join instead of Array#*.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#array-join'
   Enabled: false
 
 Style/AsciiComments:
-  Description: 'Use only ascii symbols in comments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-comments'
   Enabled: false
 
 Style/AutoResourceCleanup:
   Enabled: true
 
 Style/BeginBlock:
-  Description: 'Avoid the use of BEGIN blocks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-BEGIN-blocks'
   Enabled: false
 
 Style/BlockDelimiters:
-  Description: >-
-                Avoid using {...} for multi-line blocks (multiline chaining is
-                always ugly).
-                Prefer {...} over do...end for single-line blocks.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
   Enabled: false
 
 Style/BracesAroundHashParameters:
-  Description: 'Enforce braces style around hash parameters.'
   Enabled: false
 
 Style/ClassAndModuleChildren:
-  Description: 'Checks style of children classes and modules.'
   Enabled: false
 
 Style/CommandLiteral:
-  Description: 'Use `` or %x around command literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-x'
   Enabled: false
 
 Style/CommentAnnotation:
-  Description: 'Checks formatting of annotation comments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#annotate-keywords'
   Enabled: false
 
 Style/ConditionalAssignment:
-  Description: >-
-                 Check for if and case statements where each branch is used
-                 for assignment to the same variable when using the return
-                 of the condition can be used instead.
   Enabled: false
 
 Style/Documentation:
-  Description: 'Document classes and non-namespace modules.'
   Enabled: false
 
 Style/DoubleNegation:
-  Description: 'Checks for uses of double negation (!!).'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
   Enabled: false
 
 Style/EmptyMethod:
@@ -355,8 +246,6 @@ Style/Encoding:
   Enabled: false
 
 Style/FormatString:
-  Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#sprintf'
   Enabled: false
 
 Style/FormatStringToken:
@@ -366,41 +255,24 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 
 Style/GlobalVars:
-  Description: 'Do not introduce global variables.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#instance-vars'
-  Reference: 'http://www.zenspider.com/Languages/Ruby/QuickRef.html'
   Enabled: false
 
 Style/GuardClause:
-  Description: 'Check for conditionals that can be replaced with guard clauses'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
   Enabled: false
 
 Style/HashSyntax:
-  Description: >-
-                 Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax
-                 { :a => 1, :b => 2 }.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-literals'
   Enabled: false
 
 Style/IfWithSemicolon:
-  Description: 'Do not use if x; .... Use the ternary operator instead.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs'
   Enabled: false
 
 Style/InfiniteLoop:
-  Description: 'Use Kernel#loop for infinite loops.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#infinite-loop'
   Enabled: false
 
 Style/Lambda:
-  Description: 'Use the new lambda literal syntax for single-line blocks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#lambda-multi-line'
   Enabled: false
 
 Style/ModuleFunction:
-  Description: 'Checks for usage of `extend self` in modules.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
   Enabled: false
 
 Style/MultilineMemoization:
@@ -413,68 +285,39 @@ Style/NumericPredicate:
   Enabled: false
 
 Style/OneLineConditional:
-  Description: >-
-                 Favor the ternary operator(?:) over
-                 if/then/else/end constructs.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: false
 
 Style/ParallelAssignment:
-  Description: >-
-                  Check for simple usages of parallel assignment.
-                  It will only warn when the number of variables
-                  matches on both sides of the assignment.
-                  This also provides performance benefits
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parallel-assignment'
   Enabled: false
 
 Style/PercentLiteralDelimiters:
-  Description: 'Use `%`-literal delimiters consistently'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-literal-braces'
   Enabled: false
 
 Style/PercentQLiterals:
-  Description: 'Checks if uses of %Q/%q match the configured preference.'
   Enabled: false
 
 Style/Proc:
-  Description: 'Use proc instead of Proc.new.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc'
   Enabled: false
 
 Style/RaiseArgs:
-  Description: 'Checks the arguments passed to raise/fail.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#exception-class-messages'
   Enabled: false
 
 Style/RedundantException:
-  Description: "Checks for an obsolete RuntimeException argument in raise/fail."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-explicit-runtimeerror'
   Enabled: false
 
 Style/RedundantSelf:
-  Description: "Don't use self where it's not needed."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-self-unless-required'
   Enabled: false
 
 Style/RegexpLiteral:
-  Description: 'Use / or %r around regular expressions.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
   Enabled: false
 
 Style/SignalException:
-  Description: 'Checks for proper usage of fail and raise.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#fail-method'
   Enabled: false
 
 Style/SingleLineMethods:
-  Description: 'Avoid single-line methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-single-line-methods'
   Enabled: false
 
 Style/StringLiterals:
-  Description: 'Checks if uses of quotes match the configured preference.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-string-literals'
   Enabled: false
 
 Style/StringMethods:
@@ -487,47 +330,27 @@ Style/TernaryParentheses:
   Enabled: false
 
 Style/TrailingCommaInArguments:
-  Description: 'Checks for trailing comma in parameter lists.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
   Enabled: true
   EnforcedStyleForMultiline: 'comma'
 
 Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: false
   EnforcedStyleForMultiline: 'comma'
 
 Style/TrailingUnderscoreVariable:
-  Description: >-
-                 Checks for the usage of unneeded trailing underscores at the
-                 end of parallel variable assignment.
   Enabled: true
 
 Style/UnneededCapitalW:
-  Description: 'Checks for %W when interpolation is not needed.'
   Enabled: false
 
 Style/VariableInterpolation:
-  Description: >-
-                 Don't interpolate global, instance and class variables
-                 directly in strings.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#curlies-interpolate'
   Enabled: false
 
 Style/WhenThen:
-  Description: 'Use when x then ... for one-line cases.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#one-line-cases'
   Enabled: false
 
 Style/WhileUntilModifier:
-  Description: >-
-                 Favor modifier while/until usage when you have a
-                 single-line body.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier'
   Enabled: false
 
 Style/WordArray:
-  Description: 'Use %w or %W for arrays of words.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-w'
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.5
   TargetRailsVersion: 5.1
-  DisabledByDefault: true
+  DisabledByDefault: false
   Exclude:
     - 'config/initializers/resque.rb'
     - 'config/initializers/rack_cors.rb'
@@ -14,36 +14,13 @@ AllCops:
 Rails:
   Enabled: true
 
-#################### Bundler ################################
-
-Bundler/DuplicatedGem:
-  Description: >-
-                 A Gem's requirements should be listed only once in a
-                 Gemfile.
-  Enabled: true
-
 #################### Layout ##############################
-
-Layout/AccessModifierIndentation:
-  Description: Check indentation of private/protected visibility modifiers.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected'
-  Enabled: true
-  EnforcedStyle: 'indent'
-
-Layout/AlignArray:
-  Description: >-
-                 Align the elements of an array literal if they span more than
-                 one line.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays'
-  Enabled: true
 
 Layout/AlignHash:
   Description: >-
                  Align the elements of a hash literal if they span more than
                  one line.
   Enabled: false
-  EnforcedHashRocketStyle: 'key'
-  EnforcedColonStyle: 'key'
 
 Layout/AlignParameters:
   Description: >-
@@ -51,11 +28,6 @@ Layout/AlignParameters:
                  than one line.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
   Enabled: false
-  EnforcedStyle: 'with_first_parameter'
-
-Layout/BlockEndNewline:
-  Description: 'Put end statement of multiline block on its own line.'
-  Enabled: true
 
 Layout/CaseIndentation:
   Description: 'Indentation of when in a case/when/[else/]end.'
@@ -68,19 +40,6 @@ Layout/ClosingParenthesisIndentation:
   Description: 'Checks the indentation of hanging closing parentheses.'
   Enabled: false
 
-Layout/CommentIndentation:
-  Description: 'Indentation of comments.'
-  Enabled: true
-
-Layout/DotPosition:
-  Description: 'Checks the position of the dot in multi-line method calls.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
-  Enabled: true
-
-Layout/ElseAlignment:
-  Description: 'Align elses and elsifs correctly.'
-  Enabled: true
-
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 
@@ -88,7 +47,6 @@ Layout/EmptyLineBetweenDefs:
   Description: 'Use empty lines between defs.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods'
   Enabled: false
-  AllowAdjacentOneLineDefs: false
 
 Layout/EmptyLines:
   Description: "Don't use several empty lines in a row."
@@ -98,66 +56,17 @@ Layout/EmptyLinesAroundAccessModifier:
   Description: "Keep blank lines around access modifiers."
   Enabled: true
 
-Layout/EmptyLinesAroundBeginBody:
-  Enabled: true
-
-Layout/EmptyLinesAroundBlockBody:
-  Description: "Keeps track of empty lines around block bodies."
-  Enabled: true
-  EnforcedStyle: 'no_empty_lines'
-
-Layout/EmptyLinesAroundClassBody:
-  Description: "Keeps track of empty lines around class bodies."
-  Enabled: true
-  EnforcedStyle: 'no_empty_lines'
-
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
   Enabled: true
-
-Layout/EmptyLinesAroundMethodBody:
-  Description: "Keeps track of empty lines around method bodies."
-  Enabled: true
-
-Layout/EmptyLinesAroundModuleBody:
-  Description: "Keeps track of empty lines around module bodies."
-  Enabled: true
-  EnforcedStyle: 'no_empty_lines'
 
 Layout/EndOfLine:
   Description: 'Use Unix-style line endings.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#crlf'
   Enabled: false
 
-Layout/ExtraSpacing:
-  Description: 'Do not use unnecessary spacing.'
-  Enabled: true
-  AllowForAlignment: true
-
-Layout/FirstArrayElementLineBreak:
-  Enabled: false
-
-Layout/FirstHashElementLineBreak:
-  Enabled: false
-
-Layout/FirstMethodArgumentLineBreak:
-  Enabled: false
-
-Layout/FirstMethodParameterLineBreak:
-  Enabled: false
-
 Layout/FirstParameterIndentation:
   Description: 'Checks the indentation of the first parameter in a method call.'
   Enabled: false
-
-Layout/IndentAssignment:
-  Enabled: true
-
-Layout/IndentHeredoc:
-  Enabled: true
-
-Layout/IndentationConsistency:
-  Description: 'Keep indentation straight.'
-  Enabled: true
 
 Layout/IndentationWidth:
   Description: 'Use 2 spaces for indentation.'
@@ -177,23 +86,6 @@ Layout/IndentHash:
   Enabled: true
   EnforcedStyle: 'consistent'
 
-Layout/InitialIndentation:
-  Description: >-
-    Checks the indentation of the first non-blank non-comment line in a file.
-  Enabled: true
-
-Layout/LeadingCommentSpace:
-  Description: 'Comments should start with a space.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-space'
-  Enabled: true
-
-Layout/MultilineArrayBraceLayout:
-  Enabled: false
-
-Layout/MultilineBlockLayout:
-  Description: 'Ensures newlines after multiline block do statements.'
-  Enabled: true
-
 Layout/MultilineHashBraceLayout:
   Enabled: false
 
@@ -212,37 +104,6 @@ Layout/MultilineOperationIndentation:
                  one line.
   Enabled: false
 
-Layout/RescueEnsureAlignment:
-  Description: 'Align rescues and ensures correctly.'
-  Enabled: true
-
-Layout/SpaceAfterColon:
-  Description: 'Use spaces after colons.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: true
-
-Layout/SpaceAfterComma:
-  Description: 'Use spaces after commas.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: true
-
-Layout/SpaceAfterMethodName:
-  Description: >-
-                 Do not put a space between a method name and the opening
-                 parenthesis in a method definition.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
-  Enabled: true
-
-Layout/SpaceAfterNot:
-  Description: Tracks redundant space after the ! operator.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-bang'
-  Enabled: true
-
-Layout/SpaceAfterSemicolon:
-  Description: 'Use spaces after semicolons.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: true
-
 Layout/SpaceAroundBlockParameters:
   Description: 'Checks the spacing inside and after block parameters pipes.'
   Enabled: false
@@ -255,10 +116,6 @@ Layout/SpaceAroundEqualsInParameterDefault:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-around-equals'
   Enabled: false
 
-Layout/SpaceAroundKeyword:
-  Description: 'Use spaces around keywords.'
-  Enabled: true
-
 Layout/SpaceAroundOperators:
   Description: 'Use a single space around operators.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
@@ -270,36 +127,8 @@ Layout/SpaceBeforeBlockBraces:
                  before it.
   Enabled: false
 
-Layout/SpaceBeforeComma:
-  Description: 'No spaces before commas.'
-  Enabled: true
-
-Layout/SpaceBeforeComment:
-  Description: >-
-                 Checks for missing space between code and a comment on the
-                 same line.
-  Enabled: true
-
-Layout/SpaceBeforeFirstArg:
-  Description: >-
-                 Checks that exactly one space is used between a method name
-                 and the first argument for method calls without parentheses.
-  Enabled: true
-
-Layout/SpaceBeforeSemicolon:
-  Description: 'No spaces before semicolons.'
-  Enabled: true
-
 Layout/SpaceInLambdaLiteral:
   Enabled: false
-
-Layout/SpaceInsideArrayLiteralBrackets:
-  Description: 'No spaces after [ or before ].'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
-  Enabled: true
-
-Layout/SpaceInsideArrayPercentLiteral:
-  Enabled: true
 
 Layout/SpaceInsideBlockBraces:
   Description: >-
@@ -313,11 +142,6 @@ Layout/SpaceInsideHashLiteralBraces:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: false
 
-Layout/SpaceInsideParens:
-  Description: 'No spaces after ( or before ).'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
-  Enabled: true
-
 Layout/SpaceInsidePercentLiteralDelimiters:
   Enabled: false
 
@@ -326,192 +150,17 @@ Layout/SpaceInsideRangeLiteral:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals'
   Enabled: false
 
-Layout/SpaceInsideReferenceBrackets:
-  Description: 'No spaces after [ or before ].'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
-  Enabled: true
-
-Layout/SpaceInsideStringInterpolation:
-  Description: 'Checks for padding/surrounding spaces inside string interpolation.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#string-interpolation'
-  Enabled: true
-
-Layout/Tab:
-  Description: 'No hard tabs.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
-  Enabled: true
-
 Layout/TrailingBlankLines:
   Description: 'Checks trailing blank lines and final newline.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#newline-eof'
   Enabled: false
 
-Layout/TrailingWhitespace:
-  Description: 'Avoid trailing whitespace.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
-  Enabled: true
-
 #################### Lint ################################
-
-Lint/AmbiguousBlockAssociation:
-  Description: >-
-                 Checks for ambiguous block association with method when
-                 param passed without parentheses.
-  Enabled: true
-
-Lint/AmbiguousOperator:
-  Description: >-
-                 Checks for ambiguous operators in the first argument of a
-                 method invocation without parentheses.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-as-args'
-  Enabled: true
-
-Lint/AmbiguousRegexpLiteral:
-  Description: >-
-                 Checks for ambiguous regexp literals in the first argument of
-                 a method invocation without parenthesis.
-  Enabled: true
-
-Lint/AssignmentInCondition:
-  Description: "Don't use assignment in conditions."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'
-  Enabled: true
-
-Lint/BlockAlignment:
-  Description: 'Align block ends correctly.'
-  Enabled: true
-
-Lint/CircularArgumentReference:
-  Description: "Don't refer to the keyword argument in the default value."
-  Enabled: true
-
-Lint/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
-  Enabled: true
-
-Lint/Debugger:
-  Description: 'Check for debugger calls.'
-  Enabled: true
-
-Lint/DefEndAlignment:
-  Description: 'Align ends corresponding to defs correctly.'
-  Enabled: true
-
-Lint/DeprecatedClassMethods:
-  Description: 'Check for deprecated class method calls.'
-  Enabled: true
-
-Lint/DuplicateCaseCondition:
-  Description: 'Check that there are no repeated conditions used in case when expressions.'
-  Enabled: true
-
-Lint/DuplicateMethods:
-  Description: 'Check for duplicate methods calls.'
-  Enabled: true
-
-Lint/DuplicatedKey:
-  Description: 'This cop checks for duplicated keys in hash literals.'
-  Enabled: true
-
-Lint/EachWithObjectArgument:
-  Description: 'Check for immutable argument given to each_with_object.'
-  Enabled: true
-
-Lint/ElseLayout:
-  Description: 'Check for odd code arrangement in an else block.'
-  Enabled: true
-
-Lint/EmptyEnsure:
-  Description: 'Checks for empty ensure block.'
-  Enabled: true
-
-Lint/EmptyExpression:
-  Description: 'Checksfor the presence of empty expressions.'
-  Enabled: true
-
-Lint/EmptyInterpolation:
-  Description: 'Checks for empty string interpolation.'
-  Enabled: true
-
-Lint/EmptyWhen:
-  Description: 'Check for the presence of when branches without a body.'
-  Enabled: true
 
 Lint/EndAlignment:
   Description: 'Align ends correctly.'
   Enabled: true
   EnforcedStyleAlignWith: 'variable'
-
-Lint/EndInMethod:
-  Description: 'END blocks should not be placed inside method definitions.'
-  Enabled: true
-
-Lint/EnsureReturn:
-  Description: 'Do not use return in an ensure block.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-return-ensure'
-  Enabled: true
-
-Lint/FloatOutOfRange:
-  Description: 'Identify Float literals which are, like, really really really really really really really really big.'
-  Enabled: true
-
-Lint/FormatParameterMismatch:
-  Description: 'The number of parameters to format/sprint must match the fields.'
-  Enabled: true
-
-Lint/HandleExceptions:
-  Description: "Don't suppress exception."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
-  Enabled: true
-
-Lint/ImplicitStringConcatenation:
-  Description: 'Check for implicit string concatenation of string literals which are on the same line.'
-  Enabled: true
-
-Lint/IneffectiveAccessModifier:
-  Description: 'Check for private or protected access modifiers which are applied to a singleton method.'
-  Enabled: true
-
-Lint/InheritException:
-  Description: 'Look for error classes inheriting from Exception and its standard library subclasses, excluding subclasses of StandardError.'
-  Enabled: true
-
-Lint/LiteralAsCondition:
-  Description: 'Checks of literals used in conditions.'
-  Enabled: true
-
-Lint/LiteralInInterpolation:
-  Description: 'Checks for literals used in interpolation.'
-  Enabled: true
-
-Lint/Loop:
-  Description: >-
-                 Use Kernel#loop with break rather than begin/end/until or
-                 begin/end/while for post-loop tests.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#loop-with-break'
-  Enabled: true
-
-Lint/MultipleCompare:
-  Description: 'Check for the x < y < z style of comparison to compare multiple values.'
-  Enabled: true
-
-Lint/NestedMethodDefinition:
-  Description: 'Do not use nested method definitions.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-methods'
-  Enabled: true
-
-Lint/NextWithoutAccumulator:
-  Description: >-
-                 Don't omit the accumulator when calling next in a reduce
-                 block.
-  Enabled: true
-
-Lint/NonLocalExitFromIterator:
-  Description: 'Do not use return in iterator to cause non-local exit.'
-  Enabled: true
 
 Lint/ParenthesesAsGroupedExpression:
   Description: >-
@@ -519,109 +168,6 @@ Lint/ParenthesesAsGroupedExpression:
                  parenthesis.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
   Enabled: false
-
-Lint/PercentStringArray:
-  Description: >-
-                 This cop checks for quotes and commas in %w, e.g. %w('foo',
-                 "bar")
-  Enabled: true
-
-Lint/PercentSymbolArray:
-  Description: >-
-                 This cop checks for colons and commas in %i, e.g. %i(:foo,
-                 :bar)
-  Enabled: true
-
-Lint/RandOne:
-  Description: 'Check for rand(1) calls. Such calls always return 0.'
-  Enabled: true
-
-Lint/RequireParentheses:
-  Description: >-
-                 Use parentheses in the method call to avoid confusion
-                 about precedence.
-  Enabled: true
-
-Lint/RescueException:
-  Description: 'Avoid rescuing the Exception class.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-blind-rescues'
-  Enabled: true
-
-Lint/SafeNavigationChain:
-  Description: 'We should use a safe navigation operator after a safe navigation operator.'
-  Enabled: true
-
-Lint/ShadowedException:
-  Description: >-
-                 Check for a rescued exception that get shadowed by a less
-                 specific exception being rescued before a more specific
-                 exception is rescued.
-  Enabled: true
-
-Lint/ShadowingOuterLocalVariable:
-  Description: >-
-                 Do not use the same name as outer local variable
-                 for block arguments or block local variables.
-  Enabled: true
-
-Lint/StringConversionInInterpolation:
-  Description: 'Checks for Object#to_s usage in string interpolation.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-to-s'
-  Enabled: true
-
-Lint/UnderscorePrefixedVariableName:
-  Description: 'Do not use prefix `_` for a variable that is used.'
-  Enabled: true
-
-Lint/UnneededDisable:
-  Description: >-
-                 Checks for rubocop:disable comments that can be removed.
-                 Note: this cop is not disabled when disabling all cops.
-                 It must be explicitly disabled.
-  Enabled: true
-
-Lint/UnneededSplatExpansion:
-  Description: 'This cop checks for unneeded usages of splat expansion.'
-  Enabled: true
-
-Lint/UnreachableCode:
-  Description: 'Unreachable code.'
-  Enabled: true
-
-Lint/UnusedBlockArgument:
-  Description: 'Checks for unused block arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
-  Enabled: true
-
-Lint/UnusedMethodArgument:
-  Description: 'Checks for unused method arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
-  Enabled: true
-
-Lint/UselessAccessModifier:
-  Description: 'Checks for useless access modifiers.'
-  Enabled: true
-
-Lint/UselessAssignment:
-  Description: 'Checks for useless assignment to a local variable.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
-  Enabled: true
-
-Lint/UselessComparison:
-  Description: 'Checks for comparison of something with itself.'
-  Enabled: true
-
-Lint/UselessElseWithoutRescue:
-  Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
-  Enabled: true
-
-Lint/UselessSetterCall:
-  Description: 'Checks for useless setter call to a local variable.'
-  Enabled: true
-
-Lint/Void:
-  Description: 'Possible use of operator/literal/variable in void context.'
-  Enabled: true
 
 ###################### Metrics ####################################
 
@@ -633,6 +179,9 @@ Metrics/AbcSize:
   Enabled: false
   Max: 20
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
@@ -642,7 +191,6 @@ Metrics/BlockNesting:
 Metrics/ClassLength:
   Description: 'Avoid classes longer than 250 lines of code.'
   Enabled: false
-  Max: 250
 
 Metrics/CyclomaticComplexity:
   Description: >-
@@ -659,12 +207,10 @@ Metrics/MethodLength:
   Description: 'Avoid methods longer than 30 lines of code.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#short-methods'
   Enabled: false
-  Max: 30
 
 Metrics/ModuleLength:
   Description: 'Avoid modules longer than 250 lines of code.'
   Enabled: false
-  Max: 250
 
 Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'
@@ -688,233 +234,25 @@ Naming/AsciiIdentifiers:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-identifiers'
   Enabled: false
 
-Naming/BinaryOperatorParameterName:
-  Description: 'When defining binary operators, name the argument other.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
-  Enabled: true
-
-Naming/ClassAndModuleCamelCase:
-  Description: 'Use CamelCase for classes and modules.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#camelcase-classes'
-  Enabled: true
-
-Naming/ConstantName:
-  Description: 'Constants should use SCREAMING_SNAKE_CASE.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#screaming-snake-case'
-  Enabled: true
-
-Naming/FileName:
-  Description: 'Use snake_case for source file names.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
-  Enabled: true
-
-Naming/MethodName:
-  Description: 'Use the configured style when naming methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
-  Enabled: true
-
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
   Enabled: false
 
-Naming/VariableName:
-  Description: 'Use the configured style when naming variables.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
-  Enabled: true
-  EnforcedStyle: 'snake_case'
-
 Naming/VariableNumber:
   Enabled: false
 
-##################### Performance #############################
-
-Performance/CaseWhenSplat:
-  Enabled: true
-
-Performance/Casecmp:
-  Enabled: true
-
-Performance/CompareWithBlock:
-  Enabled: true
-
-Performance/Count:
-  Description: >-
-                  Use `count` instead of `select...size`, `reject...size`,
-                  `select...count`, `reject...count`, `select...length`,
-                  and `reject...length`.
-  Enabled: true
-
-Performance/Detect:
-  Description: >-
-                  Use `detect` instead of `select.first`, `find_all.first`,
-                  `select.last`, and `find_all.last`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
-  Enabled: true
-
-Performance/DoubleStartEndWith:
-  Enabled: true
-
-Performance/EndWith:
-  Enabled: true
-
-Performance/FixedSize:
-  Enabled: true
-
-Performance/FlatMap:
-  Description: >-
-                  Use `Enumerable#flat_map`
-                  instead of `Enumerable#map...Array#flatten(1)`
-                  or `Enumberable#collect..Array#flatten(1)`
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code'
-  Enabled: true
-  EnabledForFlattenWithoutParams: false
-  # If enabled, this cop will warn about usages of
-  # `flatten` being called without any parameters.
-  # This can be dangerous since `flat_map` will only flatten 1 level, and
-  # `flatten` without any parameters can flatten multiple levels.
-
-Performance/HashEachMethods:
-  Enabled: true
-
-Performance/LstripRstrip:
-  Enabled: true
-
-Performance/RangeInclude:
-  Enabled: true
-
-Performance/RedundantBlockCall:
-  Enabled: true
-
-Performance/RedundantMatch:
-  Enabled: true
-
-Performance/RedundantMerge:
-  Enabled: true
-
-Performance/RedundantSortBy:
-  Enabled: true
-
-Performance/ReverseEach:
-  Description: 'Use `reverse_each` instead of `reverse.each`.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
-  Enabled: true
-
-Performance/Sample:
-  Description: >-
-                  Use `sample` instead of `shuffle.first`,
-                  `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
-  Enabled: true
-
-Performance/Size:
-  Description: >-
-                  Use `size` instead of `count` for counting
-                  the number of elements in `Array` and `Hash`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code'
-  Enabled: true
-
-Performance/StartWith:
-  Enabled: true
-
-Performance/StringReplacement:
-  Description: >-
-                  Use `tr` instead of `gsub` when you are replacing the same
-                  number of characters. Use `delete` instead of `gsub` when
-                  you are deleting characters.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
-  Enabled: true
-
-Performance/TimesMap:
-  Enabled: true
-
 ##################### Rails ##################################
-
-Rails/ActionFilter:
-  Description: 'Enforces consistent use of action filter methods.'
-  Enabled: true
-
-Rails/ActiveSupportAliases:
-  Enabled: true
 
 Rails/Blank:
   Enabled: true
   UnlessPresent: false
-
-Rails/Date:
-  Description: >-
-                  Checks the correct usage of date aware methods,
-                  such as Date.today, Date.current etc.
-  Enabled: true
-
-Rails/Delegate:
-  Description: 'Prefer delegate method for delegations.'
-  Enabled: true
-
-Rails/DelegateAllowBlank:
-  Enabled: true
 
 Rails/DynamicFindBy:
   Enabled: true
   Whitelist:
     - find_by_sql
     - find_by_id
-
-Rails/Exit:
-  Enabled: true
-
-Rails/FilePath:
-  Enabled: true
-
-Rails/FindBy:
-  Description: 'Prefer find_by over where.first.'
-  Enabled: true
-
-Rails/FindEach:
-  Description: 'Prefer all.find_each over all.each.'
-  Enabled: true
-
-Rails/HasAndBelongsToMany:
-  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#has-many-through'
-  Enabled: true
-
-Rails/NotNullColumn:
-  Enabled: true
-
-# ?
-
-Rails/Output:
-  Description: 'Checks for calls to puts, print, etc.'
-  Enabled: true
-
-Rails/OutputSafety:
-  Description: 'This cop checks for the use of output safety calls like html_safe and raw.'
-  Enabled: true
-
-Rails/PluralizationGrammar:
-  Enabled: true
-
-Rails/Present:
-  Enabled: true
-
-Rails/ReadWriteAttribute:
-  Description: >-
-                 Checks for read_attribute(:attr) and
-                 write_attribute(:attr, val).
-  Enabled: true
-
-Rails/RelativeDateConstant:
-  Enabled: true
-
-Rails/RequestReferer:
-  Enabled: true
-
-Rails/ReversibleMigration:
-  Enabled: true
-
-Rails/SafeNavigation:
-  Enabled: true
 
 Rails/SaveBang:
   Enabled: true
@@ -923,9 +261,6 @@ Rails/ScopeArgs:
   Description: 'Checks the arguments of ActiveRecord scopes.'
   Enabled: false
 
-Rails/SkipsModelValidations:
-  Enabled: true
-
 Rails/TimeZone:
   Description: 'Checks the correct usage of time zone aware methods.'
   StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
@@ -933,37 +268,6 @@ Rails/TimeZone:
   Enabled: true
   Exclude:
     - 'spec/**/*'
-
-Rails/UniqBeforePluck:
-  Enabled: true
-
-Rails/Validation:
-  Description: 'Use validates :attribute, hash of validations.'
-  Enabled: true
-
-################## Security ##############################
-
-Security/Eval:
-  Description: 'The use of eval represents a serious security risk.'
-  Enabled: true
-
-Security/JSONLoad:
-  Description: 'This cop checks for the use of JSON class methods which have potential security issues.'
-  Enabled: true
-
-Security/MarshalLoad:
-  Description: >-
-                 This cop checks for the use of Marshal class methods which
-                 have potential security issues leading to remote code
-                 execution when loading from an untrusted source.
-  Enabled: true
-
-Security/YAMLLoad:
-  Description: >-
-                 This cop checks for the use of YAML class methods which
-                 have potential security issues leading to remote code
-                 execution when loading from an untrusted source.
-  Enabled: true
 
 ################## Style #################################
 
@@ -987,28 +291,13 @@ Style/AsciiComments:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-comments'
   Enabled: false
 
-Style/Attr:
-  Description: 'Checks for uses of Module#attr.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr'
-  Enabled: true
-
 Style/AutoResourceCleanup:
-  Enabled: true
-
-Style/BarePercentLiterals:
-  Description: 'Checks if usage of %() or %Q() matches configuration.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand'
   Enabled: true
 
 Style/BeginBlock:
   Description: 'Avoid the use of BEGIN blocks.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-BEGIN-blocks'
   Enabled: false
-
-Style/BlockComments:
-  Description: 'Do not use block comments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-block-comments'
-  Enabled: true
 
 Style/BlockDelimiters:
   Description: >-
@@ -1022,42 +311,9 @@ Style/BracesAroundHashParameters:
   Description: 'Enforce braces style around hash parameters.'
   Enabled: false
 
-Style/CaseEquality:
-  Description: 'Avoid explicit use of the case equality operator(===).'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-case-equality'
-  Enabled: true
-
-Style/CharacterLiteral:
-  Description: 'Checks for uses of character literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-character-literals'
-  Enabled: true
-
 Style/ClassAndModuleChildren:
   Description: 'Checks style of children classes and modules.'
   Enabled: false
-
-Style/ClassCheck:
-  Description: 'Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.'
-  Enabled: true
-
-Style/ClassMethods:
-  Description: 'Use self when defining module/class methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#def-self-class-methods'
-  Enabled: true
-
-Style/ClassVars:
-  Description: 'Avoid the use of class variables.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-class-vars'
-  Enabled: false
-
-Style/CollectionMethods:
-  Description: 'This cop enforces the use of consistent method names from the Enumerable module.'
-  Enabled: false
-
-Style/ColonMethodCall:
-  Description: 'Do not use :: for method call.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#double-colons'
-  Enabled: true
 
 Style/CommandLiteral:
   Description: 'Use `` or %x around command literals.'
@@ -1076,19 +332,8 @@ Style/ConditionalAssignment:
                  of the condition can be used instead.
   Enabled: false
 
-Style/Copyright:
-  Enabled: false
-
-Style/DefWithParentheses:
-  Description: 'Use def with parentheses when there are arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
-  Enabled: true
-
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
-  Enabled: false
-
-Style/DocumentationMethod:
   Enabled: false
 
 Style/DoubleNegation:
@@ -1096,55 +341,18 @@ Style/DoubleNegation:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
   Enabled: false
 
-Style/EachForSimpleLoop:
-  Enabled: true
-
-Style/EachWithObject:
-  Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
-  Enabled: true
-
-Style/EmptyCaseCondition:
-  Enabled: true
-
-Style/EmptyElse:
-  Description: 'Avoid empty else-clauses.'
-  Enabled: true
-
-Style/EmptyLiteral:
-  Description: 'Prefer literals to Array.new/Hash.new/String.new.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#literal-array-hash'
-  Enabled: true
-
 Style/EmptyMethod:
   Enabled: false
-  EnforcedStyle: 'compact'
 
 Style/Encoding:
   Enabled: false
 
-Style/EndBlock:
-  Description: 'Avoid the use of END blocks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-END-blocks'
-  Enabled: true
-
-Style/EvenOdd:
-  Description: 'Favor the use of Fixnum#even? && Fixnum#odd?'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
-  Enabled: true
-
-Style/FlipFlop:
-  Description: 'Checks for flip flops'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
-  Enabled: true
-
-Style/For:
-  Description: 'Checks use of for or each in multiline loops.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-for-loops'
-  Enabled: true
-
 Style/FormatString:
   Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#sprintf'
+  Enabled: false
+
+Style/FormatStringToken:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
@@ -1168,28 +376,9 @@ Style/HashSyntax:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-literals'
   Enabled: false
 
-Style/IdenticalConditionalBranches:
-  Enabled: true
-
-Style/IfInsideElse:
-  Enabled: true
-
-Style/IfUnlessModifier:
-  Description: >-
-                 Favor modifier if/unless usage when you have a
-                 single-line body.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier'
-  Enabled: true
-
-Style/IfUnlessModifierOfIfUnless:
-  Enabled: true
-
 Style/IfWithSemicolon:
   Description: 'Do not use if x; .... Use the ternary operator instead.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs'
-  Enabled: false
-
-Style/ImplicitRuntimeError:
   Enabled: false
 
 Style/InfiniteLoop:
@@ -1197,133 +386,21 @@ Style/InfiniteLoop:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#infinite-loop'
   Enabled: false
 
-Style/InlineComment:
-  Enabled: false
-
-Style/InverseMethods:
-  Enabled: true
-
 Style/Lambda:
   Description: 'Use the new lambda literal syntax for single-line blocks.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#lambda-multi-line'
   Enabled: false
-
-Style/LambdaCall:
-  Description: 'Use lambda.call(...) instead of lambda.(...).'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc-call'
-  Enabled: true
-
-Style/LineEndConcatenation:
-  Description: >-
-                 Use \ instead of + or << to concatenate two string literals at
-                 line end.
-  Enabled: true
-
-Style/MethodCallWithArgsParentheses:
-  Enabled: false
-  IgnoreMacros: true
-
-Style/MethodCallWithoutArgsParentheses:
-  Description: 'Do not use parentheses for method calls with no arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
-  Enabled: true
-
-Style/MethodCalledOnDoEndBlock:
-  Enabled: false
-
-Style/MethodDefParentheses:
-  Description: >-
-                 Checks if the method definitions have or don't have
-                 parentheses.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
-  Enabled: true
-
-Style/MethodMissing:
-  Enabled: true
 
 Style/ModuleFunction:
   Description: 'Checks for usage of `extend self` in modules.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
   Enabled: false
 
-Style/MultilineBlockChain:
-  Description: 'Avoid multi-line chains of blocks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
-  Enabled: true
-
-Style/MultilineIfModifier:
-  Enabled: true
-
-Style/MultilineIfThen:
-  Description: 'Do not use then for multi-line if/unless.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-then'
-  Enabled: true
-
 Style/MultilineMemoization:
   Enabled: false
 
-Style/MultilineTernaryOperator:
-  Description: >-
-                 Avoid multi-line ?: (the ternary operator);
-                 use if/unless instead.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-multiline-ternary'
-  Enabled: true
-
 Style/MutableConstant:
   Enabled: false
-
-Style/NegatedIf:
-  Description: >-
-                 Favor unless over if for negative conditions
-                 (or control flow or).
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#unless-for-negatives'
-  Enabled: true
-
-Style/NegatedWhile:
-  Description: 'Favor until over while for negative conditions.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#until-for-negatives'
-  Enabled: true
-
-Style/NestedModifier:
-  Enabled: true
-
-Style/NestedParenthesizedCalls:
-  Enabled: true
-
-Style/NestedTernaryOperator:
-  Description: 'Use one expression per branch in a ternary operator.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-ternary'
-  Enabled: true
-
-Style/Next:
-  Description: 'Use `next` to skip iteration instead of a condition at the end.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
-  Enabled: true
-
-Style/NilComparison:
-  Description: 'Prefer x.nil? to x == nil.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
-  Enabled: true
-
-Style/NonNilCheck:
-  Description: 'Checks for redundant nil checks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-non-nil-checks'
-  Enabled: true
-
-Style/Not:
-  Description: 'Use ! instead of not.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bang-not-not'
-  Enabled: true
-
-Style/NumericLiteralPrefix:
-  Enabled: true
-
-Style/NumericLiterals:
-  Description: >-
-                 Add underscores to large numeric literals to improve their
-                 readability.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
-  Enabled: true
 
 Style/NumericPredicate:
   Enabled: false
@@ -1335,16 +412,6 @@ Style/OneLineConditional:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: false
 
-Style/OptionHash:
-  Enabled: false
-
-Style/OptionalArguments:
-  Description: >-
-                 Checks for optional arguments that do not appear at the end
-                 of the argument list
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#optional-arguments'
-  Enabled: true
-
 Style/ParallelAssignment:
   Description: >-
                   Check for simple usages of parallel assignment.
@@ -1354,13 +421,6 @@ Style/ParallelAssignment:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parallel-assignment'
   Enabled: false
 
-Style/ParenthesesAroundCondition:
-  Description: >-
-                 Don't use parentheses around the condition of an
-                 if/unless/while.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-parens-if'
-  Enabled: true
-
 Style/PercentLiteralDelimiters:
   Description: 'Use `%`-literal delimiters consistently'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-literal-braces'
@@ -1369,16 +429,6 @@ Style/PercentLiteralDelimiters:
 Style/PercentQLiterals:
   Description: 'Checks if uses of %Q/%q match the configured preference.'
   Enabled: false
-
-Style/PerlBackrefs:
-  Description: 'Avoid Perl-style regex back references.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers'
-  Enabled: true
-
-Style/PreferredHashMethods:
-  Description: 'Checks for use of deprecated Hash methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-key'
-  Enabled: true
 
 Style/Proc:
   Description: 'Use proc instead of Proc.new.'
@@ -1390,26 +440,10 @@ Style/RaiseArgs:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#exception-class-messages'
   Enabled: false
 
-Style/RedundantBegin:
-  Description: "Don't use begin blocks when they are not needed."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#begin-implicit'
-  Enabled: true
-
 Style/RedundantException:
   Description: "Checks for an obsolete RuntimeException argument in raise/fail."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-explicit-runtimeerror'
   Enabled: false
-
-Style/RedundantFreeze:
-  Enabled: true
-
-Style/RedundantParentheses:
-  Enabled: true
-
-Style/RedundantReturn:
-  Description: "Don't use return where it's not required."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-explicit-return'
-  Enabled: true
 
 Style/RedundantSelf:
   Description: "Don't use self where it's not needed."
@@ -1421,37 +455,9 @@ Style/RegexpLiteral:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
   Enabled: false
 
-Style/RescueModifier:
-  Description: 'Avoid using rescue in its modifier form.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers'
-  Enabled: true
-
-Style/SafeNavigation:
-  Enabled: true
-
-Style/SelfAssignment:
-  Description: >-
-                 Checks for places where self-assignment shorthand should have
-                 been used.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#self-assignment'
-  Enabled: true
-
-Style/Semicolon:
-  Description: "Don't use semicolons to terminate expressions."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon'
-  Enabled: true
-
-Style/Send:
-  Enabled: false
-
 Style/SignalException:
   Description: 'Checks for proper usage of fail and raise.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#fail-method'
-  Enabled: false
-
-Style/SingleLineBlockParams:
-  Description: 'Enforces the names of some block params.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#reduce-blocks'
   Enabled: false
 
 Style/SingleLineMethods:
@@ -1459,46 +465,16 @@ Style/SingleLineMethods:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-single-line-methods'
   Enabled: false
 
-Style/SpecialGlobalVars:
-  Description: 'Avoid Perl-style global variables.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms'
-  Enabled: true
-
-Style/StabbyLambdaParentheses:
-  Enabled: true
-  EnforcedStyle: 'require_parentheses'
-
 Style/StringLiterals:
   Description: 'Checks if uses of quotes match the configured preference.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-string-literals'
   Enabled: false
-  EnforcedStyle: 'single_quotes'
-
-Style/StringLiteralsInInterpolation:
-  Description: >-
-                 Checks if uses of quotes inside expressions in interpolated
-                 strings match the configured preference.
-  Enabled: true
-  EnforcedStyle: 'single_quotes'
 
 Style/StringMethods:
   Enabled: true
 
-Style/StructInheritance:
-  Description: 'Checks for inheritance from Struct.new.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new'
-  Enabled: true
-
 Style/SymbolArray:
   Enabled: false
-
-Style/SymbolLiteral:
-  Description: 'Use plain symbols instead of string symbols when possible.'
-  Enabled: true
-
-Style/SymbolProc:
-  Description: 'Use symbols as procs instead of blocks when possible.'
-  Enabled: true
 
 Style/TernaryParentheses:
   Enabled: false
@@ -1521,29 +497,9 @@ Style/TrailingUnderscoreVariable:
                  end of parallel variable assignment.
   Enabled: true
 
-Style/TrivialAccessors:
-  Description: 'Prefer attr_* methods to trivial readers/writers.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr_family'
-  Enabled: true
-
-Style/UnlessElse:
-  Description: >-
-                 Do not use unless with else. Rewrite these with the positive
-                 case first.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-else-with-unless'
-  Enabled: true
-
 Style/UnneededCapitalW:
   Description: 'Checks for %W when interpolation is not needed.'
   Enabled: false
-
-Style/UnneededInterpolation:
-  Enabled: true
-
-Style/UnneededPercentQ:
-  Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-q'
-  Enabled: true
 
 Style/VariableInterpolation:
   Description: >-
@@ -1557,11 +513,6 @@ Style/WhenThen:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#one-line-cases'
   Enabled: false
 
-Style/WhileUntilDo:
-  Description: 'Checks for redundant do after while or until.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-multiline-while-do'
-  Enabled: true
-
 Style/WhileUntilModifier:
   Description: >-
                  Favor modifier while/until usage when you have a
@@ -1573,6 +524,3 @@ Style/WordArray:
   Description: 'Use %w or %W for arrays of words.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-w'
   Enabled: false
-
-Style/ZeroLengthPredicate:
-  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ AllCops:
     - 'features/support/env.rb'
     - 'spec/spec_helper.rb'
 
+Rails:
+  Enabled: true
+
 #################### Bundler ################################
 
 Bundler/DuplicatedGem:
@@ -713,7 +716,7 @@ Naming/MethodName:
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
-  Enabled: true
+  Enabled: false
 
 Naming/VariableName:
   Description: 'Use the configured style when naming variables.'
@@ -836,6 +839,7 @@ Rails/ActiveSupportAliases:
 
 Rails/Blank:
   Enabled: true
+  UnlessPresent: false
 
 Rails/Date:
   Description: >-
@@ -852,6 +856,9 @@ Rails/DelegateAllowBlank:
 
 Rails/DynamicFindBy:
   Enabled: true
+  Whitelist:
+    - find_by_sql
+    - find_by_id
 
 Rails/Exit:
   Enabled: true
@@ -924,6 +931,8 @@ Rails/TimeZone:
   StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
   Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: true
+  Exclude:
+    - 'spec/**/*'
 
 Rails/UniqBeforePluck:
   Enabled: true
@@ -1498,13 +1507,13 @@ Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in parameter lists.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
   Enabled: true
-  EnforcedStyleForMultiline: 'no_comma'
+  EnforcedStyleForMultiline: 'comma'
 
 Style/TrailingCommaInLiteral:
   Description: 'Checks for trailing comma in literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: false
-  EnforcedStyleForMultiline: 'no_comma'
+  EnforcedStyleForMultiline: 'comma'
 
 Style/TrailingUnderscoreVariable:
   Description: >-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -201,9 +201,6 @@ Rails/HasManyOrHasOneDependent:
 Rails/SaveBang:
   Enabled: true
 
-Rails/ScopeArgs:
-  Enabled: false
-
 Rails/TimeZone:
   Enabled: true
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
-  gem 'rubocop'
+  gem 'rubocop', '~> 0.52'
   gem 'web-console', '~> 3.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,7 +454,7 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails
-  rubocop
+  rubocop (~> 0.52)
   sanitize
   sass-rails
   seed_dump (~> 3.2)


### PR DESCRIPTION
* Cleans up things being set to defaults to make the file much shorter
* Excludes a bunch of files
* Configures and disables various cops
* Pins the rubocop version to 0.52.*