### PR TITLE
Fix nil .fields error

### DIFF
--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -64,6 +64,9 @@ class IconsController < UploadingController
       flash.now[:error][:message] = "Your icon could not be saved due to the following problems:"
       flash.now[:error][:array] = @icon.errors.full_messages
       @page_title = 'Edit icon: ' + @icon.keyword_was
+      use_javascript('galleries/update_existing')
+      use_javascript('galleries/uploader')
+      set_s3_url
       render action: :edit and return
     end
 


### PR DESCRIPTION
We got the following error email:
```An ActionView::Template::Error occurred in icons#update:

  undefined method `fields' for nil:NilClass
  app/views/icons/edit.haml:13```

which was occuring because when you tried and failed to edit an icon, the update method would render edit, but the s3 url was only intiialized on #edit not #update. This makes the initializations match.