### PR TITLE
Lock Bundler version to match Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - postgresql
 cache: bundler
 before_install:
-  - gem install bundler
+  - gem install bundler -v 1.15.2
 before_script:
   - psql -c 'create database glowfic_test;' -U postgres
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN apt-get install -y curl
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
 RUN apt-get install -y nodejs postgresql-client-9.4
 
-RUN gem install bundler
+RUN gem install bundler -v 1.15.2
 RUN bundle install


### PR DESCRIPTION
Heroku [uses Bundler 1.15.2](https://devcenter.heroku.com/articles/ruby-support#libraries) and [does not allow other versions](https://devcenter.heroku.com/articles/bundler-version#why-can-t-the-bundler-version-be-configured) so we should adopt that same version both in our local development Docker image and in our Travis CI builds.