### PR TITLE
Fix double-escaping of &s in post description hovers

### DIFF
--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -19,9 +19,9 @@
         = link_to unread_path(post) do
           = image_tag lastlink_img, class: 'vmid', title: 'First Unread'
     - if logged_in? && @opened_ids.present? && !@opened_ids.include?(post.id)
-      %b= link_to post.subject, post_path(post), title: strip_tags(post.description)
+      %b= link_to post.subject, post_path(post), title: strip_tags(post.description).html_safe
     - else
-      = link_to post.subject, post_path(post), title: strip_tags(post.description)
+      = link_to post.subject, post_path(post), title: strip_tags(post.description).html_safe
     - if !@hide_quicklinks && (!logged_in? || per_page > 0)
       - total_pages = (replies_count.to_f / per_page).ceil
       - if total_pages > 1

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe PostsController do
       ids_fetched = controller.instance_variable_get('@posts').map(&:id)
       expect(ids_fetched).to eq([post5.id, post4.id, post3.id, post2.id, post1.id])
     end
+
+    context "with views" do
+      render_views
+
+      it "sanitizes post descriptions" do
+        post1 = create(:post, description: "<a href=\"/characters/1\">Name</a> and <a href=\"/characters/2\">Other Name</a> do a thing.")
+        post2 = create(:post, description: "A & B do a thing")
+        get :index
+        expect(response.body).to include('title="Name and Other Name do a thing."')
+        expect(response.body).to include('title="A &amp; B do a thing"')
+      end
+    end
   end
 
   describe "GET search" do


### PR DESCRIPTION
Adds `.html_safe` to uses of `strip_tags` in displaying post descriptions. Fixes double-escaping of `&` symbols (`&` → `&amp;` by way of `strip_tags`, → `&amp;amp;` by way of not being `html_safe?`).

The strings outputted from `strip_tags` should all be basically perfectly safe. Behind the scenes, it uses `Rails::Html::Sanitizer.full_sanitizer.sanitize(html)`, which itself uses Loofah to remove all HTML stuff (and convert special symbols to entities and so on), and so should be as safe as basically all of our sanitization.

It would be a lot harder to treat this field as a mix of HTML and non-HTML, but the current approach (treating the whole field as HTML) has some downsides if people accidentally use `&`s without putting space characters after them, as it might be parsed as an entity and get eaten in rendering.