### PR TITLE
News migration for patch notes etc

### DIFF
--- a/db/migrate/20190122034907_create_news.rb
+++ b/db/migrate/20190122034907_create_news.rb
@@ -1,0 +1,16 @@
+class CreateNews < ActiveRecord::Migration[5.2]
+  def change
+    create_table :news do |t|
+      t.integer :user_id, null: false
+      t.text :content
+      t.timestamps
+    end
+
+    create_table :news_views do |t|
+      t.integer :user_id, null: false
+      t.datetime :read_at
+      t.timestamps
+    end
+    add_index :news_views, :user_id
+  end
+end


### PR DESCRIPTION
Things I considered:
- Is subject required, optional, or unnecessary
- Should we have some kind of Type field, like "new release went out" or "announcement" or "feedback requested" or whatever?
- Should we have pinned news?
- Should we support comments? Should we have a field for comments allowed/restricted/off?
- I am not inclined to forbid edits; we'll just have to be responsible about including an EDIT: field at the end of things if we need to edit. Sensible? Does this or does this not mark the thing unread again?
- Do we need a user setting to ignore this like we have with Daily Report, or is this important enough that we want users to have to dismiss it? Do we have a user setting and also an importance column on News where we can override that setting?

Right now all this supports is:
- A user can make a news post with a (planned optional) subject and (planned HTML-friendly) content. Does not require an index, we are not ordering news, we are not pulling up news-only-by-Marri, it can just be ranked by id.
- Site users can have the News marked as read at a particular time. It is not size of user * news, you can only have seen the News page at a given news post, it is just size of users.

What am I missing, we have learned our lesson about letting 3am Marri make decisions.