### PR TITLE
Filter messages from blocked users from in/outboxes

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,12 +4,15 @@ class MessagesController < ApplicationController
   before_action :editor_setup, only: :new
 
   def index
+    blocked_ids = Block.where(blocking_user: current_user).select(:blocked_user_id)
     if params[:view] == 'outbox'
       @page_title = 'Outbox'
       from_table = current_user.sent_messages.where(visible_outbox: true).ordered_by_thread.select('distinct on (thread_id) messages.*')
+      from_table = from_table.where.not(recipient_id: blocked_ids)
     else
       @page_title = 'Inbox'
-      from_table = current_user.messages.where(visible_outbox: true).ordered_by_thread.select('distinct on (thread_id) messages.*')
+      from_table = current_user.messages.where(visible_inbox: true).ordered_by_thread.select('distinct on (thread_id) messages.*')
+      from_table = from_table.where.not(sender_id: blocked_ids)
     end
     @messages = Message.from(from_table).select('*').order('subquery.id desc').paginate(per_page: 25, page: page)
     @view = @page_title.downcase

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -6,7 +6,7 @@ class Message < ApplicationRecord
   belongs_to :first_thread, class_name: 'Message', foreign_key: :thread_id, inverse_of: false, optional: false
 
   validates :sender, presence: { if: Proc.new { |m| m.sender_id != 0 } }
-  validate :unblocked_recipient
+  validate :unblocked_recipient, on: :create
 
   before_validation :set_thread_id
   before_create :check_recipient

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -118,4 +118,11 @@ RSpec.describe Block, type: :model do
       expect(block.hide_their_posts?).to be(false)
     end
   end
+
+  it "should hide messages when first blocking" do
+    message = create(:message)
+    expect(message).to be_unread
+    create(:block, blocking_user: message.recipient, blocked_user: message.sender, block_interactions: true)
+    expect(message.reload).not_to be_unread
+  end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -54,4 +54,11 @@ RSpec.describe Message do
     expect(message.save).to eq(false)
     expect(message.errors.full_messages.first).to eq("Recipient must not be blocked by you")
   end
+
+  it "does not error to blocked user if updating an existing message" do
+    message = create(:message)
+    block = create(:block, blocking_user: message.sender, blocked_user: message.recipient)
+    message.unread = false
+    message.save!
+  end
 end


### PR DESCRIPTION
If user A has blocked user B, user A should not see messages (including old messages) to or from user B in ther inbox or outbox. User B should continue to see messages as normal. This will handle blocks with threading.