### PR TITLE
Galleries fixes

### DIFF
--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -1,4 +1,4 @@
-/* global gon, createTagSelect */
+/* global gon, createTagSelect, processResults, queryTransform */
 var galleryIds, oldTemplate;
 var galleryGroupIds = [];
 var galleryGroups = {};
@@ -133,7 +133,7 @@ $(document).ready(function() {
       data: function(params) {
         var data = queryTransform(params);
         data.t = 'GalleryGroup';
-        data.user_id = gon.user_id
+        data.user_id = gon.user_id;
         return data;
       },
       processResults: function(data, params) {
@@ -143,7 +143,7 @@ $(document).ready(function() {
 
         // Remove duplicates
         var existingIds = $("#character_gallery_group_ids").val() || [];
-        var validResults = []
+        var validResults = [];
         results.results.forEach(function(gallery) {
           if(!existingIds.includes(gallery.id.toString())) validResults.push(gallery);
         });
@@ -152,7 +152,6 @@ $(document).ready(function() {
         return results;
       },
       cache: true,
-      createTag: function(params) { return null; }
     },
     width: '300px'
   });

--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -123,8 +123,39 @@ $(document).ready(function() {
     });
   });
 
-  createTagSelect("GalleryGroup", "gallery_group", "character", {user_id: gon.user_id});
   createTagSelect("Setting", "setting", "character");
+  $("#character_gallery_group_ids").select2({
+    placeholder: 'Enter gallery group(s) separated by commas',
+    ajax: {
+      delay: 200,
+      url: '/api/v1/tags',
+      dataType: 'json',
+      data: function(params) {
+        var data = queryTransform(params);
+        data.t = 'GalleryGroup';
+        data.user_id = gon.user_id
+        return data;
+      },
+      processResults: function(data, params) {
+        params.page = params.page || 1;
+        var total = this._request.getResponseHeader('Total');
+        var results = processResults(data, params, total);
+
+        // Remove duplicates
+        var existingIds = $("#character_gallery_group_ids").val() || [];
+        var validResults = []
+        results.results.forEach(function(gallery) {
+          if(!existingIds.includes(gallery.id.toString())) validResults.push(gallery);
+        });
+        results.results = validResults;
+
+        return results;
+      },
+      cache: true,
+      createTag: function(params) { return null; }
+    },
+    width: '300px'
+  });
 });
 
 function findGalleryInGroups(galleryId) {

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -258,7 +258,6 @@ class GalleriesController < UploadingController
         icon_attributes: [:url, :keyword, :credit, :id, :_destroy, :s3_key]
       ],
       icon_ids: [],
-      ungrouped_gallery_ids: [],
     )
   end
 


### PR DESCRIPTION
* Removed typoed permitted param
* Makes the GalleryGroup select2 in the character editor not a tag select (which allows creating new groups) because in the API we explicitly only send up gallery groups that contain galleries, and allowing users to create and attach new-and-therefore-empty gallery groups to a character violates that (and, tbh, probably hides the gallery groups in the Mystery Realm where no one can see them).