### PR TITLE
Improve post tests

### DIFF
--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -110,7 +110,7 @@ class Reply < ApplicationRecord
   end
 
   def author_can_write_in_post
-    return unless post && user
+    return unless post && user && post.id
     errors.add(:user, "#{user.username} is not a valid continuity author for #{post.board.name}") unless user.writes_in?(post.board)
     return unless post.authors_locked?
     errors.add(:user, "#{user.username} cannot write in this post") unless post.author_for(user)&.can_reply

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -110,7 +110,7 @@ class Reply < ApplicationRecord
   end
 
   def author_can_write_in_post
-    return unless post && user && post.id
+    return unless post&.id && user
     errors.add(:user, "#{user.username} is not a valid continuity author for #{post.board.name}") unless user.writes_in?(post.board)
     return unless post.authors_locked?
     errors.add(:user, "#{user.username} cannot write in this post") unless post.author_for(user)&.can_reply

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1363,7 +1363,7 @@ RSpec.describe PostsController do
         Timecop.freeze(post.created_at + 2.minutes) do
           post.mark_read(post.user)
         end
-        expect(post.last_read(post.user)).to be_the_same_time_as(post.created_at + 2.minutes)\
+        expect(post.last_read(post.user)).to be_the_same_time_as(post.created_at + 2.minutes)
         login_as(post.user)
 
         put :update, params: { id: post.id, unread: true, at_id: unread_reply.id }

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -688,6 +688,21 @@ RSpec.describe PostsController do
       expect(Label.count).to eq(3)
       expect(PostTag.count).to eq(9)
     end
+
+    it "generates a flat post" do
+      user = create(:user)
+      login_as(user)
+      post :create, params: {
+        post: {
+          subject: 'subject',
+          board_id: create(:board).id,
+          privacy: Concealable::REGISTERED,
+          content: 'content',
+        }
+      }
+      post = assigns(:post)
+      expect(post.flat_post).not_to be_nil
+    end
   end
 
   describe "GET show" do

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -275,6 +275,7 @@ RSpec.describe RepliesController do
       other_user = create(:user)
       login_as(user)
       reply_post = create(:post, user: other_user, tagging_authors: [user, other_user], authors_locked: true)
+      reply_post.mark_read(user)
       post :create, params: { reply: {post_id: reply_post.id, content: 'test content!'} }
       expect(Reply.count).to eq(1)
     end
@@ -284,6 +285,7 @@ RSpec.describe RepliesController do
       other_user = create(:user)
       login_as(user)
       other_post = create(:post, user: user, tagging_authors: [user, other_user], authors_locked: true)
+      other_post.mark_read(user)
       post :create, params: { reply: {post_id: other_post.id, content: 'more test content!'} }
       expect(Reply.count).to eq(1)
     end
@@ -292,6 +294,7 @@ RSpec.describe RepliesController do
       user = create(:user)
       login_as(user)
       reply_post = create(:post)
+      reply_post.mark_read(user)
       Timecop.freeze(Time.zone.now) do
         post :create, params: { reply: {post_id: reply_post.id, content: 'test content!'} }
       end
@@ -326,6 +329,7 @@ RSpec.describe RepliesController do
       user = create(:user)
       login_as(user)
       reply_post = create(:post, authors_locked: true)
+      reply_post.mark_read(user)
       post :create, params: { reply: {post_id: reply_post.id, content: 'test'} }
       expect(flash[:error][:message]).to eq("Your reply could not be saved because of the following problems:")
       expect(flash[:error][:array]).to eq(["User #{user.username} cannot write in this post"])
@@ -334,6 +338,7 @@ RSpec.describe RepliesController do
     it "sets reply_order correctly on the first reply" do
       reply_post = create(:post)
       login_as(reply_post.user)
+      reply_post.mark_read(reply_post.user)
       searchable = 'searchable content'
       post :create, params: { reply: {post_id: reply_post.id, content: searchable} }
       reply = reply_post.replies.ordered.last

--- a/spec/features/posts/edit_spec.rb
+++ b/spec/features/posts/edit_spec.rb
@@ -233,4 +233,37 @@ RSpec.feature "Editing posts", :type => :feature do
       expect(page).to have_no_selector('.post-updated')
     end
   end
