### PR TITLE
User#edit cleanup

### DIFF
--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -1,4 +1,4 @@
-= form_for current_user, :url => user_path(current_user), :method => :put do |f|
+= form_for current_user do |f|
   %table.form-table
     %tr
       %th.centered{colspan: 2} Account Settings
@@ -87,7 +87,7 @@
       %th.form-table-ender{colspan: 2}= submit_tag "Save", class: 'button'
 
 %br
-= form_for current_user, :url => password_user_path(current_user), :method => :put do |f|
+= form_for current_user, url: password_user_path(current_user), method: :put, html: {id: 'change_password_form'} do |f|
   %table.form-table#change-password
     %tr
       %th.centered{colspan: 2} Change Password


### PR DESCRIPTION
In sane commits and everything! Things covered here:

- For sanity's sake, remove the :pass option in flash. I believe it was added because a) we used to have HTML tags in there that needs html_safe and that needed special handling and b) we wanted it not to conflict with other error tags, but we have few enough password-broken users now (and c) I think flashes changed from IndifferentAccess so it was actually incorrectly displaying as flash.pass not flash.error) that I went with the consolidated code for clarity

- The user#edit page no longer specifies url or method for the user edit form, as Rails can detect that itself. (Change password needs specifying still because they're non standard)

- The user#edit page sets the id of the change password form to #change_password_form explicitly, as otherwise it autogenerates an ID which conflicts with the user edit form

- User#update now renders edit on failure instead of redirecting, as this allows us to use the flash message/array syntax to actually explain to the user what they did wrong. (Just updating the flash object wouldn't work, as flash.now objects have :keys but flash objects have "keys".)

- We now support images with the .flash-dismiss class within links that will dismiss their parent div when you click them. This has been installed in our ephemeral error and success divs (but not warnings or inbox) to allow users to dismiss notices without reloading the page.

- Database migration for subcontinuity descriptions in preparation for actually adding them to the code.