### PR TITLE
Consistently use begin/rescue/else syntax on create/update/destroy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -344,6 +344,9 @@ Style/Proc:
 Style/RaiseArgs:
   Enabled: false
 
+Style/RedundantBegin:
+  Enabled: false
+
 Style/RedundantException:
   Enabled: false
 

--- a/app/controllers/aliases_controller.rb
+++ b/app/controllers/aliases_controller.rb
@@ -13,26 +13,31 @@ class AliasesController < ApplicationController
     @alias = CharacterAlias.new(calias_params)
     @alias.character = @character
 
-    unless @alias.save
-      flash.now[:error] = {}
-      flash.now[:error][:message] = "Alias could not be created."
-      flash.now[:error][:array] = @alias.errors.full_messages
+    begin
+      @alias.save!
+    rescue ActiveRecord::RecordInvalid
+      flash.now[:error] = {
+        message: "Alias could not be created.",
+        array: @alias.errors.full_messages
+      }
       @page_title = "New Alias: " + @character.name
-      render :new and return
+      render :new
+    else
+      flash[:success] = "Alias created."
+      redirect_to edit_character_path(@character)
     end
-
-    flash[:success] = "Alias created."
-    redirect_to edit_character_path(@character)
   end
 
   def destroy
     begin
       @alias.destroy!
-      flash[:success] = "Alias removed."
     rescue ActiveRecord::RecordNotDestroyed
-      flash[:error] = {}
-      flash[:error][:message] = "Alias could not be deleted."
-      flash[:error][:array] = @alias.errors.full_messages
+      flash[:error] = {
+        message: "Alias could not be deleted.",
+        array: @alias.errors.full_messages
+      }
+    else
+      flash[:success] = "Alias removed."
     end
     redirect_to edit_character_path(@character)
   end

--- a/app/controllers/board_sections_controller.rb
+++ b/app/controllers/board_sections_controller.rb
@@ -16,15 +16,18 @@ class BoardSectionsController < ApplicationController
       redirect_to boards_path and return
     end
 
-    if @board_section.save
-      flash[:success] = "New section, #{@board_section.name}, has successfully been created for #{@board_section.board.name}."
-      redirect_to edit_board_path(@board_section.board)
-    else
-      flash.now[:error] = {}
-      flash.now[:error][:message] = "Section could not be created."
-      flash.now[:error][:array] = @board_section.errors.full_messages
+    begin
+      @board_section.save!
+    rescue ActiveRecord::RecordInvalid
+      flash.now[:error] = {
+        message: "Section could not be created.",
+        array: @board_section.errors.full_messages
+      }
       @page_title = 'New Section'
       render :new
+    else
+      flash[:success] = "New section, #{@board_section.name}, has successfully been created for #{@board_section.board.name}."
+      redirect_to edit_board_path(@board_section.board)
     end
   end
 
@@ -43,29 +46,37 @@ class BoardSectionsController < ApplicationController
     @board_section.assign_attributes(section_params)
     require_permission
     return if performed?
-    if @board_section.save
-      flash[:success] = "#{@board_section.name} has been successfully updated."
-      redirect_to board_section_path(@board_section)
-    else
-      flash.now[:error] = {}
-      flash.now[:error][:message] = "Section could not be updated."
-      flash.now[:error][:array] = @board_section.errors.full_messages
+
+    begin
+      @board_section.save!
+    rescue ActiveRecord::RecordInvalid
+      flash.now[:error] = {
+        message: "Section could not be updated.",
+        array: @board_section.errors.full_messages
+      }
       @page_title = 'Edit ' + @board_section.name_was
       use_javascript('board_sections')
       gon.section_id = @board_section.id
       render :edit
+    else
+      flash[:success] = "#{@board_section.name} has been successfully updated."
+      redirect_to board_section_path(@board_section)
     end
   end
 
   def destroy
-    @board_section.destroy!
-    flash[:success] = "Section deleted."
-    redirect_to edit_board_path(@board_section.board)
-  rescue ActiveRecord::RecordNotDestroyed
-    flash[:error] = {}
-    flash[:error][:message] = "Section could not be deleted."
-    flash[:error][:array] = @board_section.errors.full_messages
-    redirect_to board_section_path(@board_section)
+    begin
+      @board_section.destroy!
+    rescue ActiveRecord::RecordNotDestroyed
+      flash[:error] = {
+        message: "Section could not be deleted.",
+        array: @board_section.errors.full_messages
+      }
+      redirect_to board_section_path(@board_section)
+    else
+      flash[:success] = "Section deleted."
+      redirect_to edit_board_path(@board_section.board)
+    end
   end
 
   private

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -67,12 +67,15 @@ class FavoritesController < ApplicationController
     fav = Favorite.new
     fav.user = current_user
     fav.favorite = favorite
