### PR TITLE
Tweaks

### DIFF
--- a/app/assets/javascripts/reorder.js
+++ b/app/assets/javascripts/reorder.js
@@ -119,7 +119,7 @@ function syncRowOrders(orderBox, path, param) {
   unbindArrows(orderBox);
   disableSortable(orderBox);
   $("#loading", orderBox).show();
-  $("#saveconf", orderBox).stop(true, true).hide();
+  $(".saveconf", orderBox).stop(true, true).hide();
 
   // Switch the row order pre-emptively
   var orderedRows = reorderRows(orderBox);
@@ -152,7 +152,7 @@ function syncRowOrders(orderBox, path, param) {
 
     // Re-enable the buttons
     $("#loading", orderBox).hide();
-    $("#saveconf", orderBox).show().delay(2000).fadeOut();
+    $(".saveconf", orderBox).show().delay(2000).fadeOut();
     bindArrows(orderBox, path, param);
     enableSortable(orderBox);
   }).fail(function(resp) {

--- a/app/assets/javascripts/users/new.js
+++ b/app/assets/javascripts/users/new.js
@@ -1,28 +1,28 @@
 /* global gon */
 $(document).ready(function() {
   $("#user_username").blur(function() {
-    $("#username .alert").hide();
+    $("#username .user-alert").hide();
     validateUsername();
   });
 
   $("#user_email").blur(function() {
-    $("#email .alert").hide();
+    $("#email .user-alert").hide();
     validateEmail();
   });
 
   $("#user_password").blur(function() {
-    $("#password .alert").hide();
+    $("#password .user-alert").hide();
     validatePassword();
   });
 
   $("#user_password_confirmation").blur(function() {
-    $("#conf .alert").hide();
+    $("#conf .user-alert").hide();
     validateConfirmation();
   });
 
   $("#new_user").submit(function() {
     // Clear existing alerts before validating
-    $(".alert").hide();
+    $(".user-alert").hide();
 
     // Do not submit if any validation fails
     var usernameValid = validateUsername();
@@ -104,6 +104,6 @@ function validateTosAccepted() {
 }
 
 function addAlertAfter(id, message) {
-  $("#" + id + " .alert span.msg").text(message);
-  $("#" + id + " .alert").show();
+  $("#" + id + " .user-alert span.msg").text(message);
+  $("#" + id + " .user-alert").show();
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -325,6 +325,7 @@ td, .table-list li { font-size: $font_size_small; }
   .sub { width: 90px; }
   .user-alert { margin: 7px 0 2px 0; }
   .msg { vertical-align: middle; }
+  #terms td { padding: 15px; }
 }
 .continuity-spacer { height: 20px; }
 .post-ignored { opacity: 0.3; }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -321,7 +321,11 @@ td, .table-list li { font-size: $font_size_small; }
 
 /* Not yet deserving of its own CSS file */
 #stats ul { margin-top: 0; margin-bottom: 0; padding-left: 15px; }
-#signup .sub { width: 90px; }
+#signup {
+  .sub { width: 90px; }
+  .user-alert { margin: 7px 0 2px 0; }
+  .msg { vertical-align: middle; }
+}
 .continuity-spacer { height: 20px; }
 .post-ignored { opacity: 0.3; }
 #loading img { height: 20px; width: 20px; }
@@ -368,9 +372,7 @@ td, .table-list li { font-size: $font_size_small; }
   }
 }
 
-.user-moiety {
-  font-size: 80%;
-}
+.user-moiety { font-size: 80%; }
 
 #footer {
   font-size: $font_size_small;
@@ -396,6 +398,7 @@ The copy box can't be invisible/hidden or copy fails but opacity works
   height: 20px;
 }
 #_hiddenCopyText_ { height: 0px; width: 0px; opacity: 0; padding: 0px; margin: 0px; }
+
 #tag-search-name {
   margin: 0px 5px;
   width: 210px;

--- a/app/views/about/_accept_tos.haml
+++ b/app/views/about/_accept_tos.haml
@@ -5,7 +5,7 @@
         %th Accept our Terms of Service
     %tbody
       %tr#terms
-        %td.odd{style: 'padding: 15px;'}
+        %td.odd
           Our Terms of Service have recently changed!
           Please read and agree to the
           = link_to 'Terms of Service', tos_path

--- a/app/views/board_sections/edit.haml
+++ b/app/views/board_sections/edit.haml
@@ -24,7 +24,7 @@
       #saveerror.float-right.hidden
         = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: '!'
         Error, please refresh
-      #saveconf.float-right.hidden
+      .saveconf.float-right.hidden
         = image_tag "icons/accept.png", title: 'Saved', class: 'vmid', alt: ''
         Saved
     %ul.sortable.table-list

--- a/app/views/boards/edit.haml
+++ b/app/views/boards/edit.haml
@@ -24,7 +24,7 @@
     #saveerror.float-right.hidden
       = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: '!'
       Error, please refresh
-    #saveconf.float-right.hidden
+    .saveconf.float-right.hidden
       = image_tag "icons/accept.png", title: 'Saved', class: 'vmid', alt: ''
       Saved
   %ul.sortable.table-list
@@ -54,7 +54,7 @@
       #saveerror.float-right.hidden
         = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: '!'
         Error, please refresh
-      #saveconf.float-right.hidden
+      .saveconf.float-right.hidden
         = image_tag "icons/accept.png", title: 'Saved', class: 'vmid', alt: ''
         Saved
     %ul.sortable.table-list

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -87,7 +87,7 @@
           #saveerror.float-right.hidden
             = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: '!'
             Error, please refresh
-          #saveconf.float-right.hidden
+          .saveconf.float-right.hidden
             = image_tag "icons/accept.png", title: 'Saved', class: 'vmid', alt: ''
             Saved
     %tbody

--- a/app/views/users/new.haml
+++ b/app/views/users/new.haml
@@ -8,28 +8,28 @@
         %th.sub.vtop Username
         %td.even
           = f.text_field :username, placeholder: "Username"
-          .alert.hidden{style: 'margin: 2px 0px;'}
+          .user-alert.hidden
             = image_tag 'icons/exclamation.png', alt: '!', title: '', class: 'vmid'
             %span.msg
       %tr#email
         %th.sub.vtop Email
         %td.odd
           = f.text_field :email, placeholder: "Email address"
-          .alert.hidden{style: 'margin: 2px 0px;'}
+          .user-alert.hidden
             = image_tag 'icons/exclamation.png', alt: '!', title: '', class: 'vmid'
             %span.msg
       %tr#password
         %th.sub.vtop Password
         %td.even
           = f.password_field :password, placeholder: "Password"
-          .alert.hidden{style: 'margin: 2px 0px;'}
+          .user-alert.hidden
             = image_tag 'icons/exclamation.png', alt: '!', title: '', class: 'vmid'
             %span.msg
       %tr#conf
         %th.sub.vtop Confirm
         %td.odd
           = f.password_field :password_confirmation, placeholder: "Confirm Password"
-          .alert.hidden{style: 'margin: 2px 0px;'}
+          .user-alert.hidden
             = image_tag 'icons/exclamation.png', alt: '!', title: '', class: 'vmid'
             %span.msg
       %tr#secret
@@ -45,7 +45,7 @@
             = link_to 'Terms of Service', tos_path
             and the
             = link_to 'Privacy Policy', privacy_path
-          .alert.hidden{style: 'margin: 2px 0px;'}
+          .user-alert.hidden
             = image_tag 'icons/exclamation.png', alt: '!', title: '', class: 'vmid'
             %span.msg
     %tr


### PR DESCRIPTION
Gets us from 65 haml-lint errors to 57 by:

- Changing #saveconf to .saveconf so we don't duplicate IDs
- Removing inline CSS for .alert divs and incidentally renaming them .user-alert to avoid Bootstrap conflict
- Removing inline CSS from the Accept Terms partial