### PR TITLE
Add an X button to flashes to allow a user to dismiss them

### DIFF
--- a/app/assets/javascripts/global.js
+++ b/app/assets/javascripts/global.js
@@ -7,6 +7,11 @@ $(document).ready(function() {
     minimumResultsForSearch: 10,
   });
 
+  $(".flash-dismiss").click(function() {
+    $(this).closest('.flash').slideUp(200);
+    return false;
+  });
+
   // Set localStorage if login status has changed
   // storage values are usually strings, cast to be sure
   var loggedInKey = 'loggedIn';

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ class ApplicationController < ActionController::Base
     reset_session
     cookies.delete(:user_id, cookie_delete_options)
     @current_user = nil
-    flash.now[:pass] = "Because Marri accidentally made passwords a bit too secure, you must log back in to continue using the site."
+    flash.now[:error] = "Because Marri accidentally made passwords a bit too secure, you must log back in to continue using the site."
   end
 
   def use_javascript(js)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -67,11 +67,16 @@ class UsersController < ApplicationController
     store_tos and return if params[:tos_check]
 
     params[:user][:per_page] = -1 if params[:user].try(:[], :per_page) == 'all'
-    if current_user.update(user_params)
-      flash[:success] = "Changes saved successfully."
-    else
-      flash[:error] = "There was a problem with your changes."
+    unless current_user.update(user_params)
+      flash.now[:error] = {}
+      flash.now[:error][:message] = "There was a problem updating your account."
+      flash.now[:error][:array] = current_user.errors.full_messages
+      use_javascript('users/edit')
+      @page_title = 'Edit Account'
+      render action: :edit and return
     end
+
+    flash[:success] = "Changes saved successfully."
     redirect_to edit_user_path(current_user)
   end
 

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -111,6 +111,8 @@
         .flash.breadcrumbs= content_for :breadcrumbs
       - if flash[:error].is_a?(Hash)
         .flash.error
+          = link_to '#' do
+            = image_tag 'icons/cross.png', class: 'float-right flash-dismiss'
           - if flash[:error].has_key? :image
             = image_tag flash[:error][:image], class: 'vmid'.freeze
           = flash[:error][:message]
@@ -120,10 +122,10 @@
                 %li= error
         - flash.delete(:error)
       - flash.keys.each do |key|
-        - if key == :pass
-          .flash{class: 'error'.freeze}= flash[key].html_safe
-        - else
-          .flash{:class=>key}= flash[key]
+        .flash{class: key}
+          = link_to '#' do
+            = image_tag 'icons/cross.png', class: 'float-right flash-dismiss'
+          = flash[key]
       - if content_for?(:flashes)
         = content_for :flashes
       - if logged_in?

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ApplicationController do
   describe "#show_password_warning" do
     it "shows no warning if logged out" do
       controller.send(:show_password_warning) do
-        expect(flash.now[:pass]).not_to eq("Because Marri accidentally made passwords a bit too secure, you must log back in to continue using the site.")
+        expect(flash.now[:error]).not_to eq("Because Marri accidentally made passwords a bit too secure, you must log back in to continue using the site.")
       end
     end
 
@@ -43,7 +43,7 @@ RSpec.describe ApplicationController do
       login_as(user)
       expect(user.salt_uuid).not_to be_nil
       controller.send(:show_password_warning) do
-        expect(flash.now[:pass]).not_to eq("Because Marri accidentally made passwords a bit too secure, you must log back in to continue using the site.")
+        expect(flash.now[:error]).not_to eq("Because Marri accidentally made passwords a bit too secure, you must log back in to continue using the site.")
         expect(controller.send(:logged_in?)).to eq(true)
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe ApplicationController do
       login_as(user)
       user.update_columns(salt_uuid: nil)
       controller.send(:show_password_warning) do
-        expect(flash.now[:pass]).to eq("Because Marri accidentally made passwords a bit too secure, you must log back in to continue using the site.")
+        expect(flash.now[:error]).to eq("Because Marri accidentally made passwords a bit too secure, you must log back in to continue using the site.")
         expect(controller.send(:logged_in?)).not_to eq(true)
       end
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -221,8 +221,8 @@ RSpec.describe UsersController do
       user = create(:user)
       login_as(user)
       put :update, params: { id: user.id, user: {moiety: 'A'} }
-      expect(response).to redirect_to(edit_user_url(user))
-      expect(flash[:error]).to eq('There was a problem with your changes.')
+      expect(response).to render_template(:edit)
+      expect(flash[:error][:message]).to eq('There was a problem updating your account.')
     end
 
     it "does not update another user" do


### PR DESCRIPTION
Fixes #698

- For sanity's sake, remove the :pass option in flash. I believe it was added because a) we used to have HTML tags in there that needs html_safe and that needed special handling and b) we wanted it not to conflict with other error tags, but we have few enough password-broken users now (and c) I think flashes changed from IndifferentAccess so it was actually incorrectly displaying as flash.pass not flash.error) that I went with the consolidated code for clarity

- User#update now renders edit on failure instead of redirecting, as this allows us to use the flash message/array syntax to actually explain to the user what they did wrong. (Just updating the flash object wouldn't work, as flash.now objects have :keys but flash objects have "keys".)

- We now support images with the .flash-dismiss class within links that will dismiss their parent div when you click them. This has been installed in our ephemeral error and success divs (but not warnings or inbox) to allow users to dismiss notices without reloading the page.