### PR TITLE
Update Message inbox sql 

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,7 +12,7 @@ class MessagesController < ApplicationController
     else
       @page_title = 'Inbox'
       from_table = current_user.messages.where(visible_inbox: true).ordered_by_thread.select('distinct on (thread_id) messages.*')
-      from_table = from_table.where.not(sender_id: blocked_ids).left_outer_joins(:sender).where.not(users: {deleted: true})
+      from_table = from_table.where.not(sender_id: blocked_ids).left_outer_joins(:sender).where('users.deleted IS NULL OR users.deleted = false')
     end
     @messages = Message.from(from_table).select('*').order('subquery.id desc').paginate(per_page: 25, page: page)
     @view = @page_title.downcase

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -35,6 +35,15 @@ RSpec.describe MessagesController do
         expect(assigns(:page_title)).to eq('Outbox')
         expect(assigns(:messages)).to match_array(messages)
       end
+
+      it "includes site messages" do
+        user = create(:user)
+        login_as(user)
+        message = create(:message, sender_id: 0, recipient: user)
+        get :index, params: { view: 'inbox' }
+        expect(response).to have_http_status(200)
+        expect(assigns(:messages)).to match_array([message])
+      end
     end
 
     context "blocking" do


### PR DESCRIPTION
Site messages were being vanished because 'not true' does not mean 'false or null' just 'false'