### PR TITLE
gallery#add_new: Don't process directional keys as grid movement if text selected

### DIFF
--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -20,6 +20,9 @@ function processDirectionalKey(event) {
   if (input.get(0).type !== 'text') return;
 
   var caret = input.get(0).selectionStart;
+  var caretEnd = input.get(0).selectionEnd;
+  if (caret !== caretEnd) return; // skip processing if user has text selected
+
   var length = input.val().length;
   var index = $(this).closest('td').index();
 


### PR DESCRIPTION
In gallery#add_new, if all text in an input box was previously
selected, and the left directional key was pressed, it would move box;
this change means that, if some text is selected (the start and end
selection carets don't match), then the event will be processed
normally instead (and so the directional triggers only occur if there's
no selection in the input box).

Fixes #445.