### PR TITLE
Make the TOS 'I agree' text more natural

### DIFF
--- a/app/views/about/_accept_tos.haml
+++ b/app/views/about/_accept_tos.haml
@@ -12,7 +12,7 @@
           and the
           = link_to 'Privacy Policy', privacy_path
       %tr
-        %th.form-table-ender{colspan: 2}= submit_tag "I agree/consent to the terms", class: 'button', name: :tos_check, id: :tos_check
+        %th.form-table-ender{colspan: 2}= submit_tag "I agree to the terms of service", class: 'button', name: :tos_check, id: :tos_check
 
 - if logged_in?
   = form_for current_user, url: user_path(current_user), method: :put, name: :tos_form do


### PR DESCRIPTION
Per #constellation, make the button text simpler.

Since the ToS contains the "5.a Privacy Policy" section, this should still bind you to the privacy policy even were this to use a capital T and S, but I figure that this is clear enough that the terms of service are both the ToS and the privacy policy that we can get by with just "agree to", not "consent to".