### PR TITLE
Remove TuneMyGC gem as we no longer use it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :production do
   gem 'rack-cors'
   gem 'rack-timeout'
   gem 'rails_12factor'
-  gem 'tunemygc'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,7 +386,6 @@ GEM
     timecop (0.9.1)
     tinymce-rails (4.6.7)
       railties (>= 3.1.1)
-    tunemygc (1.0.71)
     twitter-bootstrap-rails (4.0.0)
       actionpack (~> 5.0, >= 5.0.1)
       execjs (~> 2.7)
@@ -475,7 +474,6 @@ DEPENDENCIES
   thin
   timecop
   tinymce-rails (~> 4.6.7)
-  tunemygc
   uglifier
   web-console (~> 3.0)
   webmock


### PR DESCRIPTION
I have already uninstalled the Heroku addon; this is just cleanliness.