### PR TITLE
Upgrade Ruby to 2.6.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   TargetRailsVersion: 5.1
   DisabledByDefault: false
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
- - 2.6.0
+ - 2.6.1
 env:
 - CI=true
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
- - 2.5.3
+ - 2.6.0
 env:
 - CI=true
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
- - 2.6.1
+ - 2.6.2
 env:
 - CI=true
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
- - 2.6.2
+ - 2.6.3
 env:
 - CI=true
 services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3
+FROM ruby:2.6.0
 
 ADD Gemfile* /code/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.2
+FROM ruby:2.6.3
 
 ADD Gemfile* /code/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.0
+FROM ruby:2.6.1
 
 ADD Gemfile* /code/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.1
+FROM ruby:2.6.2
 
 ADD Gemfile* /code/
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.5.3'
+ruby '2.6.0'
 
 gem 'api-pagination'
 gem 'apipie-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.6.0'
+ruby '2.6.1'
 
 gem 'api-pagination'
 gem 'apipie-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.6.1'
+ruby '2.6.2'
 
 gem 'api-pagination'
 gem 'apipie-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.6.2'
+ruby '2.6.3'
 
 gem 'api-pagination'
 gem 'apipie-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,7 +518,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 2.5.3p105
+   ruby 2.6.0p0
 
 BUNDLED WITH
-   1.17.3
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,7 +518,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 2.6.2p47
+   ruby 2.6.3p62
 
 BUNDLED WITH
    1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,7 +518,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 2.6.1p33
+   ruby 2.6.2p47
 
 BUNDLED WITH
    1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,7 +518,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 2.6.0p0
+   ruby 2.6.1p33
 
 BUNDLED WITH
    1.17.2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-*   [Ruby](https://www.ruby-lang.org/en/) 2.6.2
+*   [Ruby](https://www.ruby-lang.org/en/) 2.6.3
 *   [Rails](http://rubyonrails.org/) 5.2
 *   [Redis](https://redis.io/topics/quickstart)
 *   [PostgreSQL](https://www.postgresql.org/) (guide to set this up [later](#setting-up-postgresql))
@@ -97,7 +97,7 @@ First, go to the glowfic folder and download the latest code:
 *   `git pull`
 
 Then look at this README again, to make sure the version of Ruby hasn't changed; alternatively, in case this file is not up to date, look at the top of the `Gemfile` file, where it states the version of ruby.
-As of writing, this is `ruby '2.6.2'`.
+As of writing, this is `ruby '2.6.3'`.
 If it has changed, you can rebuild the glowfic image with:
 
 *   `docker-compose stop`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-*   [Ruby](https://www.ruby-lang.org/en/) 2.6.1
+*   [Ruby](https://www.ruby-lang.org/en/) 2.6.2
 *   [Rails](http://rubyonrails.org/) 5.2
 *   [Redis](https://redis.io/topics/quickstart)
 *   [PostgreSQL](https://www.postgresql.org/) (guide to set this up [later](#setting-up-postgresql))
@@ -97,7 +97,7 @@ First, go to the glowfic folder and download the latest code:
 *   `git pull`
 
 Then look at this README again, to make sure the version of Ruby hasn't changed; alternatively, in case this file is not up to date, look at the top of the `Gemfile` file, where it states the version of ruby.
-As of writing, this is `ruby '2.6.1'`.
+As of writing, this is `ruby '2.6.2'`.
 If it has changed, you can rebuild the glowfic image with:
 
 *   `docker-compose stop`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-*   [Ruby](https://www.ruby-lang.org/en/) 2.5.3
+*   [Ruby](https://www.ruby-lang.org/en/) 2.6.0
 *   [Rails](http://rubyonrails.org/) 5.2
 *   [Redis](https://redis.io/topics/quickstart)
 *   [PostgreSQL](https://www.postgresql.org/) (guide to set this up [later](#setting-up-postgresql))
@@ -97,7 +97,7 @@ First, go to the glowfic folder and download the latest code:
 *   `git pull`
 
 Then look at this README again, to make sure the version of Ruby hasn't changed; alternatively, in case this file is not up to date, look at the top of the `Gemfile` file, where it states the version of ruby.
-As of writing, this is `ruby '2.5.3'`.
+As of writing, this is `ruby '2.6.0'`.
 If it has changed, you can rebuild the glowfic image with:
 
 *   `docker-compose stop`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-*   [Ruby](https://www.ruby-lang.org/en/) 2.6.0
+*   [Ruby](https://www.ruby-lang.org/en/) 2.6.1
 *   [Rails](http://rubyonrails.org/) 5.2
 *   [Redis](https://redis.io/topics/quickstart)
 *   [PostgreSQL](https://www.postgresql.org/) (guide to set this up [later](#setting-up-postgresql))
@@ -97,7 +97,7 @@ First, go to the glowfic folder and download the latest code:
 *   `git pull`
 
 Then look at this README again, to make sure the version of Ruby hasn't changed; alternatively, in case this file is not up to date, look at the top of the `Gemfile` file, where it states the version of ruby.
-As of writing, this is `ruby '2.6.0'`.
+As of writing, this is `ruby '2.6.1'`.
 If it has changed, you can rebuild the glowfic image with:
 
 *   `docker-compose stop`


### PR DESCRIPTION
Ruby changelogs:
- [2.6.0](https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/)
- [2.6.1](https://www.ruby-lang.org/en/news/2019/01/30/ruby-2-6-1-released/)
- [2.6.2](https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-6-2-released/)
- [2.6.3](https://www.ruby-lang.org/en/news/2019/04/17/ruby-2-6-3-released/)