### PR TITLE
Character dropdown supports midword matching

### DIFF
--- a/app/controllers/api/v1/characters_controller.rb
+++ b/app/controllers/api/v1/characters_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::CharactersController < Api::ApiController
   error 403, "Post is not visible to the user"
   error 422, "Invalid parameters provided"
   def index
-    queryset = Character.where("name LIKE ?", params[:q].to_s + '%').ordered
+    queryset = Character.with_name(params[:q].to_s).ordered
     if @post
       char_ids = @post.replies.select(:character_id).distinct.pluck(:character_id) + [@post.character_id]
       queryset = queryset.where(id: char_ids)

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -28,6 +28,7 @@ class Character < ApplicationRecord
   after_destroy :clear_char_ids
 
   scope :ordered, -> { order(name: :asc).order(Arel.sql('lower(screenname) asc'), created_at: :asc, id: :asc) }
+  scope :with_name, -> (charname) { where("lower(concat_ws(' | ', name, template_name, screenname)) LIKE ?", "%#{charname.downcase}%") }
 
   accepts_nested_attributes_for :template, reject_if: :all_blank
 

--- a/spec/controllers/api/v1/characters_controller_spec.rb
+++ b/spec/controllers/api/v1/characters_controller_spec.rb
@@ -45,6 +45,46 @@ RSpec.describe Api::V1::CharactersController do
         expect(response.json).to have_key('results')
         expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
+
+      it "matches lowercase" do
+        char = create(:character, name: 'Upcase')
+        get :index, params: { q: 'upcase' }
+        expect(response).to have_http_status(200)
+        expect(response.json).to have_key('results')
+        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+      end
+
+      it "matches uppercase" do
+        char = create(:character, name: 'downcase')
+        get :index, params: { q: 'DOWNcase' }
+        expect(response).to have_http_status(200)
+        expect(response.json).to have_key('results')
+        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+      end
+
+      it "matches nickname" do
+        char = create(:character, name: 'a', template_name: 'b', screenname: 'c')
+        get :index, params: { q: 'b' }
+        expect(response).to have_http_status(200)
+        expect(response.json).to have_key('results')
+        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+      end
+
+      it "matches screenname" do
+        char = create(:character, name: 'a', template_name: 'b', screenname: 'c')
+        get :index, params: { q: 'c' }
+        expect(response).to have_http_status(200)
+        expect(response.json).to have_key('results')
+        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+      end
+
+      it "matches midword" do
+        char = create(:character, name: 'abcdefg')
+        get :index, params: { q: 'cde' }
+        expect(response).to have_http_status(200)
+        expect(response.json).to have_key('results')
+        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+      end
     end
 
     context "when logged in" do


### PR DESCRIPTION
Select2 does not perform local searches on remote results, so the fix needed to be applied to the API controller. This moves us from doing case sensitive prefix search on character name to doing case insensitive substring search on name+template name+screenname.

Could have been done with pgsearch and indexes, but that's much more overhead for something that may need refactoring later regardless if we move template_name to be a CharacterAlias.

Fixes #706