### PR TITLE
Fix contribute link for pull requests

### DIFF
--- a/app/views/contribute/index.haml
+++ b/app/views/contribute/index.haml
@@ -8,6 +8,6 @@
     %tr
       %td.odd= link_to 'Donate via Paypal', 'http://paypal.me/aschloss'
     %tr
-      %td.even= link_to 'Submit a pull request', 'https://bitbucket.org/MarriNikari/glowfic/overview'
+      %td.even= link_to 'Submit a pull request', 'https://github.com/Marri/glowfic'
     %tr
       %td.odd= link_to 'Write something!', new_post_path


### PR DESCRIPTION
We moved from bitbucket to github forever ago, and the site should be updated to reflect this change.