### PR TITLE
Terms of Service and Privacy Policy pages

### DIFF
--- a/app/assets/javascripts/accept_tos.js
+++ b/app/assets/javascripts/accept_tos.js
@@ -1,0 +1,6 @@
+$(document).ready(function() {
+  // Use hide/show for anonymous users rather than removing content
+  // server-side improves SEO as search bots can still scrape content.
+  $("#content").hide();
+  $("#tos").show();
+});

--- a/app/assets/javascripts/users/new.js
+++ b/app/assets/javascripts/users/new.js
@@ -29,7 +29,8 @@ $(document).ready(function() {
     var passwordValid = validatePassword();
     var confirmationValid = validateConfirmation();
     var emailValid = validateEmail();
-    if (!(usernameValid && passwordValid && confirmationValid && emailValid)) {
+    var tosValid = validateTosAccepted();
+    if (!(usernameValid && passwordValid && confirmationValid && emailValid && tosValid)) {
       return false;
     }
     return true;
@@ -93,6 +94,12 @@ function validateConfirmation() {
     addAlertAfter('conf', 'Your passwords do not match.');
     success = false;
   }
+  return success;
+}
+
+function validateTosAccepted() {
+  var success = $("#tos").is(':checked');
+  if (!success) addAlertAfter('terms', 'You must accept the Terms of Service to use the Constellation.');
   return success;
 }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -99,18 +99,20 @@
 }
 
 /* Main Content */
-#content {
+#holder { min-height: 100%; position: relative; }
+#content, #tos {
   padding: 20px;
   font-size: $font_size_main;
   line-height: 20px;
   text-align: left;
   position: relative;
+  padding-bottom: 35px;
 }
 @media (max-width: 600px) {
-  #content { padding: 10px; }
+  #content, #tos { padding: 10px; padding-bottom: 35px; }
 }
 @media (max-width: 500px) {
-  #content { padding: 5px; }
+  #content, #tos { padding: 5px; padding-bottom: 35px; }
 }
 
 /* Flash Displays */
@@ -359,4 +361,19 @@ td, .table-list li { font-size: 14px; }
 
 .user-moiety {
   font-size: 80%;
+}
+
+
+#footer {
+  font-size: $font_size_small;
+  background-color: $bg_color_header_middle;
+  color: $font_color_header_link;
+  position: absolute;
+  left: 0px;
+  bottom: 0px;
+  width: 100%;
+
+  a { color: $font_color_header_link; }
+  a:hover { color: $font_color_header_link_hover; }
+  div { padding: 5px; padding-left: 20px; }
 }

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,0 +1,17 @@
+class AboutController < ApplicationController
+  def tos
+    @page_title = 'Terms of Service'
+  end
+
+  def privacy
+    @page_title = 'Privacy Policy'
+  end
+
+  def contact
+    @page_title = 'Contact Us'
+  end
+
+  def dmca
+    @page_title = 'DMCA Policy'
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class SessionsController < ApplicationController
-  before_action :logout_required, only: [:new, :create]
+  before_action :logout_required, only: [:new, :create, :confirm_tos]
   before_action :login_required, only: [:destroy]
 
   def index
@@ -31,6 +31,11 @@ class SessionsController < ApplicationController
     else
       flash[:error] = "You have entered an incorrect password."
     end
+    redirect_to session[:previous_url] || root_url
+  end
+
+  def confirm_tos
+    cookies.permanent[:accepted_tos] = cookie_hash(User::CURRENT_TOS_VERSION)
     redirect_to session[:previous_url] || root_url
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
 
   MIN_USERNAME_LEN = 3
   MAX_USERNAME_LEN = 80
+  CURRENT_TOS_VERSION = 20181109
 
   attr_accessor :password, :password_confirmation
   attr_writer :validate_password

--- a/app/views/about/_accept_tos.haml
+++ b/app/views/about/_accept_tos.haml
@@ -1,0 +1,22 @@
+- content_for :tos_form do
+  %table#signup.form-table
+    %thead
+      %tr
+        %th Accept our Terms of Service
+    %tbody
+      %tr#terms
+        %td.odd{style: 'padding: 15px;'}
+          Our Terms of Service have recently changed!
+          Please read and agree to the
+          = link_to 'Terms of Service', tos_path
+          and the
+          = link_to 'Privacy Policy', privacy_path
+      %tr
+        %th.form-table-ender{colspan: 2}= submit_tag "I agree/consent to the terms", class: 'button', name: :tos_check, id: :tos_check
+
+- if logged_in?
+  = form_for current_user, url: user_path(current_user), method: :put, name: :tos_form do |f|
+    = content_for :tos_form
+- else
+  = form_tag confirm_tos_path, method: :patch do
+    = content_for :tos_form

--- a/app/views/about/accept_tos.haml
+++ b/app/views/about/accept_tos.haml
@@ -1,0 +1,1 @@
+= render partial: 'about/accept_tos'

--- a/app/views/about/contact.haml
+++ b/app/views/about/contact.haml
@@ -1,0 +1,12 @@
+#contact-content.odd{style: 'padding: 15px;'}
+  %h1 Contact the Constellation
+
+  %p
+    Currently, to contact the Constellation for help or to report a violation of our
+    = succeed ',' do
+      = link_to 'Terms of Service', tos_path
+    you may visit us in the #constellation channel of the
+    = link_to "Glowfic Discord", Glowfic::DISCORD_LINK, target: '_blank'
+    or email us at
+    = succeed '.' do
+      = link_to 'glowfic.constellation@gmail.com', 'mailto:glowfic.constellation@gmail.com'

