### PR TITLE
Fix bug with the character_split argument

### DIFF
--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -6,7 +6,7 @@
 
 %table
   %tr
-    %th{colspan: 6}
+    %th{colspan: (character_split == 'none' ? 7 : 6)}
       - if @group
         Character Group:
         = @group.name


### PR DESCRIPTION
Loading a character list with character_split=none causes the header to display with one too few columns, distorting the table's appearance.