-    if fav.save
-      flash[:success] = "Your favorite has been saved."
+    begin
+      fav.save!
+    rescue ActiveRecord::RecordInvalid
+      flash[:error] = {
+        message: "Your favorite could not be saved because of the following problems:",
+        array: fav.errors.full_messages
+      }
     else
-      flash[:error] = {}
-      flash[:error][:message] = "Your favorite could not be saved because of the following problems:"
-      flash[:error][:array] = fav.errors.full_messages
+      flash[:success] = "Your favorite has been saved."
     end
     redirect_to fav_path
   end
@@ -90,6 +93,13 @@ class FavoritesController < ApplicationController
 
     begin
       fav.destroy!
+    rescue ActiveRecord::RecordNotDestroyed
+      flash[:error] = {
+        message: "Favorite could not be deleted.",
+        array: fav.errors.full_messages
+      }
+      redirect_to favorites_path
+    else
       flash[:success] = "Favorite removed."
       if fav.favorite_type == User.to_s
         redirect_to user_path(fav.favorite)
@@ -98,11 +108,6 @@ class FavoritesController < ApplicationController
       else
         redirect_to board_path(fav.favorite)
       end
-    rescue ActiveRecord::RecordNotDestroyed
-      flash[:error] = {}
-      flash[:error][:message] = "Favorite could not be deleted."
-      flash[:error][:array] = fav.errors.full_messages
-      redirect_to favorites_path
     end
   end
 end

--- a/app/controllers/index_posts_controller.rb
+++ b/app/controllers/index_posts_controller.rb
@@ -26,17 +26,20 @@ class IndexPostsController < ApplicationController
       redirect_to index_path(@index_post.index) and return
     end
 
-    if @index_post.save
+    begin
+      @index_post.save!
+    rescue ActiveRecord::RecordInvalid
+      flash.now[:error] = {
+        message: "Post could not be added to index.",
+        array: @index_post.errors.full_messages
+      }
+      @page_title = 'Add Posts to Index'
+      use_javascript('posts/index_post_new')
+      render :new
+    else
       flash[:success] = "Post added to index!"
-      redirect_to index_path(@index_post.index) and return
+      redirect_to index_path(@index_post.index)
     end
-
-    flash.now[:error] = {}
-    flash.now[:error][:message] = "Post could not be added to index."
-    flash.now[:error][:array] = @index_post.errors.full_messages
-    @page_title = 'Add Posts to Index'
-    use_javascript('posts/index_post_new')
-    render :new
   end
 
   def destroy
@@ -52,11 +55,13 @@ class IndexPostsController < ApplicationController
 
     begin
       index_post.destroy!
-      flash[:success] = "Post removed from index."
     rescue ActiveRecord::RecordNotDestroyed
-      flash[:error] = {}
-      flash[:error][:message] = "Post could not be removed from index."
-      flash[:error][:array] = index_post.errors.full_messages
+      flash[:error] = {
+        message: "Post could not be removed from index.",
+        array: index_post.errors.full_messages
+      }
+    else
+      flash[:success] = "Post removed from index."
     end
     redirect_to index_path(index_post.index)
   end

--- a/app/controllers/index_sections_controller.rb
+++ b/app/controllers/index_sections_controller.rb
@@ -27,16 +27,19 @@ class IndexSectionsController < ApplicationController
       redirect_to index_path(@section.index) and return
     end
 
-    if @section.save
+    begin
+      @section.save!
+    rescue ActiveRecord::RecordInvalid
+      flash.now[:error] = {
+        message: "Index section could not be created.",
+        array: @section.errors.full_messages
+      }
+      @page_title = 'New Index Section'
+      render :new
+    else
       flash[:success] = "New section, #{@section.name}, has successfully been created for #{@section.index.name}."
-      redirect_to index_path(@section.index) and return
+      redirect_to index_path(@section.index)
     end
-
-    flash.now[:error] = {}
-    flash.now[:error][:message] = "Index section could not be created."
-    flash.now[:error][:array] = @section.errors.full_messages
-    @page_title = 'New Index Section'
-    render :new
   end
 
   def show
@@ -48,26 +51,30 @@ class IndexSectionsController < ApplicationController
   end
 
   def update
