### PR TITLE
For some reason, the new puma patch version doesn't work with Docker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
     popper_js (1.14.5)
     power_assert (1.1.4)
     public_suffix (3.0.3)
-    puma (3.12.1)
+    puma (3.12.0)
     raabro (1.1.6)
     rack (2.0.7)
     rack-cors (1.0.3)


### PR DESCRIPTION
So we downgrade