### PR TITLE
Add --rm flags to docker-compose run commands, to autoremove containers

### DIFF
--- a/bin-docker/bundle
+++ b/bin-docker/bundle
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose run web bundle "$@"
+docker-compose run --rm web bundle "$@"

--- a/bin-docker/psql
+++ b/bin-docker/psql
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose run postgres psql "$@"
+docker-compose run --rm postgres psql "$@"

--- a/bin-docker/rails
+++ b/bin-docker/rails
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose run web bin/rails $@
+docker-compose run --rm web bin/rails $@

--- a/bin-docker/rake
+++ b/bin-docker/rake
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose run web rake "$@"
+docker-compose run --rm web rake "$@"

--- a/bin-docker/record_examples
+++ b/bin-docker/record_examples
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose run -e "APIPIE_RECORD=examples" web bundle exec rspec spec/controllers/api
+docker-compose run --rm -e "APIPIE_RECORD=examples" web bundle exec rspec spec/controllers/api

--- a/bin-docker/rspec
+++ b/bin-docker/rspec
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose run web bundle exec rspec "$@"
+docker-compose run --rm web bundle exec rspec "$@"


### PR DESCRIPTION
Prior to this, containers would remain (though stopped) after tasks finish
executing. This causes them to automatically remove themselves after they
finish execution.