--- a/app/views/about/dmca.haml
+++ b/app/views/about/dmca.haml
@@ -1,0 +1,200 @@
+#dcma-content.odd{style: 'padding: 15px;'}
+  %h1 Glowfic Constellation DMCA Policy
+
+  %h3 Table of Contents
+
+  %ol
+    %li= link_to 'Overview', '#overview'
+    %li= link_to 'Notification of Copyright Infringement', '#notification'
+    %li= link_to 'Takedown Process', '#takedown'
+    %li= link_to 'Counter-Notification', '#counter'
+    %li= link_to 'Restoration Process', '#restoration'
+    %li= link_to 'Repeat Offenses', '#repeats'
+    %li= link_to 'Attribution and License', '#license'
+
+  %h3#overview Overview
+
+  %p
+    The Digital Millennium Copyright Act (DMCA), and specifically the provisions located at
+    = succeed ',' do
+      = link_to '17 USC 512', 'http://www.law.cornell.edu/uscode/text/17/512', target: '_blank'
+    set forth the steps an online service provider such as the Glowfic Constellation must follow in the event of copyright infringement on their servers.
+
+  %p
+    We believe that the DMCA takedown process is a powerful tool that can help copyright holders protect their intellectual property from being exploited.
+    We also believe that the DMCA takedown process is a powerful tool that is frequently misused to force a chilling effect on legitimate and legal speech.
+    Our enforcement policy is an attempt to prevent the worst abuses of this process that we've seen over the years, while still upholding our legal obligations and protecting copyright holders from the misuse of their intellectual property.
+
+  %p
+    This is a complicated process, and the law surrounding it is unclear in many situations. We've tried to make this as readable as possible.
+    If you have any questions that aren't covered here, please
+    = link_to 'contact us', contact_path
+    with your questions.
+
+  %p
+    None of this material should be construed as legal advice.
+    We cannot advise you on how to protect your rights online, either your rights as a copyright holder or your rights as someone accused of copyright infringement.
+    If you are in need of legal advice, contact a lawyer who is licensed to practice in your jurisdiction.
+
+  %h3#notification Notification of Copyright Infringement
+
+  %p
+    If you believe that someone on the Glowfic Constellation has violated your copyright, you may send us a Notification of Copyright Infringement.
+    For us to process such a notification, it must substantially comply with the requirements set forth in United States law.
+    To speed our handling of your notification, please make sure it complies with the following criteria:
+
+    %ol
+      %li
+        Notifications may be submitted to the Constellation via email (no attachments, please) to
+        = succeed '.' do
+          %b= link_to 'glowfic.constellation@gmail.com', 'mailto:glowfic.constellation@gmail.com'
+      %li
+        Notifications must be signed by the copyright holder or the copyright holder's designated agent.
+        Signatures may be a physical signature or a digital signature in a recognized industry-standard format such as PGP.
+        Unsigned notifications will not be processed.
+      %li
+        Notifications must specifically identify the copyrighted work being infringed upon.
+        For instance, if the work is a published book, provide the title, author, and ISBN;
+        if the work is a magazine article, provide the title, author, magazine name, and magazine issue;
+        if the work is available on the Internet, provide the URL of the work.
+      %li
+        Notifications must specifically include the URL where the work is being infringed upon the Constellation's servers.
+        For us to be able to reasonably identify the material, you must provide us with the complete URL.
+        For instance, provide https://www.glowfic.com/posts/123 (a link to the specific entry).
+      %li
+        Notifications must include sufficient information for us to contact you, including your address, your telephone number, and your email address.
+      %li
+        Notifications must contain a statement that you have a good faith belief that the use of the material in this manner is not authorized by the copyright owner(s), their agent, or the law.
+      %li
+        Notifications must contain a statement that the information in the notification is accurate, and under penalty of perjury, that you are authorized to act on behalf of the owner of the copyright that is allegedly being infringed.
+
+  %p
+    Your notification will be forwarded, in its entirety, to the owner of the account posting the allegedly-infringing content.
+    We reserve the right to make copies available to third parties, such as the
+    = succeed ',' do
+      = link_to 'Chilling Effects Clearinghouse', 'http://www.chillingeffects.org/', target: '_blank'
+    as we see fit, for purposes of academic study and legal review.
+
+  %h3#takedown Takedown Process
+
+  %p
+    When we receive a properly-formatted notice of copyright infringement, we will forward it to the account owner and provide a limited amount of time to disable access to the allegedly-infringing content.
+
+  %p
+    If you have received this notice from us, you must delete the entry, comment, or image in question.
+    %i Setting an entry's security to Private is not sufficient to qualify as 'disabling access' under the law,
+    as this can be undone at any time.
+
+  %p
+    If we do not hear back from you within 48 hours, we will delete the content on your behalf.
+    This will not affect the rest of your account.
+
+  %p
+    You then have one of three choices:
+
+  %ol
+    %li
+      You can accept the allegation of infringement, and state that you will not restore the content, file a counter-notification, or make further infringement upon the work in the future.
+      If you choose to do this, you must delete the entry, comment, or image, if you have not already done so.
+      This will count against you for determination of 'repeat offender' status.
+      If you do not reply to any of our contact about an alleged infringement within 10 days of our forwarding the notification, we must assume that you have chosen this option.
+    %li
+      You can state that you do not accept the allegation of infringement, but you do not want to file a counter-notification or have us restore access to the allegedly-infringing content.
+      If you choose to do this, we will not restore access to the entry, comment, or image.
+      This will not affect the rest of your account.
+      This will not count against you for determination of 'repeat offender' status.
+    %li
+      You can state that you do not accept the allegation of infringement, and let us know that you want to file a counter-notification under the provisions of law.
+      If you choose to do this, please see the section below.
+      This will not count against you for determination of 'repeat offender' status.
+
+  %p
+    If you have received a notice of alleged infringement, you may not re-upload or re-post the allegedly-infringing material, unless you have gone through the counter-notification process.
+    This applies whether you have deleted the material yourself, or we deleted the material on your behalf.
+    If you do re-upload or re-post the material, we will be forced to entirely disable your account.
+
+  %h3#counter Counter-Notification
+
+  %p
+    A counter-notification is a statement, under the provisions of 17 USC 512(g)(3), that you do not believe your content infringes on another person's rights, or that your use of another person's copyrighted material falls into one of the protected categories under law.
+
+  %p
+    %i By filing a counter-notification, you are indicating that you are willing to defend your use of the material in court,
+    if the copyright owner chooses to bring a lawsuit against you for your use of the material.
+    This may involve civil and/or criminal penalties.
+    %i We strongly suggest you contact an intellectual property lawyer licensed to practice law in your jurisdiction before you do this,
+    so that you are aware of your rights and obligations under the law.
+
+  %p
+    There are groups that may help you understand your rights and obligations, including the
+    = succeed ',' do
+      = link_to 'Chilling Effects Clearinghouse', 'http://www.chillingeffects.org/', target: '_blank'
+    the
+    = succeed ',' do
+      = link_to 'Electronic Frontier Foundation', 'http://www.eff.org/', target: '_blank'
+    and the
+    = succeed '.' do
+      = link_to 'Organization for Transformative Works', 'http://transformativeworks.org/', target: '_blank'
+    We are not affiliated with any of these organizations, and they may not be able to help you, but their mission and mandate involves educating people about their rights and obligations under intellectual property law.
+
+  %p
+    A counter-notification must contain the following items:
+
+  %ol
+    %li
+      Your signature. Signatures may be a physical signature or a digital signature in a recognized industry-standard format such as PGP.
+    %li
+      The URL of your entry, comment, or image that has been called into question.
+    %li
+      A statement, under penalty of perjury, that you have a good faith belief that the material was removed or disabled as a result of mistake or misidentification of the material.
+      This should include any reasons why you believe your use of the material is not infringing.
+    %li
+      Your name, address, and telephone number.
+    %li
+      A statement that you consent to the jurisdiction of Federal District Court where you reside, or (if you live outside the United States) that you consent to the jurisdiction of Federal District Court where the Glowfic Constellation is located (currently New York county, New York).
+    %li
+      A statement that you will accept service of process from the person who provided notification of infringement, or that person's designated agent.
+
+  %p
+    Your counter-notification will be provided, in its entirety, to the person who provided notification of alleged infringement.
+
+  %h3#restoration Restoration Process
+
+  %p
+    When we receive a counter-notification, we will forward it to the person who made the original notification of alleged infringement.
+    From that point, the original notifier has 10 business days after receiving the counter-notification to file an action in court, seeking an injunction against the use of that material.
+
+  %p
+    If you have provided us with a notification of infringement, and the user of our service has chosen to file counter-notification, you must inform us that you have filed court action no more than 14 days after we forward the counter-notification to you.
+    If you do not, we will re-enable access to the allegedly-infringing material no less than 10 days, and no more than 14 days, after we forward the counter-notification.
+
+  %p
+    If you have received a notification of infringement, and you have provided us with your counter-notification, we will re-enable access to the allegedly-infringing material, or let you know that you can re-post the allegedly-infringing material, no less than 10 days, and no more than 14 days, after we have forwarded your counter-notification to the original notifier.
+
+  %p
+    If you have filed a counter-notification, you can not re-upload or re-post the allegedly-infringing material until we notify you that the waiting period has expired.
+    If you do, we will be forced to entirely disable your account during that time period.
+
+  %h3#repeats Repeat Offenses
+
+  %p
+    US law requires us to disable the accounts of repeat offenders of others' copyright.
+    What constitutes a repeat offender is not defined by law.
+
+  %p
+    We currently define a repeat offender as anyone who has received five valid notifications of copyright infringement.
+    Instances where you have filed a counter-notification, or instances where you have indicated that you do not accept the allegation of copyright infringement but do not wish to file a counter-notification, will not count against your account for purposes of determining 'repeat offender' status.
+    We reserve the right to alter this definition in the future, at our sole discretion.
+
+  %p
+    We also reserve the right to terminate the accounts of those who, in our opinion, misuse or abuse the DMCA notification process against other users.
+
+  %h3#license Attribution and License
+
+  %p
+    This DCMA Policy document is based on one developed by Dreamwidth
+    = surround '(', ')' do
+      = link_to 'https://www.dreamwidth.org/legal/dcma', target: '_blank'
+    and is licensed under a Creative Commons Attribution-ShareAlike 2.5 License.
+
+  %p.details Last revised July 8, 2018

