### PR TITLE
Fix displayed icon count

### DIFF
--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -53,6 +53,15 @@ class IconsController < UploadingController
     else
       posts_using = Post.where(icon_id: @icon.id)
       replies_using = Reply.where(icon_id: @icon.id)
+      if logged_in?
+        unless @icon.user == current_user
+          posts_using = posts_using.where(privacy: [Concealable::PUBLIC, Concealable::REGISTERED])
+          replies_using = replies_using.where(posts: {privacy: [Concealable::PUBLIC, Concealable::REGISTERED]}).joins(:post)
+        end
+      else
+        posts_using = posts_using.where(privacy: Concealable::PUBLIC)
+        replies_using = replies_using.where(posts: {privacy: Concealable::PUBLIC}).joins(:post)
+      end
       @times_used = (posts_using.count + replies_using.count)
       @posts_used = (posts_using.pluck(:id) + replies_using.pluck('distinct post_id')).uniq.count
     end

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -54,7 +54,7 @@ class IconsController < UploadingController
       posts_using = Post.where(icon_id: @icon.id).visible_to(current_user)
       replies_using = Reply.where(icon_id: @icon.id).visible_to(current_user)
       @times_used = (posts_using.count + replies_using.count)
-      @posts_used = (posts_using.pluck(:id) + replies_using.pluck('distinct post_id')).uniq.count
+      @posts_used = (posts_using.pluck(:id) + replies_using.select(:post_id).distinct.pluck(:post_id)).uniq.count
     end
   end
 

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -50,6 +50,11 @@ class IconsController < UploadingController
       @posts = posts_from_relation(Post.where(where_calc).ordered)
     elsif params[:view] == 'galleries'
       use_javascript('galleries/expander_old')
+    else
+      posts_using = Post.where(icon_id: @icon.id)
+      replies_using = Reply.where(icon_id: @icon.id)
+      @times_used = (posts_using.count + replies_using.count)
+      @posts_used = (posts_using.pluck(:id) + replies_using.pluck('distinct post_id')).uniq.count
     end
   end
 

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -51,17 +51,8 @@ class IconsController < UploadingController
     elsif params[:view] == 'galleries'
       use_javascript('galleries/expander_old')
     else
-      posts_using = Post.where(icon_id: @icon.id)
-      replies_using = Reply.where(icon_id: @icon.id)
-      if logged_in?
-        unless @icon.user == current_user
-          posts_using = posts_using.where(privacy: [Concealable::PUBLIC, Concealable::REGISTERED])
-          replies_using = replies_using.where(posts: {privacy: [Concealable::PUBLIC, Concealable::REGISTERED]}).joins(:post)
-        end
-      else
-        posts_using = posts_using.where(privacy: Concealable::PUBLIC)
-        replies_using = replies_using.where(posts: {privacy: Concealable::PUBLIC}).joins(:post)
-      end
+      posts_using = Post.where(icon_id: @icon.id).visible_to(current_user)
+      replies_using = Reply.where(icon_id: @icon.id).visible_to(current_user)
       @times_used = (posts_using.count + replies_using.count)
       @posts_used = (posts_using.pluck(:id) + replies_using.pluck('distinct post_id')).uniq.count
     end

--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -87,8 +87,6 @@
     Posts Containing Icon
   = render 'posts/list', posts: @posts, table_class: 'icon-right-content-box'
 - else
-  - posts_using = Post.where(icon_id: @icon.id)
-  - replies_using = Reply.where(icon_id: @icon.id)
   %table.icon-right-content-box
     %thead
       %tr
@@ -96,7 +94,7 @@
     %tbody
       %tr
         %th.sub.width-150 Times Used
-        %td.even=(posts_using.count + replies_using.count).to_s
+        %td.even= @times_used.to_s
       %tr
         %th.sub.width-150 Posts In
-        %td.even= (posts_using.pluck(:id) + replies_using.pluck('distinct post_id')).uniq.count
+        %td.even= @posts_used

--- a/spec/controllers/icons_controller_spec.rb
+++ b/spec/controllers/icons_controller_spec.rb
@@ -235,6 +235,43 @@ RSpec.describe IconsController do
         expect(assigns(:javascripts)).to include('galleries/expander_old')
       end
     end
+
+    context "stats view" do
+      let(:icon) { create(:icon) }
+      let(:post) { create(:post, icon: icon, user: icon.user) }
+      let(:reply) { create(:reply, icon: icon, user: icon.user, post: create(:post)) }
+      let(:private_post) { create(:post, icon: icon, user: icon.user, privacy: Concealable::PRIVATE) }
+      let(:registered_post) { create(:post, icon: icon, user: icon.user, privacy: Concealable::REGISTERED) }
+      before(:each) do
+        create(:reply, post: post, user: icon.user, icon: icon)
+        reply
+        private_post
+        registered_post
+      end
+
+      it "fetches correct counts for icon owner" do
+        login_as(icon.user)
+        get :show, params: { id: icon.id }
+        expect(response).to have_http_status(200)
+        expect(assigns(:times_used)).to eq(5)
+        expect(assigns(:posts_used)).to eq(4)
+      end
+
+      it "fetches correct counts when logged out" do
+        login
+        get :show, params: { id: icon.id }
+        expect(response).to have_http_status(200)
+        expect(assigns(:times_used)).to eq(4)
+        expect(assigns(:posts_used)).to eq(3)
+      end
+
+      it "fetches corect counts when logged in" do
+        get :show, params: { id: icon.id }
+        expect(response).to have_http_status(200)
+        expect(assigns(:times_used)).to eq(3)
+        expect(assigns(:posts_used)).to eq(2)
+      end
+    end
   end
 
   describe "GET edit" do


### PR DESCRIPTION
* Moves calculating the times an icon is used and the number of posts it's used in from the view to the controller
* Limits the posts the count is determined from to public posts, and constellation-only posts for logged in users who are not the icon owner (the count is should be unaffected for the icon owner) (Fixes #901)