### PR TITLE
Allow soft-deletion of users

### DIFF
--- a/app/concerns/writable.rb
+++ b/app/concerns/writable.rb
@@ -60,6 +60,7 @@ module Writable
     end
 
     def username
+      return '(deleted user)' if user_deleted?
       return read_attribute(:username) if has_attribute?(:username)
       user.username
     end

--- a/app/controllers/api/v1/galleries_controller.rb
+++ b/app/controllers/api/v1/galleries_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::GalleriesController < Api::ApiController
 
   def show_galleryless
     user = if params[:user_id].present?
-      User.find_by_id(params[:user_id])
+      User.active.find_by_id(params[:user_id])
     else
       current_user
     end

--- a/app/controllers/api/v1/replies_controller.rb
+++ b/app/controllers/api/v1/replies_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::RepliesController < Api::ApiController
     access_denied and return unless post.visible_to?(current_user)
 
     replies = post.replies
-      .select('replies.*, characters.name, characters.screenname, icons.keyword, icons.url, users.username, character_aliases.name as alias')
+      .select('replies.*, characters.name, characters.screenname, icons.keyword, icons.url, users.username, users.deleted as user_deleted, character_aliases.name as alias')
       .joins(:user)
       .left_outer_joins(:character)
       .left_outer_joins(:icon)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -11,9 +11,9 @@ class Api::V1::UsersController < Api::ApiController
   error 422, "Invalid parameters provided"
   def index
     queryset = if params[:match] == 'exact'
-      User.where(username: params[:q])
+      User.active.where(username: params[:q])
     else
-      User.where("username LIKE ?", params[:q].to_s + '%').ordered
+      User.active.where("username LIKE ?", params[:q].to_s + '%').ordered
     end
     if params[:hide_unblockable].present? && params[:hide_unblockable] == 'true' && logged_in?
       blocked_users = Block.where(blocking_user_id: current_user.id).pluck(:blocked_user_id)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::UsersController < Api::ApiController
       blocked_users = Block.where(blocking_user_id: current_user.id).pluck(:blocked_user_id)
       queryset = queryset.where.not(id: blocked_users + [current_user.id])
     end
-    users = paginate queryset, per_page: 25
+    users = paginate queryset.active, per_page: 25
     render json: {results: users}
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -11,9 +11,9 @@ class Api::V1::UsersController < Api::ApiController
   error 422, "Invalid parameters provided"
   def index
     queryset = if params[:match] == 'exact'
-      User.active.where(username: params[:q])
+      User.where(username: params[:q])
     else
