### PR TITLE
Fix footer overlap issues with character editor

### DIFF
--- a/app/assets/stylesheets/characters.scss
+++ b/app/assets/stylesheets/characters.scss
@@ -1,10 +1,17 @@
 @import 'variables';
 
 // default icon selector
-#character-icon-selector { display: inline-block; vertical-align: top; margin-left: 5px; }
+#character-icon-selector {
+  display: inline-block;
+  vertical-align: top;
+  margin-left: 5px;
+}
 .character-galleries-simple { padding: 10px; }
 .character-screenname { font-size: 85%; }
-.character-form { display: inline-block; vertical-align: top; }
+.character-form {
+  display: inline-block;
+  vertical-align: top;
+}
 
 // template descriptions on templates#show
 .single-description {

--- a/app/assets/stylesheets/characters.scss
+++ b/app/assets/stylesheets/characters.scss
@@ -1,13 +1,10 @@
 @import 'variables';
 
 // default icon selector
-#character-icon-selector {
-  position: absolute;
-  left: 450px;
-  top: 20px;
-}
+#character-icon-selector { display: inline-block; vertical-align: top; margin-left: 5px; }
 .character-galleries-simple { padding: 10px; }
 .character-screenname { font-size: 85%; }
+.character-form { display: inline-block; vertical-align: top; }
 
 // template descriptions on templates#show
 .single-description {

--- a/app/views/characters/_editor.haml
+++ b/app/views/characters/_editor.haml
@@ -46,22 +46,3 @@
     %td{class: cycle('even', 'odd')}= f.text_area :audit_comment, placeholder: 'Explain reason for moderation here', class: 'text', cols: 35
 %tr
   %th.form-table-ender{colspan: 2}= submit_tag "Save", class: 'button'
-
-#character-icon-selector
-  %strong Icons
-  %br
-  Pick default icon (optional):
-  %br
-  .character-galleries-simple
-    - galleries = @character.galleries.present? ? @character.galleries.ordered : [Struct.new(:id, :name, :icons).new(0, 'Galleryless', @character.user.galleryless_icons || [])]
-    - if galleries.present?
-      - galleries.each do |gallery|
-        %div{id: "gallery#{gallery.id}", :'data-id' => gallery.id }
-          %br
-          %b.gallery-name= gallery.name
-          %br
-          .gallery-icons
-            - gallery.icons.each do |icon|
-              - klass = 'icon character-icon'
-              - klass += ' selected-icon' if icon == @character.default_icon
-              = icon_tag icon, class: klass, data: { id: icon.id }

--- a/app/views/characters/_icon_selector.haml
+++ b/app/views/characters/_icon_selector.haml
@@ -1,0 +1,18 @@
+#character-icon-selector
+  %strong Icons
+  %br
+  Pick default icon (optional):
+  %br
+  .character-galleries-simple
+    - galleries = @character.galleries.present? ? @character.galleries.ordered : [Struct.new(:id, :name, :icons).new(0, 'Galleryless', @character.user.galleryless_icons || [])]
+    - if galleries.present?
+      - galleries.each do |gallery|
+        %div{id: "gallery#{gallery.id}", :'data-id' => gallery.id }
+          %br
+          %b.gallery-name= gallery.name
+          %br
+          .gallery-icons
+            - gallery.icons.each do |icon|
+              - klass = 'icon character-icon'
+              - klass += ' selected-icon' if icon == @character.default_icon
+              = icon_tag icon, class: klass, data: { id: icon.id }

--- a/app/views/characters/edit.haml
+++ b/app/views/characters/edit.haml
@@ -9,27 +9,30 @@
   %b Edit
 
 = form_for @character, url: character_path(@character), method: :put do |f|
-  %table.form-table
-    %tr
-      %th.centered{colspan: 2}= @character.name
-    = render partial: 'editor', locals: {f: f}
+  .character-form
+    %table.form-table
+      %tr
+        %th.centered{colspan: 2}= @character.name
+      = render 'editor', f: f
 
-%br
-%table.form-table
-  %tr
-    %th.centered
-      Aliases and Pseudonyms
-      - if @character.user_id == current_user.id
-        = link_to new_character_alias_path(@character) do
-          .link-box.action-new + New Alias
-  - @aliases.each do |calias|
-    %tr
-      %td.padding-5{class: cycle('even', 'odd')}
-        = calias.name
-        - if @character.user_id == current_user.id
-          .float-right
-            = link_to character_alias_path(@character, calias), method: :delete, confirm: 'Are you sure you want to delete this alias?' do
-              = image_tag "icons/cross.png"
-  - if @aliases.empty?
-    %tr
-      %td.centered.padding-10{ class: cycle('even','odd'), colspan: 6 } — No aliases yet —
+    %br
+    %table.form-table
+      %tr
+        %th.centered
+          Aliases and Pseudonyms
+          - if @character.user_id == current_user.id
+            = link_to new_character_alias_path(@character) do
+              .link-box.action-new + New Alias
+      - @aliases.each do |calias|
+        %tr
+          %td.padding-5{class: cycle('even', 'odd')}
+            = calias.name
+            - if @character.user_id == current_user.id
+              .float-right
+                = link_to character_alias_path(@character, calias), method: :delete, confirm: 'Are you sure you want to delete this alias?' do
+                  = image_tag "icons/cross.png"
+      - if @aliases.empty?
+        %tr
+          %td.centered.padding-10{ class: cycle('even','odd'), colspan: 6 } — No aliases yet —
+
+  = render 'icon_selector'

--- a/app/views/characters/new.haml
+++ b/app/views/characters/new.haml
@@ -1,6 +1,9 @@
 = form_for @character, url: characters_path, method: :post do |f|
   = f.hidden_field :default_icon_id
-  %table.form-table
-    %tr
-      %th.centered{colspan: 2} New Character
-    = render partial: 'editor', locals: {f: f}
+  .character-form
+    %table.form-table
+      %tr
+        %th.centered{colspan: 2} New Character
+      = render 'editor', f: f
+
+  = render 'icon_selector'


### PR DESCRIPTION
Absolute positioning broke the thing, so this refactors the editor to not use absolute position (and incidentally to not stick the icon selector div within the table tag).