### PR TITLE
Post read time takes priority over board read time

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -45,11 +45,21 @@ class PostsController < WritableController
     @started = (params[:started] == 'true') || (params[:started].nil? && current_user.unread_opened)
     @posts = Post.joins("LEFT JOIN post_views ON post_views.post_id = posts.id AND post_views.user_id = #{current_user.id}")
     @posts = @posts.joins("LEFT JOIN board_views on board_views.board_id = posts.board_id AND board_views.user_id = #{current_user.id}")
-    @posts = @posts.where("post_views.user_id IS NULL OR ((post_views.read_at IS NULL OR (date_trunc('second', post_views.read_at) < date_trunc('second', posts.tagged_at))) AND post_views.ignored = '0')")
-    @posts = @posts.where("board_views.user_id IS NULL OR ((board_views.read_at IS NULL OR (date_trunc('second', board_views.read_at) < date_trunc('second', posts.tagged_at))) AND board_views.ignored = '0')")
+
+    # I am so very sorry I cannot make this more legible. I blame Rails? Posts are unread when:
+    #   post view does not exist and (board view does not exist or post has updated since non-ignored board view read_at)
+    #   or
+    #   post view exists and post has updated since non-ignored post view read_at
+    @posts = @posts.where("(\
+      post_views.user_id IS NULL AND (\
+        board_views.user_id IS NULL OR ((board_views.read_at IS NULL OR (date_trunc('second', board_views.read_at) < date_trunc('second', posts.tagged_at))) AND board_views.ignored = '0')))\
+      OR (post_views.user_id IS NOT NULL AND (\
+        (post_views.read_at IS NULL OR (date_trunc('second', post_views.read_at) < date_trunc('second', posts.tagged_at))) AND post_views.ignored = '0'))")
+
     @posts = posts_from_relation(@posts.ordered, with_pagination: false)
     @posts = @posts.select { |p| @opened_ids.include?(p.id) } if @started
     @posts = @posts.paginate(per_page: 25, page: page)
+
     @hide_quicklinks = true
     @page_title = @started ? 'Opened Threads' : 'Unread Threads'
     use_javascript('posts/unread')

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -301,14 +301,8 @@ class PostsController < WritableController
     if params[:at_id].present?
       reply = Reply.find(params[:at_id])
       if reply && reply.post == @post
-        board_read = @post.board.last_read(current_user)
-        if board_read && board_read > reply.created_at
-          flash[:error] = "You have marked this continuity read more recently than that reply was written; it will not appear in your Unread posts."
-          Message.send_site_message(1, 'Unread at failure', "#{current_user.username} tried to mark post #{@post.id} unread at reply #{reply.id}")
-        else
-          @post.mark_read(current_user, reply.created_at - 1.second, true)
-          flash[:success] = "Post has been marked as read until reply ##{reply.id}."
-        end
+        @post.mark_read(current_user, reply.created_at - 1.second, true)
+        flash[:success] = "Post has been marked as read until reply ##{reply.id}."
       end
       return redirect_to unread_posts_path
     end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -2654,6 +2654,43 @@ RSpec.describe PostsController do
       expect(assigns(:posts)).to eq([post1, post2, post3])
     end
 
+    it "manages board/post read time mismatches" do
+      user = create(:user)
+
+      # no views exist
+      unread_post = create(:post)
+
+      # only post view exists
+      post_unread_post = create(:post)
+      post_unread_post.mark_read(user, post_unread_post.created_at - 1.second, true)
+      post_read_post = create(:post)
+      post_read_post.mark_read(user)
+
+      # only board view exists
+      board_unread_post = create(:post)
+      board_unread_post.board.mark_read(user, board_unread_post.created_at - 1.second, true)
+      board_read_post = create(:post)
+      board_read_post.board.mark_read(user)
+
+      # both exist
+      both_unread_post = create(:post)
+      both_unread_post.mark_read(user, both_unread_post.created_at - 1.second, true)
+      both_unread_post.board.mark_read(user, both_unread_post.created_at - 1.second, true)
+      both_board_read_post = create(:post)
+      both_board_read_post.mark_read(user, both_unread_post.created_at - 1.second, true)
+      both_board_read_post.board.mark_read(user)
+      both_post_read_post = create(:post)
+      both_post_read_post.board.mark_read(user, both_unread_post.created_at - 1.second, true)
+      both_post_read_post.mark_read(user)
+      both_read_post = create(:post)
+      both_read_post.mark_read(user)
+      both_read_post.board.mark_read(user)
+
+      login_as(user)
+      get :unread
+      expect(assigns(:posts)).to match_array([unread_post, post_unread_post, board_unread_post, both_unread_post, both_board_read_post])
+    end
+
     context "opened" do
       it "accepts parameter to force opened mode" do
         user = create(:user)

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1357,26 +1357,6 @@ RSpec.describe PostsController do
         skip "TODO does not notify"
       end
 
-      it "notifies Marri about board_read" do
-        # TODO fix the board_read thing better
-        post = create(:post)
-        post.mark_read(post.user, post.created_at)
-        unread_reply = create(:reply, post: post)
-        create(:reply, post: post)
-        time = Time.zone.now
-        post.board.mark_read(post.user, time)
-
-        login_as(post.user)
-        create(:user, id: 1) # to receive the alert message
-        expect {
-          put :update, params: { id: post.id, unread: true, at_id: unread_reply.id }
-        }.to change{ Message.count }.by(1)
-
-        expect(response).to redirect_to(unread_posts_url)
-        expect(flash[:error]).to eq("You have marked this continuity read more recently than that reply was written; it will not appear in your Unread posts.")
-        expect(post.reload.last_read(post.user)).to be_the_same_time_as(post.created_at)
-      end
-
       it "works with at_id" do
         post = create(:post)
         unread_reply = build(:reply, post: post)


### PR DESCRIPTION
The edge case didn't work before so we hacked in a notification about it; this has horrible SQL but actually does the thing correctly.

TBD: Do I want to just use update_all for the PostView update when marking a board read?