-      User.active.where("username LIKE ?", params[:q].to_s + '%').ordered
+      User.where("username LIKE ?", params[:q].to_s + '%').ordered
     end
     if params[:hide_unblockable].present? && params[:hide_unblockable] == 'true' && logged_in?
       blocked_users = Block.where(blocking_user_id: current_user.id).pluck(:blocked_user_id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -143,7 +143,7 @@ class ApplicationController < ActionController::Base
 
   def posts_from_relation(relation, no_tests: true, with_pagination: true, select: '', max: false)
     if max
-      posts = relation.select('posts.*, max(boards.name) as board_name, max(users.username) as last_user_name, max(users.deleted) as last_user_deleted'+ select)
+      posts = relation.select('posts.*, max(boards.name) as board_name, max(users.username) as last_user_name, bool_or(users.deleted) as last_user_deleted'+ select)
     else
       posts = relation.select('posts.*, boards.name as board_name, users.username as last_user_name, users.deleted as last_user_deleted'+ select)
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -143,9 +143,9 @@ class ApplicationController < ActionController::Base
 
   def posts_from_relation(relation, no_tests: true, with_pagination: true, select: '', max: false)
     if max
-      posts = relation.select('posts.*, max(boards.name) as board_name, max(users.username) as last_user_name'+ select)
+      posts = relation.select('posts.*, max(boards.name) as board_name, max(users.username) as last_user_name, max(users.deleted) as last_user_deleted'+ select)
     else
-      posts = relation.select('posts.*, boards.name as board_name, users.username as last_user_name'+ select)
+      posts = relation.select('posts.*, boards.name as board_name, users.username as last_user_name, users.deleted as last_user_deleted'+ select)
     end
 
     posts = posts

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   before_action :show_password_warning
   before_action :require_glowfic_domain
   before_action :set_login_gon
-  before_action :check_suspension
+  before_action :check_forced_logout
   around_action :set_timezone
   after_action :store_location
 
@@ -31,9 +31,9 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def check_suspension
+  def check_forced_logout
     return unless logged_in?
-    return unless current_user.suspended?
+    return unless current_user.suspended? || current_user.deleted?
     logout
   end
 

--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -6,7 +6,7 @@ class BlocksController < ApplicationController
 
   def index
     @page_title = "Blocked Users"
-    @blocks = Block.where(blocking_user: current_user)
+    @blocks = Block.where(blocking_user: current_user).ordered.reject{ |b| b.blocked_user.deleted? }
   end
 
   def new

--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -36,7 +36,7 @@ class BlocksController < ApplicationController
   end
 
   def edit
-    @page_title = "Edit Block: #{@block.blocked_user.username}"
+    @page_title = 'Edit Block: ' + @block.blocked_user.username
   end
 
   def update
@@ -48,7 +48,7 @@ class BlocksController < ApplicationController
       flash.now[:error][:message] = "Block could not be saved."
       flash.now[:error][:array] = @block.errors.full_messages
       editor_setup
-      @page_title = "Edit Block: #{@block.blocked_user.username}"
+      @page_title = 'Edit Block: ' + @block.blocked_user.username
       render :edit
     end
   end

--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -37,7 +37,7 @@ class BlocksController < ApplicationController
 
   def edit
     @page_title = 'Edit Block'
-    @page_title += ": #{@block.blocked_user.username}" unless @block.user.deleted?
+    @page_title += ": #{@block.blocked_user.username}" unless @block.blocked_user.deleted?
   end
 
   def update
@@ -50,7 +50,7 @@ class BlocksController < ApplicationController
       flash.now[:error][:array] = @block.errors.full_messages
       editor_setup
       @page_title = 'Edit Block'
-      @page_title += ": #{@block.blocked_user.username}" unless @block.user.deleted?
+      @page_title += ": #{@block.blocked_user.username}" unless @block.blocked_user.deleted?
       render :edit
     end
   end

--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -36,7 +36,8 @@ class BlocksController < ApplicationController
   end
 
   def edit
-    @page_title = 'Edit Block: ' + @block.blocked_user.username
+    @page_title = 'Edit Block'
+    @page_title += ": #{@block.blocked_user.username}" unless @block.user.deleted?
   end
 
   def update
@@ -48,7 +49,8 @@ class BlocksController < ApplicationController
       flash.now[:error][:message] = "Block could not be saved."
       flash.now[:error][:array] = @block.errors.full_messages
       editor_setup
-      @page_title = 'Edit Block: ' + @block.blocked_user.username
+      @page_title = 'Edit Block'
+      @page_title += ": #{@block.blocked_user.username}" unless @block.user.deleted?
       render :edit
     end
   end

--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -6,7 +6,7 @@ class BlocksController < ApplicationController
 
   def index
     @page_title = "Blocked Users"
-    @blocks = Block.where(blocking_user: current_user).ordered.reject{ |b| b.blocked_user.deleted? }
+    @blocks = Block.where(blocking_user: current_user)
   end
 
   def new
@@ -36,8 +36,7 @@ class BlocksController < ApplicationController
   end
 
   def edit
-    @page_title = 'Edit Block'
-    @page_title += ": #{@block.blocked_user.username}" unless @block.blocked_user.deleted?
+    @page_title = "Edit Block: #{@block.blocked_user.username}"
   end
 
   def update
@@ -49,8 +48,7 @@ class BlocksController < ApplicationController
       flash.now[:error][:message] = "Block could not be saved."
       flash.now[:error][:array] = @block.errors.full_messages
       editor_setup
-      @page_title = 'Edit Block'
-      @page_title += ": #{@block.blocked_user.username}" unless @block.blocked_user.deleted?
+      @page_title = "Edit Block: #{@block.blocked_user.username}"
       render :edit
     end
   end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -7,7 +7,7 @@ class BoardsController < ApplicationController
 
   def index
     if params[:user_id].present?
-      unless (@user = User.find_by_id(params[:user_id]) || current_user)
+      unless (@user = User.find_by_id(params[:user_id]) || current_user) && !@user.deleted?
         flash[:error] = "User could not be found."
         redirect_to root_path and return
       end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -7,7 +7,7 @@ class BoardsController < ApplicationController
 
   def index
     if params[:user_id].present?
-      unless (@user = User.find_by_id(params[:user_id]) || current_user) && !@user.deleted?
+      unless (@user = User.active.find_by_id(params[:user_id]))
         flash[:error] = "User could not be found."
         redirect_to root_path and return
       end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -120,7 +120,7 @@ class BoardsController < ApplicationController
   private
 
   def set_available_cowriters
-    @authors = @cameos = User.ordered
+    @authors = @cameos = User.active.ordered
     if @board
       @authors -= @board.cameos
       @cameos -= @board.coauthors

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -134,7 +134,7 @@ class CharactersController < ApplicationController
 
   def facecasts
     @page_title = 'Facecasts'
-    chars = Character.where('pb is not null')
+    chars = Character.where(users: {deleted: false}).where.not(pb: nil)
       .joins(:user)
       .left_outer_joins(:template)
       .pluck('characters.id, characters.name, characters.pb, users.id, users.username, templates.id, templates.name')

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -12,7 +12,7 @@ class CharactersController < ApplicationController
     (return if login_required) unless params[:user_id].present?
 
     @user = User.find_by_id(params[:user_id]) || current_user
-    unless @user
+    unless @user && !@user.deleted?
       flash[:error] = "User could not be found."
       redirect_to users_path and return
     end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -257,7 +257,7 @@ class CharactersController < ApplicationController
     @search_results = Character.unscoped
 
     if params[:author_id].present?
-      @users = User.where(id: params[:author_id])
+      @users = User.active.where(id: params[:author_id])
       if @users.present?
         @search_results = @search_results.where(user_id: params[:author_id])
       else

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -11,8 +11,13 @@ class CharactersController < ApplicationController
   def index
     (return if login_required) unless params[:user_id].present?
 
-    @user = User.find_by_id(params[:user_id]) || current_user
-    unless @user && !@user.deleted?
+    @user = if params[:user_id].present?
+      User.active.find_by_id(params[:user_id])
+    else
+      current_user
+    end
+
+    unless @user
       flash[:error] = "User could not be found."
       redirect_to users_path and return
     end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -39,7 +39,7 @@ class FavoritesController < ApplicationController
     favorite = nil
 
     if params[:user_id].present?
-      unless (favorite = User.find_by_id(params[:user_id]))
+      unless (favorite = User.active.find_by_id(params[:user_id]))
         flash[:error] = "User could not be found."
         redirect_to users_path and return
       end

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -10,7 +10,7 @@ class GalleriesController < UploadingController
 
   def index
     if params[:user_id].present?
-      unless (@user = User.find_by_id(params[:user_id]) || current_user)
+      unless (@user = User.find_by_id(params[:user_id]) || current_user) && !@user.deleted?
         flash[:error] = 'User could not be found.'
         redirect_to root_path and return
       end

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -10,7 +10,7 @@ class GalleriesController < UploadingController
 
   def index
     if params[:user_id].present?
-      unless (@user = User.find_by_id(params[:user_id]) || current_user) && !@user.deleted?
+      unless (@user = User.active.find_by_id(params[:user_id]))
         flash[:error] = 'User could not be found.'
         redirect_to root_path and return
       end
@@ -59,7 +59,7 @@ class GalleriesController < UploadingController
   def show
     if params[:id].to_s == '0' # avoids casting nils to 0
       if params[:user_id].present?
-        unless (@user = User.find_by_id(params[:user_id]))
+        unless (@user = User.active.find_by_id(params[:user_id]))
           flash[:error] = 'User could not be found.'
           redirect_to root_path and return
         end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -119,7 +119,7 @@ class MessagesController < ApplicationController
     use_javascript('messages')
     unless @message.try(:parent)
       recent_ids = Message.where(sender_id: current_user.id).order(Arel.sql('MAX(id) desc')).limit(5).group(:recipient_id).pluck(:recipient_id)
-      base_users = User.where.not(id: [current_user.id] + current_user.user_ids_blocked_interaction)
+      base_users = User.active.where.not(id: [current_user.id] + current_user.user_ids_blocked_interaction)
       recents = base_users.where(id: recent_ids).pluck(:username, :id).sort_by{|x| recent_ids.index(x[1]) }
       users = base_users.ordered.pluck(:username, :id)
       @select_items = if recents.present?

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -20,7 +20,7 @@ class MessagesController < ApplicationController
 
   def new
     @message = Message.new
-    recipient = User.find_by_id(params[:recipient_id])
+    recipient = User.active.find_by_id(params[:recipient_id])
     @message.recipient = recipient unless recipient && current_user.has_interaction_blocked?(recipient)
     @page_title = 'Compose Message'
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -58,6 +58,11 @@ class MessagesController < ApplicationController
       redirect_to messages_path(view: 'inbox') and return
     end
 
+    if message.sender&.deleted? || message.recipient.deleted?
+      flash[:error] = "Message could not be found."
+      redirect_to messages_path(view: 'inbox') and return
+    end
+
     unless message.visible_to?(current_user)
       flash[:error] = "That is not your message!"
       redirect_to messages_path(view: 'inbox') and return

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -345,7 +345,7 @@ class PostsController < WritableController
 
   def editor_setup
     super
-    @permitted_authors = User.ordered - (@post.try(:joined_authors) || [])
+    @permitted_authors = User.active.ordered - (@post.try(:joined_authors) || [])
     @author_ids = post_params[:unjoined_author_ids].reject(&:blank?).map(&:to_i) if post_params.key?(:unjoined_author_ids)
     @author_ids ||= @post.try(:unjoined_author_ids) || []
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -218,7 +218,7 @@ class PostsController < WritableController
     # don't start blank if the parameters are set
     @setting = Setting.where(id: params[:setting_id]) if params[:setting_id].present?
     @character = Character.where(id: params[:character_id]) if params[:character_id].present?
-    @user = User.where(id: params[:author_id]).ordered if params[:author_id].present?
+    @user = User.active.where(id: params[:author_id]).ordered if params[:author_id].present?
     @board = Board.where(id: params[:board_id]) if params[:board_id].present?
 
     return unless params[:commit].present?

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -20,7 +20,7 @@ class RepliesController < WritableController
       @templates = Template.where(id: @characters.map(&:template_id).uniq.compact).ordered
       gon.post_id = @post.id
     else
-      @users = User.where(id: params[:author_id]) if params[:author_id].present?
+      @users = User.active.where(id: params[:author_id]) if params[:author_id].present?
       @characters = Character.where(id: params[:character_id]) if params[:character_id].present?
       @templates = Template.ordered.limit(25)
       @boards = Board.where(id: params[:board_id]) if params[:board_id].present?

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -77,7 +77,7 @@ class RepliesController < WritableController
     end
 
     @search_results = @search_results
-      .select('replies.*, characters.name, characters.screenname, users.username')
+      .select('replies.*, characters.name, characters.screenname, users.username, users.deleted as user_deleted')
       .visible_to(current_user)
       .joins(:user)
       .left_outer_joins(:character)

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -14,7 +14,7 @@ class RepliesController < WritableController
     @post = Post.find_by_id(params[:post_id]) if params[:post_id].present?
     @icon = Icon.find_by_id(params[:icon_id]) if params[:icon_id].present?
     if @post.try(:visible_to?, current_user)
-      @users = @post.authors
+      @users = @post.authors.reject { |author| author.deleted? }
       char_ids = @post.replies.select(:character_id).distinct.pluck(:character_id) + [@post.character_id]
       @characters = Character.where(id: char_ids).ordered
       @templates = Template.where(id: @characters.map(&:template_id).uniq.compact).ordered

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -14,7 +14,7 @@ class RepliesController < WritableController
     @post = Post.find_by_id(params[:post_id]) if params[:post_id].present?
     @icon = Icon.find_by_id(params[:icon_id]) if params[:icon_id].present?
     if @post.try(:visible_to?, current_user)
-      @users = @post.authors.reject { |author| author.deleted? }
+      @users = @post.authors.active
       char_ids = @post.replies.select(:character_id).distinct.pluck(:character_id) + [@post.character_id]
       @characters = Character.where(id: char_ids).ordered
       @templates = Template.where(id: @characters.map(&:template_id).uniq.compact).ordered

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,7 +13,7 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(username: params[:username])
 
-    if !user or user.deleted?
+    if !user || user.deleted?
       flash[:error] = "That username does not exist."
     elsif user.suspended?
       flash[:error] = "You could not be logged in."

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,11 +9,11 @@ class UsersController < ApplicationController
 
   def index
     @page_title = 'Users'
-    @users = User.where(deleted: false).ordered.paginate(page: page, per_page: 25)
+    @users = User.active.ordered.paginate(page: page, per_page: 25)
   end
 
   def show
-    unless (@user = User.find_by_id(params[:id])) && !@user.deleted?
+    unless (@user = User.active.find_by_id(params[:id]))
       flash[:error] = "User could not be found."
       redirect_to users_path and return
     end
@@ -104,7 +104,7 @@ class UsersController < ApplicationController
     @page_title = 'Search Users'
     return unless params[:commit].present?
     username = '%' + params[:username].to_s + '%'
-    @search_results = User.where(deleted: false).where("username LIKE ?", username).ordered.paginate(per_page: 25, page: page)
+    @search_results = User.active.where("username LIKE ?", username).ordered.paginate(per_page: 25, page: page)
   end
 
   def output

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -156,11 +156,7 @@ class WritableController < ApplicationController
 
     post_description = generate_short(post.description)
     post_description += ' ('
-    if post.authors.length < 4
-      post_description += post.authors.map(&:username).sort.join(', ')
-    else
-      post_description += "#{post.user.username} and #{post.authors.length-1} others"
-    end
+    post_description += author_links(post)
     post_description += " – page #{page} of #{total_pages}"
     post_description += ", #{per_page}/page" unless per_page == 25
     post_description += ')'

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -156,7 +156,7 @@ class WritableController < ApplicationController
 
     post_description = generate_short(post.description)
     post_description += ' ('
-    post_description += author_links(post)
+    post_description += helpers.author_links(post, linked: false)
     post_description += " – page #{page} of #{total_pages}"
     post_description += ", #{per_page}/page" unless per_page == 25
     post_description += ')'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -229,21 +229,22 @@ module ApplicationHelper
     link_to username, user_path(user_id)
   end
 
-  def author_links(post)
+  def author_links(post, linked: true, colored: false)
     authors = post.authors.active.order(Arel.sql('lower(username) asc'))
     num_deleted = post.authors.where(deleted: true).count
-    deleted = '(' + 'deleted user'.pluralize(num_deleted) + ')'
-    return deleted if authors.empty?
+    deleted = 'deleted user'.pluralize(num_deleted)
+    return "(#{deleted})" if authors.empty?
 
-    total = authors.size + (num_deleted > 0 ? 1 : 0)
+    total = authors.size + num_deleted
     if total < 4
-      links = authors.map { |author| user_link(author, colored: colored) }
-      links << deleted if num_deleted > 0
-      return links.join(', ')
+      links = authors.map { |author| linked ? user_link(author, colored: colored) : author.username }
+      return links.join(', ') if num_deleted.zero?
+      return links.join(', ') + " and #{num_deleted} #{deleted}"
     end
 
     first_author = post.user.deleted? ? authors.first : post.user
-    first_link = user_link(first_author, colored: colored)
-    first_link + ' and ' + link_to("#{total-1} others", stats_post_path(post))
+    first_link = linked ? user_link(first_author, colored: colored) : first_author.username
+    others = linked ? link_to("#{total-1} others", stats_post_path(post)) : "#{total-1} others"
+    first_link + ' and ' + others
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -237,12 +237,13 @@ module ApplicationHelper
 
     total = authors.size + (num_deleted > 0 ? 1 : 0)
     if total < 4
-      links = authors.map { |author| user_link(author) }
+      links = authors.map { |author| user_link(author, colored: colored) }
       links << deleted if num_deleted > 0
       return links.join(', ')
     end
 
     first_author = post.user.deleted? ? authors.first : post.user
-    user_link(first_author) + ' and ' + link_to("#{total-1} others", stats_post_path(post))
+    first_link = user_link(first_author, colored: colored)
+    first_link + ' and ' + link_to("#{total-1} others", stats_post_path(post))
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -215,6 +215,7 @@ module ApplicationHelper
 
   def message_sender(message)
     return message.sender_name if message.site_message?
+    return "(deleted user)" if message.sender.deleted?
     link_to(message.sender_name, user_path(message.sender))
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -216,12 +216,16 @@ module ApplicationHelper
 
   def message_sender(message)
     return message.sender_name if message.site_message?
-    user_link(message.sender, message.sender_name)
+    user_mem_link(message.sender.id, message.sender_name, message.sender.deleted?)
   end
 
-  def user_link(user, text = nil)
-    return '(deleted user)'.html_safe if user.deleted?
-    link_to text, user_path(user) if text
-    link_to user.username, user_path(user)
+  def user_link(user, colored: false)
+    username = colored ? fun_name(user) : user.username
+    user_mem_link(user.id, username, user.deleted?)
+  end
+
+  def user_mem_link(user_id, username, deleted)
+    return '(deleted user)'.html_safe if deleted
+    link_to username, user_path(user_id)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -216,7 +216,7 @@ module ApplicationHelper
 
   def message_sender(message)
     return message.sender_name if message.site_message?
-    user_mem_link(message.sender.id, message.sender_name, message.sender.deleted?)
+    link_to(message.sender_name, user_path(message.sender))
   end
 
   def user_link(user, colored: false)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -218,8 +218,9 @@ module ApplicationHelper
     link_to(message.sender_name, user_path(message.sender))
   end
 
-  def user_link(user)
+  def user_link(user, text = nil)
     return '(deleted user)'.html_safe if user.deleted?
+    link_to text, user_path(user) if text
     link_to user.username, user_path(user)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -228,4 +228,21 @@ module ApplicationHelper
     return '(deleted user)'.html_safe if deleted
     link_to username, user_path(user_id)
   end
+
+  def author_links(post)
+    authors = post.authors.active.order(Arel.sql('lower(username) asc'))
+    num_deleted = post.authors.where(deleted: true).count
+    deleted = '(' + 'deleted user'.pluralize(num_deleted) + ')'
+    return deleted if authors.empty?
+
+    total = authors.size + (num_deleted > 0 ? 1 : 0)
+    if total < 4
+      links = authors.map { |author| user_link(author) }
+      links << deleted if num_deleted > 0
+      return links.join(', ')
+    end
+
+    first_author = post.user.deleted? ? authors.first : post.user
+    user_link(first_author) + ' and ' + link_to("#{total-1} others", stats_post_path(post))
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,6 +59,7 @@ module ApplicationHelper
   end
 
   def fun_name(user)
+    return '(deleted user)'.html_safe if user.deleted?
     return user.username unless user.moiety
     content_tag :span, user.username, style: 'font-weight: bold; color: #' + user.moiety
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -215,8 +215,7 @@ module ApplicationHelper
 
   def message_sender(message)
     return message.sender_name if message.site_message?
-    return "(deleted user)" if message.sender.deleted?
-    link_to(message.sender_name, user_path(message.sender))
+    user_link(message.sender, message.sender_name)
   end
 
   def user_link(user, text = nil)

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -63,21 +63,4 @@ module WritableHelper
       content_tag(:span, sanitize_post_description(desc[255..-1]).html_safe, class: 'hidden', id: "desc-#{id}") +
       content_tag(:a, 'more &raquo;'.html_safe, href: '#', id: "expanddesc-#{id}", class: 'expanddesc')
   end
-
-  def author_links(post)
-    authors = post.authors.active.order(Arel.sql('lower(username) asc'))
-    num_deleted = post.authors.where(deleted: true).count
-    deleted = '(' + 'deleted user'.pluralize(num_deleted) + ')'
-    return deleted if authors.empty?
-
-    total = authors.size + (num_deleted > 0 ? 1 : 0)
-    if total < 4
-      links = authors.map { |author| user_link(author) }
-      links << deleted if num_deleted > 0
-      return links.join(', ')
-    end
-
-    first_author = post.user.deleted? ? authors.first : post.user
-    user_link(first_author) + ' and ' + link_to("#{total-1} others", stats_post_path(post))
-  end
 end

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -63,4 +63,21 @@ module WritableHelper
       content_tag(:span, sanitize_post_description(desc[255..-1]).html_safe, class: 'hidden', id: "desc-#{id}") +
       content_tag(:a, 'more &raquo;'.html_safe, href: '#', id: "expanddesc-#{id}", class: 'expanddesc')
   end
+
+  def author_links(post)
+    authors = post.authors.active.order(Arel.sql('lower(username) asc'))
+    num_deleted = post.authors.where(deleted: true).count
+    deleted = '(' + 'deleted user'.pluralize(num_deleted) + ')'
+    return deleted if authors.empty?
+
+    total = authors.size + (num_deleted > 0 ? 1 : 0)
+    if total < 4
+      links = authors.map { |author| user_link(author) }
+      links << deleted if num_deleted > 0
+      return links.join(', ')
+    end
+
+    first_author = post.user.deleted? ? authors.first : post.user
+    user_link(first_author) + ' and ' + link_to("#{total-1} others", stats_post_path(post))
+  end
 end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -44,6 +44,7 @@ class Board < ApplicationRecord
     return false unless user
     return true if creator_id == user.id
     return true if user.has_permission?(:edit_continuities)
+    return false if creator.deleted?
     board_coauthors.where(user_id: user.id).exists?
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -45,6 +45,7 @@ class Message < ApplicationRecord
 
   def sender_name
     return 'Glowfic Constellation' if site_message?
+    return '(deleted user)' if sender.deleted?
     sender.username
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -45,7 +45,6 @@ class Message < ApplicationRecord
 
   def sender_name
     return 'Glowfic Constellation' if site_message?
-    return '(deleted user)' if sender.deleted?
     sender.username
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,7 +8,7 @@ class Message < ApplicationRecord
   validates :sender, presence: { if: Proc.new { |m| m.sender_id != 0 } }
   validate :unblocked_recipient, on: :create
 
-  before_validation :set_thread_id
+  before_validation :set_thread_id, :remove_deleted_recipient
   before_create :check_recipient
   after_create :notify_recipient
 
@@ -84,5 +84,10 @@ class Message < ApplicationRecord
     return unless sender && recipient
     return unless sender.has_interaction_blocked?(recipient)
     errors.add(:recipient, "must not be blocked by you")
+  end
+
+  def remove_deleted_recipient
+    return unless recipient&.deleted?
+    self.recipient = nil
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -240,7 +240,7 @@ class Post < ApplicationRecord
 
   # only returns for authors who have written in the post (it's zero for authors who have not joined)
   def author_word_counts
-    joined_authors.map { |author| [author.username, word_count_for(author)] }.sort_by{|a| -a[1] }
+    joined_authors.map { |author| [!author.deleted? ? author.username : '(deleted user)', word_count_for(author)] }.sort_by{|a| -a[1] }
   end
 
   def character_appearance_counts

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -264,6 +264,11 @@ class Post < ApplicationRecord
     audits.count > 1
   end
 
+  def last_user_deleted?
+    return read_attribute(:last_user_deleted) if has_attribute?(:last_user_deleted)
+    last_user.deleted?
+  end
+
   def user_joined(user)
     NotifyFollowersOfNewPostJob.perform_later(self.id, user.id)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,14 +74,6 @@ class User < ApplicationRecord
     super || 'icon'
   end
 
-  def username
-    if deleted?
-      "(deleted user)"
-    else
-      self[:username]
-    end
-  end
-
   def archive
     User.transaction do
       self.update!(email_notifications: false, deleted: true)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,7 @@ class User < ApplicationRecord
   after_save :clear_password
 
   scope :ordered, -> { order(username: :asc) }
+  scope :active, -> { where(deleted: false) }
 
   nilify_blanks
 
@@ -76,7 +77,7 @@ class User < ApplicationRecord
 
   def archive
     User.transaction do
-      self.update!(email_notifications: false, deleted: true)
+      self.update!(email_notifications: false, deleted: true, favorite_notifications: false)
       Setting.where(user_id: self.id).where(owned: true).find_each do |setting|
         setting.update!(owned: false)
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,6 +83,7 @@ class User < ApplicationRecord
       Setting.where(user_id: self.id).where(owned: true).find_each do |setting|
         setting.update!(owned: false)
       end
+      Block.where(blocking_user: self).or(Block.where(blocked_user: self)).destroy_all
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   MIN_USERNAME_LEN = 3
   MAX_USERNAME_LEN = 80
   CURRENT_TOS_VERSION = 20181109
+  RESERVED_NAMES = ['(deleted user)', 'Glowfic Constellation']
 
   attr_accessor :password, :password_confirmation
   attr_writer :validate_password
@@ -41,6 +42,7 @@ class User < ApplicationRecord
     confirmation: { if: :validate_password? }
   validates :moiety, format: { with: /\A([0-9A-F]{3}){0,2}\z/i }
   validates :password, :password_confirmation, presence: { if: :validate_password? }
+  validate :username_not_reserved
 
   before_validation :encrypt_password, :strip_spaces
   after_save :clear_password
@@ -120,5 +122,11 @@ class User < ApplicationRecord
 
   def validate_password?
     !!@validate_password
+  end
+
+  def username_not_reserved
+    return unless self.username.present?
+    return unless RESERVED_NAMES.include?(self.username)
+    errors.add(:username, 'is invalid')
   end
 end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -7,6 +7,7 @@ class UserPresenter
 
   def as_json(options={})
     return {} unless user
+    return {id: user.id, username: '(deleted user)'} if user.deleted?
     user.as_json_without_presenter({only: [:id, :username]}.reverse_merge(options))
   end
 end

--- a/app/views/blocks/_editor.haml
+++ b/app/views/blocks/_editor.haml
@@ -3,7 +3,7 @@
   %th.sub User
   %td{class: klass}
     - if local_assigns[:blocked_user]
-      = blocked_user.username
+      = blocked_user.deleted? ? blocked_user.username : (deleted user)
     - else
       = f.select :blocked_user_id, options_from_collection_for_select(@users, :id, :username, params.fetch(:block, {})[:blocked_user_id]), {class: 'text chosen-select', prompt: '— Choose User —'}
 %tr

--- a/app/views/blocks/_editor.haml
+++ b/app/views/blocks/_editor.haml
@@ -3,7 +3,7 @@
   %th.sub User
   %td{class: klass}
     - if local_assigns[:blocked_user]
-      = blocked_user.deleted? ? blocked_user.username : '(deleted user)'
+      = blocked_user.username
     - else
       = f.select :blocked_user_id, options_from_collection_for_select(@users, :id, :username, params.fetch(:block, {})[:blocked_user_id]), {class: 'text chosen-select', prompt: '— Choose User —'}
 %tr

--- a/app/views/blocks/_editor.haml
+++ b/app/views/blocks/_editor.haml
@@ -3,7 +3,7 @@
   %th.sub User
   %td{class: klass}
     - if local_assigns[:blocked_user]
-      = blocked_user.deleted? ? blocked_user.username : (deleted user)
+      = blocked_user.deleted? ? blocked_user.username : '(deleted user)'
     - else
       = f.select :blocked_user_id, options_from_collection_for_select(@users, :id, :username, params.fetch(:block, {})[:blocked_user_id]), {class: 'text chosen-select', prompt: '— Choose User —'}
 %tr

--- a/app/views/blocks/index.haml
+++ b/app/views/blocks/index.haml
@@ -23,7 +23,7 @@
       - klass = cycle('even', 'odd')
       %tr
         %td.padding-5{class: klass}
-          = link_to block.blocked_user.username, user_path(block.blocked_user)
+          = user_link(block.blocked_user)
         %td.padding-5{class: klass}= block.block_interactions? ? 'Yes' : 'No'
         %td.padding-5{class: klass}
           - if block.hide_their_content?

--- a/app/views/blocks/index.haml
+++ b/app/views/blocks/index.haml
@@ -19,7 +19,7 @@
       %th.sub Hidden (Yours)
       %th.sub
   %tbody
-    - @blocks.ordered.each do |block|
+    - @blocks.each do |block|
       - klass = cycle('even', 'odd')
       %tr
         %td.padding-5{class: klass}
@@ -42,8 +42,7 @@
         %td.width-70.right-align{class: klass}
           = link_to edit_block_path(block) do
             = image_tag "icons/pencil.png"
-          - username = !block.blocked_user.deleted? ? block.blocked_user.username : 'this deleted user'
-          = link_to block_path(block), :method => :delete, data: { confirm: "Are you sure you want to unblock #{username}?" } do
+          = link_to block_path(block), :method => :delete, data: { confirm: "Are you sure you want to unblock #{block.blocked_user.username}?" } do
             = image_tag "icons/cross.png"
           &nbsp;
     - if @blocks.empty?

--- a/app/views/blocks/index.haml
+++ b/app/views/blocks/index.haml
@@ -42,7 +42,8 @@
         %td.width-70.right-align{class: klass}
           = link_to edit_block_path(block) do
             = image_tag "icons/pencil.png"
-          = link_to block_path(block), :method => :delete, data: { confirm: 'Are you sure you want to unblock '+block.blocked_user.username+'?' } do
+          - username = !block.blocked_user.deleted? ? block.blocked_user.username : 'this deleted user'
+          = link_to block_path(block), :method => :delete, data: { confirm: "Are you sure you want to unblock #{username}?" } do
             = image_tag "icons/cross.png"
           &nbsp;
     - if @blocks.empty?

--- a/app/views/blocks/index.haml
+++ b/app/views/blocks/index.haml
@@ -19,7 +19,7 @@
       %th.sub Hidden (Yours)
       %th.sub
   %tbody
-    - @blocks.each do |block|
+    - @blocks.ordered.each do |block|
       - klass = cycle('even', 'odd')
       %tr
         %td.padding-5{class: klass}

--- a/app/views/boards/_list_item.haml
+++ b/app/views/boards/_list_item.haml
@@ -5,5 +5,5 @@
     - if board.open_to_anyone?
       Anyone
     - else
-      = board.writers.sort_by{ |author| author.username.downcase }.map { |u| link_to u.username, user_path(u) }.join(', ').html_safe
+      = board.writers.sort_by{ |author| author.username.downcase }.sort_by(&:deleted?).map { |u| user_link(u) }.join(', ').html_safe
   %td.padding-10.board-time{class: klass}= pretty_time(board.posts.ordered.first.try(:tagged_at))

--- a/app/views/boards/_list_item.haml
+++ b/app/views/boards/_list_item.haml
@@ -5,5 +5,5 @@
     - if board.open_to_anyone?
       Anyone
     - else
-      = board.writers.sort_by{ |author| author.username.downcase }.sort_by(&:deleted?).map { |u| user_link(u) }.join(', ').html_safe
+      = board.writers.reject(&:deleted?).sort_by{ |author| author.username.downcase }.map { |u| user_link(u) }.join(', ').html_safe
   %td.padding-10.board-time{class: klass}= pretty_time(board.posts.ordered.first.try(:tagged_at))

--- a/app/views/boards/index.haml
+++ b/app/views/boards/index.haml
@@ -1,6 +1,6 @@
 - if @user.present? && @user.id != current_user.try(:id)
   - content_for :breadcrumbs do
-    = link_to @user.username, user_path(@user)
+    = user_link(@user)
     &raquo;
     %b #{@user.username}'s Continuities
 

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -64,7 +64,7 @@
       %td.padding-5{class: klass, style: 'width:20%'}= character.pb
       %td.padding-5{class: klass, style: 'width:15%'}
         - if local_assigns[:show_user]
-          = link_to character.user.username, character.user
+          = user_link(character.user)
         - else
           = character.settings.map { |setting| link_to(setting.name, tag_path(setting)) }.join(', ').html_safe
 

--- a/app/views/characters/facecasts.haml
+++ b/app/views/characters/facecasts.haml
@@ -16,4 +16,4 @@
           = link_to obj.item_name, character_path(obj.item_id)
         - else
           = link_to obj.item_name, template_path(obj.item_id)
-      %td.padding-5{class: klass}= link_to obj.username, user_path(obj.user_id)
+      %td.padding-5{class: klass}= user_link(obj.user)

--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -1,6 +1,6 @@
 - content_for :breadcrumbs do
   - unless @user.id == current_user.try(:id)
-    = link_to @user.username, user_path(@user)
+    = user_link(@user)
     &raquo;
     %b #{@user.username}'s Characters
 

--- a/app/views/characters/search.haml
+++ b/app/views/characters/search.haml
@@ -71,7 +71,7 @@
                     %td.padding-5{class: klass, style: 'width:15%'}= character.template_name
                     %td.padding-5{class: klass, style: 'width:15%'}= breakable_text(character.screenname)
                     %td.padding-5{class: klass, style: 'width:25%'}= character.pb
-                    %td.padding-5{class: klass, style: 'width:15%'}= link_to character.user.username, user_path(character.user)
+                    %td.padding-5{class: klass, style: 'width:15%'}= user_link(character.user)
 
     - if @search_results && @search_results.total_pages > 1
       %tfoot

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -1,12 +1,11 @@
 - content_for :breadcrumbs do
   - if @character.user_id == current_user.try(:id)
     = link_to "Characters", user_characters_path(current_user)
-  - elsif @character.user.deleted?
-    %em (deleted user)
   - else
     = user_link(@character.user)
-    &raquo;
-    = link_to "#{@character.user.username}'s Characters", user_characters_path(@character.user)
+    - unless @character.user.deleted?
+      &raquo;
+      = link_to "#{@character.user.username}'s Characters", user_characters_path(@character.user)
   - if @character.template
     &raquo;
     = link_to @character.template.name, template_path(@character.template)

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -4,7 +4,7 @@
   - elsif @character.user.deleted?
     %em (deleted user)
   - else
-    = link_to @character.user.username, user_path(@character.user)
+    = user_link(@character.user)
     &raquo;
     = link_to "#{@character.user.username}'s Characters", user_characters_path(@character.user)
   - if @character.template

--- a/app/views/favorites/index.haml
+++ b/app/views/favorites/index.haml
@@ -22,7 +22,7 @@
           - klass = cycle('even', 'odd')
           %td{class: klass}
             - if favorite_rec.favorite.is_a? User
-              = link_to favorite_rec.favorite.username, user_path(favorite_rec.favorite)
+              = user_link(favorite_rec.favorite)
             - elsif favorite_rec.favorite.is_a? Board
               = link_to favorite_rec.favorite.name, board_path(favorite_rec.favorite)
             - else

--- a/app/views/galleries/index.haml
+++ b/app/views/galleries/index.haml
@@ -1,6 +1,6 @@
 - content_for :breadcrumbs do
   - if @user.id != current_user.try(:id)
-    = link_to @user.username, user_path(@user)
+    = user_link(@user)
     &raquo;
     %b #{@user.username}'s Galleries
 

--- a/app/views/galleries/show.haml
+++ b/app/views/galleries/show.haml
@@ -4,12 +4,11 @@
     - content_for :breadcrumbs do
       - if @user.id == current_user.try(:id)
         = link_to "Galleries", user_galleries_path(current_user)
-      - elsif @user.deleted?
-        %em (deleted user)
       - else
-        = link_to @user.username, user_path(@user)
-        &raquo;
-        = link_to "#{@user.username}'s Galleries", user_galleries_path(@user)
+        = user_link(@user)
+        - unless @user.deleted?
+          &raquo;
+          = link_to "#{@user.username}'s Galleries", user_galleries_path(@user)
       &raquo;
       %b= @gallery.name
   - else
@@ -17,11 +16,10 @@
     - content_for :breadcrumbs do
       - if @user.id == current_user.try(:id)
         = link_to "Galleries", user_galleries_path(current_user)
-      - elsif @user.deleted?
-        %em (deleted user)
       - else
-        = link_to @user.username, user_path(@user)
-        &raquo;
-        = link_to "#{@user.username}'s Galleries", user_galleries_path(@user)
-      &raquo;
-      %b= 'Galleryless Icons'
+        = user_link(@user)
+        - unless @user.deleted?
+          &raquo;
+          = link_to "#{@user.username}'s Galleries", user_galleries_path(@user)
+          &raquo;
+          %b= 'Galleryless Icons'

--- a/app/views/galleries/show.haml
+++ b/app/views/galleries/show.haml
@@ -21,5 +21,5 @@
         - unless @user.deleted?
           &raquo;
           = link_to "#{@user.username}'s Galleries", user_galleries_path(@user)
-          &raquo;
-          %b= 'Galleryless Icons'
+      &raquo;
+      %b= 'Galleryless Icons'

--- a/app/views/icons/edit.haml
+++ b/app/views/icons/edit.haml
@@ -1,6 +1,8 @@
 - content_for :breadcrumbs do
   - if @icon.user_id == current_user.try(:id)
     = link_to "Galleries", user_galleries_path(current_user)
+  - elsif @icon.user.deleted?
+    %em (deleted user)
   - else
     = link_to @icon.user.username, user_path(@icon.user)
     &raquo;

--- a/app/views/icons/edit.haml
+++ b/app/views/icons/edit.haml
@@ -1,12 +1,11 @@
 - content_for :breadcrumbs do
   - if @icon.user_id == current_user.try(:id)
     = link_to "Galleries", user_galleries_path(current_user)
-  - elsif @icon.user.deleted?
-    %em (deleted user)
   - else
-    = link_to @icon.user.username, user_path(@icon.user)
-    &raquo;
-    = link_to "#{@icon.user.username}'s Galleries", user_galleries_path(@icon.user)
+    = user_link(@icon.user)
+    - unless @icon.user.deleted?
+      &raquo;
+      = link_to "#{@icon.user.username}'s Galleries", user_galleries_path(@icon.user)
   &raquo;
   = link_to @icon.keyword, icon_path(@icon)
   &raquo;

--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -1,12 +1,11 @@
 - content_for :breadcrumbs do
   - if @icon.user_id == current_user.try(:id)
     = link_to "Galleries", user_galleries_path(current_user)
-  - elsif @icon.user.deleted?
-    %em (deleted user)
   - else
-    = link_to @icon.user.username, user_path(@icon.user)
-    &raquo;
-    = link_to "#{@icon.user.username}'s Galleries", user_galleries_path(@icon.user)
+    = user_link(@icon.user)
+    - unless @icon.user.deleted?
+      &raquo;
+      = link_to "#{@icon.user.username}'s Galleries", user_galleries_path(@icon.user)
   &raquo;
   - if @icon.galleries.count == 1
     = link_to @icon.galleries.first.name, gallery_path(@icon.galleries.first)

--- a/app/views/indexes/_editor.haml
+++ b/app/views/indexes/_editor.haml
@@ -3,7 +3,7 @@
   %td.even= f.text_field :name, placeholder: "Index Name", class: 'text'
 %tr
   %th.sub Owner
-  %td.odd= @index.user.username
+  %td.odd= @inder.user.deleted? ? '(deleted user)' : @index.user.username
 %tr
   %th.sub Privacy
   %td.even

--- a/app/views/messages/_editor.haml
+++ b/app/views/messages/_editor.haml
@@ -11,7 +11,7 @@
       %th.sub.padding-10.width-150 Recipient
       %td.even.padding-10
         - if @message.parent
-          = link_to @message.recipient.try(:username), user_path(@message.recipient)
+          = user_link(@message.recipient) if @message.recipient
         - else
           = f.select :recipient_id, @select_items, prompt: true
     - unless @message.thread_id.present?

--- a/app/views/messages/_message.haml
+++ b/app/views/messages/_message.haml
@@ -34,7 +34,7 @@
         .post-screenname
           %b To:
           - if message.recipient
-            = link_to(message.recipient.username, user_path(message.recipient))
+            = user_link(message.recipient)
     .message-content= sanitize_written_content(message.message).html_safe
   .post-footer
     .right-align>

--- a/app/views/messages/index.haml
+++ b/app/views/messages/index.haml
@@ -26,7 +26,7 @@
               - if @view == 'inbox'
                 = message_sender(message)
               - else
-                = link_to user_link(message.recipient)
+                = user_link(message.recipient)
             %td{class: klass}= pretty_time(message.last_in_thread.created_at)
             %td{class: klass}= check_box_tag :"marked_ids[]", message.id, false, class: 'select-all-box'
         %tr

--- a/app/views/messages/index.haml
+++ b/app/views/messages/index.haml
@@ -26,7 +26,7 @@
               - if @view == 'inbox'
                 = message_sender(message)
               - else
-                = link_to message.recipient.username, user_path(message.recipient)
+                = link_to user_link(message.recipient)
             %td{class: klass}= pretty_time(message.last_in_thread.created_at)
             %td{class: klass}= check_box_tag :"marked_ids[]", message.id, false, class: 'select-all-box'
         %tr

--- a/app/views/news/_news.haml
+++ b/app/views/news/_news.haml
@@ -13,4 +13,4 @@
     Posted on
     = pretty_time(news.created_at)
     by
-    = link_to news.user.username, user_path(news.user)
+    = user_link(news.user)

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -43,7 +43,16 @@
   %td.post-authors.vtop{class: klass}
     - authors = post.authors.sort_by { |author| author.username.downcase }
     - if authors.length < 4
-      = authors.sort_by(&:deleted?).map { |author| user_link(author) }.join(', ').html_safe
+      - active_authors = authors.reject(&:deleted?)
+      - author_list = active_authors.map { |author| user_link(author) }.join(', ')
+      - if authors.any?(&:deleted?)
+        - deleted_authors = pluralize(authors.select(&:deleted?).length, 'deleted user')
+        - temp_list = [author_list, deleted_authors].select(&:present?)
+        - if active_authors.length == 1
+          - author_list = temp_list.join(' and ')
+        - else
+          - author_list = temp_list.join(', and ')
+      = author_list.html_safe
     - else
       = link_to user_link(post.user)
       and

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -45,7 +45,7 @@
     - if authors.length < 4
       = authors.sort_by(&:deleted?).map { |author| user_link(author) }.join(', ').html_safe
     - else
-      = link_to post.user.username, user_path(post.user)
+      = link_to user_link(post.user)
       and
       = link_to "#{authors.length-1} others", stats_post_path(post)
   %td.width-70.post-replies.vtop{class: klass}= link_to replies_count, stats_post_path(post)

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -51,10 +51,7 @@
   %td.post-time.vtop{class: klass}
     = pretty_time(post.tagged_at)
     by
-    - if post.last_user_deleted?
-      (deleted user)
-    - else
-      = link_to post.last_user_name, user_path(post.last_user_id)
+    = user_mem_link(post.last_user_id, post.last_user_name, post.last_user_deleted?)
   - if local_assigns[:check_box_name]
     %td.post-check-box{class: klass}= check_box_tag check_box_name, post.id, false, class: 'checkbox'
 - if post.respond_to?(:index_description)

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -43,7 +43,7 @@
   %td.post-authors.vtop{class: klass}
     - authors = post.authors.sort_by { |author| author.username.downcase }
     - if authors.length < 4
-      = authors.map { |author| link_to author.username, user_path(author) }.join(', ').html_safe
+      = authors.sort_by(&:deleted?).map { |author| user_link(author) }.join(', ').html_safe
     - else
       = link_to post.user.username, user_path(post.user)
       and
@@ -58,7 +58,10 @@
   %td.post-time.vtop{class: klass}
     = pretty_time(post.tagged_at)
     by
-    = link_to post.last_user_name, user_path(post.last_user_id)
+    - if post.last_user.deleted?
+      (deleted user)
+    - else
+      = link_to post.last_user_name, user_path(post.last_user_id)
   - if local_assigns[:check_box_name]
     %td.post-check-box{class: klass}= check_box_tag check_box_name, post.id, false, class: 'checkbox'
 - if post.respond_to?(:index_description)

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -41,7 +41,7 @@
   - unless local_assigns[:hide_continuity]
     %td.post-board.vtop{class: klass}= link_to post.board_name, anchored_board_path(post)
   %td.post-authors.vtop{class: klass}
-    - authors = post.authors.sort_by { |author| author.username.downcase }
+    - authors = post.authors.order(Arel.sql('lower(username) asc'))
     - if authors.length < 4
       - active_authors = authors.active
       - author_list = active_authors.map { |author| user_link(author) }.join(', ')

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -40,23 +40,7 @@
               = link_to index, post_path(post, page: index)
   - unless local_assigns[:hide_continuity]
     %td.post-board.vtop{class: klass}= link_to post.board_name, anchored_board_path(post)
-  %td.post-authors.vtop{class: klass}
-    - authors = post.authors.order(Arel.sql('lower(username) asc'))
-    - if authors.length < 4
-      - active_authors = authors.active
-      - author_list = active_authors.map { |author| user_link(author) }.join(', ')
-      - if authors.any?(&:deleted?)
-        - deleted_authors = pluralize(authors.select(&:deleted?).length, 'deleted user')
-        - temp_list = [author_list, deleted_authors].select(&:present?)
-        - author_list = temp_list.join(active_authors.length == 1 ? ' and ' : ', and ')
-      = author_list.html_safe
-    - else
-      - if post.user.deleted? && authors.active.present?
-        = user_link(authors.active.first)
-      - else
-        = user_link(post.user)
-      and
-      = link_to "#{authors.length-1} others", stats_post_path(post)
+  %td.post-authors.vtop{class: klass}= author_links(post).html_safe
   %td.width-70.post-replies.vtop{class: klass}= link_to replies_count, stats_post_path(post)
   - if logged_in? && local_assigns[:show_unread_count]
     %td.width-70.vtop{class: klass}
@@ -67,7 +51,7 @@
   %td.post-time.vtop{class: klass}
     = pretty_time(post.tagged_at)
     by
-    - if post.last_user.deleted?
+    - if post.last_user_deleted?
       (deleted user)
     - else
       = link_to post.last_user_name, user_path(post.last_user_id)

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -43,18 +43,18 @@
   %td.post-authors.vtop{class: klass}
     - authors = post.authors.sort_by { |author| author.username.downcase }
     - if authors.length < 4
-      - active_authors = authors.reject(&:deleted?)
+      - active_authors = authors.active
       - author_list = active_authors.map { |author| user_link(author) }.join(', ')
       - if authors.any?(&:deleted?)
         - deleted_authors = pluralize(authors.select(&:deleted?).length, 'deleted user')
         - temp_list = [author_list, deleted_authors].select(&:present?)
-        - if active_authors.length == 1
-          - author_list = temp_list.join(' and ')
-        - else
-          - author_list = temp_list.join(', and ')
+        - author_list = temp_list.join(active_authors.length == 1 ? ' and ' : ', and ')
       = author_list.html_safe
     - else
-      = user_link(post.user)
+      - if post.user.deleted? && authors.active.present?
+        = user_link(authors.active.first)
+      - else
+        = user_link(post.user)
       and
       = link_to "#{authors.length-1} others", stats_post_path(post)
   %td.width-70.post-replies.vtop{class: klass}= link_to replies_count, stats_post_path(post)

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -54,7 +54,7 @@
           - author_list = temp_list.join(', and ')
       = author_list.html_safe
     - else
-      = link_to user_link(post.user)
+      = user_link(post.user)
       and
       = link_to "#{authors.length-1} others", stats_post_path(post)
   %td.width-70.post-replies.vtop{class: klass}= link_to replies_count, stats_post_path(post)

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -44,7 +44,7 @@
     = f.select :privacy, options_from_collection_for_select(post_privacy_settings.to_a, :second, :first, post.privacy)
     #access_list
       = f.label :viewer_ids, '&#8627; Who can view this post? '.html_safe
-      = f.collection_select(:viewer_ids, User.where.not(id: post.user_id).ordered,
+      = f.collection_select(:viewer_ids, User.active.where.not(id: post.user_id).ordered,
       :id, :username, {selected: @viewer_ids.nil? ? post.viewer_ids : @viewer_ids}, {multiple: true})
 
     #current_authors

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -53,7 +53,7 @@
         - authors = post.joined_authors.ordered
         = authors.map { |author| user_link(author) }.join(', ').html_safe
       - else
-        = link_to current_user.username, user_path(current_user)
+        = user_link(current_user)
 
 
     %div{title: 'Invite users to be authors in this post. Once they post, they will be removed from this section and moved to a Current Authors section. Invited authors will have this post show on their Replies Owed page, even if they have not yet joined the post. If the post is locked, invited users will have permission to reply. This field will not override privacy settings. You are automatically added as an author when you create a new post.'}

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -51,7 +51,7 @@
       = f.label :joined_author_ids, 'Current authors:'
       - if post.persisted?
         - authors = post.joined_authors.ordered
-        = authors.map { |author| link_to author.username, user_path(author) }.join(', ').html_safe
+        = authors.map { |author| link_to user_link(author) }.join(', ').html_safe
       - else
         = link_to current_user.username, user_path(current_user)
 

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -51,7 +51,7 @@
       = f.label :joined_author_ids, 'Current authors:'
       - if post.persisted?
         - authors = post.joined_authors.ordered
-        = authors.map { |author| link_to user_link(author) }.join(', ').html_safe
+        = authors.map { |author| user_link(author) }.join(', ').html_safe
       - else
         = link_to current_user.username, user_path(current_user)
 

--- a/app/views/posts/flat.haml
+++ b/app/views/posts/flat.haml
@@ -34,11 +34,11 @@
                   .post-screenname= breakable_text(@post.character.screenname)
               - else
                 .spacer-alt
-              - if @post.user.deleted?
-                .post-author
+              .post-author
+                - if @post.user.deleted?
                   %em (deleted user)
-              - else
-                .post-author= @post.user.username
+                - else
+                  = @post.user.username
           .post-edit-box
             = link_to post_path(@post), rel: 'alternate' do
               = image_tag "icons/link.png", title: 'Permalink', alt: 'Permalink'

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -50,9 +50,9 @@
           - @post.post_viewers.each_with_index do |viewer, i|
             - if i < @post.post_viewers.count - 1
               = succeed ',' do
-                = link_to viewer.user.username, user_path(viewer.user)
+                = user_link(viewer.user)
             - else
-              = link_to viewer.user.username, user_path(viewer.user)
+              = user_link(viewer.user)
     %tr
       %th.sub.width-150 Authors
       %td{class: cycle('odd', 'even')}

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -61,12 +61,9 @@
           - post_authors.each do |post_author|
             - author = post_author.user
             %li
-              - if author.deleted?
-                %em (deleted user)
-              - else
-                = link_to author.username, user_path(author)
-                - unless post_author.joined?
-                  (invited)
+              = user_link(author)
+              - unless post_author.joined?
+                (invited)
     %tr
       %th.sub.width-150.vtop Characters
       %td{class: cycle('odd', 'even')}

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -27,11 +27,7 @@
             .post-screenname= breakable_text(reply.screenname)
         - else
           .spacer-alt
-        .post-author
-          - if reply.user_deleted?
-            %em (deleted user)
-          - else
-            = link_to reply.username, user_path(reply.user_id)
+        .post-author= user_link(reply.user_id)
     .post-edit-box
       - if reply.id.present?
         = link_to post_or_reply_link(reply), rel: 'alternate'.freeze do

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -27,7 +27,7 @@
             .post-screenname= breakable_text(reply.screenname)
         - else
           .spacer-alt
-        .post-author= user_link(reply.user_id)
+        .post-author= user_mem_link(reply.user_id, reply.username, reply.user_deleted?)
     .post-edit-box
       - if reply.id.present?
         = link_to post_or_reply_link(reply), rel: 'alternate'.freeze do

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -29,7 +29,7 @@
           .spacer-alt
         .post-author
           - if reply.user_deleted?
-            %i (deleted user)
+            %em (deleted user)
           - else
             = link_to reply.username, user_path(reply.user_id)
     .post-edit-box

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -76,7 +76,7 @@
                           .post-screenname= breakable_text(reply.screenname)
                         .post-author
                           - if reply.user_deleted?
-                            %i (deleted user)
+                            %em (deleted user)
                           - else
                             = link_to reply.username, user_path(reply.user_id)
                     .post-edit-box

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -74,7 +74,11 @@
                           .post-character= link_to reply.name, character_path(reply.character_id)
                         - unless params[:condensed]
                           .post-screenname= breakable_text(reply.screenname)
-                        .post-author= link_to reply.username, user_path(reply.user_id)
+                        .post-author
+                          - if reply.user_deleted?
+                            %i (deleted user)
+                          - else
+                            = link_to reply.username, user_path(reply.user_id)
                     .post-edit-box
                       = link_to reply_path(reply, anchor: "reply-#{reply.id}") do
                         = image_tag "icons/link.png".freeze, title: 'Permalink'.freeze, alt: 'Permalink'.freeze

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -74,11 +74,7 @@
                           .post-character= link_to reply.name, character_path(reply.character_id)
                         - unless params[:condensed]
                           .post-screenname= breakable_text(reply.screenname)
-                        .post-author
-                          - if reply.user_deleted?
-                            %em (deleted user)
-                          - else
-                            = link_to reply.username, user_path(reply.user_id)
+                        .post-author= user_link(reply.user_id)
                     .post-edit-box
                       = link_to reply_path(reply, anchor: "reply-#{reply.id}") do
                         = image_tag "icons/link.png".freeze, title: 'Permalink'.freeze, alt: 'Permalink'.freeze

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -52,9 +52,9 @@
           %td.vtop.post-authors{class: klass}
             - authors = post.authors.sort_by { |author| author.username.downcase }
             - if authors.length < 4
-              = authors.map { |author| link_to fun_name(author), user_path(author) }.join(', ').html_safe
+              = authors.map { |author| user_link(author, fun_name(author)) }.join(', ').html_safe
             - else
-              = link_to fun_name(post.user), user_path(post.user)
+              = link_to user_link(post.user, fun_name(post.user))
               and
               = link_to "#{authors.length-1} others", stats_post_path(post)
           %td.vtop.centered.post-replies{class: klass}= link_to post.reply_count, stats_post_path(post)

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -49,14 +49,7 @@
               %br
               %span.details= sanitize_post_description(post.description).html_safe
           %td.vtop.post-board{class: klass}= link_to post.board_name, board_path(post.board_id)
-          %td.vtop.post-authors{class: klass}
-            - authors = post.authors.sort_by { |author| author.username.downcase }
-            - if authors.length < 4
-              = authors.map { |author| user_link(author, colored: true) }.join(', ').html_safe
-            - else
-              = user_link(post.user, colored: true)
-              and
-              = link_to "#{authors.length-1} others", stats_post_path(post)
+          %td.vtop.post-authors{class: klass}= author_links(post, colored: true)
           %td.vtop.centered.post-replies{class: klass}= link_to post.reply_count, stats_post_path(post)
           %td.vtop.centered.post-replies{class: klass}= link_to replies_today.count, post_or_reply_link(linked)
           %td.vtop.centered.post-time{class: klass}= linked.created_at.strftime("%l:%M %p")

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -54,7 +54,7 @@
             - if authors.length < 4
               = authors.map { |author| user_link(author, fun_name(author)) }.join(', ').html_safe
             - else
-              = link_to user_link(post.user, fun_name(post.user))
+              = user_link(post.user, fun_name(post.user))
               and
               = link_to "#{authors.length-1} others", stats_post_path(post)
           %td.vtop.centered.post-replies{class: klass}= link_to post.reply_count, stats_post_path(post)

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -52,9 +52,9 @@
           %td.vtop.post-authors{class: klass}
             - authors = post.authors.sort_by { |author| author.username.downcase }
             - if authors.length < 4
-              = authors.map { |author| user_link(author, fun_name(author)) }.join(', ').html_safe
+              = authors.map { |author| user_link(author, colored: true) }.join(', ').html_safe
             - else
-              = user_link(post.user, fun_name(post.user))
+              = user_link(post.user, colored: true)
               and
               = link_to "#{authors.length-1} others", stats_post_path(post)
           %td.vtop.centered.post-replies{class: klass}= link_to post.reply_count, stats_post_path(post)

--- a/app/views/tags/_editor.haml
+++ b/app/views/tags/_editor.haml
@@ -11,7 +11,7 @@
     - if current_user.admin? || f.object.user_id == current_user.id
       = f.select :user_id, options_from_collection_for_select(User.ordered, :id, :username, f.object.user_id), {}, {class: 'chosen-select'}
     - else
-      = link_to f.object.user.username, user_path(f.object.user)
+      = user_link(f.object.user)
 %tr
   %th.sub Owned?
   %td{class: cycle('even', 'odd')}

--- a/app/views/tags/_editor.haml
+++ b/app/views/tags/_editor.haml
@@ -9,7 +9,7 @@
   %th.sub Owner
   %td{class: cycle('even', 'odd')}
     - if current_user.admin? || f.object.user_id == current_user.id
-      = f.select :user_id, options_from_collection_for_select(User.ordered, :id, :username, f.object.user_id), {}, {class: 'chosen-select'}
+      = f.select :user_id, options_from_collection_for_select(User.ordered.active, :id, :username, f.object.user_id), {}, {class: 'chosen-select'}
     - else
       = user_link(f.object.user)
 %tr

--- a/app/views/tags/_info.haml
+++ b/app/views/tags/_info.haml
@@ -18,7 +18,7 @@
               - if @tag.owned?
                 = @tag.user.username
               - else
-                %em= @tag.user.username
+                %em= @tag.user.deleted? ? 'deleted user' : tag.user.username
     - if @tag.description.present?
       %tr
         %th.centered.sub.width-150.vtop Description

--- a/app/views/tags/_info.haml
+++ b/app/views/tags/_info.haml
@@ -11,14 +11,11 @@
       %tr
         %th.centered.sub.width-150 Owner
         %td{class: cycle('even', 'odd'), title: ('This setting is not marked as owned' unless @tag.owned?)}
-          - if @tag.user.deleted?
-            %em (deleted user)
-          - else
-            = link_to @tag.user do
-              - if @tag.owned?
-                = @tag.user.username
-              - else
-                %em= @tag.user.deleted? ? 'deleted user' : tag.user.username
+          = link_to @tag.user do
+            - if @tag.owned?
+              = @tag.user.username
+            - else
+              %em= @tag.user.deleted? ? 'deleted user' : tag.user.username
     - if @tag.description.present?
       %tr
         %th.centered.sub.width-150.vtop Description

--- a/app/views/tags/_info.haml
+++ b/app/views/tags/_info.haml
@@ -11,11 +11,14 @@
       %tr
         %th.centered.sub.width-150 Owner
         %td{class: cycle('even', 'odd'), title: ('This setting is not marked as owned' unless @tag.owned?)}
-          = link_to @tag.user do
-            - if @tag.owned?
-              = @tag.user.username
-            - else
-              %em= @tag.user.username
+          - if @tag.user.deleted?
+            %em (deleted user)
+          - else
+            = link_to @tag.user do
+              - if @tag.owned?
+                = @tag.user.username
+              - else
+                %em= @tag.user.username
     - if @tag.description.present?
       %tr
         %th.centered.sub.width-150.vtop Description

--- a/app/views/tags/index.haml
+++ b/app/views/tags/index.haml
@@ -42,7 +42,7 @@
               - if tag.owned?
                 = tag.user.username
               - else
-                %em= tag.user.username
+                %em= tag.user.deleted? ? 'deleted user' : tag.user.username
         %td{class: klass}= tag.post_count
         %td{class: klass}= tag.character_count
         %td.width-70.right-align{class: klass}

--- a/app/views/templates/show.haml
+++ b/app/views/templates/show.haml
@@ -1,12 +1,11 @@
 - content_for :breadcrumbs do
   - if @template.user_id == current_user.try(:id)
     = link_to "Characters", user_characters_path(current_user)
-  - elsif @template.user.deleted?
-    %em (deleted user)
   - else
-    = link_to @template.user.username, user_path(@template.user)
-    &raquo;
-    = link_to "#{@template.user.username}'s Characters", user_characters_path(@template.user)
+    = user_link(@template.user)
+    - unless @template.user.deleted?
+      &raquo;
+      = link_to "#{@template.user.username}'s Characters", user_characters_path(@template.user)
   &raquo;
   %b= @template.name
 

--- a/app/views/users/search.haml
+++ b/app/views/users/search.haml
@@ -32,7 +32,7 @@
               - @search_results.each do |user|
                 %tr
                   - klass = cycle('even', 'odd')
-                  %td.padding-10.username{class: klass}= link_to user.username, user_path(user)
+                  %td.padding-10.username{class: klass}= user_link(user)
                   %td.padding-10.user-moiety.centered.width-70{class: klass}= color_block(user)
                   %td.padding-10.user-date{class: klass}= pretty_time(user.created_at)
 

--- a/app/views/writable/_history.haml
+++ b/app/views/writable/_history.haml
@@ -19,7 +19,7 @@
             = image_tag 'icons/shield.png', class: 'vmid', alt: '', title: 'Moderator edit'
             Moderator note from
             = succeed ' - ' do
-              = link_to audit.user.username, user_path(audit.user)
+              = user_link(audit.user)
             = surround '"' do
               = audit.comment
       %tr

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -56,5 +56,12 @@ RSpec.describe Api::V1::UsersController do
       get :index
       expect(response.json['results'].count).to eq(6)
     end
+
+    it "does not return deleted users" do
+      user = create(:user, deleted: true)
+      unblocked = create(:user)
+      get :index
+      expect(response.json['results'].count).to eq(1)
+    end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -368,14 +368,14 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe "#check_suspension" do
+  describe "#check_forced_logout" do
     controller do
       def index
         render json: {logged_in: current_user.present?}
       end
     end
 
-    it "does not log out unsuspended" do
+    it "does not log out unsuspended undeleted" do
       user = create(:user)
       login_as(user)
       get :index
@@ -384,7 +384,17 @@ RSpec.describe ApplicationController do
 
     it "logs out suspended" do
       user = create(:user)
+      login_as(user)
       user.role_id = Permissible::SUSPENDED
+      user.save
+      get :index
+      expect(response.json['logged_in']).to eq(false)
+    end
+
+    it "logs out deleted" do
+      user = create(:user)
+      login_as(user)
+      user.deleted = true
       user.save
       get :index
       expect(response.json['logged_in']).to eq(false)

--- a/spec/controllers/boards_controller_spec.rb
+++ b/spec/controllers/boards_controller_spec.rb
@@ -36,15 +36,6 @@ RSpec.describe BoardsController do
         expect(assigns(:page_title)).to eq("#{user.username}'s Continuities")
       end
 
-      it "defaults to current user if user id invalid" do
-        user = create(:user)
-        login_as(user)
-        get :index, params: { user_id: -1 }
-        expect(response.status).to eq(200)
-        expect(assigns(:user)).to eq(user)
-        expect(assigns(:page_title)).to eq('Your Continuities')
-      end
-
       it "displays error if user id invalid and logged out" do
         get :index, params: { user_id: -1 }
         expect(flash[:error]).to eq('User could not be found.')

--- a/spec/controllers/boards_controller_spec.rb
+++ b/spec/controllers/boards_controller_spec.rb
@@ -42,6 +42,20 @@ RSpec.describe BoardsController do
         expect(response).to redirect_to(root_url)
       end
 
+      it "displays error if user id invalid and logged in" do
+        login
+        get :index, params: { user_id: -1 }
+        expect(flash[:error]).to eq('User could not be found.')
+        expect(response).to redirect_to(root_url)
+      end
+
+      it "does not use logged in user's username" do
+        board = create(:board)
+        login_as(board.creator)
+        get :index, params: { user_id: board.creator_id }
+        expect(assigns(:page_title)).to eq('Your Continuities')
+      end
+
       it "sets correct variables" do
         user = create(:user)
         owned_board = create(:board, creator_id: user.id)

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -29,15 +29,6 @@ RSpec.describe GalleriesController do
         expect(assigns(:page_title)).to eq("#{user.username}'s Galleries")
       end
 
-      it "defaults to current user if user id invalid" do
-        user = create(:user)
-        login_as(user)
-        get :index, params: { user_id: -1 }
-        expect(response.status).to eq(200)
-        expect(assigns(:user)).to eq(user)
-        expect(assigns(:page_title)).to eq('Your Galleries')
-      end
-
       it "displays error if user id invalid and logged out" do
         get :index, params: { user_id: -1 }
         expect(flash[:error]).to eq('User could not be found.')

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe MessagesController do
         user = create(:user)
         login_as(user)
         messages = Array.new(4) { create(:message, recipient: user) }
+        deleted = create(:message, recipient: user)
+        deleted.sender.archive
         get :index
         expect(response).to have_http_status(200)
         expect(assigns(:view)).to eq('inbox')
@@ -25,6 +27,8 @@ RSpec.describe MessagesController do
         user = create(:user)
         login_as(user)
         messages = Array.new(4) { create(:message, sender: user) }
+        deleted = create(:message, sender: user)
+        deleted.recipient.archive
         get :index, params: { view: 'outbox' }
         expect(response).to have_http_status(200)
         expect(assigns(:view)).to eq('outbox')

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -307,6 +307,24 @@ RSpec.describe MessagesController do
       expect(flash[:error]).to eq("That is not your message!")
     end
 
+    it "requires extant sender" do
+      message = create(:message)
+      login_as(message.recipient)
+      message.sender.archive
+      get :show, params: { id: message.id }
+      expect(response).to redirect_to(messages_url(view: 'inbox'))
+      expect(flash[:error]).to eq("Message could not be found.")
+    end
+
+    it "requires extant recipient" do
+      message = create(:message)
+      login_as(message.sender)
+      message.recipient.archive
+      get :show, params: { id: message.id }
+      expect(response).to redirect_to(messages_url(view: 'inbox'))
+      expect(flash[:error]).to eq("Message could not be found.")
+    end
+
     context "with views" do
       render_views
       it "works for sender" do

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe ReportsController do
       expect(response).to have_http_status(200)
     end
 
+    it "succeeds with deleted user" do
+      valid = create(:post)
+      invalid = create(:post, user: create(:user, deleted: true))
+      get :show, params: { id: 'daily' }
+      valid_report = assigns(:posts).detect { |p| p.id == valid.id }
+      invalid_report = assigns(:posts).detect { |p| p.id == invalid.id }
+      expect(valid_report.last_user_deleted).to eq(false)
+      expect(invalid_report.last_user_deleted).to eq(true)
+    end
+
     context "with views" do
       render_views
 

--- a/spec/features/boards/show_spec.rb
+++ b/spec/features/boards/show_spec.rb
@@ -23,12 +23,55 @@ RSpec.feature "Show a single continuity", :type => :feature do
     expect(page).to have_text("Author board")
     expect(page).to have_selector('.post-subject', count: 2)
     within("tbody tr:nth-child(2)") do
-      expect(page).to have_selector('.post-subject', text: post1.subject)
-      expect(page).to have_selector('.post-authors', text: /#{reply.user.username}/)
+      expect(page).to have_selector('.post-subject', exact_text: post1.subject)
+      expect(page).to have_selector('.post-authors', text: reply.user.username)
     end
     within("tbody tr:nth-child(1)") do
-      expect(page).to have_selector('.post-subject', text: post2.subject)
-      expect(page).to have_selector('.post-authors', text: /and 4 others/)
+      expect(page).to have_selector('.post-subject', exact_text: post2.subject)
+      expect(page).to have_selector('.post-authors', text: 'and 4 others')
+    end
+  end
+
+  scenario "View a continuity with deleted users" do
+    del_user1 = create(:user, username: "John Doe")
+    del_user2 = create(:user, username: "Jane Doe")
+    coauthor1 = create(:user, username: "Alice")
+    coauthor2 = create(:user, username: "Bob")
+    coauthor3 = create(:user, username: "Poe")
+    board = create(:board, name: "Test board")
+    post1 = create(:post, user: del_user1, board: board)
+    create(:reply, post: post1, user: coauthor3)
+    post2 = create(:post, user: del_user2, board: board)
+    post3 = create(:post, user: del_user2, board: board, authors: [del_user1, del_user2, coauthor1, coauthor2, coauthor3])
+    create(:reply, post: post3, user: coauthor2)
+    post4 = create(:post, user: coauthor1, board: board, authors: [del_user2, coauthor1, coauthor3])
+    [coauthor1, coauthor3, del_user2].each do |u| create(:reply, post: post4, user: u) end
+    del_user1.archive
+    del_user2.archive
+
+    visit board_path(board)
+
+    expect(page).to have_text("Test board")
+    expect(page).to have_selector('.post-subject', count: 4)
+    within("tbody tr:nth-child(4)") do
+      expect(page).to have_selector('.post-subject', exact_text: post1.subject)
+      expect(page).to have_selector('.post-authors', text: 'Poe, (deleted user)')
+      expect(page).to have_selector('.post-time', text: 'Poe')
+    end
+    within("tbody tr:nth-child(3)") do
+      expect(page).to have_selector('.post-subject', exact_text: post2.subject)
+      expect(page).to have_selector('.post-authors', text: '(deleted user)')
+      expect(page).to have_selector('.post-time', text: '(deleted user)')
+    end
+    within("tbody tr:nth-child(2)") do
+      expect(page).to have_selector('.post-subject', exact_text: post3.subject)
+      expect(page).to have_selector('.post-authors', text: '(deleted user), 3 others')
+      expect(page).to have_selector('.post-time', text: 'Bob')
+    end
+    within("tbody tr:nth-child(1)") do
+      expect(page).to have_selector('.post-subject', exact_text: post4.subject)
+      expect(page).to have_selector('.post-authors', text: 'Alice, Poe, (deleted user)')
+      expect(page).to have_selector('.post-time', text: '(deleted user)')
     end
   end
 end

--- a/spec/features/boards/show_spec.rb
+++ b/spec/features/boards/show_spec.rb
@@ -55,22 +55,22 @@ RSpec.feature "Show a single continuity", :type => :feature do
     expect(page).to have_selector('.post-subject', count: 4)
     within("tbody tr:nth-child(4)") do
       expect(page).to have_selector('.post-subject', exact_text: post1.subject)
-      expect(page).to have_selector('.post-authors', text: 'Poe, (deleted user)')
+      expect(page).to have_selector('.post-authors', text: 'Poe and 1 deleted user')
       expect(page).to have_selector('.post-time', text: 'Poe')
     end
     within("tbody tr:nth-child(3)") do
       expect(page).to have_selector('.post-subject', exact_text: post2.subject)
-      expect(page).to have_selector('.post-authors', text: '(deleted user)')
+      expect(page).to have_selector('.post-authors', text: '1 deleted user')
       expect(page).to have_selector('.post-time', text: '(deleted user)')
     end
     within("tbody tr:nth-child(2)") do
       expect(page).to have_selector('.post-subject', exact_text: post3.subject)
-      expect(page).to have_selector('.post-authors', text: '(deleted user), 3 others')
+      expect(page).to have_selector('.post-authors', text: '(deleted user) and 4 others')
       expect(page).to have_selector('.post-time', text: 'Bob')
     end
     within("tbody tr:nth-child(1)") do
       expect(page).to have_selector('.post-subject', exact_text: post4.subject)
-      expect(page).to have_selector('.post-authors', text: 'Alice, Poe, (deleted user)')
+      expect(page).to have_selector('.post-authors', text: 'Alice, Poe, and 1 deleted user')
       expect(page).to have_selector('.post-time', text: '(deleted user)')
     end
   end

--- a/spec/features/boards/show_spec.rb
+++ b/spec/features/boards/show_spec.rb
@@ -60,17 +60,17 @@ RSpec.feature "Show a single continuity", :type => :feature do
     end
     within("tbody tr:nth-child(3)") do
       expect(page).to have_selector('.post-subject', exact_text: post2.subject)
-      expect(page).to have_selector('.post-authors', text: '1 deleted user')
+      expect(page).to have_selector('.post-authors', text: '(deleted user)')
       expect(page).to have_selector('.post-time', text: '(deleted user)')
     end
     within("tbody tr:nth-child(2)") do
       expect(page).to have_selector('.post-subject', exact_text: post3.subject)
-      expect(page).to have_selector('.post-authors', text: '(deleted user) and 4 others')
+      expect(page).to have_selector('.post-authors', text: 'Alice and 4 others')
       expect(page).to have_selector('.post-time', text: 'Bob')
     end
     within("tbody tr:nth-child(1)") do
       expect(page).to have_selector('.post-subject', exact_text: post4.subject)
-      expect(page).to have_selector('.post-authors', text: 'Alice, Poe, and 1 deleted user')
+      expect(page).to have_selector('.post-authors', text: 'Alice, Poe and 1 deleted user')
       expect(page).to have_selector('.post-time', text: '(deleted user)')
     end
   end

--- a/spec/features/characters/show_spec.rb
+++ b/spec/features/characters/show_spec.rb
@@ -176,7 +176,7 @@ RSpec.feature "Creating a new character", :type => :feature do
     expect(page).to have_selector('.breadcrumbs', text: 'Test char » ')
     within('.breadcrumbs') do
       expect(page).to have_no_link(href: user_path(user))
-      expect(page).to have_text("Archived » ")
+      expect(page).to have_text("(deleted user) » ")
     end
   end
 

--- a/spec/features/posts/show_spec.rb
+++ b/spec/features/posts/show_spec.rb
@@ -22,14 +22,14 @@ RSpec.feature "Viewing posts", :type => :feature do
     visit post_path(post)
 
     within('.post-post') do
-      expect(page).to have_selector('.post-author', exact_text: 'N/A')
+      expect(page).to have_selector('.post-author', exact_text: '(deleted user)')
     end
     replies = page.all('.post-reply')
     within(replies[0]) do
       expect(page).to have_selector('.post-author', exact_text: reply.user.username)
     end
     within(replies[1]) do
-      expect(page).to have_selector('.post-author', exact_text: 'N/A')
+      expect(page).to have_selector('.post-author', exact_text: '(deleted user)')
     end
   end
 end

--- a/spec/helpers/writable_helper_spec.rb
+++ b/spec/helpers/writable_helper_spec.rb
@@ -28,4 +28,123 @@ RSpec.describe WritableHelper do
       expect(helper.anchored_board_path(post)).to eq(board_path(post.board_id))
     end
   end
+
+  describe "#author_links" do
+    context "with only deleted users" do
+      it "handles only a deleted user" do
+        post = create(:post)
+        post.user.update_attributes(deleted: true)
+        expect(helper.author_links(post)).to eq('(deleted user)')
+      end
+
+      it "handles only two deleted users" do
+        post = create(:post)
+        post.user.update_attributes(deleted: true)
+        reply = create(:reply, post: post)
+        reply.user.update_attributes(deleted: true)
+        expect(helper.author_links(post)).to eq('(deleted users)')
+      end
+
+      it "handles >4 deleted users" do
+        post = create(:post)
+        post.user.update_attributes(deleted: true)
+        reply = create(:reply, post: post)
+        reply.user.update_attributes(deleted: true)
+        reply = create(:reply, post: post)
+        reply.user.update_attributes(deleted: true)
+        reply = create(:reply, post: post)
+        reply.user.update_attributes(deleted: true)
+        reply = create(:reply, post: post)
+        reply.user.update_attributes(deleted: true)
+        expect(helper.author_links(post)).to eq('(deleted users)')
+      end
+    end
+
+    context "with active and deleted users" do
+      it "handles two users with post user deleted" do
+        post = create(:post)
+        post.user.update_attributes(deleted: true)
+        reply = create(:reply, post: post)
+        expect(helper.author_links(post)).to eq(helper.user_link(reply.user) + ', (deleted user)')
+      end
+
+      it "handles two users with reply user deleted" do
+        post = create(:post)
+        reply = create(:reply, post: post)
+        reply.user.update_attributes(deleted: true)
+        expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ', (deleted user)')
+      end
+
+      it "handles three users with one deleted" do
+        post = create(:post, user: create(:user, username: 'xxx'))
+        reply = create(:reply, post: post)
+        reply.user.update_attributes(deleted: true)
+        reply = create(:reply, post: post, user: create(:user, username: 'yyy'))
+        links = [post.user, reply.user].map { |u| helper.user_link(u) }.join(', ')
+        expect(helper.author_links(post)).to eq(links + ', (deleted user)')
+      end
+
+      it "handles three users with two deleted" do
+        post = create(:post)
+        reply = create(:reply, post: post)
+        reply.user.update_attributes(deleted: true)
+        reply = create(:reply, post: post)
+        reply.user.update_attributes(deleted: true)
+        expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ', (deleted users)')
+      end
+
+      it "handles >4 users with post user first" do
+        post = create(:post, user: create(:user, username: 'zzz'))
+        create(:reply, post: post, user: create(:user, username: 'yyy'))
+        reply = create(:reply, post: post, user: create(:user, username: 'xxx'))
+        reply.user.update_attributes(deleted: true)
+        create(:reply, post: post, user: create(:user, username: 'www'))
+        create(:reply, post: post, user: create(:user, username: 'vvv'))
+        stats_link = helper.link_to('4 others', stats_post_path(post))
+        expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ' and ' + stats_link)
+      end
+
+      it "handles >4 users with alphabetical user first iff post user deleted" do
+        post = create(:post, user: create(:user, username: 'zzz'))
+        post.user.update_attributes(deleted: true)
+        create(:reply, post: post, user: create(:user, username: 'yyy'))
+        create(:reply, post: post, user: create(:user, username: 'xxx'))
+        reply = create(:reply, post: post, user: create(:user, username: 'aaa'))
+        create(:reply, post: post, user: create(:user, username: 'vvv'))
+        stats_link = helper.link_to('4 others', stats_post_path(post))
+        expect(helper.author_links(post)).to eq(helper.user_link(reply.user) + ' and ' + stats_link)
+      end
+    end
+
+    context "with only active users" do
+      it "handles only one user" do
+        post = create(:post)
+        expect(helper.author_links(post)).to eq(helper.user_link(post.user))
+      end
+
+      it "handles two users with commas" do
+        post = create(:post, user: create(:user, username: 'xxx'))
+        reply = create(:reply, post: post, user: create(:user, username: 'yyy'))
+        expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ', ' + helper.user_link(reply.user))
+      end
+
+      it "handles three users with commas and no and" do
+        post = create(:post, user: create(:user, username: 'zzz'))
+        users = [post.user]
+        users << create(:reply, post: post, user: create(:user, username: 'yyy')).user
+        users << create(:reply, post: post, user: create(:user, username: 'xxx')).user
+        expect(helper.author_links(post)).to eq(users.reverse.map { |u| helper.user_link(u) }.join(', '))
+      end
+
+      it "handles >4 users with post user first" do
+        post = create(:post, user: create(:user, username: 'zzz'))
+        create(:reply, post: post, user: create(:user, username: 'yyy'))
+        create(:reply, post: post, user: create(:user, username: 'xxx'))
+        create(:reply, post: post, user: create(:user, username: 'www'))
+        create(:reply, post: post, user: create(:user, username: 'vvv'))
+        stats_link = helper.link_to('4 others', stats_post_path(post))
+        expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ' and ' + stats_link)
+      end
+    end
+  end
 end

