### PR TITLE
Remove Tumblr information from the home page

### DIFF
--- a/app/views/sessions/index.haml
+++ b/app/views/sessions/index.haml
@@ -11,4 +11,3 @@
       %li= link_to "Alicorn's forum", 'http://alicorn.elcenia.com/board/index.php', target: '_blank'
       %li= link_to "IRC", 'https://client00.chat.mibbit.com/?channel=%23glowfic&server=irc.psigenix.net', target: '_blank'
       %li= link_to "Discord", 'https://discord.gg/Ss6fRFj', target: '_blank'
-      %li= link_to "Tumblr", 'http://alicorn.elcenia.com/board/viewtopic.php?f=10&t=615', target: '_blank'


### PR DESCRIPTION
Per Kaylin's request, we should have a properly curated public Tumblr list for the home page; this list was built assuming community-only and should not be on the home page for now.