### PR TITLE
Add gitlab dependency scanning

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,16 @@
+dependency_scanning:
+  image: docker:stable
+  variables:
+    DOCKER_DRIVER: overlay2
+  allow_failure: true
+  services:
+    - docker:stable-dind
+  script:
+    - export SP_VERSION=$(echo "$CI_SERVER_VERSION" | sed 's/^\([0-9]*\)\.\([0-9]*\).*/\1-\2-stable/')
+    - docker run
+        --env DEP_SCAN_DISABLE_REMOTE_CHECKS="${DEP_SCAN_DISABLE_REMOTE_CHECKS:-false}"
+        --volume "$PWD:/code"
+        --volume /var/run/docker.sock:/var/run/docker.sock
+        "registry.gitlab.com/gitlab-org/security-products/dependency-scanning:$SP_VERSION" /code
+  artifacts:
+    paths: [gl-dependency-scanning-report.json]


### PR DESCRIPTION
We have a mirror repository here: https://gitlab.com/throne3d/glowfic and this file sets GitLab up to check for dependency vulnerabilities when we push commits. (In case we don't push for a while, I've set up a schedule for it to check weekly.)

It doesn't otherwise affect the code, so I think it's good to merge. Since Gemnasium is shutting down, and it recommends to use GitLab instead, this seems like it should be merged soon. See <https://docs.gitlab.com/ee/user/project/import/gemnasium.html> for more information.

**Edit**: Oh, it looks like it also runs a check on PRs, but since that's not required, we'll just have it as extra useful information?