+
+  scenario "Fields are preserved on failed post#update" do
+    user = login
+    post = create(:post, user: user, subject: 'test subject', content: 'test content')
+
+    visit post_path(post)
+    expect(page).to have_selector('.post-container', count: 1)
+    within('.post-container') do
+      click_link 'Edit'
+    end
+
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.content-header', exact_text: 'Edit post')
+    expect(page).to have_no_selector('.post-container')
+    within('#post-editor') do
+      expect(page).to have_field('Subject', with: 'test subject')
+      expect(page).to have_field('post_content', with: 'test content')
+      fill_in 'Subject', with: ''
+      fill_in "Description", with: "test description"
+      fill_in "post_content", with: "other content"
+      click_button 'Save'
+    end
+
+    expect(page).to have_no_selector('.post-container')
+    expect(page).to have_selector('.error', text: "Subject can't be blank")
+
+    expect(page).to have_selector('#post-editor')
+    within('#post-editor') do
+      expect(page).to have_field('Subject', with: '')
+      expect(page).to have_field('Description', with: 'test description')
+      expect(page).to have_field('post_content', with: 'other content')
+    end
+  end
 end

--- a/spec/features/posts/edit_spec.rb
+++ b/spec/features/posts/edit_spec.rb
@@ -257,8 +257,8 @@ RSpec.feature "Editing posts", :type => :feature do
       fill_in 'Subject', with: ''
       fill_in "Description", with: "test description"
       fill_in "post_content", with: "other content"
-      click_button 'Save'
     end
+    click_button 'Save'
 
     expect(page).to have_no_selector('.post-container')
     expect(page).to have_selector('.error', text: "Subject can't be blank")

--- a/spec/features/posts/edit_spec.rb
+++ b/spec/features/posts/edit_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature "Editing posts", :type => :feature do
     expect(page).to have_no_selector('.post-container')
     within('#post-editor') do
       fill_in 'Subject', with: 'other subject'
+      fill_in "post_content", with: "other content"
     end
     click_button 'Save'
 
@@ -41,6 +42,10 @@ RSpec.feature "Editing posts", :type => :feature do
     expect(page).to have_selector('.success', text: 'has been updated.')
     expect(page).to have_selector('.post-container', count: 1)
     expect(page).to have_selector('#post-title', exact_text: 'other subject')
+
+    within('.post-content') do
+      expect(page).to have_selector('p', exact_text: 'other content')
+    end
   end
 
   scenario "User edits a post with preview" do
@@ -61,6 +66,7 @@ RSpec.feature "Editing posts", :type => :feature do
     expect(page).to have_no_selector('.post-container')
     within('#post-editor') do
       fill_in 'Subject', with: 'other subject'
+      fill_in "post_content", with: "other content"
     end
     click_button 'Preview'
 
@@ -71,7 +77,9 @@ RSpec.feature "Editing posts", :type => :feature do
     expect(page).to have_selector('#post-editor')
     within('#post-editor') do
       expect(page).to have_field('Subject', with: 'other subject')
+      expect(page).to have_field('post_content', with: 'other content')
       fill_in 'Subject', with: 'third subject'
+      fill_in "post_content", with: "third content"
     end
     click_button 'Save'
 
@@ -79,6 +87,10 @@ RSpec.feature "Editing posts", :type => :feature do
     expect(page).to have_selector('.success', text: 'has been updated.')
     expect(page).to have_selector('.post-container', count: 1)
     expect(page).to have_selector('#post-title', exact_text: 'third subject')
+
+    within('.post-content') do
+      expect(page).to have_selector('p', exact_text: 'third content')
+    end
   end
 
   scenario "User tries to edit someone else's post" do
@@ -114,6 +126,7 @@ RSpec.feature "Editing posts", :type => :feature do
     expect(page).to have_no_selector('.post-container')
     within('#post-editor') do
       fill_in 'Subject', with: 'other subject'
+      fill_in "post_content", with: "other content"
       fill_in 'Moderator note', with: 'example edit'
     end
     click_button 'Save'
@@ -122,6 +135,11 @@ RSpec.feature "Editing posts", :type => :feature do
     expect(page).to have_selector('.success', text: 'has been updated.')
     expect(page).to have_selector('.post-container', count: 1)
     expect(page).to have_selector('#post-title', exact_text: 'other subject')
+
+    within('.post-content') do
+      expect(page).to have_selector('p', exact_text: 'other content')
+    end
+
     within('.post-container') do
       # must not change post's user
       expect(page).to have_selector('.post-author', exact_text: user.username)
@@ -146,6 +164,7 @@ RSpec.feature "Editing posts", :type => :feature do
     expect(page).to have_no_selector('.post-container')
     within('#post-editor') do
       fill_in 'Subject', with: 'other subject'
+      fill_in "post_content", with: "other content"
       fill_in 'Moderator note', with: 'example edit'
     end
     click_button 'Preview'
