### PR TITLE
Upgrade rubocop to 0.59

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,9 @@ Layout/EmptyLineBetweenDefs:
 Layout/EmptyLines:
   Enabled: false
 
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
 Layout/EmptyLinesAroundAccessModifier:
   Enabled: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
-  gem 'rubocop', '~> 0.57.0'
+  gem 'rubocop', '~> 0.59.0'
   gem 'web-console', '~> 3.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,10 +317,10 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.57.2)
+    rubocop (0.59.2)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
@@ -465,7 +465,7 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails (~> 3.7.2)
-  rubocop (~> 0.57.0)
+  rubocop (~> 0.59.0)
   sanitize
   sass-rails
   seed_dump (~> 3.2)


### PR DESCRIPTION
Only new rubocop failures are the Rails/SaveBang thing and some false positives on rescue statement alignment, unless something is hiding. 

(I checked this by making a auto-generated todo before upgrading rubocop, so something could be hiding for one of the old cops in a file that's excluding.)