### PR TITLE
Add an additional select2 selector

### DIFF
--- a/app/assets/stylesheets/layouts/_dark_themes_selectors.scss
+++ b/app/assets/stylesheets/layouts/_dark_themes_selectors.scss
@@ -36,6 +36,7 @@
 .select2-container--default .select2-search--dropdown .select2-search__field { background-color: $bg_color_select2_search; color: $font_color_input; border-color: $border_color_input; }
 /* --- disabled input */
 .select2-container--default.select2-container--disabled .select2-selection--single { background-color: $bg_color_mce_panel; color: $font_color_input; border-color: $border_color_input; }
+.select2-search__field { color: $font_color_input; }
 
 /* HTML written editor */
 #post-editor input:not([type='submit']), #post-editor textarea, #message_form input:not([type='submit']), #message_form textarea { background-color: $bg_color_input; color: $font_color_input; border-color: $border_color_input; }


### PR DESCRIPTION
Currently does not catch the text inputs where you enter text that will be used to dynamically populate a search dropdown, in this case specifically the Setting etc fields on Post, as reported by Moriwen. Naively tested on Starry Dark and Dark and is now much more legible.

EDIT: `.select2-container--default .select2-search--dropdown .select2-search__field` doesn't catch it because it looks like this might be `.select2-container--default .select2-search--inline .select2-search__field`