### PR TITLE
Fix bug with selecting New Template

### DIFF
--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -29,22 +29,16 @@ $(document).ready(function() {
 
   oldTemplate = $("#character_template_id").val();
   $("#new_template").change(function() {
+    $("#character_template_attributes_name").val('');
+    $("#character_template_attributes_id").val('');
+
     if ($("#new_template").is(":checked")) {
-      $("#character_template_attributes_name").val('');
-      $("#character_template_attributes_id").val('');
       $("#create_template").show();
       oldTemplate = $("#character_template_id").val();
       $("#character_template_id").attr("disabled", true).val('').trigger("change.select2");
     } else {
       $("#create_template").hide();
       $("#character_template_id").attr("disabled", false).val(oldTemplate).trigger("change.select2");
-      if (oldTemplate) {
-        $("#character_template_attributes_name").val($("#character_template_id option:selected").text());
-        $("#character_template_attributes_id").val(oldTemplate);
-      } else {
-        $("#character_template_attributes_name").val('');
-        $("#character_template_attributes_id").val('');
-      }
     }
   });
 


### PR DESCRIPTION
As reported by Unbitwise, selecting then unselecting the New Template button when you do not mean to click it causes an error when creating a template. I think Rails used to update the template with an empty name if we didn't do this? But I tried various things and it doesn't seem to be doing that any more, so this seems tentatively safe. (I think as long as the template_attribute_id is empty?) It does definitely fix the reported error.