--- a/spec/helpers/writable_helper_spec.rb
+++ b/spec/helpers/writable_helper_spec.rb
@@ -65,14 +65,14 @@ RSpec.describe WritableHelper do
         post = create(:post)
         post.user.update_attributes(deleted: true)
         reply = create(:reply, post: post)
-        expect(helper.author_links(post)).to eq(helper.user_link(reply.user) + ', (deleted user)')
+        expect(helper.author_links(post)).to eq(helper.user_link(reply.user) + ' and 1 deleted user')
       end
 
       it "handles two users with reply user deleted" do
         post = create(:post)
         reply = create(:reply, post: post)
         reply.user.update_attributes(deleted: true)
-        expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ', (deleted user)')
+        expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ' and 1 deleted user')
       end
 
       it "handles three users with one deleted" do
@@ -81,7 +81,7 @@ RSpec.describe WritableHelper do
         reply.user.update_attributes(deleted: true)
         reply = create(:reply, post: post, user: create(:user, username: 'yyy'))
         links = [post.user, reply.user].map { |u| helper.user_link(u) }.join(', ')
-        expect(helper.author_links(post)).to eq(links + ', (deleted user)')
+        expect(helper.author_links(post)).to eq(links + ' and 1 deleted user')
       end
 
       it "handles three users with two deleted" do
