### PR TITLE
Catch and handle InvalidAuthenticityToken errors

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -493,3 +493,8 @@ The copy box can't be invisible/hidden or copy fails but opacity works
   width: 210px;
 }
 #tag-search { margin-left: 5px; }
+
+#remember-link {
+  font-size: $font_size_smaller;
+  text-align: right;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   include Memorylogic
 
   protect_from_forgery with: :exception
+  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_token
+
   before_action :check_tos
   before_action :check_permanent_user
   before_action :show_password_warning
@@ -42,6 +44,12 @@ class ApplicationController < ActionController::Base
     return unless current_user.salt_uuid.nil?
     logout
     flash.now[:error] = "Because Marri accidentally made passwords a bit too secure, you must log back in to continue using the site."
+  end
+
+  def handle_invalid_token
+    flash[:error] = 'Oops, looks like your session expired! Please try another tab or log in again to resume glowficcing. If you were writing a reply, it has been cached for your next page load.'
+    session[:attempted_reply] = params[:reply] if params[:reply].present?
+    redirect_to root_path
   end
 
   def use_javascript(js)

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -240,17 +240,6 @@ class RepliesController < WritableController
     render :preview
   end
 
-  def reply_params
-    params.fetch(:reply, {}).permit(
-      :post_id,
-      :content,
-      :character_id,
-      :icon_id,
-      :audit_comment,
-      :character_alias_id,
-    )
-  end
-
   def make_draft(show_message=true)
     if (draft = ReplyDraft.draft_for(params[:reply][:post_id], current_user.id))
       draft.assign_attributes(reply_params)

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -113,7 +113,12 @@ class WritableController < ApplicationController
 
       if @post.taggable_by?(current_user)
         build_template_groups
-        @reply = @post.build_new_reply_for(current_user)
+
+        session_params = ActionController::Parameters.new(reply: session.fetch(:attempted_reply, {}))
+        reply_hash = reply_params(session_params)
+        session.delete(:attempted_reply)
+
+        @reply = @post.build_new_reply_for(current_user, reply_hash)
       end
 
       @post.mark_read(current_user, @post.read_time_for(@replies))
@@ -166,5 +171,16 @@ class WritableController < ApplicationController
       title: post.subject + ' · ' + post_location,
       description: post_description,
     }
+  end
+
+  def reply_params(param_hash=nil)
+    (param_hash || params).fetch(:reply, {}).permit(
+      :post_id,
+      :content,
+      :character_id,
+      :icon_id,
+      :audit_comment,
+      :character_alias_id,
+    )
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -98,13 +98,14 @@ class Post < ApplicationRecord
     (post_viewers.pluck(:user_id) + [user_id]).include?(user.id)
   end
 
-  def build_new_reply_for(user)
+  def build_new_reply_for(user, reply_params={})
     draft = ReplyDraft.draft_reply_for(self, user)
     return draft if draft.present?
 
-    reply = Reply.new(post: self, user: user)
-    user_replies = replies.where(user_id: user.id).ordered
+    reply = Reply.new(reply_params.merge(post: self, user: user))
+    return reply if reply_params.present?
 
+    user_replies = replies.where(user_id: user.id).ordered
     if user_replies.exists?
       last_user_reply = user_replies.last
       reply.character_id = last_user_reply.character_id

--- a/app/views/sessions/new.haml
+++ b/app/views/sessions/new.haml
@@ -1,4 +1,4 @@
-= form_for login_path, method: :post do
+= form_tag login_path, method: :post do
   %table.form-table
     %thead
       %tr
@@ -9,11 +9,11 @@
         %td.even= text_field_tag :username, params[:username], placeholder: "Username"
       %tr#password
         %th.sub.vtop Password
-        %td.odd= password_field_tag :password, params[:password], placeholder: "Password"
+        %td.odd
+          = password_field_tag :password, params[:password], placeholder: "Password"
+          #remember-link= link_to "Forgot Password?", new_password_reset_path
       %tr#remember-me
         %th.sub.vtop Remember me
         %td.even= check_box_tag :remember_me
     %tr
       %th.form-table-ender{colspan: 2}= submit_tag "Sign In", class: 'button'
-  %br
-  .centered= link_to "Forgot Password?", new_password_reset_path

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1007,7 +1007,7 @@ RSpec.describe PostsController do
 
         login_as(user)
         expect(post).to be_taggable_by(user)
-        expect(post).to receive(:build_new_reply_for).with(user).and_call_original
+        expect(post).to receive(:build_new_reply_for).with(user, {}).and_call_original
         expect(controller).to receive(:setup_layout_gon).and_call_original
 
         get :show, params: { id: post.id }
@@ -1037,7 +1037,7 @@ RSpec.describe PostsController do
 
         login_as(user)
         expect(post).to be_taggable_by(user)
-        expect(post).to receive(:build_new_reply_for).with(user).and_call_original
+        expect(post).to receive(:build_new_reply_for).with(user, {}).and_call_original
 
         get :show, params: { id: post.id }
         expect(response).to have_http_status(200)


### PR DESCRIPTION
I am so very, very tired of receiving these emails and I'm sure users are equally tired of losing the replies they're writing.

- Does not presently handle literally anything other than replies. Should probably someday be extended to handle posts, but I vote that waits on the post-to-replies stuff.