### PR TITLE
Only show .subber bar for Post forms

### DIFF
--- a/app/views/posts/_editor.haml
+++ b/app/views/posts/_editor.haml
@@ -78,4 +78,5 @@
       %br> No Icon
   = yield :form
   .clear &nbsp;
-.subber.centered= yield :buttons
+- if item.is_a?(Post)
+  .subber.centered= yield :buttons


### PR DESCRIPTION
Gets rid of new useless bar at the bottom of posts#show cause it's only for posts#new