@@ -159,6 +178,7 @@ RSpec.feature "Editing posts", :type => :feature do
       expect(page).to have_field('Subject', with: 'other subject')
       expect(page).to have_field('Moderator note', with: 'example edit')
       fill_in 'Subject', with: 'third subject'
+      fill_in "post_content", with: "third content"
       fill_in 'Moderator note', with: 'another edit'
     end
     click_button 'Save'
@@ -167,6 +187,10 @@ RSpec.feature "Editing posts", :type => :feature do
     expect(page).to have_selector('.success', text: 'has been updated.')
     expect(page).to have_selector('.post-container', count: 1)
     expect(page).to have_selector('#post-title', exact_text: 'third subject')
+
+    within('.post-content') do
+      expect(page).to have_selector('p', exact_text: 'third content')
+    end
   end
 
   scenario "Moderator saves no change to a post in a board they can't write in" do

--- a/spec/features/posts/edit_spec.rb
+++ b/spec/features/posts/edit_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Editing posts", :type => :feature do
 
   scenario "User edits a post" do
     user = create(:user, password: 'known')
-    post = create(:post, user: user, subject: 'test subject')
+    post = create(:post, user: user, subject: 'test subject', content: 'test content')
 
     login(user, 'known')
 
@@ -33,6 +33,8 @@ RSpec.feature "Editing posts", :type => :feature do
     expect(page).to have_selector('.content-header', exact_text: 'Edit post')
     expect(page).to have_no_selector('.post-container')
     within('#post-editor') do
+      expect(page).to have_field('Subject', with: 'test subject')
+      expect(page).to have_field('post_content', with: 'test content')
       fill_in 'Subject', with: 'other subject'
       fill_in "post_content", with: "other content"
     end
@@ -111,7 +113,7 @@ RSpec.feature "Editing posts", :type => :feature do
 
   scenario "Moderator edits a post" do
     user = create(:user)
-    post = create(:post, user: user, subject: 'test subject')
+    post = create(:post, user: user, subject: 'test subject', content: 'test content')
 
     login(create(:mod_user, password: 'known'), 'known')
 
@@ -125,6 +127,8 @@ RSpec.feature "Editing posts", :type => :feature do
     expect(page).to have_selector('.content-header', exact_text: 'Edit post')
     expect(page).to have_no_selector('.post-container')
     within('#post-editor') do
+      expect(page).to have_field('Subject', with: 'test subject')
+      expect(page).to have_field('post_content', with: 'test content')
       fill_in 'Subject', with: 'other subject'
       fill_in "post_content", with: "other content"
       fill_in 'Moderator note', with: 'example edit'

--- a/spec/features/posts/flat_spec.rb
+++ b/spec/features/posts/flat_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.feature "Viewing flat posts", :type => :feature do
+  scenario "User views a flat post" do
+    user = login
+    post = create(:post, user: user, subject: "test subject", content: "test content")
+
+    GenerateFlatPostJob.perform_now(post.id)
+
+    visit post_path(post, view: 'flat')
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_selector('.post-post', count: 1)
+    expect(page).to have_selector('#post-title', exact_text: "test subject")
+
+    within('.post-content') do
+      expect(page).to have_selector('p', exact_text: 'test content')
+    end
+  end
+end

--- a/spec/features/posts/new_spec.rb
+++ b/spec/features/posts/new_spec.rb
@@ -17,15 +17,19 @@ RSpec.feature "Creating posts", :type => :feature do
     expect(page).to have_selector(".content-header", text: "Create a new post")
 
     fill_in "post_subject", with: "test subject"
+    fill_in "post_content", with: "test content"
     click_button "Post"
     expect(page).to have_no_selector(".error")
     expect(page).to have_selector('.success', text: 'successfully posted.')
     expect(page).to have_selector('.post-container', count: 1)
     expect(page).to have_selector('#post-title', exact_text: 'test subject')
 
+    within('.post-content') do
+      expect(page).to have_selector('p', exact_text: 'test content')
+    end
+
     within('.post-container') do
       expect(page).to have_selector('.post-author', exact_text: user.username)
-      expect(page).to have_selector('.post-content', exact_text: '')
     end
   end
 

--- a/spec/features/posts/new_spec.rb
+++ b/spec/features/posts/new_spec.rb
@@ -71,6 +71,24 @@ RSpec.feature "Creating posts", :type => :feature do
     end
   end
 
