### PR TITLE
Use dependent: :nullify and :destroy correctly

### DIFF
--- a/app/concerns/owable.rb
+++ b/app/concerns/owable.rb
@@ -3,19 +3,19 @@ module Owable
 
   included do
     has_many :post_authors, inverse_of: :post, dependent: :destroy
-    has_many :authors, class_name: 'User', through: :post_authors, source: :user
+    has_many :authors, class_name: 'User', through: :post_authors, source: :user, dependent: :destroy
 
     # list of users who owe replies on this post, whether or not they have posted yet
     has_many :tagging_post_authors, -> { where(can_owe: true) }, class_name: 'PostAuthor', inverse_of: :post
-    has_many :tagging_authors, class_name: 'User', through: :tagging_post_authors, source: :user
+    has_many :tagging_authors, class_name: 'User', through: :tagging_post_authors, source: :user, dependent: :destroy
 
     # quick way to pull author list without calculating from post + replies
     has_many :joined_post_authors, -> { where(joined: true) }, class_name: 'PostAuthor', inverse_of: :post
-    has_many :joined_authors, class_name: 'User', through: :joined_post_authors, source: :user
+    has_many :joined_authors, class_name: 'User', through: :joined_post_authors, source: :user, dependent: :destroy
 
     # used in the post#write UI to handle inviting users
     has_many :unjoined_post_authors, -> { where(joined: false) }, class_name: 'PostAuthor', inverse_of: :post
-    has_many :unjoined_authors, class_name: 'User', through: :unjoined_post_authors, source: :user
+    has_many :unjoined_authors, class_name: 'User', through: :unjoined_post_authors, source: :user, dependent: :destroy
 
     after_create :add_creator_to_authors
     after_save :update_board_cameos

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -11,9 +11,9 @@ class Board < ApplicationRecord
 
   has_many :board_authors, inverse_of: :board, dependent: :destroy
   has_many :board_coauthors, -> { where(cameo: false) }, class_name: 'BoardAuthor', inverse_of: :board
-  has_many :coauthors, class_name: 'User', through: :board_coauthors, source: :user
+  has_many :coauthors, class_name: 'User', through: :board_coauthors, source: :user, dependent: :destroy
   has_many :board_cameos, -> { where(cameo: true) }, class_name: 'BoardAuthor', inverse_of: :board
-  has_many :cameos, class_name: 'User', through: :board_cameos, source: :user
+  has_many :cameos, class_name: 'User', through: :board_cameos, source: :user, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
 

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -15,7 +15,7 @@ class Character < ApplicationRecord
   has_many :icons, -> { group('icons.id').ordered }, through: :galleries
 
   has_many :character_tags, inverse_of: :character, dependent: :destroy
-  has_many :settings, -> { ordered_by_char_tag }, through: :character_tags, source: :setting
+  has_many :settings, -> { ordered_by_char_tag }, through: :character_tags, source: :setting, dependent: :destroy
   has_many :gallery_groups, -> { ordered_by_char_tag }, through: :character_tags, source: :gallery_group, dependent: :destroy
 
   validates :name,

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -3,7 +3,7 @@ class Gallery < ApplicationRecord
 
   has_many :galleries_icons, dependent: :destroy, inverse_of: :gallery
   accepts_nested_attributes_for :galleries_icons, allow_destroy: true
-  has_many :icons, -> { ordered }, through: :galleries_icons
+  has_many :icons, -> { ordered }, through: :galleries_icons, dependent: :destroy
 
   has_many :characters_galleries, inverse_of: :gallery, dependent: :destroy
   has_many :characters, through: :characters_galleries, dependent: :destroy

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -9,7 +9,7 @@ class Icon < ApplicationRecord
   has_many :replies, dependent: false
   has_many :reply_drafts, dependent: :nullify
   has_many :galleries_icons, dependent: :destroy, inverse_of: :icon
-  has_many :galleries, through: :galleries_icons
+  has_many :galleries, through: :galleries_icons, dependent: :destroy
 
   validates :keyword, presence: true
   validates :url,

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -4,9 +4,10 @@ class Icon < ApplicationRecord
   S3_DOMAIN = '.s3.amazonaws.com'
 
   belongs_to :user, optional: false
+  has_one :avatar_user, inverse_of: :avatar, class_name: 'User', foreign_key: :avatar_id, dependent: :nullify
   has_many :posts, dependent: false
   has_many :replies, dependent: false
-  has_many :reply_drafts, dependent: false # These are handled in callbacks
+  has_many :reply_drafts, dependent: :nullify
   has_many :galleries_icons, dependent: :destroy, inverse_of: :icon
   has_many :galleries, through: :galleries_icons
 
@@ -68,8 +69,6 @@ class Icon < ApplicationRecord
   end
 
   def clear_icon_ids
-    ReplyDraft.where(icon_id: id).update_all(icon_id: nil)
-    User.where(avatar_id: id).update_all(avatar_id: nil)
     UpdateModelJob.perform_later(Post.to_s, {icon_id: id}, {icon_id: nil})
     UpdateModelJob.perform_later(Reply.to_s, {icon_id: id}, {icon_id: nil})
   end

--- a/app/models/index.rb
+++ b/app/models/index.rb
@@ -2,7 +2,7 @@ class Index < ApplicationRecord
   include Concealable
 
   has_many :index_posts, inverse_of: :index, dependent: :destroy
