### PR TITLE
Fix character lists with character groups

### DIFF
--- a/app/views/characters/_group.haml
+++ b/app/views/characters/_group.haml
@@ -2,7 +2,7 @@
 - skip_grouped_templates = false unless defined?(:skip_grouped_templates)
 - if characters.try(:exists?)
   - template_ids = characters.group(:template_id).pluck(:template_id).uniq.compact
-  - templates = ActiveRecord::Base::Template.where(id: template_ids).order('name asc').each do |template|
+  - templates = ::Template.where(id: template_ids).order('name asc').each do |template|
     - next if skip_grouped_templates && template.characters.where('character_group_id is not null').exists?
     = render partial: partial_type, locals: {name: template, characters: template.characters.order('name asc')}
   - if characters.where(template_id: nil).exists?


### PR DESCRIPTION
After the upgrade to Ruby 2.5, which removed top-level constant lookup,
we now have an error where we try to specify explicitly the path to the
Template class (to prevent a conflict with `ActionView::Template`). Fix
this by looking for the model as a top-level constant.

Relevant Ruby change:
https://bugs.ruby-lang.org/issues/11547