### PR TITLE
Address some Rubocop validation errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -222,6 +222,15 @@ Rails/HasManyOrHasOneDependent:
 Rails/SaveBang:
   Enabled: true
 
+# read_attribute(:attr) and self[:attr] are no longer equivalent
+Rails/ReadWriteAttribute:
+  Enabled: false
+
+# post_scraper.rb is run manually in the command line so stdout is fine
+Rails/Output:
+  Exclude:
+    - 'app/services/post_scraper.rb'
+
 ################## Style #################################
 
 Style/Alias:

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path('config/application', __dir__)
 
 Rails.application.load_tasks

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -288,6 +288,9 @@ class CharactersController < ApplicationController
     @search_results = @search_results.ordered.paginate(page: page, per_page: 25)
   end
 
+  def icon
+  end
+
   private
 
   def find_character

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -122,7 +122,7 @@ class RepliesController < WritableController
         preview(ReplyDraft.reply_from_draft(draft)) and return
       end
 
-      if reply.user_id.present? && !params[:allow_dupe].present?
+      if reply.user_id.present? && params[:allow_dupe].blank?
         last_by_user = reply.post.replies.where(user_id: reply.user_id).ordered.last
         if last_by_user.present?
           match_attrs = ['content', 'icon_id', 'character_id', 'character_alias_id']

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -118,7 +118,7 @@ module ApplicationHelper
   end
 
   def time_display_options(default=nil)
