### PR TITLE
Fix styling semantic th

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -223,6 +223,7 @@ td, .table-list li { font-size: $font_size_small; }
   background-color: $bg_color_sub;
   color: $font_color_sub;
   font-size: $font_size_main;
+  font-weight: normal;
   &.width-150 { width: 170px; }
 }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -194,6 +194,11 @@ table { width: 100%; }
   text-align: center;
 }
 
+.search-params-header {
+  @extend .table-title;
+  width: 150px;
+}
+
 .content-header {
   width: 100%;
   overflow: hidden;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -181,7 +181,7 @@ table { width: 100%; }
   margin: 0;
 }
 
-th, .content-header {
+th, .content-header, .search-results-header {
   background-color: $bg_color_head;
   color: $font_color_head;
   padding: 15px;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -181,7 +181,7 @@ table { width: 100%; }
   margin: 0;
 }
 
-th, .content-header, .search-results-header {
+.table-title, .content-header, .search-results-header {
   background-color: $bg_color_head;
   color: $font_color_head;
   padding: 15px;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -189,10 +189,11 @@ table { width: 100%; }
   font-weight: normal;
 }
 
-.info-box-header {
+.info-box-header, .editor-title {
   @extend .table-title;
   text-align: center;
 }
+
 .content-header {
   width: 100%;
   overflow: hidden;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -189,6 +189,10 @@ table { width: 100%; }
   font-weight: normal;
 }
 
+.info-box-header {
+  @extend .table-title;
+  text-align: center;
+}
 .content-header {
   width: 100%;
   overflow: hidden;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -199,6 +199,11 @@ table { width: 100%; }
   width: 150px;
 }
 
+.gallery-table-title {
+  @extend .table-title;
+  &, &.subber { padding: 10px; }
+}
+
 .content-header {
   width: 100%;
   overflow: hidden;

--- a/app/assets/stylesheets/layouts/_dark_selectors.scss
+++ b/app/assets/stylesheets/layouts/_dark_selectors.scss
@@ -63,7 +63,7 @@ a:hover { color: $font_color_link_hover; }
 }
 
 /* - content headers */
-th, .content-header, .search-results-header {
+.table-title, .content-header, .search-results-header {
   background-color: $bg_color_head;
   color: $font_color_head;
 }

--- a/app/assets/stylesheets/layouts/_dark_selectors.scss
+++ b/app/assets/stylesheets/layouts/_dark_selectors.scss
@@ -63,7 +63,7 @@ a:hover { color: $font_color_link_hover; }
 }
 
 /* - content headers */
-.table-title, .content-header, .info-box-header, .search-results-header {
+.table-title, .content-header, .info-box-header, .editor-title, .search-results-header {
   background-color: $bg_color_head;
   color: $font_color_head;
 }

--- a/app/assets/stylesheets/layouts/_dark_selectors.scss
+++ b/app/assets/stylesheets/layouts/_dark_selectors.scss
@@ -63,7 +63,7 @@ a:hover { color: $font_color_link_hover; }
 }
 
 /* - content headers */
-th, .content-header {
+th, .content-header, .search-results-header {
   background-color: $bg_color_head;
   color: $font_color_head;
 }

--- a/app/assets/stylesheets/layouts/_dark_selectors.scss
+++ b/app/assets/stylesheets/layouts/_dark_selectors.scss
@@ -63,7 +63,7 @@ a:hover { color: $font_color_link_hover; }
 }
 
 /* - content headers */
-.table-title, .content-header, .search-results-header {
+.table-title, .content-header, .info-box-header, .search-results-header {
   background-color: $bg_color_head;
   color: $font_color_head;
 }

--- a/app/assets/stylesheets/layouts/_dark_selectors.scss
+++ b/app/assets/stylesheets/layouts/_dark_selectors.scss
@@ -63,7 +63,7 @@ a:hover { color: $font_color_link_hover; }
 }
 
 /* - content headers */
-.table-title, .content-header, .info-box-header, .editor-title, .search-params-header, .search-results-header {
+.table-title, .content-header, .info-box-header, .editor-title, .search-params-header, .search-results-header, .gallery-table-title {
   background-color: $bg_color_head;
   color: $font_color_head;
 }

--- a/app/assets/stylesheets/layouts/_dark_selectors.scss
+++ b/app/assets/stylesheets/layouts/_dark_selectors.scss
@@ -63,7 +63,7 @@ a:hover { color: $font_color_link_hover; }
 }
 
 /* - content headers */
-.table-title, .content-header, .info-box-header, .editor-title, .search-results-header {
+.table-title, .content-header, .info-box-header, .editor-title, .search-params-header, .search-results-header {
   background-color: $bg_color_head;
   color: $font_color_head;
 }

--- a/app/assets/stylesheets/layouts/_starry_default_selectors.scss
+++ b/app/assets/stylesheets/layouts/_starry_default_selectors.scss
@@ -50,7 +50,7 @@ a:visited { color: $font_color_link_visited; }
 }
 
 /* - content headers */
-th, .content-header, .search-results-header {
+.table-title, .content-header, .search-results-header {
   background-color: $bg_color_head;
   a { color: $font_color_head_link; }
   a:visited { color: $font_color_head_link_visited; }

--- a/app/assets/stylesheets/layouts/_starry_default_selectors.scss
+++ b/app/assets/stylesheets/layouts/_starry_default_selectors.scss
@@ -50,7 +50,7 @@ a:visited { color: $font_color_link_visited; }
 }
 
 /* - content headers */
-.table-title, .content-header, .info-box-header, .search-results-header {
+.table-title, .content-header, .info-box-header, .editor-title, .search-results-header {
   background-color: $bg_color_head;
   a { color: $font_color_head_link; }
   a:visited { color: $font_color_head_link_visited; }

--- a/app/assets/stylesheets/layouts/_starry_default_selectors.scss
+++ b/app/assets/stylesheets/layouts/_starry_default_selectors.scss
@@ -50,7 +50,7 @@ a:visited { color: $font_color_link_visited; }
 }
 
 /* - content headers */
-.table-title, .content-header, .info-box-header, .editor-title, .search-params-header, .search-results-header {
+.table-title, .content-header, .info-box-header, .editor-title, .search-params-header, .search-results-header, .gallery-table-title {
   background-color: $bg_color_head;
   a { color: $font_color_head_link; }
   a:visited { color: $font_color_head_link_visited; }

--- a/app/assets/stylesheets/layouts/_starry_default_selectors.scss
+++ b/app/assets/stylesheets/layouts/_starry_default_selectors.scss
@@ -50,18 +50,24 @@ a:visited { color: $font_color_link_visited; }
 }
 
 /* - content headers */
-.table-title, .content-header, .info-box-header, .editor-title, .search-params-header, .search-results-header, .gallery-table-title {
-  background-color: $bg_color_head;
+@mixin header-links {
   a { color: $font_color_head_link; }
   a:visited { color: $font_color_head_link_visited; }
 }
 
+.table-title, .content-header, .info-box-header, .editor-title, .search-params-header, .search-results-header, .gallery-table-title {
+  @include header-links;
+  background-color: $bg_color_head;
+}
+
 .sub {
+  @include header-links;
   color: $font_color_sub;
   background-color: $bg_color_sub;
 }
 
 .form-table-ender {
+  @include header-links;
   background-color: $bg_color_ender;
   color: $font_color_ender;
 }

--- a/app/assets/stylesheets/layouts/_starry_default_selectors.scss
+++ b/app/assets/stylesheets/layouts/_starry_default_selectors.scss
@@ -50,7 +50,7 @@ a:visited { color: $font_color_link_visited; }
 }
 
 /* - content headers */
-.table-title, .content-header, .search-results-header {
+.table-title, .content-header, .info-box-header, .search-results-header {
   background-color: $bg_color_head;
   a { color: $font_color_head_link; }
   a:visited { color: $font_color_head_link_visited; }

--- a/app/assets/stylesheets/layouts/_starry_default_selectors.scss
+++ b/app/assets/stylesheets/layouts/_starry_default_selectors.scss
@@ -50,7 +50,7 @@ a:visited { color: $font_color_link_visited; }
 }
 
 /* - content headers */
-th, .content-header {
+th, .content-header, .search-results-header {
   background-color: $bg_color_head;
   a { color: $font_color_head_link; }
   a:visited { color: $font_color_head_link_visited; }

--- a/app/assets/stylesheets/layouts/_starry_default_selectors.scss
+++ b/app/assets/stylesheets/layouts/_starry_default_selectors.scss
@@ -50,7 +50,7 @@ a:visited { color: $font_color_link_visited; }
 }
 
 /* - content headers */
-.table-title, .content-header, .info-box-header, .editor-title, .search-results-header {
+.table-title, .content-header, .info-box-header, .editor-title, .search-params-header, .search-results-header {
   background-color: $bg_color_head;
   a { color: $font_color_head_link; }
   a:visited { color: $font_color_head_link_visited; }

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -324,17 +324,10 @@ div.post-subheader { width: 100%; }
   }
 
   /* - Tables in post-content */
-  th {
+  th, td {
+    border: 1px solid $border_color_reply_table;
     padding: 5px;
-    background-color: unset;
-    color: unset;
-    font-size: unset;
-    font-weight: bold;
   }
-
-  td { padding: 5px; }
-
-  th, td { border: 1px solid $border_color_reply_table; }
 }
 
 /* - Character quick switcher - small icons for selecting characters in post-editor */

--- a/app/views/aliases/new.haml
+++ b/app/views/aliases/new.haml
@@ -14,7 +14,7 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2}= "New Alias"
+        %th.editor-title{colspan: 2}= "New Alias"
     %tbody
       %tr
         %th.sub Name

--- a/app/views/blocks/edit.haml
+++ b/app/views/blocks/edit.haml
@@ -2,5 +2,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Edit Block
+        %th.editor-title{colspan: 2} Edit Block
     = render 'editor', f: f, blocked_user: @block.blocked_user

--- a/app/views/blocks/index.haml
+++ b/app/views/blocks/index.haml
@@ -8,7 +8,7 @@
 %table
   %thead
     %tr
-      %th{colspan: 5}
+      %th.table-title{colspan: 5}
         = @page_title
         = link_to new_block_path do
           .link-box.action-new + Block User

--- a/app/views/blocks/new.haml
+++ b/app/views/blocks/new.haml
@@ -2,5 +2,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Block User
+        %th.editor-title{colspan: 2} Block User
     = render 'editor', f: f

--- a/app/views/board_sections/edit.haml
+++ b/app/views/board_sections/edit.haml
@@ -10,7 +10,7 @@
 = form_for @board_section, url: board_section_path(@board_section), method: :put do |f|
   %table.form-table
     %tr
-      %th.centered{colspan: 2} Edit #{@board_section.name}
+      %th.editor-title{colspan: 2} Edit #{@board_section.name}
     = render 'editor', f: f
 
 - if @board_section.posts.present?

--- a/app/views/board_sections/new.haml
+++ b/app/views/board_sections/new.haml
@@ -1,5 +1,5 @@
 = form_for @board_section, url: board_sections_path, method: :post do |f|
   %table.form-table
     %tr
-      %th.centered{colspan: 2} Create #{@board_section&.board&.name} Section
+      %th.editor-title{colspan: 2} Create #{@board_section&.board&.name} Section
     = render 'editor', f: f

--- a/app/views/boards/edit.haml
+++ b/app/views/boards/edit.haml
@@ -9,7 +9,7 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Edit Continuity
+        %th.editor-title{colspan: 2} Edit Continuity
     = render 'editor', f: f
 
 %br

--- a/app/views/boards/index.haml
+++ b/app/views/boards/index.haml
@@ -9,7 +9,7 @@
 %table
   %thead
     %tr
-      %th{colspan: 3}
+      %th.table-title{colspan: 3}
         = @page_title
         - if logged_in? && (@user.nil? || @user.id == current_user.id)
           = link_to new_board_path do

--- a/app/views/boards/new.haml
+++ b/app/views/boards/new.haml
@@ -2,5 +2,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Create Continuity
+        %th.editor-title{colspan: 2} Create Continuity
     = render 'editor', f: f

--- a/app/views/boards/show.haml
+++ b/app/views/boards/show.haml
@@ -33,7 +33,7 @@
   %table
     %thead
       %tr
-        %th{colspan: 5}= content_for :posts_title
+        %th.table-title{colspan: 5}= content_for :posts_title
       - if @board.description.present?
         %tr
           %td.odd.written-content{colspan: 5}= sanitize_written_content(@board.description)

--- a/app/views/characters/edit.haml
+++ b/app/views/characters/edit.haml
@@ -13,14 +13,14 @@
     %table.form-table
       %thead
         %tr
-          %th.centered{colspan: 2}= @character.name
+          %th.editor-title{colspan: 2}= @character.name
       = render 'editor', f: f
 
     %br
     %table.form-table
       %thead
         %tr
-          %th.centered
+          %th.editor-title
             Aliases and Pseudonyms
             - if @character.user_id == current_user.id
               = link_to new_character_alias_path(@character) do

--- a/app/views/characters/facecasts.haml
+++ b/app/views/characters/facecasts.haml
@@ -1,7 +1,7 @@
 %table
   %thead
     %tr
-      %th{colspan: 4} Facecasts
+      %th.table-title{colspan: 4} Facecasts
     %tr
       %th.sub= link_to 'Facecast', url_for(sort: nil)
       %th.sub Type

--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -6,7 +6,7 @@
 
 %table
   %tr
-    %th{colspan: (character_split == 'none' ? 7 : 6)}
+    %th.table-title{colspan: (character_split == 'none' ? 7 : 6)}
       - if @group
         Character Group:
         = @group.name

--- a/app/views/characters/new.haml
+++ b/app/views/characters/new.haml
@@ -4,7 +4,7 @@
     %table.form-table
       %thead
         %tr
-          %th.centered{colspan: 2} New Character
+          %th.editor-title{colspan: 2} New Character
       = render 'editor', f: f
 
   = render 'icon_selector'

--- a/app/views/characters/search.haml
+++ b/app/views/characters/search.haml
@@ -3,7 +3,7 @@
 %table.search-collapsible
   %thead
     %tr
-      %th.width-150
+      %th.search-params-header
         Search Characters
         - if @search_results
           = '- '+@search_results.total_entries.to_s+' results'
@@ -76,5 +76,5 @@
   - if @search_results && @search_results.total_pages > 1
     %tfoot
       %tr
-        %th.width-150.empty
+        %th.search-params-header.empty
         %th.search-results-header= render 'posts/paginator', paginated: @search_results, no_per: true

--- a/app/views/characters/search.haml
+++ b/app/views/characters/search.haml
@@ -7,7 +7,7 @@
         Search Characters
         - if @search_results
           = '- '+@search_results.total_entries.to_s+' results'
-      %th
+      %th.search-results-header
         - if @search_results
           = render 'posts/paginator', paginated: @search_results, no_per: true
   %tbody
@@ -77,4 +77,4 @@
     %tfoot
       %tr
         %th.width-150.empty
-        %th= render 'posts/paginator', paginated: @search_results, no_per: true
+        %th.search-results-header= render 'posts/paginator', paginated: @search_results, no_per: true

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -22,7 +22,7 @@
 %table.left-info-box.character-info-box
   %thead
     %tr
-      %th.centered
+      %th.info-box-header
         %span.character-name= @character.name
         - if @character.screenname
           %br

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -82,7 +82,7 @@
   %table.character-right-content-box#reorder-galleries-table
     %thead
       %tr
-        %th
+        %th.table-title
           Galleries
           #loading.float-right.hidden= loading_tag
           #saveerror.float-right.hidden
@@ -106,7 +106,7 @@
   %table.character-right-content-box
     %thead
       %tr
-        %th{colspan: 2} Info
+        %th.table-title{colspan: 2} Info
     %tbody
       - nicknames = ([@character.template_name] + @character.aliases.ordered.pluck(:name)).compact
       - if nicknames.present?

--- a/app/views/favorites/index.haml
+++ b/app/views/favorites/index.haml
@@ -8,7 +8,7 @@
   %table
     %thead
       %tr
-        %th{colspan: 2}
+        %th.table-title{colspan: 2}
           Your Favorites
           = link_to favorites_path do
             .view-button

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -6,7 +6,7 @@
 - gallery_klass << "gallery-title-#{gallery.id}" if gallery
 %tbody{class: gallery_klass, **attrs}
   %tr.gallery-header
-    %th.padding-10{class: (klass if defined? klass)}
+    %th.gallery-table-title{class: (klass if defined? klass)}
       - link = gallery ? gallery_path(gallery) : user_gallery_path(id: 0, user_id: @user.id)
       = link_to gallery ? gallery.name : 'Galleryless icons', link, class: 'gallery-title'
       - if is_owner && !skip_forms

--- a/app/views/galleries/edit.haml
+++ b/app/views/galleries/edit.haml
@@ -9,7 +9,7 @@
   %table.form-table.gallery-edit-form
     %thead
       %tr
-        %th.centered{colspan: 3}
+        %th.editor-title{colspan: 3}
           Edit Gallery
     %tbody.gallery-editor
       %tr

--- a/app/views/galleries/index.haml
+++ b/app/views/galleries/index.haml
@@ -7,7 +7,7 @@
 %table
   %thead
     %tr
-      %th.padding-10{colspan: 4}
+      %th.gallery-table-title{colspan: 4}
         - if @user.id == current_user.try(:id)
           Your Galleries
           = link_to new_gallery_path, class: 'gallery-new' do

--- a/app/views/galleries/new.haml
+++ b/app/views/galleries/new.haml
@@ -3,7 +3,7 @@
   %table.form-table{style: (icons_present ? 'width: 100%;' : nil)}
     %thead
       %tr
-        %th.centered{colspan: 2}New Gallery
+        %th.editor-title{colspan: 2}New Gallery
     %tbody
       %tr
         %th.vtop.sub Name

--- a/app/views/global/_replace.haml
+++ b/app/views/global/_replace.haml
@@ -1,7 +1,7 @@
 %table.form-table
   %thead
     %tr
-      %th.centered{colspan: 2} Replace All Uses of #{obj.class}
+      %th.editor-title{colspan: 2} Replace All Uses of #{obj.class}
   %tbody
     = content_for :disclaimer
     %tr

--- a/app/views/icons/edit.haml
+++ b/app/views/icons/edit.haml
@@ -13,7 +13,7 @@
 
 %table.form-table
   %tr
-    %th
+    %th.table-title
       Edit Icon
 
 = form_for @icon, method: :put, html: {class: 'icon-upload'}, data: { 'form-data' => @s3_direct_post.fields, url: @s3_direct_post.url, host: URI.parse(@s3_direct_post.url).host, limit: 1 } do |f|

--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -23,7 +23,7 @@
 
 %table.left-info-box.icon-info-box
   %tr
-    %th.centered.icon-keyword= @icon.keyword
+    %th.info-box-header.icon-keyword= @icon.keyword
   %tr
     %td.icons-box.centered.icon-icon= icon_tag @icon
   - if @icon.credit

--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -76,7 +76,7 @@
   %table.icon-right-content-box
     %thead
       %tr
-        %th Galleries
+        %th.table-title Galleries
     - if @icon.galleries.exists?
       = render partial: 'galleries/single', collection: @icon.galleries.ordered_by_name, as: :gallery, locals: {klass: 'subber', skip_forms: true, is_owner: @icon.user == current_user}
     - else
@@ -91,7 +91,7 @@
   %table.icon-right-content-box
     %thead
       %tr
-        %th{colspan: 2} Stats
+        %th.table-title{colspan: 2} Stats
     %tbody
       %tr
         %th.sub.width-150 Times Used

--- a/app/views/index_posts/new.haml
+++ b/app/views/index_posts/new.haml
@@ -10,7 +10,7 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Add Post to Index
+        %th.editor-title{colspan: 2} Add Post to Index
     %tbody
       %tr
         %th.sub Index

--- a/app/views/index_sections/_single.haml
+++ b/app/views/index_sections/_single.haml
@@ -3,7 +3,7 @@
   %tr
     %td.continuity-spacer{colspan: 6}
 %tr
-  %th{colspan: 6, class: ('sub continuity-header' if in_collection)}
+  %th.table-title{colspan: 6, class: ('sub continuity-header' if in_collection)}
     = link_to section.name, index_section_path(section)
     - if section.index.editable_by?(current_user)
       = link_to new_index_post_path params: {index_id: section.index.id, index_section_id: section.id} do

--- a/app/views/index_sections/edit.haml
+++ b/app/views/index_sections/edit.haml
@@ -9,5 +9,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Edit Index
+        %th.editor-title{colspan: 2} Edit Index
     = render 'editor', f: f

--- a/app/views/index_sections/new.haml
+++ b/app/views/index_sections/new.haml
@@ -10,5 +10,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Create #{@index.try(:name)} Section
+        %th.editor-title{colspan: 2} Create #{@index.try(:name)} Section
     = render 'editor', f: f

--- a/app/views/indexes/edit.haml
+++ b/app/views/indexes/edit.haml
@@ -9,5 +9,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Edit Index
+        %th.editor-title{colspan: 2} Edit Index
     = render 'editor', f: f

--- a/app/views/indexes/index.haml
+++ b/app/views/indexes/index.haml
@@ -1,7 +1,7 @@
 %table
   %thead
     %tr
-      %th{colspan: 3}
+      %th.table-title{colspan: 3}
         Indexes
         - if logged_in? && current_user.admin?
           = link_to new_index_path do

--- a/app/views/indexes/new.haml
+++ b/app/views/indexes/new.haml
@@ -8,5 +8,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Create Index
+        %th.editor-title{colspan: 2} Create Index
     = render 'editor', f: f

--- a/app/views/indexes/show.haml
+++ b/app/views/indexes/show.haml
@@ -20,7 +20,7 @@
 %table
   %thead
     %tr
-      %th{colspan: 6}= content_for :posts_title
+      %th.table-title{colspan: 6}= content_for :posts_title
     - if @index.description.present?
       %tr
         %td.odd.written-content{colspan: 6}= sanitize_written_content(@index.description)

--- a/app/views/messages/_editor.haml
+++ b/app/views/messages/_editor.haml
@@ -3,7 +3,7 @@
   %table
     %thead
       %tr
-        %th{colspan: 2}
+        %th.table-title{colspan: 2}
           - if @message.thread_id.present?
             Reply to Thread
           - else

--- a/app/views/messages/_inbox.haml
+++ b/app/views/messages/_inbox.haml
@@ -1,5 +1,5 @@
 %tr
-  %th{colspan: 5}
+  %th.table-title{colspan: 5}
     Inbox
     = link_to messages_path params: {view: 'outbox'} do
       .view-button Outbox &raquo;

--- a/app/views/messages/_outbox.haml
+++ b/app/views/messages/_outbox.haml
@@ -1,5 +1,5 @@
 %tr
-  %th{colspan: 5}
+  %th.table-title{colspan: 5}
     Outbox
     = link_to messages_path params: {view: 'inbox'} do
       .view-button &laquo; Inbox

--- a/app/views/news/edit.haml
+++ b/app/views/news/edit.haml
@@ -7,5 +7,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Edit News Post
+        %th.editor-title{colspan: 2} Edit News Post
     = render 'editor', f: f

--- a/app/views/news/new.haml
+++ b/app/views/news/new.haml
@@ -7,5 +7,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Create News Post
+        %th.editor-title{colspan: 2} Create News Post
     = render 'editor', f: f

--- a/app/views/password_resets/new.haml
+++ b/app/views/password_resets/new.haml
@@ -1,7 +1,7 @@
 = form_tag password_resets_path, method: :post do
   %table.form-table
     %tr
-      %th.centered{colspan: 2} Request Password Reset
+      %th.editor-title{colspan: 2} Request Password Reset
     %tr
       %th.sub Username
       %td.even= text_field_tag :username, params[:username], placeholder: "Username", class: 'text', id: 'user_username'

--- a/app/views/password_resets/show.haml
+++ b/app/views/password_resets/show.haml
@@ -1,7 +1,7 @@
 = form_for @password_reset, url: password_reset_path(id: @password_reset.auth_token), method: :put do
   %table.form-table
     %tr
-      %th.centered{colspan: 2} Change Password
+      %th.editor-title{colspan: 2} Change Password
     %tr
       %th.sub New
       %td.odd= password_field_tag :password, params[:password], placeholder: "New Password", class: 'text'

--- a/app/views/posts/_list.haml
+++ b/app/views/posts/_list.haml
@@ -9,7 +9,7 @@
 %table{class: local_assigns[:table_class].to_s}
   %thead
     %tr
-      %th{colspan: col_count}= content_for :posts_title
+      %th.table-title{colspan: col_count}= content_for :posts_title
     - if content_for? :post_list_description
       %tr
         %td.odd.written-content{colspan: col_count}= content_for :post_list_description

--- a/app/views/posts/hidden.haml
+++ b/app/views/posts/hidden.haml
@@ -2,7 +2,7 @@
   %table
     %thead
       %tr
-        %th{colspan: 7}
+        %th.table-title{colspan: 7}
           Hidden from Unread
           = link_to unread_posts_path do
             .view-button Unread &raquo;

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -7,7 +7,7 @@
         Search Posts
         - if @search_results
           = '- ' + @search_results.total_entries.to_s + ' results'
-      %th
+      %th.search-results-header
         - if @search_results
           = render 'paginator', paginated: @search_results
   %tbody
@@ -55,4 +55,4 @@
     %tfoot
       %tr
         %th.width-150.empty
-        %th= render 'paginator', paginated: @search_results
+        %th.search-results-header= render 'paginator', paginated: @search_results

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -3,7 +3,7 @@
 %table.search-collapsible
   %thead
     %tr
-      %th.width-150
+      %th.search-params-header
         Search Posts
         - if @search_results
           = '- ' + @search_results.total_entries.to_s + ' results'
@@ -54,5 +54,5 @@
   - if @search_results && @search_results.total_pages > 1
     %tfoot
       %tr
-        %th.width-150.empty
+        %th.search-params-header.empty
         %th.search-results-header= render 'paginator', paginated: @search_results

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -13,7 +13,7 @@
 %table#stats
   %thead
     %tr
-      %th{colspan: 2}
+      %th.table-title{colspan: 2}
         Metadata:
         = link_to @post.subject, post_path(@post)
         - if @post.metadata_editable_by?(current_user)

--- a/app/views/posts/unread.haml
+++ b/app/views/posts/unread.haml
@@ -27,7 +27,7 @@
   %table.float-left.form-table{style: 'margin-bottom: 10px;'}
     %thead
       %tr
-        %th Mark Entire Continuity
+        %th.table-title Mark Entire Continuity
     %tbody
       %tr
         %td.even.padding-5.centered

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -7,7 +7,7 @@
         Search Replies
         - if @search_results
           = '- '+@search_results.total_entries.to_s+' results'
-      %th
+      %th.search-results-header
         - if @search_results
           = render 'posts/paginator', paginated: @search_results, no_per: true
   %tbody
@@ -98,4 +98,4 @@
     %tfoot
       %tr
         %th.width-150.empty
-        %th= render 'posts/paginator', paginated: @search_results, no_per: true
+        %th.search-results-header= render 'posts/paginator', paginated: @search_results, no_per: true

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -3,7 +3,7 @@
 %table.search-collapsible
   %thead
     %tr
-      %th.width-150
+      %th.search-params-header
         Search Replies
         - if @search_results
           = '- '+@search_results.total_entries.to_s+' results'
@@ -97,5 +97,5 @@
   - if @search_results && @search_results.total_pages > 1
     %tfoot
       %tr
-        %th.width-150.empty
+        %th.search-params-header.empty
         %th.search-results-header= render 'posts/paginator', paginated: @search_results, no_per: true

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -3,7 +3,7 @@
 %table
   %thead
     %tr
-      %th{colspan: 7}
+      %th.table-title{colspan: 7}
         Daily Report -
         = @day.strftime("%b %d, %Y")
         - if @day == Time.zone.today

--- a/app/views/reports/_monthly.haml
+++ b/app/views/reports/_monthly.haml
@@ -3,7 +3,7 @@
 %table
   %thead
     %tr
-      %th{colspan: 6} Monthly Report
+      %th.table-title{colspan: 6} Monthly Report
   - 1.upto(1.month.ago.end_of_month.day) do |num_days|
     - day = 1.month.ago.end_of_month - (num_days - 1).days
     - posts = posts_from_relation(Post.where(tagged_at: day.beginning_of_day .. day.end_of_day))

--- a/app/views/sessions/new.haml
+++ b/app/views/sessions/new.haml
@@ -2,7 +2,7 @@
   %table.form-table
     %thead
       %tr
-        %th{colspan: 2} Sign In
+        %th.table-title{colspan: 2} Sign In
     %tbody
       %tr#username-row
         %th.sub.vtop Username

--- a/app/views/tags/_characters.haml
+++ b/app/views/tags/_characters.haml
@@ -1,6 +1,6 @@
 %table.tag-right-content-box
   %thead
     %tr
-      %th{colspan: 7} Characters Tagged: #{@tag.name}
+      %th.table-title{colspan: 7} Characters Tagged: #{@tag.name}
   %tbody
     = render 'characters/list_section', name: nil, characters: @characters, hide_buttons: true, show_user: true, show_template: true

--- a/app/views/tags/_galleries.haml
+++ b/app/views/tags/_galleries.haml
@@ -1,7 +1,7 @@
 %table.tag-right-content-box
   %thead
     %tr
-      %th{colspan: 4} Galleries Tagged: #{@tag.name}
+      %th.table-title{colspan: 4} Galleries Tagged: #{@tag.name}
   %tbody
     - if @galleries.present?
       = render partial: 'galleries/expandable', collection: @galleries, as: :gallery, locals: {tag: @tag}

--- a/app/views/tags/_info.haml
+++ b/app/views/tags/_info.haml
@@ -1,7 +1,7 @@
 %table.tag-right-content-box
   %thead
     %tr
-      %th{colspan: 2} Info
+      %th.table-title{colspan: 2} Info
   %tbody
     - if @tag.is_a?(Setting) && @tag.parent_settings.present?
       %tr

--- a/app/views/tags/_info.haml
+++ b/app/views/tags/_info.haml
@@ -5,12 +5,12 @@
   %tbody
     - if @tag.is_a?(Setting) && @tag.parent_settings.present?
       %tr
-        %th.centered.sub.width-150= 'Parent Setting'.pluralize(@tag.parent_settings.count)
+        %th.sub.centered.width-150= 'Parent Setting'.pluralize(@tag.parent_settings.count)
         - setting_links = @tag.parent_settings.map { |c| link_to(c.name, tag_path(c))}
         %td{class: cycle('even', 'odd')}= safe_join(setting_links, ', ')
     - if @tag.is_a?(Setting)
       %tr
-        %th.centered.sub.width-150 Owner
+        %th.sub.centered.width-150 Owner
         %td{class: cycle('even', 'odd'), title: ('This setting is not marked as owned' unless @tag.owned?)}
           = link_to @tag.user do
             - if @tag.owned?
@@ -19,5 +19,5 @@
               %em= @tag.user.deleted? ? 'deleted user' : @tag.user.username
     - if @tag.description.present?
       %tr
-        %th.centered.sub.width-150.vtop Description
+        %th.sub.centered.width-150.vtop Description
         %td.written-content{class: cycle('even', 'odd')}= sanitize_written_content(@tag.description)

--- a/app/views/tags/_settings.haml
+++ b/app/views/tags/_settings.haml
@@ -1,7 +1,7 @@
 %table.tag-right-content-box
   %thead
     %tr
-      %th{colspan: 6} Settings Tagged: #{@tag.name}
+      %th.table-title{colspan: 6} Settings Tagged: #{@tag.name}
   %tbody
     - @tag.child_settings.each do |setting|
       %tr

--- a/app/views/tags/edit.haml
+++ b/app/views/tags/edit.haml
@@ -12,5 +12,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Edit #{@tag.type.titlecase}
+        %th.editor-title{colspan: 2} Edit #{@tag.type.titlecase}
     = render 'editor', f: f

--- a/app/views/tags/index.haml
+++ b/app/views/tags/index.haml
@@ -11,7 +11,7 @@
 %table
   %thead
     %tr
-      %th{colspan: col_count}
+      %th.table-title{colspan: col_count}
         = @view.present? ? @view.titlecase.pluralize : 'Tags'
     %tr
       %th.subber.padding-10{colspan: col_count}

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -8,7 +8,7 @@
 %table.left-info-box.tag-info-box
   %thead
     %tr
-      %th.table-title-centered
+      %th.info-box-header
         %span.character-name #{@tag.type.titlecase}: #{@tag.name}
   %tbody
     %tr

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -8,7 +8,7 @@
 %table.left-info-box.tag-info-box
   %thead
     %tr
-      %th.centered
+      %th.table-title-centered
         %span.character-name #{@tag.type.titlecase}: #{@tag.name}
   %tbody
     %tr

--- a/app/views/templates/edit.haml
+++ b/app/views/templates/edit.haml
@@ -9,5 +9,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Edit Template
+        %th.editor-title{colspan: 2} Edit Template
     = render 'editor', f: f

--- a/app/views/templates/new.haml
+++ b/app/views/templates/new.haml
@@ -7,5 +7,5 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} New Template
+        %th.editor-title{colspan: 2} New Template
     = render 'editor', f: f

--- a/app/views/templates/show.haml
+++ b/app/views/templates/show.haml
@@ -12,7 +12,7 @@
 %table
   %thead
     %tr
-      %th{colspan: 6}
+      %th.table-title{colspan: 6}
         Template: #{@template.name}
         - if @template.user_id == current_user.try(:id)
           = link_to new_character_path(template_id: @template.id) do

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -2,7 +2,7 @@
   %table.form-table
     %thead
       %tr
-        %th.centered{colspan: 2} Account Settings
+        %th.editor-title{colspan: 2} Account Settings
     %tbody
       %tr
         %th.sub Username
@@ -94,7 +94,7 @@
   %table.form-table#change-password
     %thead
       %tr
-        %th.centered{colspan: 2} Change Password
+        %th.editor-title{colspan: 2} Change Password
     %tbody
       %tr
         %th.sub Old

--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -1,7 +1,7 @@
 %table
   %thead
     %tr
-      %th{colspan: 3} Users
+      %th.table-title{colspan: 3} Users
     %tr
       %th.subber.padding-10{colspan: 3}
         = form_tag search_users_path, method: :get do

--- a/app/views/users/new.haml
+++ b/app/views/users/new.haml
@@ -2,7 +2,7 @@
   %table#signup.form-table
     %thead
       %tr
-        %th{colspan: 2} Sign Up
+        %th.table-title{colspan: 2} Sign Up
     %tbody
       %tr#signup-username
         %th.sub.vtop Username

--- a/app/views/users/search.haml
+++ b/app/views/users/search.haml
@@ -3,7 +3,7 @@
 %table.search-collapsible
   %thead
     %tr
-      %th.width-150
+      %th.search-params-header
         Search Users
         - if @search_results
           = '- '+@search_results.total_entries.to_s+' results'
@@ -39,5 +39,5 @@
   - if @search_results && @search_results.total_pages > 1
     %tfoot
       %tr
-        %th.width-150.empty
+        %th.search-params-header.empty
         %th.search-results-header= render 'posts/paginator', paginated: @search_results, no_per: true

--- a/app/views/users/search.haml
+++ b/app/views/users/search.haml
@@ -7,7 +7,7 @@
         Search Users
         - if @search_results
           = '- '+@search_results.total_entries.to_s+' results'
-      %th
+      %th.search-results-header
         - if @search_results
           = render 'posts/paginator', paginated: @search_results, no_per: true
   %tbody
@@ -40,4 +40,4 @@
     %tfoot
       %tr
         %th.width-150.empty
-        %th= render 'posts/paginator', paginated: @search_results, no_per: true
+        %th.search-results-header= render 'posts/paginator', paginated: @search_results, no_per: true

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -1,7 +1,7 @@
 %table.left-info-box.user-info-box
   %thead
     %tr
-      %th.centered
+      %th.info-box-header
         .username= @user.username
         - if @user.moiety
           .user-moiety

--- a/app/views/writable/_history.haml
+++ b/app/views/writable/_history.haml
@@ -23,7 +23,7 @@
             = surround '"' do
               = audit.comment
       %tr
-        %th.history-header.sub Fields Changed
+        %th.sub.history-header Fields Changed
         %td{class: cycle('even', 'odd')}
           - if audit.version == 1
             (Original)

--- a/app/views/writable/_history.haml
+++ b/app/views/writable/_history.haml
@@ -12,7 +12,7 @@
       - reset_cycle
       %tr.bg.spacer{style: 'height:20px;'}
       %tr
-        %th{colspan: 2} Version: #{audit.version}
+        %th.table-title{colspan: 2} Version: #{audit.version}
       - if audit.comment.present?
         %tr
           %td.post-subheader{colspan: 2}


### PR DESCRIPTION
Addresses #826

- [x] Add new selector to all uses of `th` that do not have another selector overriding the css on th
- [x] Modify selectors to catch common combinations with other semantic selectors
- [x] Rename new selectors to something more descriptive
  - [x] Rename `.old_th`
  - [x] Rename `.old_th_centered`
  - [x] Rename `.old_th_width-150`
  - [x] Rename `.old_th_padding-10`
- [ ] Test with css tests