### PR TITLE
Enforce uniquness for board names

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -15,7 +15,7 @@ class Board < ApplicationRecord
   has_many :board_cameos, -> { where(cameo: true) }, class_name: 'BoardAuthor', inverse_of: :board
   has_many :cameos, class_name: 'User', through: :board_cameos, source: :user
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
   after_destroy :move_posts_to_sandbox
 

--- a/spec/controllers/boards_controller_spec.rb
+++ b/spec/controllers/boards_controller_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe BoardsController do
 
       it "orders boards correctly" do
         user = create(:user)
-        owned_board1 = create(:board, creator_id: user.id, name: 'd')
-        owned_board2 = create(:board, creator_id: user.id, name: 'b')
-        author_board1 = create(:board, coauthors: [user], name: 'a')
-        author_board2 = create(:board, coauthors: [user], name: 'c')
-        cameo_board1 = create(:board, cameos: [user], name: 'b')
-        cameo_board2 = create(:board, cameos: [user], name: 'a')
-        cameo_board3 = create(:board, cameos: [user], name: 'c')
+        owned_board1 = create(:board, creator_id: user.id, name: 'da')
+        owned_board2 = create(:board, creator_id: user.id, name: 'ba')
+        author_board1 = create(:board, coauthors: [user], name: 'aa')
+        author_board2 = create(:board, coauthors: [user], name: 'ca')
+        cameo_board1 = create(:board, cameos: [user], name: 'bb')
+        cameo_board2 = create(:board, cameos: [user], name: 'ab')
+        cameo_board3 = create(:board, cameos: [user], name: 'cb')
 
         get :index, params: { user_id: user.id }
         expect(assigns(:boards)).to eq([author_board1, owned_board2, author_board2, owned_board1])

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -3,6 +3,35 @@ require "spec_helper"
 RSpec.describe Board do
   include ActiveJob::TestHelper
 
+  describe "validations" do
+    it "succeeds" do
+      expect(create(:board)).to be_valid
+    end
+
+    it "succeeds with multiple boards with a single creator" do
+      user = create(:user)
+      create(:board, creator: user)
+      second = build(:board, creator: user)
+      expect(second).to be_valid
+      expect { second.save! }.not_to raise_error
+    end
+
+    it "should require a name" do
+      board = build(:board, name: '')
+      expect(board).not_to be_valid
+      board.name = 'Name'
+      expect(board).to be_valid
+    end
+
+    it "should require a unique name" do
+      create(:board, name: 'Test Board')
+      board = build(:board, name: 'Test Board')
+      expect(board).not_to be_valid
+      board.name = 'Name'
+      expect(board).to be_valid
+    end
+  end
+
   it "should allow everyone to post if open to anyone" do
     board = create(:board)
     user = create(:user)


### PR DESCRIPTION
Fixes #678 (also contains a few unrelated validation tests for boards)

(Check we don't have any existing identically named boards before releasing!)