### PR TITLE
Prevent Select2 from showing users duplicate elements

### DIFF
--- a/app/assets/javascripts/global.js
+++ b/app/assets/javascripts/global.js
@@ -159,9 +159,10 @@ function createTagSelect(tagType, selector, formType, scope) {
       var term = $.trim(params.term);
       if (term === '') return null;
 
-      foundTags[selector].forEach(function(tag) {
+      for(var i = 0; i < foundTags[selector].length; i++) {
+        var tag = foundTags[selector][i];
         if (tag.text.toUpperCase() === term.toUpperCase()) return null;
-      });
+      }
 
       return {
         id: '_' + term,

--- a/app/assets/javascripts/global.js
+++ b/app/assets/javascripts/global.js
@@ -158,11 +158,10 @@ function createTagSelect(tagType, selector, formType, scope) {
     createTag: function(params) {
       var term = $.trim(params.term);
       if (term === '') return null;
-      var extantTag;
+
       foundTags[selector].forEach(function(tag) {
-        if (tag.text.toUpperCase() === term.toUpperCase()) extantTag = tag;
+        if (tag.text.toUpperCase() === term.toUpperCase()) return null;
       });
-      if (extantTag) return extantTag;
 
       return {
         id: '_' + term,


### PR DESCRIPTION
Select2 seems to dedupe just fine, but our createTag function was pulling shenanigans on case insensitive text matches. Local testing seems to work as expected.