### PR TITLE
Update Code Climate config file to new 2.0 format

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,6 @@
 ---
-engines:
+version: "2"
+plugins:
   brakeman:
     enabled: true
   bundler-audit:
@@ -18,20 +19,8 @@ engines:
     enabled: true
   rubocop:
     enabled: true
-ratings:
-  paths:
-  - Gemfile.lock
-  - "**.erb"
-  - "**.haml"
-  - "**.rb"
-  - "**.rhtml"
-  - "**.slim"
-  - "**.css"
-  - "**.inc"
-  - "**.js"
-  - "**.jsx"
-  - "**.module"
-exclude_paths:
+    channel: rubocop-0-68
+exclude_patterns:
 - config/
 - db/
 - doc/


### PR DESCRIPTION
According to [the Code Climate docs](https://docs.codeclimate.com/docs/advanced-configuration#section-analysis-configuration-versions), we need to make the following changes to our config file:
* Add a `version: "2"` declaration
* Rename `engines` to `plugins`
* Rename `exclude_paths` to `exclude_patterns`
* Remove deprecated `ratings`
* Specify a `channel` under `rubocop` to set version

(TBD: can we actually get away with the 068 version of rubocop; their doc only lists 067 but might be outdated.)