### PR TITLE
Blocks: Add functionality to hide posts

### DIFF
--- a/app/concerns/blockable.rb
+++ b/app/concerns/blockable.rb
@@ -13,6 +13,11 @@ module Blockable
     user_ids_blocked_interaction.include?(user.id)
   end
 
+  def author_blocking?(post, author_ids)
+    return false unless post.authors_locked
+    Block.where(blocking_user_id: author_ids, blocked_user: self).where("hide_me >= ?", Block::POSTS).exists?
+  end
+
   def user_ids_blocked_interaction
     Block.where(block_interactions: true, blocking_user: self).pluck(:blocked_user_id)
   end
@@ -23,5 +28,13 @@ module Blockable
 
   def user_ids_uninteractable
     (user_ids_blocking_interaction + user_ids_blocked_interaction).uniq
+  end
+
+  def hidden_post_users
+    (blocking_post_users + Block.where(blocking_user: self).where("hide_them >= ?", Block::POSTS).pluck(:blocked_user_id)).uniq
+  end
+
+  def blocking_post_users
+    Block.where(blocked_user: self).where("hide_me >= ?", Block::POSTS).pluck(:blocking_user_id)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,15 +90,15 @@ class ApplicationController < ActionController::Base
   end
   helper_method :tos_skippable?
 
-  def posts_from_relation(relation, no_tests: true, with_pagination: true, select: '', max: false, with_unread: false)
-    posts = posts_list_relation(relation, no_tests: no_tests, select: select, max: max)
+  def posts_from_relation(relation, no_tests: true, with_pagination: true, select: '', max: false, with_unread: false, show_blocked: false)
+    posts = posts_list_relation(relation, no_tests: no_tests, select: select, max: max, show_blocked: show_blocked)
     posts = posts.paginate(page: page) if with_pagination
     calculate_view_status(posts, with_unread: with_unread) if logged_in?
     posts
   end
   helper_method :posts_from_relation
 
-  def posts_list_relation(relation, no_tests: true, select: '', max: false)
+  def posts_list_relation(relation, no_tests: true, select: '', max: false, show_blocked: false)
     select = if max
       <<~SQL
         posts.*,
@@ -126,6 +126,7 @@ class ApplicationController < ActionController::Base
       .with_has_content_warnings
       .with_reply_count
 
+    posts = posts.where_not_hidden(current_user) unless show_blocked
     posts = posts.no_tests if no_tests
     posts
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,7 +126,7 @@ class ApplicationController < ActionController::Base
       .with_has_content_warnings
       .with_reply_count
 
-    posts = posts.where_not_hidden(current_user) unless show_blocked
+    posts = posts.where.not(id: current_user.hidden_posts) if logged_in? && !show_blocked
     posts = posts.no_tests if no_tests
     posts
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < WritableController
   before_action :editor_setup, only: [:new, :edit]
 
   def index
-    @posts = posts_from_relation(Post.ordered)
+    @posts = posts_from_relation(Post.ordered, show_blocked: !!params[:show_blocked])
     @page_title = 'Recent Threads'
   end
 
@@ -59,7 +59,7 @@ class PostsController < WritableController
       .or(with_post_view.where("date_trunc('second', post_views.read_at) < date_trunc('second', posts.tagged_at)"))
 
     @posts = with_post_view.or(no_post_view)
-    @posts = posts_from_relation(@posts.ordered, with_unread: true)
+    @posts = posts_from_relation(@posts.ordered, with_unread: true, show_blocked: !!params[:show_blocked])
 
     @hide_quicklinks = true
     @page_title = @started ? 'Opened Threads' : 'Unread Threads'
@@ -280,7 +280,7 @@ class PostsController < WritableController
       post_ids = Reply.where(character_id: params[:character_id]).select(:post_id).distinct.pluck(:post_id)
       @search_results = @search_results.where(character_id: params[:character_id]).or(@search_results.where(id: post_ids))
     end
