### PR TITLE
Fixes #894 - Daily Report crashes with out of range dates

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -17,7 +17,10 @@ class ReportsController < ApplicationController
     if params[:day].present?
       @day = begin
          params[:day].in_time_zone(Time.zone).to_date
-       rescue NoMethodError # invalid time stamps processed with .in_time_zone return nil
+
+       # invalid time stamps processed with .in_time_zone return nil and raise NoMethodError
+       # whereas out of range timestamps like January 32nd raise ArgumentError
+       rescue NoMethodError, ArgumentError
          Time.zone.now.to_date
        end
     else

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe ReportsController do
       expect(assigns(:opened_posts).first.read_at).to be_the_same_time_as(time)
     end
 
+    it "handles invalid day argument" do
+      get :show, params: { id: 'daily', day: 'asdf' }
+      expect(response).to have_http_status(200)
+    end
+
+    it "handles out of range argument" do
+      get :show, params: { id: 'daily', day: '2018-28-10' }
+      expect(response).to have_http_status(200)
+    end
+
     it "succeeds with monthly" do
       get :show, params: { id: 'monthly' }
       expect(response).to have_http_status(200)


### PR DESCRIPTION
Example we saw that caused error emails was a user passing month and day switched, e.g. 2018-28-10 instead of 2018-10-28 to represent October 28, 2018.