### PR TITLE
Strip spaces from character facecasts

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -25,6 +25,7 @@ class Character < ApplicationRecord
 
   attr_accessor :group_name
 
+  before_validation :strip_spaces
   after_destroy :clear_char_ids
 
   scope :ordered, -> { order(name: :asc).order(Arel.sql('lower(screenname) asc'), created_at: :asc, id: :asc) }
@@ -147,5 +148,9 @@ class Character < ApplicationRecord
     UpdateModelJob.perform_later(Reply.to_s, {character_id: id}, {character_id: nil})
     ReplyDraft.where(character_id: id).update_all(character_id: nil)
     User.where(active_character_id: id).update_all(active_character_id: nil)
+  end
+
+  def strip_spaces
+    self.pb = self.pb.strip if self.pb.present?
   end
 end

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Character do
       character.gallery_ids = [gallery.id]
       expect(character).not_to be_valid
     end
+
+    it "strips facecast" do
+      character = create(:character, pb: 'Chris Pine ')
+      expect(character.reload.pb).to eq('Chris Pine')
+    end
   end
 
   it "uniqs gallery images" do


### PR DESCRIPTION
Strip whitespace from characters.pb to prevent accidental "non-duplicates" caused by leading or trailing spaces, as reported by Unbitwise