-    @search_results = posts_from_relation(@search_results)
+    @search_results = posts_from_relation(@search_results, show_blocked: !!params[:show_blocked])
   end
 
   def warnings

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -85,7 +85,7 @@ class RepliesController < WritableController
       .paginate(page: page)
       .includes(:post)
 
-    @search_results = @search_results.where_not_hidden(current_user) unless !!params[:show_blocked]
+    @search_results = @search_results.where.not(post_id: current_user.hidden_posts) if logged_in? && !params[:show_blocked]
 
     unless params[:condensed]
       @search_results = @search_results

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -85,6 +85,8 @@ class RepliesController < WritableController
       .paginate(page: page)
       .includes(:post)
 
+    @search_results = @search_results.where_not_hidden(current_user) unless !!params[:show_blocked]
+
     unless params[:condensed]
       @search_results = @search_results
         .select('icons.keyword, icons.url')

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -31,6 +31,8 @@ class Reply < ApplicationRecord
 
   scope :visible_to, ->(user) { where(post_id: Post.visible_to(user).select(:id)) }
 
+  scope :where_not_hidden, ->(user) { where(post_id: Post.where_not_hidden(user).select(:id)) }
+
   def post_page(per=25)
     per_page = per > 0 ? per : post.replies.count
     index = post.replies.where('reply_order < ?', self.reply_order).count

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -31,8 +31,6 @@ class Reply < ApplicationRecord
 
   scope :visible_to, ->(user) { where(post_id: Post.visible_to(user).select(:id)) }
 
-  scope :where_not_hidden, ->(user) { where(post_id: Post.where_not_hidden(user).select(:id)) }
-
   def post_page(per=25)
     per_page = per > 0 ? per : post.replies.count
     index = post.replies.where('reply_order < ?', self.reply_order).count

--- a/app/views/blocks/index.haml
+++ b/app/views/blocks/index.haml
@@ -3,7 +3,8 @@
 - content_for :flashes do
   .flash.error
     = image_tag "icons/exclamation.png".freeze, class: 'vmid'.freeze
-    Warning: blocking is not currently implemented. This page should remember any blocks you have created, but they will not take effect yet.
+    Warning: full blocking is not yet implemented, and will function the same as simply blocking posts.
+    Additionally, any threads not locked to their authors will not be covered by post or (at present) full blocking.
 
 %table
   %thead

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -3133,4 +3133,99 @@ RSpec.describe PostsController do
       expect(response).to redirect_to(hidden_posts_url)
     end
   end
