### PR TITLE
Override layout-th styling in post-content tables

### DIFF
--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -266,6 +266,22 @@ div.post-subheader { width: 100%; }
   }
 }
 
+/* - Tables in post-content */
+.post-content {
+  th {
+    color: unset;
+    background-color: unset;
+    padding: 5px;
+    font-size: unset;
+  }
+  td {
+    padding: 5px;
+  }
+  th, td {
+    border: 1px solid #999;
+  }
+}
+
 /* - Character quick switcher - small icons for selecting characters in post-editor */
 .char-access-icon {
   height: 30px;


### PR DESCRIPTION
We use `th` semantically all over the place for headers, and then style
them a particular way for consistent formatting. Unfortunately, this
messes with `th` being used in replies, since it messes up the
formatting. Unset the changes we make (as a temporary hack) so they use
a more default formatting in posts.