### PR TITLE
Improve BoardSection creation

### DIFF
--- a/app/controllers/board_sections_controller.rb
+++ b/app/controllers/board_sections_controller.rb
@@ -11,7 +11,7 @@ class BoardSectionsController < ApplicationController
 
   def create
     @board_section = BoardSection.new(section_params)
-    unless @board_section.board.editable_by?(current_user)
+    unless @board_section.board.nil? || @board_section.board.editable_by?(current_user)
       flash[:error] = "You do not have permission to edit this continuity."
       redirect_to boards_path and return
     end

--- a/app/views/board_sections/new.haml
+++ b/app/views/board_sections/new.haml
@@ -1,5 +1,5 @@
 = form_for @board_section, url: board_sections_path, method: :post do |f|
   %table.form-table
     %tr
-      %th.centered{colspan: 2}= "Create #{@board.try(:name)} Section"
+      %th.centered{colspan: 2}= "Create #{@board_section&.board&.name} Section"
     = render partial: 'editor', locals: {f: f}

--- a/spec/controllers/board_sections_controller_spec.rb
+++ b/spec/controllers/board_sections_controller_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe BoardSectionsController do
       expect(flash[:error][:message]).to eq("Section could not be created.")
     end
 
+    it "requires valid board for section" do
+      board = create(:board)
+      login_as(board.creator)
+      post :create, params: { board_section: {name: 'fake'} }
+      expect(response).to have_http_status(200)
+      expect(response).to render_template(:new)
+      expect(flash[:error][:message]).to eq("Section could not be created.")
+    end
+
     it "succeeds" do
       board = create(:board)
       login_as(board.creator)


### PR DESCRIPTION
- Displaying the continuity name in the create form was broken
- Page would crash if the continuity did not exist

Fixes #858 