-    unless @section.update(index_params)
-      flash.now[:error] = {}
-      flash.now[:error][:message] = "Index section could not be saved because of the following problems:"
-      flash.now[:error][:array] = @section.errors.full_messages
+    begin
+      @section.update!(index_params)
+    rescue ActiveRecord::RecordInvalid
+      flash.now[:error] = {
+        message: "Index section could not be saved because of the following problems:",
+        array: @section.errors.full_messages
+      }
       @page_title = "Edit Index Section: #{@section.name}"
-      render :edit and return
+      render :edit
+    else
+      flash[:success] = "Index section saved!"
+      redirect_to index_path(@section.index)
     end
-
-    flash[:success] = "Index section saved!"
-    redirect_to index_path(@section.index)
   end
 
   def destroy
     begin
       @section.destroy!
-      flash[:success] = "Index section deleted."
     rescue ActiveRecord::RecordNotDestroyed
       flash[:error] = {}
       flash[:error][:message] = "Index section could not be deleted."
       flash[:error][:array] = @section.errors.full_messages
+    else
+      flash[:success] = "Index section deleted."
     end
     redirect_to index_path(@section.index)
   end

--- a/app/controllers/indexes_controller.rb
+++ b/app/controllers/indexes_controller.rb
@@ -18,16 +18,19 @@ class IndexesController < ApplicationController
     @index = Index.new(index_params)
     @index.user = current_user
 
-    if @index.save
+    begin
+      @index.save!
+    rescue ActiveRecord::RecordInvalid
+      flash.now[:error] = {
+        message: "Index could not be created.",
+        array: @index.errors.full_messages
+      }
+      @page_title = 'New Index'
+      render :new
+    else
       flash[:success] = "Index created!"
       redirect_to index_path(@index) and return
     end
-
-    flash.now[:error] = {}
-    flash.now[:error][:message] = "Index could not be created."
-    flash.now[:error][:array] = @index.errors.full_messages
-    @page_title = 'New Index'
-    render :new
   end
 
   def show
@@ -48,27 +51,34 @@ class IndexesController < ApplicationController
   end
 
   def update
-    unless @index.update(index_params)
-      flash.now[:error] = {}
-      flash.now[:error][:message] = "Index could not be saved because of the following problems:"
-      flash.now[:error][:array] = @index.errors.full_messages
+    begin
+      @index.update!(index_params)
+    rescue ActiveRecord::RecordInvalid
+      flash.now[:error] = {
+        message: "Index could not be saved because of the following problems:",
+        array: @index.errors.full_messages
+      }
       @page_title = "Edit Index: #{@index.name}"
-      render :edit and return
+      render :edit
+    else
+      flash[:success] = "Index saved!"
+      redirect_to index_path(@index)
     end
-
-    flash[:success] = "Index saved!"
-    redirect_to index_path(@index)
   end
 
   def destroy
-    @index.destroy!
-    flash[:success] = "Index deleted."
-    redirect_to indexes_path
-  rescue ActiveRecord::RecordNotDestroyed
-    flash[:error] = {}
-    flash[:error][:message] = "Index could not be deleted."
-    flash[:error][:array] = @index.errors.full_messages
-    redirect_to index_path(@index)
+    begin
+      @index.destroy!
+    rescue ActiveRecord::RecordNotDestroyed
+      flash[:error] = {
+        message: "Index could not be deleted.",
+        array: @index.errors.full_messages
+      }
+      redirect_to index_path(@index)
+    else
+      redirect_to indexes_path
+      flash[:success] = "Index deleted."
+    end
   end
 
   private

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -43,10 +43,11 @@ class MessagesController < ApplicationController
     end
 
     cached_error = flash.now[:error] # preserves errors from setting an invalid parent
-    flash.now[:error] = {}
-    flash.now[:error][:array] = @message.errors.full_messages
+    flash.now[:error] = {
+      message: "Your message could not be sent because of the following problems:",
+      array: @message.errors.full_messages
+    }
     flash.now[:error][:array] << cached_error if cached_error.present?
-    flash.now[:error][:message] = "Your message could not be sent because of the following problems:"
     editor_setup
     @page_title = 'Compose Message'
     render :new

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -20,16 +20,19 @@ class NewsController < ApplicationController
     @news = News.new(news_params)
     @news.user = current_user
 
-    unless @news.save
-      flash.now[:error] = {}
-      flash.now[:error][:message] = "News post could not be created."
-      flash.now[:error][:array] = @news.errors.full_messages
+    begin
+      @news.save!
+    rescue ActiveRecord::RecordInvalid
+      flash.now[:error] = {
+        message: "News post could not be created.",
+        array: @news.errors.full_messages
+      }
       @page_title = 'Create News Post'
