### PR TITLE
Improve setting and deleting of cookies

### DIFF
--- a/app/concerns/authentication.rb
+++ b/app/concerns/authentication.rb
@@ -24,8 +24,13 @@ module Authentication
 
     def logout
       reset_session
-      cookies.delete(:user_id, domain: '.glowfic.com')
+      cookies.delete(:user_id, cookie_delete_options)
       @current_user = nil
     end
+  end
+
+  def cookie_delete_options
+    return {domain: '.glowfic.com'} if Rails.env.production?
+    {}
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
     return unless logged_in?
     return unless current_user.salt_uuid.nil?
     reset_session
-    cookies.delete(:user_id, domain: '.glowfic.com')
+    cookies.delete(:user_id, cookie_delete_options)
     @current_user = nil
     flash.now[:pass] = "Because Marri accidentally made passwords a bit too secure, you must log back in to continue using the site."
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -25,7 +25,7 @@ class SessionsController < ApplicationController
       end
       flash[:success] = "You are now logged in as #{user.username}. Welcome back!"
       session[:user_id] = user.id
-      cookies.permanent.signed[:user_id] = {value: user.id, domain: '.glowfic.com', tld_length: 2} if params[:remember_me].present?
+      cookies.permanent.signed[:user_id] = cookie_hash(user.id) if params[:remember_me].present?
       @current_user = user
       redirect_to boards_path and return if session[:previous_url] == '/login'
     else
@@ -39,5 +39,12 @@ class SessionsController < ApplicationController
     logout
     flash[:success] = "You have been logged out."
     redirect_to url
+  end
+
+  private
+
+  def cookie_hash(value)
+    return {value: value, domain: '.glowfic.com', tld_length: 2} if Rails.env.production?
+    {value: value}
   end
 end


### PR DESCRIPTION
Only chekc for .glowfic.com domain when in production.

This is a precursor to the TOS branch in #919 in case we wind up setting cookies for logged out users. (For SEO reasons we may have to use JavaScript; tbd.)