### PR TITLE
Test users#index and users#search with feature specs (also fix some HTML errors)

### DIFF
--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -5,8 +5,8 @@
     %tr
       %th.subber.padding-10{colspan: 3}
         = form_tag search_users_path, method: :get do
-          = label_tag :username, 'Search by username:'
-          = text_field_tag :username, params[:username], style: 'margin: 0px 5px;'
+          = label_tag :search_username, 'Search by username:'
+          = text_field_tag :username, params[:username], style: 'margin: 0px 5px;', id: :search_username
           = submit_tag "Search", class: 'button'
     %tr
       %th.sub Name

--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -14,7 +14,7 @@
       %th.sub Date Joined
   %tbody
     - @users.each do |user|
-      %tr
+      %tr.user-row
         - klass = cycle('even', 'odd')
         %td.padding-10.username{class: klass}= link_to user.username, user_path(user)
         %td.padding-10.user-moiety.centered.width-70{class: klass}= color_block(user)

--- a/app/views/users/search.haml
+++ b/app/views/users/search.haml
@@ -30,7 +30,7 @@
                 %th.sub Date Joined
             %tbody
               - @search_results.each do |user|
-                %tr
+                %tr.user-row
                   - klass = cycle('even', 'odd')
                   %td.padding-10.username{class: klass}= user_link(user)
                   %td.padding-10.user-moiety.centered.width-70{class: klass}= color_block(user)

--- a/app/views/users/search.haml
+++ b/app/views/users/search.haml
@@ -16,8 +16,8 @@
         = form_tag search_users_path, method: :get do
           %table.search-form
             %tr
-              %td.width-70= label_tag :username, 'Username'
-              %td= text_field_tag :username, params[:username], style: 'width: 100%; margin: 5px 0px; box-sizing: border-box;'
+              %td.width-70= label_tag :search_username, 'Username'
+              %td= text_field_tag :username, params[:username], style: 'width: 100%; margin: 5px 0px; box-sizing: border-box;', id: :search_username
             %tr
               %td.centered{colspan: 2}= submit_tag "Search", class: 'button'
       %td.vtop

--- a/spec/features/users/index_spec.rb
+++ b/spec/features/users/index_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+RSpec.feature "Listing users", :type => :feature do
+  scenario "Logged-out user views simple list of users" do
+    simple_user = create(:user, username: 'Alice')
+    moietied_user = create(:user, username: 'Bob', moiety: 'FF0000', moiety_name: 'Test moiety')
+    old_user = create(:user, username: 'Charlie', created_at: Time.zone.local(2018,1,1))
+
+    visit users_path
+
+    expect(page).to have_text('Users')
+    within('.user-row:nth-child(1)') do
+        expect(page).to have_link('Alice', href: user_path(simple_user))
+    end
+    within('.user-row:nth-child(2)') do
+        expect(page).to have_link('Bob', href: user_path(moietied_user))
+        expect(page).to have_selector("span[title='Test moiety']")
+    end
+    within('.user-row:nth-child(3)') do
+        expect(page).to have_link('Charlie', href: user_path(old_user))
+        expect(page).to have_text('Jan 01, 2018 12:00 AM')
+    end
+  end
+end

--- a/spec/features/users/search_spec.rb
+++ b/spec/features/users/search_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+RSpec.feature "Searching users", :type => :feature do
+  scenario "Logged-out user searches simple list of users" do
+    simple_user = create(:user, username: 'Test Alice')
+    moietied_user = create(:user, username: 'Test Bob', moiety: 'FF0000', moiety_name: 'Test moiety')
+    old_user = create(:user, username: 'Test Charlie', created_at: Time.zone.local(2018,1,1))
+    other_user = create(:user, username: 'Dominique')
+
+    visit search_users_path
+
+    expect(page).to have_text("Search Users")
+
+    def search_for(str)
+        within('.search-form') do
+            fill_in 'Username', with: str
+            click_button 'Search'
+        end
+    end
+
+    search_for('Fred')
+    expect(page).to have_text("Total: 0")
+    expect(page).not_to have_text('Test')
+    expect(page).not_to have_text('Dominique')
+
+    search_for('Test')
+    expect(page).to have_text("Total: 3")
+    within('.user-row:nth-child(1)') do
+        expect(page).to have_link('Test Alice', href: user_path(simple_user))
+    end
+    within('.user-row:nth-child(2)') do
+        expect(page).to have_link('Test Bob', href: user_path(moietied_user))
+        expect(page).to have_selector("span[title='Test moiety']")
+    end
+    within('.user-row:nth-child(3)') do
+        expect(page).to have_link('Test Charlie', href: user_path(old_user))
+        expect(page).to have_text('Jan 01, 2018 12:00 AM')
+    end
+    expect(page).not_to have_text('Dominique')
+  end
+end


### PR DESCRIPTION
Only does it simplistically – logged out, creates a basic user, a user with a moiety, and a user created at a specific date, and ensures they show in the list. It also tests that only the relevant users are found in a search, and that searching for a string that's in no usernames finds no users.

Also fixes some HTML errors around duplicate `username`-ID elements.