### PR TITLE
Migration for subcontinuity descriptions

### DIFF
--- a/db/migrate/20181113044923_add_subcontinuity_descriptions.rb
+++ b/db/migrate/20181113044923_add_subcontinuity_descriptions.rb
@@ -1,0 +1,5 @@
+class AddSubcontinuityDescriptions < ActiveRecord::Migration[5.1]
+  def change
+     add_column :board_sections, :description, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -171,7 +171,8 @@ CREATE TABLE public.board_sections (
     status integer DEFAULT 0 NOT NULL,
     section_order integer NOT NULL,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    description text
 );
 
 
@@ -2367,6 +2368,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171127031443'),
 ('20171227030824'),
 ('20180109003825'),
-('20180928230642');
+('20180928230642'),
+('20181113044923');
 
 


### PR DESCRIPTION
Release separately from the code so the structure is already in the db when the code is added later. Related to #813