--- a/app/views/about/privacy.haml
+++ b/app/views/about/privacy.haml
@@ -1,0 +1,262 @@
+#privacy-content.odd{style: 'padding: 15px;'}
+  %h1 Privacy Policy
+
+  %p
+    This privacy statement ("Privacy Policy") covers all websites (such as www.glowfic.com) owned and operated by the Glowfic Constellation ("we", "us", "our", "Constellation") and all associated services.
+
+  %p
+    We use information you share with us for our own internal purposes.
+    We do not sell your information.
+    This notice tells you what information we collect, how we use it, and steps we take to protect and secure it.
+
+  %h3 Table of Contents
+  %ol
+    %li
+      = link_to 'Information we automatically collect', '#auto'
+      %ol{style: 'list-style-type: lower-alpha'}
+        %li= link_to 'Non-personally-identifying', '#impersonal'
+        %li= link_to 'Personally-identifying', '#personal'
+    %li= link_to 'Information you are required to provide to us on registration', '#required'
+    %li= link_to 'Account contents', '#contents'
+    %li= link_to 'Disclosure of information', '#disclosure'
+    %li= link_to 'Special rules regarding children', '#children'
+    %li= link_to 'Cookies', '#cookies'
+    %li= link_to 'Confidentiality and security', '#security'
+    %li= link_to 'Deleting your information', '#deleting'
+    %li
+      = link_to 'Outside vendors', '#vendors'
+      %ol{style: 'list-style-type: lower-alpha'}
+        %li= link_to 'Business vendors', '#business'
+        %li= link_to 'Site features', '#features'
+    %li= link_to 'Updates to the policy', '#updates'
+    %li= link_to 'Contacting us', '#contact'
+    %li= link_to 'Creative Commons', '#license'
+
+  %h3#auto Information we automatically collect
+
+  %h4#impersonal Non-personally-identifying
+
+  %p
+    Like most website operators, we collect non-personally-identifying information such as browser type, language preference, referring site, and the date and time of each visitor request.
+
+  %p
+    We collect this to understand how our visitors use our service, and use it to make decisions about how to change and adapt the service.
+
+  %p
+    From time to time, we may release non-personally-identifying information in aggregate form (for instance, by publishing trends in site usage) to explain our reasoning in making decisions.
+    We will not release individual information, only aggregate information.
+
+  %p
+    We collect and process Logs of server interactions, as well as event logs.
+    We need this information for legal and accounting/audit reasons, including maintaining the integrity of the Constellation and the Content that we host.
+
+  %h4#personal Personally-identifying
+
+  %p
+    We may collect personally-identifying information, such as IP address, provided by your browser and your computer.
+
+  %p
+    We collect this information for several purposes:
+
+  %ul
+    %li To diagnose and repair issues with your use of the site;
+    %li To estimate the number of users accessing the service from specific geographic regions;
+    %li To help prevent fraud and abuse.
+
+  %p
+    We collect information about certain pages users access or visit, as well as referral information (i.e. data about what site you are coming to the Constellation from) and whether there are errors in displaying Content to you.
+    This information may be associated with your account (for instance, when we log that a user has read the first page of a post).
+    We need this information
+    to maintain the integrity of the site, the Service and the Content that we host;
+    to provide you with the Content that you are seeking;
+    to support site functionality such as identifying unread posts;
+    to minimize spam;
+    and for other legal and accounting/audit reasons.
+
+  %h3#required Information you are required to provide to us on registration
+
+  %p
+    In order to register for the service, you must give us your email address.
+    We will use your email address to send confirmation of certain actions, such as when you reset your password.
+    We may contact you if there's a critical or administrative issue affecting your use of the service.
+    We may occasionally send emails to you about your Content and account, or news that we reasonably believe to be of interest to our registered users.
+    By creating and maintaining a User Account on and with the Constellation, you consent to receiving such emails.
+    We reserve the right to send you notice of complaints raised against you, or alleged violations by you of the Terms of Service, as well as to reply to any email message you send to the Constellation and/or its personnel. 
+
+  %p
+    Once you have created your account, you can choose to subscribe to certain events and have notifications of those events sent to you via email.
+    You will be able to change your mind and opt out of receiving notifications via email at any time.
+
+  %p
+    We will never sell or provide your email address to any third party, with
+    = succeed '.' do
+      = link_to 'exceptions as set forth below', '#disclosure'
+
+  %h3#contents Account contents
+
+  %p
+    You consent to our collection, processing, retention and display of your Content, including personal data, when you submit Content to the Constellation.
+    We need such consent because your purpose in and reason for uploading Content to the Constellation is for that Content to be visible to users and, if you opt to, the general public, or for that Content to be accessible to you at a later date.
+
+  %p
+    You may optionally post content to your account with varying security levels.
+    To the best of our ability, and limited only by the possibility of bugs or technical difficulties, we will honor the security levels you choose for your content and display that content only to those whom you have authorized to see it.
+
+  %p
+    By choosing to make any Content public, including any personally-identifiable information you may share, you recognize and accept that other people, not affiliated with us, may use this data to contact you.
+    We can't be responsible for the use of any information you post publicly.
+
+  %p
+    While maintaining the site, Constellation staff may need to view the contents of your account, including information for which you have chosen a restrictive security level.
+    Circumstances in which this is necessary include, but are not limited to: troubleshooting and diagnosing technical problems, investigating possible Terms of Service violations, and legal compliance issues.
+    Constellation staff only use the ability to override your chosen security levels during the course of these investigations.
+    At no time is your secured content disclosed to any third party, with
+    = succeed '.' do
+      = link_to 'exceptions as set forth below', '#disclosure'
+    Any use of this ability may be logged and regularly audited.
+
+  %h3#disclosure Disclosure of information
+
+  %p
+    We disclose personally-identifying information only to those of our employees and contractors who
+    (i) need to know that information in order to operate the service and
+    (ii) have agreed not to disclose it to others.
+    Some of these employees and contractors may be located outside your home country.
+    By using this website, you consent to the transfer of your information to them.
+
+  %p
+    If all of our assets were transferred or acquired, your information would be one of the assets that is transferred or acquired by a third party.
+
+  %p
+    We may disclose account contents, potentially personally-identifying, and personally-identifying information when that release is required by law or by court order, or when we believe in good faith that disclosure is reasonably necessary to protect the safety or rights of us, third parties, or the public at large.
+
+  %p
+    If we receive a complaint about a violation of someone's intellectual property rights, we reserve the right to disclose the information provided by the rightsholder or the rightsholder's representative to the subject of the complaint.
+
+  %h3#children Special rules regarding children
+
+  %p
+    The Children's Online Privacy Protection Act ('COPPA') requires that we inform parents on how we collect and disclose the personal information of children under the age of 13.
+
+  %p
+    We do not permit children under the age of 13 to use our service.
+    If your child under the age of 13 has mis-represented their age or is using this site in violation of our
+    = succeed ',' do
+      = link_to 'Age Policy', tos_path(anchor: 'age')
+    please
+    = succeed '.' do
+      = link_to 'contact us', contact_path
+    After confirming your identity, we will remove the account.
+
+  %h3#cookies Cookies
+
+  %p
+    A cookie is a string of information that a website stores on a visitor's computer, and that the visitor's browser provides to the website each time the visitor returns.
+    We use cookies to help us identify and track visitors, their usage of the website, and their website access preferences.
+    We also use cookies to govern logging into your account.
+
+  %p
+    Visitors who do not wish to have cookies placed on their computers should set their browsers to refuse cookies before using the site, with the drawback that many features of the site may not function properly without the aid of cookies.
+
+  %h3#security Confidentiality and security
+
+  %p
+    No data transmisson over the Internet can ever be guaranteed to be 100% secure.
+    You use this service at your own risk.
+    However, we do take steps to ensure security on our systems.
+
+  %p
+    Your account information is password-protected.
+    We recommend that you choose a strong and secure password.
+    We use industry-standard SSL encryption to safeguard any transmission between your computer and ours.
+
+  %p
+    If we learn of a system security breach, we will notify you electronically so you can take appropriate steps to protect yourself.
+    Depending on where you live, you may have a legal right to receive notice of a security breach in writing.
+    To receive free written notice, please
+    = succeed '.' do
+      = link_to 'contact us', contact_path
+
+  %h3#deleting Deleting your information
+
+  %p
+    You may choose to delete your account entirely by contacting a site administrator.
+    If you choose to delete your account entirely, your information will be removed entirely from the Website.
+    We may retain any records or personally identifying information which we deem necessary for legal, auditing or disaster recovery purposes.
+    Any information so retained will not be available through the Website and will be available solely to Constellation staff with a legitimate reason for access.
+
+  %p
+    As part of the day to day operation of the Constellation, we will make regular copies of the data contained in the databases for backup purposes.
+    These backups can potentially contain deleted data for several weeks or months.
+    These backups will also be governed by the rules for disclosure of personally-identifying information.
+
+  %p
+    For additional information about how we handle the deletion of Content, please see the
+    = link_to '3e. Deletion of Content', tos_path(anchor: 'deletion')
+    section of our Terms of Service.
+
+  %h3#vendors Outside vendors
+
+  %h4#business Business vendors
+
+  %p
+    We may use third-party services to store, process, or transmit data, or perform other technical functions related to hosting, operating, administering and maintaining the Constellation service.
+    These services may include, but are not limited to, spam detectors, backup services, icon hosting, and e-mail services.
+    We cannot guarantee other services' performance.
+    We or the services we use may store or process your personally identifying information in data centers which may be located in the United States or other countries.
+
+  %p
+    We will list all of our business vendors in this privacy policy.
+    Our current business vendors are:
+    %ul
+      %li Heroku
+      %li Amazon Web Services
+      %li New Relic
+      %li SumoLogic
+      %li Github for hosting of application code.*
+      %li TravisCI for automated site testing.*
+      %li CodeClimate for code quality reporting.*
+
+  %p
+    *Business vendors marked with a * do not store, process or transmit any of the Constellation's production user data, only application code and test data.
+
+  %h4#features Site features
+
+  %p
+    We reserve the right to contract with third-party vendors to provide site features we are unable to provide ourselves.
+    We will only share personal information with third-party vendors to the extent that is necessary for such affiliates to provide these site features.
+    Our third-party vendors do not have the right to share or use personal information for any purpose other than for an authorized transaction. Some of our third-party vendors may be located outside of your home country.
+    By using this website and these features, you consent to the transfer of such information to them.
+    We will clearly identify which site features are provided by third-party vendors, and provide you a way to opt out of using those site features.
+
+  %h3#updates Updates to the policy
+
+  %p
+    We reserve the right, at our sole discretion, to modify or replace any part of this privacy policy at any time.
+    If these changes are minor, we will post them to this page.
+    If the changes are major, we will post them to this page and take reasonable steps to notify users.
+    Your continued use of this site after any change in this Privacy Policy will constitute your acceptance of such change.
+    Such changes will be used only for information provided by those who have visited, used, or accessed the Service after the effective date of such policy changes.
+    If you are concerned about how your information is used, you should check the site periodically to review these policies.
+
+  %h3#contact Contacting us
+
+  %p
+    If you have questions about this policy, please
+    = succeed '.' do
+      = link_to 'contact us', contact_path
+
+  %h3#license Creative Commons
+
+  %p
+    This privacy policy is based on ones developed by Dreamwidth
+    = surround '(', ')' do
+      = link_to 'https://www.dreamwidth.org/legal/privacy', 'https://www.dreamwidth.org/legal/privacy', target: '_blank'
+    and Archive of our Own
+    = surround '(', ')' do
+      = link_to 'https://www.archiveofourown.org/tos#privacy', 'https://www.archiveofourown.org/tos#privacy', target: '_blank'
+    and is licensed under a
+    = succeed '.' do
+      = link_to 'Creative Commons Attribution-ShareAlike 2.5 License', 'https://creativecommons.org/licenses/by-sa/2.5/', target: '_blank'
+
+  .details Last revised November 9, 2018

