### PR TITLE
Use attribute_name.humanize instead of reinventing the wheel

### DIFF
--- a/app/views/writable/_history.haml
+++ b/app/views/writable/_history.haml
@@ -28,7 +28,7 @@
           - if audit.version == 1
             (Original)
           - else
-            = audit.audited_changes.keys.map{|k| k.sub('_id', '').tr('_', ' ')}.join(', ').capitalize
+            = audit.audited_changes.keys.map(&:humanize).join(', ').capitalize
       %tr
         %th.sub Updated
         %td{class: cycle('even', 'odd')}= pretty_time(audit.created_at)

--- a/app/views/writable/_history.haml
+++ b/app/views/writable/_history.haml
@@ -28,7 +28,7 @@
           - if audit.version == 1
             (Original)
           - else
-            = audit.audited_changes.keys.map{|k| k.tr('_id', '').tr('_', ' ')}.join(', ').capitalize
+            = audit.audited_changes.keys.map{|k| k.sub('_id', '').tr('_', ' ')}.join(', ').capitalize
       %tr
         %th.sub Updated
         %td{class: cycle('even', 'odd')}= pretty_time(audit.created_at)


### PR DESCRIPTION
* Fixes the thing where the current version eats all is and ds and underscores resulting in rather strange results when, for example, icon is replaced.