@@ -90,7 +90,7 @@ RSpec.describe WritableHelper do
         reply.user.update_attributes(deleted: true)
         reply = create(:reply, post: post)
         reply.user.update_attributes(deleted: true)
-        expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ', (deleted users)')
+        expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ' and 2 deleted users')
       end
 
       it "handles >4 users with post user first" do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -61,4 +61,10 @@ RSpec.describe Message do
     message.unread = false
     message.save!
   end
+
+  it "errors to sender if messaging a deleted user" do
+    message = build(:message, recipient: create(:user, deleted: true))
+    expect(message).not_to be_valid
+    expect(message.recipient).to be_nil
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -859,6 +859,21 @@ RSpec.describe Post do
     end
   end
 
+  describe "last_user_deleted" do
+    it "loads from the database if not loaded via select" do
+      post = create(:post)
+      post.last_user.archive
+      expect(post.reload.last_user_deleted?).to eq(true)
+    end
+
+    it "reads from attribute if loaded via select" do
+      post = create(:post)
+      post = Post.where(id: post.id).joins(:last_user).select('posts.*, users.deleted as last_user_deleted').first
+      post.last_user.archive
+      expect(post.last_user_deleted?).to eq(false) # not reloaded loads cached false
+    end
+  end
+
   describe "#has_edit_audits?" do
     let(:user) { create(:user) }
     before(:each) { Post.auditing_enabled = true }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -172,5 +172,15 @@ RSpec.describe User do
       user.reload
       expect(user.send(:[], :username)).to eq('test')
     end