-  has_many :posts, through: :index_posts
+  has_many :posts, through: :index_posts, dependent: :destroy
   has_many :index_sections, inverse_of: :index, dependent: :destroy
   belongs_to :user, inverse_of: :indexes, optional: false
 

--- a/app/models/index_section.rb
+++ b/app/models/index_section.rb
@@ -3,7 +3,7 @@ class IndexSection < ApplicationRecord
 
   belongs_to :index, inverse_of: :index_sections, optional: false
   has_many :index_posts, inverse_of: :index_section, dependent: :destroy
-  has_many :posts, through: :index_posts
+  has_many :posts, through: :index_posts, dependent: :destroy
 
   validates :name, presence: true
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -21,17 +21,17 @@ class Post < ApplicationRecord
   has_many :reply_drafts, dependent: :destroy
 
   has_many :post_viewers, inverse_of: :post, dependent: :destroy
-  has_many :viewers, through: :post_viewers, source: :user
+  has_many :viewers, through: :post_viewers, source: :user, dependent: :destroy
   has_many :favorites, as: :favorite, inverse_of: :favorite, dependent: :destroy
 
   has_many :post_tags, inverse_of: :post, dependent: :destroy
-  has_many :labels, -> { ordered_by_post_tag }, through: :post_tags, source: :label
-  has_many :settings, -> { ordered_by_post_tag }, through: :post_tags, source: :setting
-  has_many :content_warnings, -> { ordered_by_post_tag }, through: :post_tags, source: :content_warning, after_add: :reset_warnings
+  has_many :labels, -> { ordered_by_post_tag }, through: :post_tags, source: :label, dependent: :destroy
+  has_many :settings, -> { ordered_by_post_tag }, through: :post_tags, source: :setting, dependent: :destroy
+  has_many :content_warnings, -> { ordered_by_post_tag }, through: :post_tags, source: :content_warning, after_add: :reset_warnings, dependent: :destroy
 
   has_many :index_posts, inverse_of: :post, dependent: :destroy
-  has_many :indexes, inverse_of: :posts, through: :index_posts
-  has_many :index_sections, inverse_of: :posts, through: :index_posts
+  has_many :indexes, inverse_of: :posts, through: :index_posts, dependent: :destroy
+  has_many :index_sections, inverse_of: :posts, through: :index_posts, dependent: :destroy
 
   attr_accessor :is_import
   attr_writer :skip_edited

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -2,8 +2,8 @@ class Setting < Tag
   has_many :parent_setting_tags, class_name: 'TagTag', foreign_key: :tag_id, inverse_of: :child_setting, dependent: :destroy
   has_many :child_setting_tags, class_name: 'TagTag', foreign_key: :tagged_id, inverse_of: :parent_setting, dependent: :destroy
 
-  has_many :parent_settings, -> { ordered_by_tag_tag }, class_name: 'Setting', through: :child_setting_tags, source: :parent_setting
-  has_many :child_settings, class_name: 'Setting', through: :parent_setting_tags, source: :child_setting
+  has_many :parent_settings, -> { ordered_by_tag_tag }, class_name: 'Setting', through: :child_setting_tags, source: :parent_setting, dependent: :destroy
+  has_many :child_settings, class_name: 'Setting', through: :parent_setting_tags, source: :child_setting, dependent: :destroy
 
   def has_items?
     return true if super

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,11 +1,11 @@
 class Tag < ApplicationRecord
   belongs_to :user, optional: false
   has_many :post_tags, dependent: :destroy, inverse_of: :tag
-  has_many :posts, through: :post_tags
+  has_many :posts, through: :post_tags, dependent: :destroy
   has_many :character_tags, dependent: :destroy, inverse_of: :tag
-  has_many :characters, through: :character_tags
+  has_many :characters, through: :character_tags, dependent: :destroy
   has_many :gallery_tags, dependent: :destroy, inverse_of: :tag
-  has_many :galleries, through: :gallery_tags
+  has_many :galleries, through: :gallery_tags, dependent: :destroy
 
   TYPES = %w(Setting Label ContentWarning GalleryGroup)
 

--- a/spec/models/icon_spec.rb
+++ b/spec/models/icon_spec.rb
@@ -49,13 +49,21 @@ RSpec.describe Icon do
   end
 
   describe "#after_destroy" do
-    it "updates ids" do
+    it "updates reply ids" do
       reply = create(:reply, with_icon: true)
       perform_enqueued_jobs(only: UpdateModelJob) do
         reply.icon.destroy
       end
       reply.reload
       expect(reply.icon_id).to be_nil
+    end
+
+    it "updates avatar ids" do
+      icon = create(:icon)
+      icon.user.avatar = icon
+      icon.user.save!
+      icon.destroy
+      expect(icon.user.reload.avatar_id).to be_nil
     end
   end
 


### PR DESCRIPTION
Have Icon use dependent: :nullify instead of custom callbacks where possible. I have sanity checked and it does in fact use an update_all equivalent (which wouldn't work for posts or replies because we want audit history but is fine for avatars and drafts).

Also attach dependent: :destroy to has_many :through relationships, since otherwise callbacks will not be run when modifying the contents of the through association.