### PR TITLE
Temporarily make galleries#single use multiple tbodys

### DIFF
--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -91,10 +91,10 @@
           .saveconf.float-right.hidden
             = image_tag "icons/accept.png", title: 'Saved', class: 'vmid', alt: ''
             Saved
-    %tbody
-      - galleries.each do |gallery|
-        = render 'galleries/single', gallery: gallery, klass: 'subber', skip_forms: true, character_gallery: gallery.character_gallery_for(@character), is_owner: @character.user == current_user
-      - unless galleries.present?
+    - galleries.each do |gallery|
+      = render 'galleries/single', gallery: gallery, klass: 'subber', skip_forms: true, character_gallery: gallery.character_gallery_for(@character), is_owner: @character.user == current_user
+    - unless galleries.present?
+      %tbody
         %tr
           %td.icon-box
             .centered.padding-5 — No galleries yet —

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -1,6 +1,6 @@
 - attrs = {}
 - attrs = {class: 'section-ordered', data: {id: character_gallery.id, order: character_gallery.section_order}} if local_assigns[:character_gallery]
-%thead
+%tbody
   %tr.gallery-header{**attrs}
     %th.padding-10{class: (klass if defined? klass)}
       - link = gallery ? gallery_path(gallery) : user_gallery_path(id: 0, user_id: @user.id)


### PR DESCRIPTION
Long-term, let's make galleries#single not use a table layout at all. As it's not tabular. So. It shouldn't be in a table.

This fixes some invalid HTML on characters#show?view=galleries