### PR TITLE
Upgrade rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,11 @@ Layout/CaseIndentation:
   EnforcedStyle: 'end'
   IndentOneStep: true
 
+Layout/ClosingHeredocIndentation:
+  Enabled: true
+  Exclude:
+    - 'db/migrate/**/*'
+
 Layout/ClosingParenthesisIndentation:
   Enabled: false
 
@@ -66,6 +71,11 @@ Layout/IndentArray:
 Layout/IndentHash:
   Enabled: true
   EnforcedStyle: 'consistent'
+
+Layout/IndentHeredoc:
+  Enabled: true
+  Exclude:
+    - 'db/migrate/**/*'
 
 Layout/MultilineHashBraceLayout:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
-  gem 'rubocop', '~> 0.54.0'
+  gem 'rubocop', '~> 0.57.0'
   gem 'web-console', '~> 3.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.0.0)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.1)
     jmespath (1.3.1)
     jquery-fileupload-rails (0.4.7)
       actionpack (>= 3.1)
@@ -188,7 +189,7 @@ GEM
     nokogumbo (1.5.0)
       nokogiri
     parallel (1.12.1)
-    parser (2.5.0.5)
+    parser (2.5.1.0)
       ast (~> 2.4.0)
     pg (0.21.0)
     pg_search (2.1.2)
@@ -196,7 +197,7 @@ GEM
       activesupport (>= 4.2)
       arel (>= 6)
     power_assert (1.1.1)
-    powerpack (0.1.1)
+    powerpack (0.1.2)
     public_suffix (3.0.2)
     puma (3.11.3)
     rack (2.0.4)
@@ -310,7 +311,8 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.54.0)
+    rubocop (0.57.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5)
       powerpack (~> 0.1)
@@ -385,7 +387,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.8)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.4.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
     web-console (3.5.1)
@@ -454,7 +456,7 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails
-  rubocop (~> 0.54.0)
+  rubocop (~> 0.57.0)
   sanitize
   sass-rails
   seed_dump (~> 3.2)
@@ -474,4 +476,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -188,7 +188,7 @@ class Post < ApplicationRecord
 
     # testing for case where the post was changed in status more recently than the last reply
     audits_since_last_reply = audits.where('created_at > ?', most_recent.created_at)
-    audit = audits_since_last_reply.detect { |a| a.audited_changes.keys.include?('status') }
+    audit = audits_since_last_reply.detect { |a| a.audited_changes.key?('status') }
     return most_recent.updated_at unless audit
     self.edited_at
   end

--- a/lib/post_scraper.rb
+++ b/lib/post_scraper.rb
@@ -216,7 +216,7 @@ class PostScraper < Object
   end
 
   def set_from_username(tag, username)
-    if BASE_ACCOUNTS.keys.include?(username)
+    if BASE_ACCOUNTS.key?(username)
       tag.user = User.find_by(username: BASE_ACCOUNTS[username])
       return
     end


### PR DESCRIPTION
* Updates rubocop from 0.54 to 0.57
* Disables two cops
* Makes a minor optimization suggested by a new cop