+
+  shared_examples "logged out post list" do
+    it "does not show user-only posts" do
+      posts = create_list(:post, 2)
+      create_list(:post, 2, privacy: Concealable::REGISTERED)
+      get controller_action, params: params
+      expect(response.status).to eq(200)
+      expect(Post.all.count).to eq(4)
+      expect(assigns(assign_variable)).to match_array(posts)
+    end
+  end
+
+  shared_examples "logged in post list" do
+    let(:user) { create(:user) }
+    let(:posts) { create_list(:post, 3) }
+
+    before(:each) {
+      login_as(user)
+      posts
+    }
+
+    it "does not show access-locked or private threads" do
+      create(:post, privacy: Concealable::PRIVATE)
+      create(:post, privacy: Concealable::ACCESS_LIST)
+      get controller_action, params: params
+      expect(response.status).to eq(200)
+      expect(assigns(assign_variable)).to match_array(posts)
+    end
+
+    it "shows access-locked and private threads if you have access" do
+      posts << create(:post, user: user, privacy: Concealable::PRIVATE)
+      posts << create(:post, user: user, privacy: Concealable::ACCESS_LIST)
+      get controller_action, params: params
+      expect(response.status).to eq(200)
+      expect(assigns(assign_variable)).to match_array(posts)
+    end
+
+    it "does not show posts with blocked or blocking authors" do
+      post1 = create(:post, authors_locked: true)
+      post2 = create(:post, authors_locked: true)
+      create(:block, blocking_user: user, blocked_user: post1.user, hide_them: Block::POSTS)
+      create(:block, blocking_user: post2.user, blocked_user: user, hide_me: Block::POSTS)
+      get controller_action, params: params
+      expect(response.status).to eq(200)
+      expect(assigns(assign_variable)).to match_array(posts)
+    end
+
+    it "shows posts with a blocked (but not blocking) author with show_blocked" do
+      post1 = create(:post, authors_locked: true)
+      post2 = create(:post, authors_locked: true)
+      create(:block, blocking_user: user, blocked_user: post1.user, hide_them: Block::POSTS)
+      create(:block, blocking_user: post2.user, blocked_user: user, hide_me: Block::POSTS)
+      params[:show_blocked] = true
+      posts << post1
+      get controller_action, params: params
+      expect(response.status).to eq(200)
+      expect(assigns(assign_variable)).to match_array(posts)
+    end
+  end
+
+  context "GET index" do
+    let(:controller_action) { "index" }
+    let(:params) { { } }
+    let(:assign_variable) { :posts }
+
+    context "when logged out" do
+      include_examples "logged out post list"
+    end
+    context "when logged in" do
+      include_examples "logged in post list"
+    end
+  end
+
+  context "GET unread" do
+    let(:controller_action) { "unread" }
+    let(:params) { { } }
+    let(:assign_variable) { :posts }
+
+    context "when logged in" do
+      include_examples "logged in post list"
+    end
+  end
+
+  context "GET search" do
+    let(:controller_action) { "search" }
+    let(:params) { { commit: true } }
+    let(:assign_variable) { :search_results }
+
+    context "when logged out" do
+      include_examples "logged out post list"
+    end
+    context "when logged in" do
+      include_examples "logged in post list"
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -139,6 +139,33 @@ RSpec.describe User do
       expect(blocker).not_to have_interaction_blocked(only_posts)
       expect(blocker).to have_interaction_blocked(blockees.first)
     end
+
+    describe "content" do
+      let(:user) { create(:user) }
+      let(:blocking_post_user) { create(:user) }
+      let(:blocking_content_user) { create(:user) }
+      let(:blocked_post_user) { create(:user) }
+      let(:blocked_content_user) { create(:user) }
+      let(:irrelevant_blocker1) { create(:user) }
+      let(:irrelevant_blocker2) { create(:user) }
+
+      before(:each) {
+        create(:block, blocking_user: blocking_post_user, blocked_user: user, hide_me: Block::POSTS)
+        create(:block, blocking_user: blocking_content_user, blocked_user: user, hide_me: Block::ALL)
+        create(:block, blocking_user: user, blocked_user: blocked_post_user, hide_them: Block::POSTS)
+        create(:block, blocking_user: user, blocked_user: blocked_content_user, hide_them: Block::ALL)
+        create(:block, blocking_user: irrelevant_blocker1, blocked_user: user, block_interactions: true)
+        create(:block, blocking_user: irrelevant_blocker2, blocked_user: user, hide_them: Block::POSTS)
+      }
+
+      it "correctly handles all hidden post users" do
+        expect(user.hidden_post_users).to match_array([blocking_post_user, blocking_content_user, blocked_post_user, blocked_content_user].map(&:id))
+      end
+
+      it "correctly handles just blocking post users" do
+        expect(user.blocking_post_users).to match_array([blocking_post_user, blocking_content_user].map(&:id))
+      end
+    end
   end
 
   describe "archive" do


### PR DESCRIPTION
a. Allows hiding the posts of people the user has blocked
b. Allows hiding the user's posts from people they have blocked
c. Allows temporarily disabling a, but _not_ b with a url param (manually added only, currently)
d. Prevents notifications being sent about posts that would be hidden under a or b.