### PR TITLE
Add bold font to reply ths

### DIFF
--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -269,10 +269,11 @@ div.post-subheader { width: 100%; }
 /* - Tables in post-content */
 .post-content {
   th {
-    color: unset;
-    background-color: unset;
     padding: 5px;
+    background-color: unset;
+    color: unset;
     font-size: unset;
+    font-weight: bold;
   }
   td {
     padding: 5px;


### PR DESCRIPTION
Per <https://www.w3schools.com/tags/tag_th.asp>,

> The text in <th> elements are bold and centered by default.

The header text wasn't very clearly header-ish, prior to this change. (It had a larger font size, but that seemed to be it.) This should amend it to be clearer.