### PR TITLE
Don't crash if the session[:user_id] is invalid

### DIFF
--- a/app/concerns/authentication.rb
+++ b/app/concerns/authentication.rb
@@ -15,7 +15,14 @@ module Authentication
     helper_method :logged_in?
 
     def current_user
-      @current_user ||= User.find_by_id(session[:user_id]) if logged_in?
+      return unless logged_in?
+      @current_user ||= User.find_by_id(session[:user_id])
+      return @current_user if @current_user
+
+      # logout - something has gone wrong, and the user id stored in session does not exist
+      reset_session
+      cookies.delete(:user_id, domain: '.glowfic.com')
+      @current_user = nil
     end
     helper_method :current_user
   end

--- a/app/concerns/authentication.rb
+++ b/app/concerns/authentication.rb
@@ -18,12 +18,14 @@ module Authentication
       return unless logged_in?
       @current_user ||= User.find_by_id(session[:user_id])
       return @current_user if @current_user
+      logout # the user id stored in session does not exist, probably due to staging db reset
+    end
+    helper_method :current_user
 
-      # logout - something has gone wrong, and the user id stored in session does not exist
+    def logout
       reset_session
       cookies.delete(:user_id, domain: '.glowfic.com')
       @current_user = nil
     end
-    helper_method :current_user
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -36,9 +36,7 @@ class SessionsController < ApplicationController
 
   def destroy
     url = session[:previous_url] || root_url
-    reset_session
-    cookies.delete(:user_id, domain: '.glowfic.com')
-    @current_user = nil
+    logout
     flash[:success] = "You have been logged out."
     redirect_to url
   end


### PR DESCRIPTION
Mostly useful for staging environment, if you're logged in but we reset the data. Fixes #752 