-    time_thing = Time.new(2016, 12, 25, 21, 34, 56) # Example time: "2016-12-25 21:34:56" (for unambiguous display purposes)
+    time_thing = Time.new(2016, 12, 25, 21, 34, 56).utc # Example time: "2016-12-25 21:34:56" (for unambiguous display purposes)
     time_display_list = [
       "%b %d, %Y %l:%M %p", "%b %d, %Y %H:%M", "%b %d, %Y %l:%M:%S %p", "%b %d, %Y %H:%M:%S",
       "%d %b %Y %l:%M %p", "%d %b %Y %H:%M", "%d %b %Y %l:%M:%S %p", "%d %b %Y %H:%M:%S",

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -12,7 +12,7 @@ class ApplicationJob < ActiveJob::Base
 
   def notify_exception
     yield
-  rescue => e
+  rescue StandardError => e
     self.class.notify_exception(e, *arguments)
     raise e
   end

--- a/app/jobs/generate_flat_post_job.rb
+++ b/app/jobs/generate_flat_post_job.rb
@@ -33,7 +33,7 @@ class GenerateFlatPostJob < ApplicationJob
       flat_post.save!
 
       $redis.del(lock_key)
-    rescue => e
+    rescue StandardError => e
       $redis.del(lock_key)
       raise e # jobs are automatically retried
     end

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -51,7 +51,7 @@ class Block < ApplicationRecord
   end
 
   def mark_messages_read
-    Message.where(unread: true, sender_id: blocked_user_id, recipient_id: blocking_user_id).each do |message|
+    Message.where(unread: true, sender_id: blocked_user_id, recipient_id: blocking_user_id).find_each do |message|
       message.unread = false
       message.save
     end

--- a/app/models/board_section.rb
+++ b/app/models/board_section.rb
@@ -14,7 +14,7 @@ class BoardSection < ApplicationRecord
   private
 
   def clear_post_values
-    Post.where(section_id: id).each do |post|
+    Post.where(section_id: id).find_each do |post|
       post.section_id = nil
       post.save
     end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -7,7 +7,7 @@ class Favorite < ApplicationRecord
 
   def self.between(user, favorite)
     return unless user && favorite
-    Favorite.where(user_id: user.id, favorite_id: favorite.id, favorite_type: favorite.class.to_s).first
+    Favorite.find_by(user_id: user.id, favorite_id: favorite.id, favorite_type: favorite.class.to_s)
   end
 
   private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -61,7 +61,7 @@ class Message < ApplicationRecord
   private
 
   def set_thread_id
-    return unless thread_id.blank?
+    return if thread_id.present?
     self.first_thread = self
   end
 

--- a/app/models/reply_draft.rb
+++ b/app/models/reply_draft.rb
@@ -4,7 +4,7 @@ class ReplyDraft < ApplicationRecord
   belongs_to :post, inverse_of: :reply_drafts, optional: false
 
   def self.draft_for(post_id, user_id)
-    self.where(post_id: post_id, user_id: user_id).first
+    self.find_by(post_id: post_id, user_id: user_id)
   end
 
   def self.draft_reply_for(post, user)

--- a/app/services/post_importer.rb
+++ b/app/services/post_importer.rb
@@ -12,6 +12,18 @@ class PostImporter < Object
     ScrapePostJob.perform_later(@url, board_id, section_id, status, threaded, importer_id)
   end
 
+  def self.valid_dreamwidth_url?(url)
+    # this is simply checking for a properly formatted Dreamwidth URL
+    # errors when actually querying the URL are handled by ScrapePostJob
+    return false if url.blank?
+    return false unless url.include?('dreamwidth')
+    parsed_url = URI.parse(url)
+    return false unless parsed_url.host
+    parsed_url.host.ends_with?('dreamwidth.org')
+  rescue URI::InvalidURIError
+    false
+  end
+
   private
 
   def validate_url!
@@ -49,18 +61,6 @@ class PostImporter < Object
     data = HTTParty.get(@url).body
     Rails.logger.debug "Downloaded #{@url} for scraping"
     @dreamwidth_doc = Nokogiri::HTML(data)
-  end
-
-  def self.valid_dreamwidth_url?(url)
-    # this is simply checking for a properly formatted Dreamwidth URL
-    # errors when actually querying the URL are handled by ScrapePostJob
-    return false if url.blank?
-    return false unless url.include?('dreamwidth')
-    parsed_url = URI.parse(url)
-    return false unless parsed_url.host
-    parsed_url.host.ends_with?('dreamwidth.org')
-  rescue URI::InvalidURIError
-    false
   end
 end
 

--- a/app/services/post_scraper.rb
+++ b/app/services/post_scraper.rb
@@ -86,19 +86,19 @@ class PostScraper < Object
     # download URL, trying up to 3 times
     max_try = 3
     retried = 0
-    data = begin
-      sleep 0.25
-      HTTParty.get(url).body
-    rescue Net::OpenTimeout => e
-      retried += 1
-      if retried < max_try
-        logger.debug "Failed to get #{url}: #{e.message}; retrying (tried #{retried} #{'time'.pluralize(retried)})"
-        retry
-      else
-        logger.warn "Failed to get #{url}: #{e.message}"
-        raise
-      end
-    end
+    data =  begin
+              sleep 0.25
+              HTTParty.get(url).body
+            rescue Net::OpenTimeout => e
+              retried += 1
+              if retried < max_try
+                logger.debug "Failed to get #{url}: #{e.message}; retrying (tried #{retried} #{'time'.pluralize(retried)})"
+                retry
+              else
+                logger.warn "Failed to get #{url}: #{e.message}"
+                raise
+              end
+            end
 
     Nokogiri::HTML(data)
   end

--- a/script/rails
+++ b/script/rails
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-APP_PATH = File.expand_path('../../config/application', __FILE__)
-require_relative '../config/boot'
-require 'rails/commands'


### PR DESCRIPTION
- Per [this issue](https://github.com/rubocop-hq/rails-style-guide/issues/155), read_attribute(:attr) and self[:attr] are not in fact equivalent, specifically around handling attributes which aren't found. Therefore I have disabled Rails/ReadWriteAttribute since it appears to be out of date.

- Since post_scraper.rb is run by us in the command line, it's fine to have output going to stdout instead of Rails.logger, so disabled Rails/Output for just that file.

- Fixed a couple Style/ExpandPathArguments, one by actually fixing it and one by removing it (we do not need both bin/rails and script/rails)

- Fixed a couple Rails/LexicallyScopedActionFilter by explicitly declaring CharactersController#icon

- Fixed a Rails/TimeZone by using Time.new.utc for our example time in the time zone selector

- Fixed by rescuing `StandardError => e` in place of generic ` => e`

- Fixed a few Rails/Present by swapping some blank?s with present?s and vice versa

- Updated some `.each` to `.find_each` to fix Rails/FindEach

- Updated some `.where.first` to `.find_by` to fix Rails/FindBy

- Tabbed a begin/rescue block to fix a Layout/RescueEnsureAlignment

- Lint/IneffectiveAccessModifier made me realize that PostScraper.valid_dreamwidth_url? is within a private but not actually private; since it is not _supposed_ to be private (I tried, tests failed, private is wrong) I just moved it out of the private block.

This brings us from 146 Rubocop offenses to 124 offenses. Remaining offenses are primarily Rails/SaveBang and Rails/SkipsModelValidations and spec/*