--- a/app/views/about/tos.haml
+++ b/app/views/about/tos.haml
@@ -1,0 +1,513 @@
+#tos-content.odd{style: 'padding: 15px;'}
+  %h1 Glowfic Constellation Terms of Service
+
+  %p
+    The Glowfic Constellation is a collaborative writing community, including both original works and fan fiction based on books, TV, movies, comics, and other media.
+
+  %p
+    We (and the kind folks whose Terms of Services we 
+    = succeed ')' do
+      = link_to 'based this document on', '#license'
+    hate legalese, so we've tried our best to make our terms readable.
+    If you've got any questions, feel free to
+    = link_to 'ask us', contact_path
+    and we'll do our best to answer.
+
+  %h3 Table of Contents
+  %ol
+    %li
+      = link_to 'General Terms', '#general'
+      %ol{style: 'list-style-type: lower-alpha'}
+        %li= link_to 'Use of the Site', '#use'
+        %li= link_to 'Updates to Terms', '#updates'
+    %li
+      = link_to 'Account Terms', '#account'
+      %ol{style: 'list-style-type: lower-alpha'}
+        %li= link_to 'Account Security', '#security'
+        %li= link_to 'Age Policy', '#age'
+        %li= link_to 'Access to Features', '#features'
+        %li= link_to 'Member Conduct', '#conduct'
+        %li= link_to 'Termination', '#termination'
+        %li= link_to 'Data Collection', '#data'
+        %li= link_to 'Email Address', '#emailadd'
+    %li
+      = link_to 'Content Policies', '#content-policies'
+      %ol{style: 'list-style-type: lower-alpha'}
+        %li= link_to 'Ownership of Content', '#ownership'
+        %li= link_to 'External Content', '#external'
+        %li= link_to 'Exposure to Content', '#exposure'
+        %li= link_to 'Reproduction of Content', '#reproduction'
+        %li= link_to 'Endorsement of Content', '#endorsement'
+        %li= link_to 'Deletion of Content', '#deletion'
+    %li
+      = link_to 'Abuse and Violations Policy', '#violations'
+      %ol{style: 'list-style-type: lower-alpha'}
+        %li= link_to 'Mediating Disputes', '#mediation'
+        %li= link_to 'Submitting a Complaint', '#complaint'
+        %li= link_to 'Investigating a Complaint', '#investigation'
+        %li= link_to 'Complaint Outcomes', '#consequences'
+        %li= link_to 'Appeals Process', '#appeals'
+    %li
+      = link_to 'Legal Matters', '#legal'
+      %ol{style: 'list-style-type: lower-alpha'}
+        %li= link_to 'Privacy Policy', '#privacy'
+        %li= link_to 'Jurisdiction', '#use'
+        %li= link_to 'Indemnity', '#use'
+        %li= link_to 'Copyright Infringement', '#copyright'
+        %li= link_to 'Limitation of Liability', '#liability'
+        %li= link_to 'Partial Invalidation', '#invalidation'
+        %li= link_to 'Resale of Services', '#resale'
+    %li
+      = link_to 'Additional Terms', '#terms'
+      %ol{style: 'list-style-type: lower-alpha'}
+        %li= link_to 'Volunteers', '#volunteers'
+        %li= link_to 'Active Development Disclaimer', '#development'
+        %li= link_to 'Reporting Violations', '#reporting'
+        %li= link_to 'Section Titles', '#sections'
+        %li= link_to 'Creative Commons', '#license'
+
+  %h3#general 1. General Terms
+
+  %h4#use a. Use of the Site
+
+  %p
+    The Glowfic Constellation is offered subject to your acceptance, without modification, of all the following terms and conditions and all other policies published on this website.
+    Please read this agreement carefully. 
+    By accessing or using any part of the Website, you agree that you are bound
+    by the terms and conditions of this Agreement.
+    If you do not agree to all the terms and conditions of this Agreement,
+    then you may not access the Website or use any of its services.
+
+  %h4#updates b. Updates to Terms
+
+  %p
+    We reserve the right, at our sole discretion, to modify or replace any part of this Agreement at any time, or release new services or features subject to the terms of this Agreement.
+    We will take reasonable steps to notify you of any substantial changes to this Agreement; however, it is your responsibility to check this Agreement periodically for changes.
+    Your continued use of or access to the Website following the posting of any changes to this Agreement constitutes acceptance of those changes.
+
+  %h3#account 2. Account Terms
+
+  %h4#security a. Account Security
+
+  %p
+    If you create an account on the Website, you are responsible for maintaining the security of your account.
+    You are responsible for all activities that occur under the account and any other actions taken in connection with the account.
+    You must take reasonable steps to guard the security of your account.
+    We will not be liable for any acts or omissions resulting from a breach of security, including any damages of any kind incurred as a result of such acts or omissions.
+
+  %h4#age b. Age Policy
+
+  %p
+    In compliance with United States regulations regarding online privacy for children, the Constellation does not knowingly solicit or collect information from children under the age of 13.
+    Children under the age of 13 are therefore not permitted to have an account or upload content of any type.
+
+  %p
+    In compliance with European Union regulations regarding online privacy for teens, the Constellation does not knowingly solicit or collect information from teens who are residents/citizens of the European Union under the age of 16.
+    Teens between 13 and 16 who are residents/citizens of the European Union are therefore not permitted to have an account or upload content of any type.
+
+  %p
+    By using the Constellation or uploading Content, you thereby confirm that you are (a) at least 16 years old or (b) at least 13 years old and not a European Union resident/citizen.
+
+  %h4#features c. Access to Features
+
+  %p
+    Glowfic Constellation accounts can be registered free of charge and receive access to all site features.
+    By using this Website, you agree to our right to add or discontinue additional types of accounts, and change or modify the features available to different types of accounts, at any time at our discretion.
+
+  %h4#conduct d. Member Conduct
+
+  %p
+    Our goal is to make the Constellation a safe and positive community where our users can contribute in a healthy and constructive manner.
+    We expect our users to always, in the immortal words of
+    = succeed ',' do
+      = link_to 'Bill S. Preston, Esq', 'https://mygeekwisdom.com/2011/09/12/be-excellent-to-each-other/', target: '_blank'
+    "be excellent to each other", and be respectful of others.
+
+  %p
+    You agree that you will not use the Website to:
+
+  %ol
+    %li
+      Upload, post, or otherwise transmit any Content that is harmful, threatening, derogatory, violent, abusive, hateful, invasive to the privacy and publicity rights of any person, or violates the terms of this Agreement;
+
+    %li
+      Upload, post, or otherwise transmit any Content that is spam or solicitation, or contains unethical or unwanted commercial content designed to drive traffic to third party sites or boost the search engine rankings of third party sites, or to further unlawful acts (such as phishing) or mislead recipients as to the source of the material (such as spoofing);
+
+    %li
+      Maliciously impersonate any real person or entity, including but not limited to a Constellation staff member or volunteer, or to otherwise misrepresent your affiliation with any person or entity;
+
+    %li
+      Upload, post or otherwise transmit any Content that you do not have a right to transmit under any law or under contractual or fiduciary relationships (such as inside information, proprietary and confidential information learned or disclosed as part of employment relationships or under nondisclosure agreements);
+
+    %li
+      Upload, post or otherwise transmit any Content that infringes any patent, trademark, trade secret, copyright, or other proprietary rights of any party;
+
+    %li
+      Interfere with or disrupt the Website or servers or networks connected to the Website, or disobey any requirements, procedures, policies or regulations of networks connected to the Website;
+
+    %li
+      Solicit passwords or personal identifying information for unintended, commercial or unlawful purposes from other users;
+
+    %li
+      Provide any material that is illegal under United States law, or that violates any applicable local, state, national, or international law, including any regulation having the force of law;
+
+    %li
+      Upload, post or otherwise transmit any Content that contains viruses, worms, malware, Trojan horses or other harmful or destructive content;
+
+    %li
+      Allow usage by others in such a way as to violate this Agreement;
+
+    %li
+      Make excessive or otherwise harmful automated use of the Website;
+
+    %li
+      Access any other person's account without their knowledge and permission, or exceed the scope of the Website that you have signed up for; for example, accessing and using features you don't have a right to use.
+
+  %h4#termination e. Termination
+
+  %p
+    We may terminate your access to all or any part of the Website at any time, at our sole discretion, if we believe that you have violated this Agreement.
+    You agree that any termination of your access to the Website may involve removing or discarding any content you have provided.
+
+  %p
+    If you wish to terminate this Agreement, you may deactivate your account and cease using the Website.
+    You agree that, upon deactivation of your account, we may, but are not required to, make unavailable or permanently delete any content you have provided, at any time past the deactivation of your account.
+
+  %p
+    All provisions of this Agreement which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.
+
+  %h4#data f. Data Collection
+
+  %p
+    In order to host or share Content, we have to process certain data and information including personally identifying information that we collect from Users, and that each User inputs.
+    In order to operate the site, host the Constellation and user Content, and prevent technical issues and breaches, we need to process (e.g. collect, store, retrieve, disseminate, make available, and delete) certain data and information including personally identifying information, also known as "Personal Data".
+    Personal Data may include your username, your email address, your IP information and any personally identifying information you enter on the Constellation, including information that you put into your profile, or other Content itself.
+
+  %p
+    By using the site, you consent to our collection, processing, retention and display of your Content as set forth and explained in these Terms of Use so we can operate, manage, display and share Constellation Content;
+    if we believe that using, retaining and/or sharing that information is necessary to preserve the integrity of the Constellation and the Content that we host;
+    for legitimate legal and/or accounting audit purposes;
+    when we have a good faith belief it is required by law, such as pursuant to a subpoena or other legal process;
+    or when we have a good faith belief that doing so will help prevent imminent harm to someone.
+
+  %h4#emailadd g. Email Address
+
+  %p
+    As part of your registration, you agree to provide an accurate and current e-mail address and to update the address as necessary.
+    If your e-mail address is inaccurate or not current, the Constellation may suspend your account.
+
+  %p
+    By registering or otherwise using an e-mail address in connection with the Constellation, you assert that the e-mail address is not listed on any child protection registry.
+    (There are child protection registries in Michigan and Utah, and our policy applies to any others that exist or may be adopted, whether local, state, or national, including any outside the U.S.)
+
+  %h3#content-policies 3. Content Policies
+
+  %h4#ownership a. Ownership of Content
+
+  %p
+    You agree to the following provisions for posting Content to the Website:
+
+  %ol
+    %li
+      We claim no ownership or control over any Content that you post to the Website.
+      You retain any intellectual property rights to the Content you post, in accordance with applicable law.
+      By posting Content, you represent that you have the rights to reproduce that Content (and the right to allow us to serve such Content) without violation of the rights of any third party.
+      You agree that you will bear any liability resulting from the posting of any Content that you do not have the rights to post.
+
+    %li
+      All Content posted to the Website in any way is the responsibility of the owner.
+      Within the confines of international and local law, we will generally not place a restriction on the type or appropriateness of any Content.
+      If Content is deemed illegal by any law having jurisdiction over you, you agree that we may submit any necessary information to the proper authorities.
+
+    %li
+      We do not pre-screen Content.
+      However, you acknowledge that we have the right (but not the obligation), in our sole discretion, to remove or refuse to remove any Content from the service.
+      You also agree that we may, without limitation, take any steps necessary to remove Content from the site search engine or member directory, at our sole discretion.
+
+    %li
+      If any Content you have submitted is reported to us as violating this Agreement, you agree that we may call upon you to change, modify, or remove that Content, within a reasonable amount of time, as defined by us.
+      If you do not follow this directive, we may terminate your account.
+
+  %p
+    If you operate an account, post material to the Website, post links on the Website,
+    or otherwise make (or allow any third party to make) material available by means of the Website,
+    you are entirely responsible for that Content and any harm that may result from it.
+
+  %h4#external b. External Content
+
+  %p
+    We have not reviewed, and cannot review, all of the material made available through the websites and webpages to which we, or any user, links, or that link to us. 
+    We do not have any control over those websites and webpages, and are not responsible for their contents or their use.
+    By linking to an external website or webpage, we do not represent or imply that we endorse such website or webpage.
+    You are responsible for taking precautions as necessary to protect yourself and your computer systems from viruses, worms, Trojan horses, and other harmful or destructive content.
+    We disclaim any responsibility for any harm resulting from your use of external websites and webpages, whether that link is provided by us or by any provider of Content on the Website.
+
+  %p
+    While we limit the types of embedded content visible or accessible via the Website, some of the content that you see displayed is not hosted on the Constellation.
+    Such embedded content can include videos, tweets, images that are hosted by third-party sites, or audio files ("User-Embedded Content").
+    If you access a page that includes User-Embedded Content, the content file may share data with the hosted site as if you were on or at the hosted site.
+    Although all visible Content, including embedded images or other works, must comply with our Content Policy, User-Embedded Content is not otherwise governed by these Terms of Use or our Privacy Policy, and instead is covered by the Terms of Use and/or Privacy Policy of the service that hosts the User-Embedded Content.
+    The Constellation reserves the right to provide an indicator to users that User-Embedded Content is present on or visible via your Content.
+
+  %h4#exposure c. Exposure to Content
+
+  %p
+    You agree that by using the service, you may be exposed to Content you find offensive or objectionable. 
+    If such Content is reported to us, it will be our sole discretion as to what action, if any, should be taken.
+
+  %h4#reproduction d. Reproduction of Content
+
+  %p
+    By submitting Content to us for inclusion on the Website, you grant us a world-wide, royalty-free, and non-exclusive license to reproduce, compile, modify, adapt and publish the Content, solely for the purpose of displaying, distributing and promoting the contents of your account, including through downloadable clients and external feeds.
+
+  %p
+    Modifying and adapting here refer strictly to how your work is displayed— not how it is written or otherwise created.
+    Changes may include, but are not limited to:
+    updating formatting (such as changing "bold" html to "strong");
+    improving accessibility;
+    adapting to the technical requirements of user devices;
+    or displaying snippets in search results.
+
+  %h4#endorsement e. Endorsement of Content
+
+  %p
+    You recognize that the Constellation does not endorse Content on the Website in any way, except when material appears as an official statement.
+
+  %p
+    No one affiliated with the Constellation, including adminstrators or volunteers, is acting in an official capacity when they post Content of the type generally provided by site users, and such Content is also not endorsed by the Website in any way.
+
+  %h4#deletion f. Deletion of Content
+
+  %p
+    If you delete Content, we will use reasonable efforts to remove it from the Website, but you acknowledge that caching or references to the Content may not be made immediately unavailable or may be provided by external services such as search engines which are beyond our control.
+    By deleting Content, you agree that such Content may be unrecoverable.
+
+  %p
+    Though deleted Content will not be publicly available, for legal and disaster recovery purposes we may retain backup copies.
+    You acknowledge and agree that the Constellation may preserve Content and may disclose Content if required to do so by law or in the good faith belief that such preservation or disclosure is reasonably necessary to:
+    comply with legal process;
+    enforce the ToS;
+    respond to claims that any Content violates the rights of third parties;
+    or protect the rights, property, or personal safety of the Constellation's users and the public.
+
+  %p
+    The license stated above in
+    = link_to '3d. Reproduction of Content', '#reproduction'
+    will terminate within a reasonable time after you remove or the Constellation removes your Content from the Website.
+
+  %h3#violations 4. Abuse and Violations Policy
+
+  %p
+    We recognize that there is no such thing as a popular abuse policy. By their nature, abuse complaints are unpleasant at best. And policy needs to be applied by people, which always complicates matters. We have tried to set out clear procedures to minimize and channel the inevitable conflicts.
+
+  %p
+    The Constellation does not prescreen for content. Complaints are investigated only when they are submitted through the appropriate channels and with the appropriate information.
+
+  %h4#mediation a. Mediating Disputes
+
+  %p
+    Where possible, we encourage users to try mediating disputes themselves before contacting Policy & Abuse.
+    If you are unable to resolve the problem on your own, you can file a complaint with the Policy & Abuse team.
+
+  %p
+    In some cases, objectionable Content may have already been deleted before the Policy & Abuse team acts.
+    We appreciate good faith attempts to resolve disputes, and in most such cases will close the complaint with no further action.
+    However, we reserve the right to consider individual circumstances, including whether the poster has engaged in a pattern of such conduct.
+
+  %h4#complaint b. Submitting a Complaint
+
+  %p
+    Complaints may be submitted to our Policy & Abuse team via the
+    = succeed ',' do
+      = link_to 'contact page', contact_path
+    except in the case of copyright complaints, which should be submitted in accordance with the process detailed in our
+    = succeed '.' do
+      = link_to 'DMCA policy', dmca_path
+    Depending on the nature of the complaint, anonymity of the complainant may hinder our ability to examine and/or verify the complaint.
+    In order for personnel to follow up on any allegation, the exact location (URL) and nature of the alleged violation must be supplied in the original complaint.
+    Repeated unverified complaints from the same source may be subject to summary rejection.
+
+  %h4#investigation c. Investigating a Complaint
+
+  %p
+    Only people who need to know about a complaint will be informed about it.
+    The details of any individual complaint are confidential and must be used only in resolving that complaint.
+
+  %p
+    The subject of a complaint may also be among those who need to know about it.
+    Only information provided in the complaint will be passed on.
+    The complainant has complete control over what information is submitted to Policy & Abuse, and can submit a complaint pseudonymously.
+    Legal names and other information sufficient to identify a person in the physical world will never be disclosed as part of a standard abuse complaint; for further clarification, please refer to our our
+    = succeed '.' do
+      = link_to 'Privacy Policy', privacy_path
+
+  %p
+    In general, the Policy & Abuse team will only communicate with the subject of a complaint if there appears to be a violation of site policy, or if personnel need more information to resolve the issue.
+
+  %p
+    Subject to obligations of confidentiality about specific complaints, the Policy & Abuse team may release statistics about general trends, such as the number of plagiarism complaints made and the actions taken by the team, in public to facilitate discussions of policies, procedures, and trends in complaints.
+
+  %h4#consequences d. Complaint Outcomes
+  %p
+    If Policy & Abuse personnel determine that a violation of this Agreement has taken place, they may, at their sole discretion, take remediation steps they deem necessary, including but not limited to:
+    %ul
+      %li setting a deadline for voluntary removal of the Content;
+      %li removing Content that has not been voluntarily removed within the deadline;
+      %li hiding the Content from other users where appropriate;
+      %li removing content immediately without waiting for a response (if, for instance, we determine the Content reveals an individual's personal information without consent), notifying the original poster and allowing them the option to resubmit with the violating Content removed;
+      %li adding, editing or removing Content tags, including content warnings;
+      %li removing Content without notifying the original poster in cases where invalid contact information has been provided;
+      %li issuing warnings to the user for minor or unintentional infractions;
+      %li suspending for a defined period of time, or permanently terminating, the user's access to any or all areas of the Constellation;
+      %li taking no action.
+
+  %p
+    The team's discretion will be informed by the nature of the violation and the response of the user, including the user's decision to voluntarily remove, modify or edit Content that violates the ToS.
+
+  %p
+    Penalties are not retroactive: a user's existing, nonobjectionable Content will not necessarily be automatically removed.
+    Suspended users retain the right to delete their Content by contacting Constellation administrators.
+
+  %p
+    Users whose accounts have been suspended or terminated for reasons other than age may not rejoin under another identity or in any other fashion attempt to bypass their penalties or account restrictions.
+    Users whose accounts were suspended or terminated due to age may appeal or rejoin once they are of age as defined in the
+    = succeed '.' do
+      = link_to 'Age Policy', '#age'
+
+  %p
+    If the complainant requests notification of the resolution of the complaint and provides contact information, we will notify them.
+
+  %h4#appeals e. Appeals Process
+
+  %p
+    The complainant or the original poster may appeal a decision to the Policy & Abuse team as a whole.
+    During the appeal, the original decision will remain in effect.
+    We will attempt to resolve appeals as speedily as possible, but please remember that the Policy & Abuse team is entirely comprised of volunteers.
+    The team's decisions are final unless overturned by the site owner at the owner's sole discretion.
+    There is no right of appeal to the owner.
+
+  %h3#legal 5. Legal Matters
+
+  %h4#privacy a. Privacy Policy
+
+  %p
+    Your use of the Website is governed by the Privacy Policy, currently located at
+    = succeed '.' do
+      = link_to privacy_url, privacy_path
+
+  %h4#jurisdiction b. Jurisdiction
+
+  %p
+    This Agreement and all disputes arising out of or related to it, shall be governed by the laws of the United States and specifically the State of New York, without regard to its conflict of law provisions.
+    You agree to submit to the personal and exclusive jurisdiction of the courts located within New York County (Manhattan), New York, and to waive any objection to the laying of venue there.
+
+  %p
+    You agree that, regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to use of the Constellation must be filed within 1 year after such claim or cause of action arose or be forever barred.
+
+  %h4#indemnity c. Indemnity
+
+  %p
+    You agree to indemnify and hold harmless the Glowfic Constellation, and any of its representatives or agents, from and against any and all claims and expenses, including attorneys' fees, arising out of your use of the Website, including but not limited to out of your violation of this Agreement.
+
+  %h4#copyright d. Copyright Infringement
+
+  %p
+    If you believe that material located on the Website violates your copyright, you may notify us in accordance with our
+    = succeed '.' do
+      = link_to "Digital Millennium Copyright Act ('DMCA') Policy", dmca_path
+    We will respond to all such notices as required by law, including by removing the infringing material or disabling access to the infringing material.
+    As set forth by law, we will, in our sole discretion, terminate or deny access to the Website to users of the site who have repeatedly infringed upon the copyrights or intellectual property rights of others.
+
+  %h4#liability e. Limitation of Liability
+
+  %p
+    You expressly understand and agree that in no event will the Glowfic Constellation or any of its representatives be liable with respect to any subject matter of this agreement under any contract, negligence, strict liability or other legal or equitable theory for:
+    %br (i) any special, incidental or consequential damages, including from any material you download, view, or otherwise access through the Service;
+    (ii) the cost of procurement or substitute products or services;
+    %br (iii) interruption, limitation or termination of use or loss or corruption of data;
+    (iv) any statements or conduct of any third party on the service;
+    %br (v) any claims arising out of Content you make available, your use of the Service, your connection to the Service, your use of the TOS, or your violation of the rights of another; or
+    (vi) any unauthorized access to or alterations of your Content.
+    We shall have no liability for any failure or delay due to matters beyond our reasonable control.
+
+  %p
+    In other words, the Constellation is not liable to you for allowing you to post Content, download Content, use the Service, or interact with the Website.
+    The Constellation does not assume whatever legal risks you face by posting, viewing, or doing other things with the Website.
+
+  %p
+    The foregoing shall not apply to the extent prohibited by applicable law.
+
+  %h4#invalidation f. Partial Invalidation
+
+  %p
+    Failure to enforce any part of this Agreement will not waive the Constellation's ability to enforce it, and any waiver with regard to a specific instance shall not constitute a waiver of any other breaches of the terms, even with regard to the same user.
+    If any part of this Agreement is held invalid or unenforceable, that part will be construed to reflect the parties' original intent, and the remaining portions will remain in full force and effect.
+
+  %h4#resale g. Resale of Services
+
+  %p
+    You agree not to reproduce, duplicate, copy, sell, resell, or exploit any portion of the Website, use of the Website, or access to the Website except as permitted by applicable licenses.
+
+  %h3#terms 6. Additional Terms
+
+  %h4#volunteers a. Volunteers
+
+  %p
+    We appreciate the generous service of our volunteers in many aspects of our Constellation management. No user is required to volunteer; it is completely optional. By providing work, volunteers agree that:
+    %ul
+      %li they are of legal age, or volunteering with the consent of a legal parent or guardian;
+      %li they are providing work with no expectation of pay or future consideration;
+      %li they have taken reasonable diligence to ensure that the work is correct, accurate, and free of defect;
+      %li they will not disclose or share any proprietary or confidential information;
+      %li their work shall be licensed to the Constellation on a perpetual, irrevocable, and world-wide basis, to the extent permitted by law;
+      %li the Constellation may determine the basis upon which their work shall be licensed to others, including licenses that may permit the further alteration or dissemination of your work; and
+      %li never to sue the Constellation for the use of said work.
+
+  %h4#development b. Active Development Disclaimer
+
+  %p
+    The Glowfic Constellation is under active development!
+    We are making every effort to make the Constellation stable and useful and to provide the best possible service to our users;
+    however, this is a work in progress.
+    Therefore, please be aware:
+
+  %p
+    This Website is provided "as is" and "as available".
+    We make no warranty that the Constellation will meet your requirements; that our services will be uninterrupted, timely, secure, or error-free; or that the results you get from using the services will be accurate, reliable, or satisfactory to you.
+    We may, at our sole discretion, discontinue providing the Website at any time, with or without notice.
+    You agree that any interruptions to the service will not qualify for reimbursement or compensation.
+    You understand that you download from, or otherwise obtain content or services through, the Website at your own discretion and risk.
+
+  %p
+    Please report bugs, and don't use the beta version of the Constellation as your only place to store your stories if you are not comfortable with this risk.
+    We appreciate your forbearance and your willingness to be a part of the Constellation at this early stage.
+
+  %h4#reporting c. Reporting Violations
+
+  %p
+    To report a violation of this Agreement, please
+    = succeed '.' do
+      = link_to 'contact us', contact_path
+
+  %h4#sections d. Section Titles
+
+  %p
+    The section titles in this Agreement are for convenience only and have no legal or contractual effect.
+
+  %h4#license e. Creative Commons
+
+  %p
+    This Terms of Service document is based on ones developed by Dreamwidth
+    = surround '(', '),' do
+      = link_to 'https://www.dreamwidth.org/legal/tos', 'https://www.dreamwidth.org/legal/tos', target: '_blank'
+    Mozilla
+    = surround '(', '),' do
+      = link_to 'https://www.mozilla.org/en-US/about/governance/policies/participation/', 'https://www.mozilla.org/en-US/about/governance/policies/participation/', target: '_blank'
+    and Archive of our Own
+    = surround '(', ')' do
+      = link_to 'https://www.archiveofourown.org/tos', 'https://www.archiveofourown.org/tos', target: '_blank'
+    and is licensed under a
+    = succeed '.' do
+      = link_to 'Creative Commons Attribution-ShareAlike 2.5 License', 'https://creativecommons.org/licenses/by-sa/2.5/', target: '_blank'
+
+  %p.details Last revised November 9, 2018

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -45,96 +45,109 @@
 
     = include_gon
   %body
-    #header
-      - if logged_in?
-        #user-info
-          = link_to user_path(current_user) do
-            - if current_user.avatar
-              = image_tag current_user.avatar.url, class: 'icon', id: 'user-icon'
-            - else
-              .no-img
-            #user-username= current_user.username
-      #header-right
-        #logo
-          - unless logged_in?
-            #header-links
-              = link_to "Login", login_path
-              %span &nbsp;|&nbsp;
-              = link_to "Sign up", new_user_path
-          = link_to root_path do
-            = image_tag "layouts/logo.png", alt: 'Glowfic Constellation'
-        #nav-top
-          - if logged_in?
-            %ul
-              %li= link_to 'Account', edit_user_path(current_user)
-              %li= link_to 'Inbox', messages_path
-              %li= link_to "Characters", user_characters_path(current_user)
-              %li= link_to "Galleries", user_galleries_path(current_user)
-              %li= link_to 'Favorites', favorites_path
-              %li= link_to "Post", new_post_path
-            = link_to logout_path, method: :delete, id: :"header-logout" do
-              = button_tag "Log out", class: 'button'
-          - else
-            = form_tag login_path, method: :post, id: 'header-form' do
-              #header-forms
-                = text_field_tag :username, params[:username], placeholder: "Username"
-                = password_field_tag :password, params[:password], placeholder: "Password"
-              #header-remember
-                = check_box_tag :remember_me
-                = label_tag :remember_me, "Remember Me"
-              #header-buttons
-                = submit_tag "Log in", class: 'button'
-              #header-buttons-links
+    #holder
+      #header
+        - if logged_in?
+          #user-info
+            = link_to user_path(current_user) do
+              - if current_user.avatar
+                = image_tag current_user.avatar.url, class: 'icon', id: 'user-icon'
+              - else
+                .no-img
+              #user-username= current_user.username
+        #header-right
+          #logo
+            - unless logged_in?
+              #header-links
+                = link_to "Login", login_path
+                %span &nbsp;|&nbsp;
                 = link_to "Sign up", new_user_path
-                &nbsp;|&nbsp;
-                = link_to "Forgot Password?", new_password_reset_path
-      #nav-bottom
-        %ul
-          %li= link_to 'Continuities', boards_path
-          %li= link_to 'Recently Updated', posts_path
-          %li= link_to 'Search', search_posts_path
-          %li= link_to 'Users', users_path
-          %li= link_to 'Facecasts', facecasts_characters_path
-          - if logged_in?
-            %li= link_to 'Unread', unread_posts_path
-            %li= link_to 'Replies Owed', owed_posts_path
-          %li= link_to 'Contribute', contribute_path
-          %li= link_to 'Tags', tags_path
-          - if (day = DailyReport.unread_date_for(current_user)).present?
-            %li
-              = link_to report_path(id: :daily, day: day), style: 'text-shadow: 0 0 0.8em #F87, 0 0 0.8em #F87' do
-                Daily Report
-                %em= '(' + Date.parse(day).strftime("%b %d, %Y") + ')'
-          - else
-            %li= link_to 'Daily Report', report_path(id: :daily)
-    - if content_for?(:breadcrumbs)
-      .flash.breadcrumbs= content_for :breadcrumbs
-    - if flash[:error].is_a?(Hash)
-      .flash.error
-        - if flash[:error].has_key? :image
-          = image_tag flash[:error][:image], class: 'vmid'.freeze
-        = flash[:error][:message]
-        - if flash[:error].has_key? :array
+            = link_to root_path do
+              = image_tag "layouts/logo.png", alt: 'Glowfic Constellation'
+          #nav-top
+            - if logged_in?
+              %ul
+                %li= link_to 'Account', edit_user_path(current_user)
+                %li= link_to 'Inbox', messages_path
+                %li= link_to "Characters", user_characters_path(current_user)
+                %li= link_to "Galleries", user_galleries_path(current_user)
+                %li= link_to 'Favorites', favorites_path
+                %li= link_to "Post", new_post_path
+              = link_to logout_path, method: :delete, id: :"header-logout" do
+                = button_tag "Log out", class: 'button'
+            - else
+              = form_tag login_path, method: :post, id: 'header-form' do
+                #header-forms
+                  = text_field_tag :username, params[:username], placeholder: "Username"
+                  = password_field_tag :password, params[:password], placeholder: "Password"
+                #header-remember
+                  = check_box_tag :remember_me
+                  = label_tag :remember_me, "Remember Me"
+                #header-buttons
+                  = submit_tag "Log in", class: 'button'
+                #header-buttons-links
+                  = link_to "Sign up", new_user_path
+                  &nbsp;|&nbsp;
+                  = link_to "Forgot Password?", new_password_reset_path
+        #nav-bottom
           %ul
-            - flash[:error][:array].each do |error|
-              %li= error
-      - flash.delete(:error)
-    - flash.keys.each do |key|
-      - if key == :pass
-        .flash{class: 'error'.freeze}= flash[key].html_safe
-      - else
-        .flash{:class=>key}= flash[key]
-    - if content_for?(:flashes)
-      = content_for :flashes
-    - if logged_in?
-      - if current_user.messages.where(unread: true).exists?
-        - current_user.messages.where(unread: true).each do |message|
-          .flash.inbox
-            New message from
-            = message_sender(message)
-            &ndash;
-            = link_to message.unempty_subject, message_path(message)
-    #content= yield
+            %li= link_to 'Continuities', boards_path
+            %li= link_to 'Recently Updated', posts_path
+            %li= link_to 'Search', search_posts_path
+            %li= link_to 'Users', users_path
+            %li= link_to 'Facecasts', facecasts_characters_path
+            - if logged_in?
+              %li= link_to 'Unread', unread_posts_path
+              %li= link_to 'Replies Owed', owed_posts_path
+            %li= link_to 'Tags', tags_path
+            - if (day = DailyReport.unread_date_for(current_user)).present?
+              %li
+                = link_to report_path(id: :daily, day: day), style: 'text-shadow: 0 0 0.8em #F87, 0 0 0.8em #F87' do
+                  Daily Report
+                  %em= '(' + Date.parse(day).strftime("%b %d, %Y") + ')'
+            - else
+              %li= link_to 'Daily Report', report_path(id: :daily)
+      - if content_for?(:breadcrumbs)
+        .flash.breadcrumbs= content_for :breadcrumbs
+      - if flash[:error].is_a?(Hash)
+        .flash.error
+          - if flash[:error].has_key? :image
+            = image_tag flash[:error][:image], class: 'vmid'.freeze
+          = flash[:error][:message]
+          - if flash[:error].has_key? :array
+            %ul
+              - flash[:error][:array].each do |error|
+                %li= error
+        - flash.delete(:error)
+      - flash.keys.each do |key|
+        - if key == :pass
+          .flash{class: 'error'.freeze}= flash[key].html_safe
+        - else
+          .flash{:class=>key}= flash[key]
+      - if content_for?(:flashes)
+        = content_for :flashes
+      - if logged_in?
+        - if current_user.messages.where(unread: true).exists?
+          - current_user.messages.where(unread: true).each do |message|
+            .flash.inbox
+              New message from
+              = message_sender(message)
+              &ndash;
+              = link_to message.unempty_subject, message_path(message)
+      - unless logged_in? || tos_skippable?
+        #tos.hidden= render partial: 'about/accept_tos'
+      #content= yield
+      #footer
+        %div
+          = link_to 'Terms of Service', tos_path
+          &bull;
+          = link_to 'Privacy Policy', privacy_path
+          &bull;
+          = link_to 'DMCA', dmca_path
+          &bull;
+          = link_to 'Contact Us', contact_path
+          &bull;
+          = link_to 'Contribute', contribute_path
 
   = javascript_include_tag 'application'.freeze
   - (@javascripts || []).each do |javascript|

--- a/app/views/sessions/index.haml
+++ b/app/views/sessions/index.haml
@@ -10,4 +10,4 @@
     %ul
       %li= link_to "Alicorn's forum", 'http://alicorn.elcenia.com/board/index.php', target: '_blank'
       %li= link_to "IRC", 'https://client00.chat.mibbit.com/?channel=%23glowfic&server=irc.psigenix.net', target: '_blank'
-      %li= link_to "Discord", 'https://discord.gg/Ss6fRFj', target: '_blank'
+      %li= link_to "Discord", Glowfic::DISCORD_LINK, target: '_blank'

--- a/app/views/users/new.haml
+++ b/app/views/users/new.haml
@@ -36,5 +36,17 @@
         %th.sub.vtop Secret
         %td.even
           = text_field_tag :secret, params[:secret], placeholder: "Secret"
+      %tr#terms
+        %th.sub.vtop Terms
+        %td.odd
+          = check_box_tag :tos, true, params[:tos].present?
+          = label_tag :tos do
+            I have read and agree to the
+            = link_to 'Terms of Service', tos_path
+            and the
+            = link_to 'Privacy Policy', privacy_path
+          .alert.hidden{style: 'margin: 2px 0px;'}
+            = image_tag 'icons/exclamation.png', alt: '!', title: '', class: 'vmid'
+            %span.msg
     %tr
       %th.form-table-ender{colspan: 2}= submit_tag "Sign Up", class: 'button'

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,8 @@ module Glowfic
     "cite" => %w(href)
   }
 
+  DISCORD_LINK = 'https://discord.gg/Ss6fRFj'
+
   module Sanitizers
     WRITTEN_CONF = Sanitize::Config.merge(Sanitize::Config::RELAXED,
       elements: ALLOWED_TAGS,

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,5 +11,5 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w( posts/*.js users/*.js boards/*.js characters/*.js global.js paginator.js galleries/*.js messages.js icons.js board_sections.js icons.js reorder.js tags/*.js )
+Rails.application.config.assets.precompile += %w( posts/*.js users/*.js boards/*.js characters/*.js global.js paginator.js galleries/*.js messages.js icons.js board_sections.js icons.js reorder.js tags/*.js accept_tos.js )
 Rails.application.config.assets.precompile += %w( layouts/*.css tinymce.css )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   match '/login' => 'sessions#new', :as => :login, :via => :get
   match '/login' => 'sessions#create', :via => :post
   match '/logout' => 'sessions#destroy', :as => :logout, :via => :delete
+  match '/confirm_tos' => 'sessions#confirm_tos', as: :confirm_tos, via: :patch
   match '/users/:id/templates' => redirect('/users/%{id}/characters'), via: :get
   resources :users do
     resources :characters, only: :index
@@ -123,6 +124,10 @@ Rails.application.routes.draw do
   resources :reports, only: [:index, :show]
   resources :bugs, only: :create
   resources :favorites, only: [:index, :create, :destroy]
+  match '/tos' => 'about#tos', as: :tos, via: :get
+  match '/privacy' => 'about#privacy', as: :privacy, via: :get
+  match '/contact' => 'about#contact', as: :contact, via: :get
+  match '/dmca' => 'about#dmca', as: :dmca, via: :get
   match '/contribute' => 'contribute#index', as: :contribute, via: :get
   mount ResqueWeb::Engine => "/resque_web"
 end

--- a/spec/controllers/about_controller_spec.rb
+++ b/spec/controllers/about_controller_spec.rb
@@ -1,0 +1,92 @@
+require "spec_helper"
+
+RSpec.describe AboutController do
+  describe "GET tos" do
+    it "succeeds when logged out" do
+      get :tos
+      expect(response).to have_http_status(200)
+      expect(assigns(:page_title)).to eq("Terms of Service")
+    end
+
+    it "succeeds when logged in" do
+      login
+      get :tos
+      expect(response).to have_http_status(200)
+      expect(assigns(:page_title)).to eq("Terms of Service")
+    end
+
+    it "does not show TOS prompt" do
+      user = create(:user, tos_version: nil)
+      login_as(user)
+      get :tos
+      expect(response).not_to render_template('about/accept_tos')
+      expect(response).to render_template('about/tos')
+    end
+  end
+
+  describe "GET privacy" do
+    it "succeeds when logged out" do
+      get :privacy
+      expect(response).to have_http_status(200)
+      expect(assigns(:page_title)).to eq("Privacy Policy")
+    end
+
+    it "succeeds when logged in" do
+      login
+      get :privacy
+      expect(response).to have_http_status(200)
+      expect(assigns(:page_title)).to eq("Privacy Policy")
+    end
+
+    it "does not show TOS prompt" do
+      user = create(:user, tos_version: 0)
+      login_as(user)
+      get :privacy
+      expect(response).not_to render_template('about/accept_tos')
+    end
+  end
+
+  describe "GET dmca" do
+    it "succeeds when logged out" do
+      get :dmca
+      expect(response).to have_http_status(200)
+      expect(assigns(:page_title)).to eq("DMCA Policy")
+    end
+
+    it "succeeds when logged in" do
+      login
+      get :dmca
+      expect(response).to have_http_status(200)
+      expect(assigns(:page_title)).to eq("DMCA Policy")
+    end
+
+    it "does not show TOS prompt" do
+      user = create(:user, tos_version: nil)
+      login_as(user)
+      get :dmca
+      expect(response).not_to render_template('about/accept_tos')
+    end
+  end
+
+  describe "GET contact" do
+    it "succeeds when logged out" do
+      get :contact
+      expect(response).to have_http_status(200)
+      expect(assigns(:page_title)).to eq("Contact Us")
+    end
+
+    it "succeeds when logged in" do
+      login
+      get :contact
+      expect(response).to have_http_status(200)
+      expect(assigns(:page_title)).to eq("Contact Us")
+    end
+
+    it "does not show TOS prompt" do
+      user = create(:user, tos_version: 20110709)
+      login_as(user)
+      get :contact
+      expect(response).not_to render_template('about/accept_tos')
+    end
+  end
+end

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -3,6 +3,22 @@ require "support/s3_bucket_helper"
 
 RSpec.describe GalleriesController do
   describe "GET index" do
+    context "TOS" do # does not belong here but... tbh I don't have a better idea
+      render_views
+
+      it "shows TOS prompt to logged in users" do
+        user = create(:user, tos_version: nil)
+        login_as(user)
+        get :index, params: {force_tos: true}
+        expect(response).to render_template('about/accept_tos')
+      end
+
+      it "shows TOS prompt to logged out users" do
+        get :index, params: {force_tos: true, user_id: create(:user).id }
+        expect(response).to render_template(partial: 'about/_accept_tos')
+      end
+    end
+
     context "without a user_id" do
       it "requires login" do
         get :index

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     sequence :email do |n|
       "fake#{n}@faker.com"
     end
+    tos_version User::CURRENT_TOS_VERSION
 
     factory :admin_user do
       role_id { 1 }


### PR DESCRIPTION
Done:
- [x] Require logged in users to accept the new TOS
- [x] Require new users to accept the new TOS
- [x] Require logged out users to accept the new TOS
- [x] DCMA page
- [x] Contact Us page
- [x] Site menu at the bottom of the layout

Remaining:
- [x] AO3 policy 4 - policies for actually handling reported violations
- [x] Review the privacy policy? Is it actually comprehensive?
- [x] Squash the many, many commits

Later issues:
- make a way to make content Not Visible without a user having the ability to undo this for DMCA reasons; deletion is fine for audited stuff but some things are not audited. Or possibly just install more audits, or both.
- make a way for an account to be Suspended (can't create anything text/icon/etc but can read)
- make (finish) a way for an account to be Deleted (see #810)
- I'd like a cookie policy as well but I think it can be a separate project
- GDPR review at this point should probably be separate.