-      render :new and return
+      render :new
+    else
+      flash[:success] = "News post has successfully been created."
+      redirect_to news_index_path
     end
-
-    flash[:success] = "News post has successfully been created."
-    redirect_to news_index_path
   end
 
   def show
@@ -41,16 +44,19 @@ class NewsController < ApplicationController
   end
 
   def update
-    unless @news.update(news_params)
-      flash.now[:error] = {}
-      flash.now[:error][:message] = "News post could not be saved because of the following problems:"
-      flash.now[:error][:array] = @news.errors.full_messages
+    begin
+      @news.update!(news_params)
+    rescue ActiveRecord::RecordInvalid
+      flash.now[:error] = {
+        message: "News post could not be saved because of the following problems:",
+        array: @news.errors.full_messages
+      }
       @page_title = "Edit News Post"
-      render :edit and return
+      render :edit
+    else
+      flash[:success] = "News post saved!"
+      redirect_to paged_news_url(@news)
     end
-
-    flash[:success] = "News post saved!"
-    redirect_to paged_news_url(@news)
   end
 
   def destroy
@@ -61,11 +67,13 @@ class NewsController < ApplicationController
 
     begin
       @news.destroy!
-      flash[:success] = "News post deleted."
     rescue ActiveRecord::RecordNotDestroyed
-      flash[:error] = {}
-      flash[:error][:message] = "News post could not be deleted."
-      flash[:error][:array] = @news.errors.full_messages
+      flash[:error] = {
+        message: "News post could not be deleted.",
+        array: @news.errors.full_messages
+      }
+    else
+      flash[:success] = "News post deleted."
     end
     redirect_to news_index_path
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -46,15 +46,17 @@ class TagsController < ApplicationController
         @tag.parent_settings = process_tags(Setting, :tag, :parent_setting_ids) if @tag.is_a?(Setting)
         @tag.save!
       end
-      flash[:success] = "Tag saved!"
-      redirect_to tag_path(@tag)
     rescue ActiveRecord::RecordInvalid
-      flash.now[:error] = {}
-      flash.now[:error][:message] = "Tag could not be saved because of the following problems:"
-      flash.now[:error][:array] = @tag.errors.full_messages
+      flash.now[:error] = {
+        message: "Tag could not be saved because of the following problems:",
+        array: @tag.errors.full_messages
+      }
       @page_title = "Edit Tag: #{@tag.name}"
       build_editor
-      render :edit and return
+      render :edit
+    else
+      flash[:success] = "Tag saved!"
+      redirect_to tag_path(@tag)
     end
   end
 
@@ -66,17 +68,19 @@ class TagsController < ApplicationController
 
     begin
       @tag.destroy!
+    rescue ActiveRecord::RecordNotDestroyed
+      flash[:error] = {
+        message: "Tag could not be deleted.",
+        array: @tag.errors.full_messages
+      }
+      redirect_to tag_path(@tag)
+    else
       flash[:success] = "Tag deleted."
 
       url_params = {}
       url_params[:page] = page if params[:page].present?
       url_params[:view] = params[:view] if params[:view].present?
       redirect_to tags_path(url_params)
-    rescue ActiveRecord::RecordNotDestroyed
-      flash[:error] = {}
-      flash[:error][:message] = "Tag could not be deleted."
-      flash[:error][:array] = @tag.errors.full_messages
-      redirect_to tag_path(@tag)
     end
   end
 

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -1214,6 +1214,17 @@ RSpec.describe CharactersController do
       expect(char_post.character).to eq(character)
       expect(char_reply.character).to eq(character)
     end
+
+    it "handles unexpected failure" do
+      character = create(:character)
+      login_as(character.user)
+      character.update_columns(default_icon_id: create(:icon).id)
+      expect(character).not_to be_valid
+      expect{ post :duplicate, params: { id: character.id } }.to not_change { Character.count }
+      expect(response).to redirect_to(character_path(character))
+      expect(flash[:error][:message]).to eq('Character could not be duplicated.')
+      expect(flash[:error][:array]).to eq(['Default icon must be yours'])
+    end
   end
 
   describe "#character_split" do

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe GalleriesController do
         expect(response.status).to eq(200)
         expect(response).to render_template(:new)
         expect(assigns(:page_title)).to eq('New Gallery')
-        expect(flash[:error]).to eq('Your gallery could not be saved.')
+        expect(flash[:error][:message]).to eq('Your gallery could not be saved because of the following problems:')
+        expect(flash[:error][:array]).to eq(["Name can't be blank"])
         expect(assigns(:gallery).gallery_groups.map(&:id)).to eq([group.id])
         expect(assigns(:gallery).icon_ids).to eq([icon.id])
       end
