### PR TITLE
Use delete_all for a Post's dependent replies when destroying

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -17,7 +17,7 @@ class Post < ApplicationRecord
   belongs_to :last_user, class_name: 'User', inverse_of: false, optional: false
   belongs_to :last_reply, class_name: 'Reply', inverse_of: false, optional: true
   has_one :flat_post, dependent: :destroy
-  has_many :replies, inverse_of: :post, dependent: :destroy
+  has_many :replies, inverse_of: :post, dependent: :delete_all
   has_many :reply_drafts, dependent: :destroy
 
   has_many :post_viewers, inverse_of: :post, dependent: :destroy


### PR DESCRIPTION
- Have confirmed we don't need any of the existing callbacks
  - Audits are kinda superfluous since we'll have the audit on the post's delete
  - We don't need to update the post's tagged at, latest reply, author list, reply order, etc becaues the post itself is being deleted
- Attempted to continue to use destroy and just skip the identified useless callbacks, but it was still far too slow (>30seconds for a 5000 reply post). If we want to use callbacks later, we'll have to use soft delete (plausibly not faster) or background jobs or both.