### PR TITLE
Subcontinuity anchors

### DIFF
--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -11,6 +11,11 @@ module WritableHelper
     post_path(post, page: 'unread', anchor: 'unread', **kwargs)
   end
 
+  def anchored_board_path(post)
+    return board_path(post.board_id) unless post.section_id.present?
+    board_path(post.board_id, anchor: "section-#{post.section_id}")
+  end
+
   def dropdown_icons(item, galleries=nil)
     icons = []
     selected_id = nil

--- a/app/views/boards/show.haml
+++ b/app/views/boards/show.haml
@@ -42,7 +42,7 @@
         %td.continuity-spacer{colspan: 5}
       - @board_sections.each do |section|
         %tr
-          %th.sub.continuity-header{colspan: 5}= link_to section.name, board_section_path(section)
+          %th.sub.continuity-header{colspan: 5, id: "section-#{section.id}"}= link_to section.name, board_section_path(section)
         - if section.description.present?
           %tr
             %td.written-content{colspan: 5, class: cycle('even', 'odd')}= shortened_desc(section.description, section.id).html_safe

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -39,7 +39,7 @@
             - (total_pages-2).upto(total_pages) do |index|
               = link_to index, post_path(post, page: index)
   - unless local_assigns[:hide_continuity]
-    %td.post-board.vtop{class: klass}= link_to post.board_name, board_path(post.board_id)
+    %td.post-board.vtop{class: klass}= link_to post.board_name, anchored_board_path(post)
   %td.post-authors.vtop{class: klass}
     - authors = post.authors.sort_by { |author| author.username.downcase }
     - if authors.length < 4

--- a/spec/helpers/writable_helper_spec.rb
+++ b/spec/helpers/writable_helper_spec.rb
@@ -15,4 +15,17 @@ RSpec.describe WritableHelper do
       expect(helper.shortened_desc(text, 1)).to eq('a' * 255 + dots + expand + more)
     end
   end
+
+  describe "#anchored_board_path" do
+    it "anchors for sectioned post" do
+      section = create(:board_section)
+      post = create(:post, board: section.board, section: section)
+      expect(helper.anchored_board_path(post)).to eq(board_path(post.board_id) + "#section-" + section.id.to_s)
+    end
+
+    it "does not anchor for unsectioned post" do
+      post = create(:post)
+      expect(helper.anchored_board_path(post)).to eq(board_path(post.board_id))
+    end
+  end
 end


### PR DESCRIPTION
When linking to a post's continuity from a given post list, the link currently takes you to the continuity page; iff the post is part of a subcontinuity, it will now take you the subcontinuity on the continuity's page.

Does not handle pagination or sectionless posts.