@@ -83,7 +84,8 @@ RSpec.describe GalleriesController do
       post :create, params: { gallery: {icon_ids: [icon.id]} }
       expect(response).to have_http_status(200)
       expect(assigns(:page_title)).to eq('New Gallery')
-      expect(flash[:error]).to eq('Your gallery could not be saved.')
+      expect(flash[:error][:message]).to eq('Your gallery could not be saved because of the following problems:')
+      expect(flash[:error][:array]).to eq(["Name can't be blank"])
       expect(icon.reload.has_gallery).not_to eq(true)
     end
 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1474,7 +1474,8 @@ RSpec.describe PostsController do
       it "handles unexpected failure" do
         post = create(:post, status: Post::STATUS_ACTIVE)
         login_as(post.user)
-        expect_any_instance_of(Post).to receive(:save).and_return(false)
+        post.update_columns(board_id: 0)
+        expect(post.reload).not_to be_valid
         put :update, params: { id: post.id, status: 'abandoned' }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:error][:message]).to eq('Status could not be updated.')
@@ -1605,7 +1606,8 @@ RSpec.describe PostsController do
       it "handles unexpected failure" do
         post = create(:post)
         login_as(post.user)
-        expect_any_instance_of(Post).to receive(:save).and_return(false)
+        post.update_columns(board_id: 0)
+        expect(post.reload).not_to be_valid
         put :update, params: { id: post.id, authors_locked: 'true' }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:error][:message]).to eq('Post could not be updated.')

--- a/spec/controllers/templates_controller_spec.rb
+++ b/spec/controllers/templates_controller_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe TemplatesController do
       login
       post :create
       expect(response).to render_template(:new)
-      expect(flash[:error]).to eq("Your template could not be saved.")
+      expect(flash[:error][:message]).to eq("Your template could not be saved because of the following problems:")
+      expect(flash[:error][:array]).to eq(["Name can't be blank"])
       expect(assigns(:page_title)).to eq("New Template")
       expect(assigns(:template)).not_to be_valid
       expect(assigns(:template)).to be_a_new_record
@@ -149,7 +150,8 @@ RSpec.describe TemplatesController do
       put :update, params: { id: template.id, template: {name: ''} }
       expect(assigns(:template)).not_to be_valid
       expect(response).to render_template(:edit)
-      expect(flash[:error]).to eq("Your template could not be saved.")
+      expect(flash[:error][:message]).to eq("Your template could not be saved because of the following problems:")
+      expect(flash[:error][:array]).to eq(["Name can't be blank"])
     end
 
     it "works" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -310,7 +310,8 @@ RSpec.describe UsersController do
         user.update_columns(username: 'a') # too short to validate
         put :update, params: { id: user.id, tos_check: true }
         expect(user.reload.tos_version).to be_nil
-        expect(flash[:error]).to eq('There was an error saving your changes. Please try again.')
+        expect(flash[:error][:message]).to eq('There was an error saving your changes. Please try again.')
+        expect(flash[:error][:array]).to eq(["Username is too short (minimum is 3 characters)"])
         expect(response).to render_template('about/accept_tos')
       end
     end

--- a/spec/features/templates/new_spec.rb
+++ b/spec/features/templates/new_spec.rb
@@ -35,8 +35,8 @@ RSpec.feature "Creating a new template", :type => :feature do
     end
     expect(page).to have_selector('.flash.error')
     within('.flash.error') do
-      expect(page).to have_text('Your template could not be saved.')
-      # TODO: more specific error messages
+      error_message = "Your template could not be saved because of the following problems:\nName can't be blank"
+      expect(page).to have_text(error_message)
     end
   end
 
@@ -75,8 +75,8 @@ RSpec.feature "Creating a new template", :type => :feature do
 
     expect(page).to have_selector('.flash.error')
     within('.flash.error') do
-      expect(page).to have_text('Your template could not be saved.')
-      # TODO: more specific error messages
+      error_message = "Your template could not be saved because of the following problems:\nName can't be blank Characters is invalid"
+      expect(page).to have_text(error_message)
     end
     within('.form-table') do
       expect(page).to have_field('Template Name', with: '')


### PR DESCRIPTION
* Selects begin/rescue/else syntax of one of the 3/4 different ones we were using because the ones that use transaction need it, and the services will need it
* Changes existing instances to use that syntax
* Expands Template, Gallery, and User failure error messages to include model errors
* Uses hash syntax on flash[:error] calls that have array and message components