### PR TITLE
Clean up various rubocop lints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -317,6 +317,9 @@ Style/MultilineMemoization:
 Style/MutableConstant:
   Enabled: false
 
+Style/NumericLiterals:
+  Enabled: false
+
 Style/NumericPredicate:
   Enabled: false
 

--- a/app/services/post_scraper.rb
+++ b/app/services/post_scraper.rb
@@ -123,7 +123,7 @@ class PostScraper < Object
       url = first_reply_in_batch.at_css('.comment-title').at_css('a').attribute('href').value
       unless url[/(\?|&)style=site/]
         url_obj = URI.parse(url)
-        url_obj.query += ('&' unless url_obj.query.blank?) + 'style=site'
+        url_obj.query += ('&' if url_obj.query.present?) + 'style=site'
         url = url_obj.to_s
       end
       links << url

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe PostsController do
       render_views
 
       it "sanitizes post descriptions" do
-        post1 = create(:post, description: "<a href=\"/characters/1\">Name</a> and <a href=\"/characters/2\">Other Name</a> do a thing.")
-        post2 = create(:post, description: "A & B do a thing")
+        create(:post, description: "<a href=\"/characters/1\">Name</a> and <a href=\"/characters/2\">Other Name</a> do a thing.")
+        create(:post, description: "A & B do a thing")
         get :index
         expect(response.body).to include('title="Name and Other Name do a thing."')
         expect(response.body).to include('title="A &amp; B do a thing"')

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1040,7 +1040,6 @@ RSpec.describe PostsController do
 
       expect(assigns(:prev_post)).to eq(prev)
       expect(assigns(:next_post)).to eq(nextp)
-
     end
 
     it "gives the correct previous post with an intermediate private post" do

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -2327,7 +2327,7 @@ RSpec.describe PostsController do
         create(:reply, post: unhidden_post)
         create(:reply, post: hidden_post)
         author = hidden_post.post_authors.where(user_id: user.id).first
-        author.update_attributes(can_owe: false)
+        author.update!(can_owe: false)
       end
 
       it "does not show hidden without arg" do
@@ -2371,7 +2371,7 @@ RSpec.describe PostsController do
         site_test = create(:board, id: Board::ID_SITETESTING)
 
         post.board = site_test
-        post.save
+        post.save!
         create(:reply, post_id: post.id, user_id: other_user.id)
 
         get :owed

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ReportsController do
 
       it "works with logged in" do
         user = create(:user)
-        DailyReport.mark_read(user, 3.day.ago.to_date)
+        DailyReport.mark_read(user, 3.days.ago.to_date)
         PostView.create!(user: user, post: create(:post))
         login_as(user)
         get :show, params: { id: 'daily' }

--- a/spec/features/galleries/index_spec.rb
+++ b/spec/features/galleries/index_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Show a list of galleries", :type => :feature do
     user = setup_sample_data
     visit user_galleries_path(user_id: user.id)
 
-    expect(page).to have_selector('th',text: "Test user's Galleries")
+    expect(page).to have_selector('th', text: "Test user's Galleries")
     expect(page).to have_no_selector('.gallery-new')
 
     within('#content tbody') do

--- a/spec/models/flat_post_spec.rb
+++ b/spec/models/flat_post_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe FlatPost do
       nonpost = Timecop.freeze(post.tagged_at + 2.hours) { create(:post) }
       delete_lock(post)
       delete_lock(nonpost)
-      FlatPost.regenerate_all(post.tagged_at + 1.hours)
+      FlatPost.regenerate_all(post.tagged_at + 1.hour)
       expect(GenerateFlatPostJob).to have_been_enqueued.with(post.id).on_queue('high')
       expect(GenerateFlatPostJob).not_to have_been_enqueued.with(nonpost.id).on_queue('high')
     end

--- a/spec/models/icon_spec.rb
+++ b/spec/models/icon_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Icon do
   describe "#use_https" do
     it "does not update sites that might not support HTTPS" do
       icon = build(:icon, url: 'http://www.example.com')
-      icon.save
+      icon.save!
       expect(icon.reload.url).to start_with('http:')
     end
 
@@ -70,13 +70,13 @@ RSpec.describe Icon do
       icon = create(:icon, url: 'http://www.example.com')
       expect(icon.reload.url).to start_with('http:')
       icon.url = 'http://www.dreamwidth.org'
-      icon.save
+      icon.save!
       expect(icon.reload.url).to start_with('https:')
     end
 
     it "does update HTTP Imgur icons on create" do
       icon = build(:icon, url: 'http://i.imgur.com')
-      icon.save
+      icon.save!
       expect(icon.reload.url).to start_with('https:')
     end
   end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Message do
     it "does not notify blocking recipients" do
       recipient = create(:user, email_notifications: true)
       block = create(:block, block_interactions: true, blocking_user: recipient)
-      message = create(:message, sender: block.blocked_user, recipient: recipient)
+      create(:message, sender: block.blocked_user, recipient: recipient)
       expect(UserMailer).to have_queue_size_of(0)
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe Message do
 
   it "does not error to blocked user if updating an existing message" do
     message = create(:message)
-    block = create(:block, blocking_user: message.sender, blocked_user: message.recipient)
+    create(:block, blocking_user: message.sender, blocked_user: message.recipient)
     message.unread = false
     message.save!
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'


### PR DESCRIPTION
* Switches to use of save! and update! in tests
* Changes to dir expand_path syntax in rails_helper
* Does some whitespace improvement
* Cleans up assignments of objects created in tests that were not used
* Fixes an unless blank to if present
* Fixes pluralization of hours and days
* Cleans up tag options (also fixed in Marri's new tags view branch)
* Disables Style/NumericLiterals so it stops pinging on the ToS version