### PR TITLE
Handle the edge case of URL-less uploaded icons without crashing

### DIFF
--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -39,7 +39,7 @@ class Icon < ApplicationRecord
 
   def use_icon_host
     return unless uploaded?
-    return unless ENV['ICON_HOST'].present?
+    return unless url.present? && ENV['ICON_HOST'].present?
     return if url.to_s.include?(ENV['ICON_HOST'])
     self.url = ENV['ICON_HOST'] + url[(url.index(S3_DOMAIN).to_i + S3_DOMAIN.length)..-1]
   end

--- a/spec/models/icon_spec.rb
+++ b/spec/models/icon_spec.rb
@@ -154,6 +154,12 @@ RSpec.describe Icon do
       expect(icon.reload.url).to eq(asset_host + '/users%2F1%2Ficons%2Ffake_test.png')
     end
 
+    it "handles weird URL-less AWS edge case" do
+      ENV['ICON_HOST'] = asset_host
+      icon = build(:uploaded_icon, url: '')
+      expect(icon.save).to eq(false)
+    end
+
     it "updates the s3 domain to the asset host domain" do
       ENV['ICON_HOST'] = asset_host
       icon = build(:icon)


### PR DESCRIPTION
Addresses the "crashing" part of #952 though we still need to figure out the "why is it not providing a URL in the first place" part.