### PR TITLE
Simplify the visible_to scope a little

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -79,11 +79,9 @@ class Post < ApplicationRecord
 
   scope :visible_to, ->(user) {
     if user
-      where(privacy: Concealable::PUBLIC)
-      .or(where(privacy: Concealable::REGISTERED))
-      .or(where(privacy: Concealable::ACCESS_LIST, user_id: user.id))
+      where(user_id: user.id)
+      .or(where(privacy: [Concealable::PUBLIC, Concealable::REGISTERED]))
       .or(where(privacy: Concealable::ACCESS_LIST, id: PostViewer.where(user_id: user.id).select(:post_id)))
-      .or(where(privacy: Concealable::PRIVATE, user_id: user.id))
     else
       where(privacy: Concealable::PUBLIC)
     end


### PR DESCRIPTION
It doesn't matter what the post privacy setting is if you're the post owner, you can always see it. Therefore we can move that unqualified to the top and eliminate the private/access list parameters for post owners.

Flow is now:
1. if you're the post owner, you can see it
2. if the privacy setting is public or registered (and you're logged in), you can see it
3. if you're on the access list, you can see it