+  scenario "Fields are preserved on failed post#create" do
+    login
+    visit new_post_path
+    expect(page).to have_no_selector(".error")
+    expect(page).to have_selector(".content-header", text: "Create a new post")
+
+    fill_in "post_subject", with: "test subject"
+    fill_in "post_content", with: "test content"
+    click_button "Post"
+
+    expect(page).to have_selector('.error', text: 'Your post could not be saved because of the following problems: Board must exist')
+    expect(page).to have_selector('#post-editor')
+    within('#post-editor') do
+      expect(page).to have_field('Subject', with: 'test subject')
+      expect(page).to have_field('post_content', with: 'test content')
+    end
+  end
+
   scenario "User sees different editor settings" do
     user = login
     create(:board)

--- a/spec/features/posts/new_spec.rb
+++ b/spec/features/posts/new_spec.rb
@@ -33,6 +33,44 @@ RSpec.feature "Creating posts", :type => :feature do
     end
   end
 
+  scenario "User creates a post with preview" do
+    user = login
+    create(:board)
+
+    visit new_post_path
+    expect(page).to have_no_selector(".error")
+    expect(page).to have_selector(".content-header", text: "Create a new post")
+
+    fill_in "post_subject", with: "test subject"
+    fill_in "post_content", with: "test content"
+    click_button 'Preview'
+
+    # verify preview, change
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.content-header', exact_text: 'test subject')
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_selector('#post-editor')
+    within('#post-editor') do
+      expect(page).to have_field('Subject', with: 'test subject')
+      expect(page).to have_field('post_content', with: 'test content')
+      fill_in 'Subject', with: 'other subject'
+      fill_in "post_content", with: "other content"
+      click_button 'Post'
+    end
+    expect(page).to have_no_selector(".error")
+    expect(page).to have_selector('.success', text: 'successfully posted.')
+    expect(page).to have_selector('.post-container', count: 1)
+    expect(page).to have_selector('#post-title', exact_text: 'other subject')
+
+    within('.post-content') do
+      expect(page).to have_selector('p', exact_text: 'other content')
+    end
+
+    within('.post-container') do
+      expect(page).to have_selector('.post-author', exact_text: user.username)
+    end
+  end
+
   scenario "User sees different editor settings" do
     user = login
     create(:board)

--- a/spec/features/posts/new_spec.rb
+++ b/spec/features/posts/new_spec.rb
@@ -55,8 +55,9 @@ RSpec.feature "Creating posts", :type => :feature do
       expect(page).to have_field('post_content', with: 'test content')
       fill_in 'Subject', with: 'other subject'
       fill_in "post_content", with: "other content"
-      click_button 'Post'
     end
+    click_button 'Post'
+
     expect(page).to have_no_selector(".error")
     expect(page).to have_selector('.success', text: 'successfully posted.')
     expect(page).to have_selector('.post-container', count: 1)

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -50,10 +50,10 @@ RSpec.describe Template do
 
     it "returns info for multiple characters" do
       template = create(:template)
-      character1 = create(:character, template: template)
-      character2 = create(:character, template: template, template_name: "nickname")
-      character3 = create(:character, template: template, screenname: "screen_name")
-      expect(template.plucked_characters).to match_array([[character1.id, character1.name], [character2.id, "#{character2.name} | #{character2.template_name}"], [character3.id, "#{character3.name} | #{character3.screenname}"]])
+      character1 = create(:character, template: template, name: 'AAAA')
+      character2 = create(:character, template: template, template_name: "nickname", name: 'BBBB')
+      character3 = create(:character, template: template, screenname: "screen_name", name: 'CCCC')
+      expect(template.plucked_characters).to eq([[character1.id, character1.name], [character2.id, "#{character2.name} | #{character2.template_name}"], [character3.id, "#{character3.name} | #{character3.screenname}"]])
     end
   end
 

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Template do
       character1 = create(:character, template: template)
       character2 = create(:character, template: template, template_name: "nickname")
       character3 = create(:character, template: template, screenname: "screen_name")
-      expect(template.plucked_characters).to eq([[character1.id, character1.name], [character2.id, "#{character2.name} | #{character2.template_name}"], [character3.id, "#{character3.name} | #{character3.screenname}"]])
+      expect(template.plucked_characters).to match_array([[character1.id, character1.name], [character2.id, "#{character2.name} | #{character2.template_name}"], [character3.id, "#{character3.name} | #{character3.screenname}"]])
     end
   end
 


### PR DESCRIPTION
* Adds editable_by? and deletable_by? to post model
* Checks post is saved when testing if author can write in it (this is irrelevant atm but matters for the post-reply split)
* Checks a flat post is generated
* Uses timecop on some post#mark_read tests
* Marks post read on some reply tests
* Adds post content to post#new and post#edit feature specs
* Tests fields are preserved on failed post#create and post#update
* Feature specs preview on post#new
* Fixes a minor niggle on template model tests