+
+    it "removes related blocks" do
+      user = create(:user)
+      create(:block, blocking_user: user)
+      create(:block, blocked_user: user)
+      expect(Blocks.count).to be(2)
+      user.archive
+      expect(user.deleted).to be(true)
+      expect(Blocks.count).to be(0)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -177,10 +177,10 @@ RSpec.describe User do
       user = create(:user)
       create(:block, blocking_user: user)
       create(:block, blocked_user: user)
-      expect(Blocks.count).to be(2)
+      expect(Block.count).to be(2)
       user.archive
       expect(user.deleted).to be(true)
-      expect(Blocks.count).to be(0)
+      expect(Block.count).to be(0)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -153,5 +153,12 @@ RSpec.describe User do
       expect(user.deleted).to be(true)
       expect(setting.reload.owned).to be(false)
     end
+
+    it "does not change username when persisted" do
+      user = create(:user, username: 'test')
+      user.archive
+      user.reload
+      expect(user.send(:[], :username)).to eq('test')
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe User do
     expect(new_user).not_to be_valid
   end
 
+  describe "reserved usernames" do
+    it "should not allow users to use the site message placeholder" do
+      user = build(:user, username: 'Glowfic Constellation')
+      expect(user).not_to be_valid
+    end
+
+    it "should not allow users to use the deleted user placeholder" do
+      user = build(:user, username: '(deleted user)')
+      expect(user).not_to be_valid
+    end
+  end
+
   describe "emails" do
     def generate_emailless_user
       user = build(:user, email: '')


### PR DESCRIPTION
Still to do:
- [x] Make sure new users cannot name themselves `(deleted user)`
- [x] Make sure deleted user galleries/characters/posts/boards are hidden
- [x] Handle existing sessions of deleted users
- [x] Remove usernames of deleted users from facecasts page
- [x] Check whether deleted users would be loaded in dropdown lists
- [x] Remove usernames of deleted users from settings they're attached to
- [x] Make it impossible to send messages to deleted users
- [x] Remove usernames of deleted users on existing messages to/from them.
- [x] De-override username
- [x] Handle deleted favorited users