### PR TITLE
Preserve Condensed checkbox state through search form submission

### DIFF
--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -52,7 +52,7 @@
             %tr
               %td= label_tag :condensed, 'Condensed'
               %td
-                = check_box_tag :condensed, nil, true, class: 'vmid'
+                = check_box_tag :condensed, nil, (params[:commit].nil? || params[:condensed].present?), class: 'vmid'
                 = label_tag :condensed, 'Hide screennames and icons'
             %tr
               %td.centered{colspan: 2}= submit_tag "Search", class: 'button'


### PR DESCRIPTION
Update checkbox from `true` (always on) to `commit.nil or condensed.present` (true if form not submitted, true iff condensed set when submitted) to properly preserve the user selected state of the condensed checkbox through form submissions.

Fixes #853 