### PR TITLE
Include a .clear div at the end of the #content div

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -136,7 +136,9 @@
               = link_to message.unempty_subject, message_path(message)
       - unless logged_in? || tos_skippable?
         #tos.hidden= render partial: 'about/accept_tos'
-      #content= yield
+      #content
+        = yield
+        .clear
       #footer
         %div
           = link_to 'Terms of Service', tos_path


### PR DESCRIPTION
This way pages with floated elements like character profile pages don't bleed behind the new footer bar.