### PR TITLE
Upgrade rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,11 +5,10 @@ AllCops:
   Exclude:
     - 'bin/*'
     - 'config/**/*'
-    - 'db/migrate/2015*'
-    - 'db/migrate/2016*'
-    - 'db/migrate/2017*'
+    - 'db/migrate/*'
     - 'db/seeds.rb'
     - 'spec/spec_helper.rb'
+    - 'wraith/*'
 
 Rails:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
-  gem 'rubocop', '~> 0.59.0'
+  gem 'rubocop', '~> 0.62.0'
   gem 'traceroute'
   gem 'web-console', '~> 3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
     nokogumbo (1.5.0)
       nokogiri
     parallel (1.12.1)
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     pg (0.21.0)
     pg_search (2.1.2)
@@ -332,14 +332,14 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.59.2)
+    rubocop (0.62.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
+      unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     ruby_parser (3.11.0)
@@ -412,7 +412,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.19)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
     web-console (3.7.0)
@@ -482,7 +482,7 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails (~> 3.7.2)
-  rubocop (~> 0.59.0)
+  rubocop (~> 0.62.0)
   sanitize
   sass-rails
   seed_dump (~> 3.2)


### PR DESCRIPTION
Neither new cop (`Performance/OpenStruct` and `Rails/LinkToBlank`) warns on our code.