### PR TITLE
Filter for draft by the current user on Replies Owed

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,7 +24,7 @@ class PostsController < WritableController
     ids = PostAuthor.where(user_id: current_user.id, can_owe: can_owe).group(:post_id).pluck(:post_id)
     @posts = Post.where(id: ids)
     unless params[:view] == 'hidden'
-      drafts = ReplyDraft.where(post_id: @posts.select(:id)).pluck(:post_id)
+      drafts = ReplyDraft.where(post_id: @posts.select(:id)).where(user: current_user).pluck(:post_id)
       solo = PostAuthor.where(post_id: ids).group(:post_id).having('count(post_id) < 2').pluck(:post_id)
       @posts = @posts.where.not(last_user: current_user).or(@posts.where(id: (drafts + solo).uniq))
     end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -2510,6 +2510,15 @@ RSpec.describe PostsController do
         expect(assigns(:posts)).to match_array([post])
       end
 
+      it "does not show threads with drafts by coauthors" do
+        create(:reply, post: post, user: other_user)
+        create(:reply, post: post, user: user)
+        create(:reply_draft, post: post, user: other_user)
+        get :owed
+        expect(response.status).to eq(200)
+        expect(assigns(:posts)).to be_empty
+      end
+
       it "shows solo threads" do
         create(:reply, user: user, post: post)
         get :owed


### PR DESCRIPTION
Because, in fact, you should only see posts where _you_ have a draft on your replies owed, not where your coauthor does, oops.