### PR TITLE
Use update_all instead of multiple calls to mark_read

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -121,7 +121,7 @@ class BoardsController < ApplicationController
         board.mark_read(current_user)
         read_time = board.last_read(current_user)
         post_views = PostView.joins(post: :board).where(user: current_user, boards: {id: board.id})
-        post_views.update_all(read_at: read_time, updated_at: read_time)
+        post_views.update_all(read_at: read_time, updated_at: read_time) # rubocop:disable Rails/SkipsModelValidations
       end
       flash[:success] = "#{board.name} marked as read."
     elsif params[:commit] == "Hide from Unread"

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -119,10 +119,9 @@ class BoardsController < ApplicationController
     if params[:commit] == "Mark Read"
       Board.transaction do
         board.mark_read(current_user)
+        read_time = board.last_read(current_user)
         post_views = PostView.joins(post: :board).where(user: current_user, boards: {id: board.id})
-        post_views.includes(:post).each do |post_view|
-          post_view.post.mark_read(current_user, board.last_read(current_user))
-        end
+        post_views.update_all(read_at: read_time, updated_at: read_time)
       end
       flash[:success] = "#{board.name} marked as read."
     elsif params[:commit] == "Hide from Unread"


### PR DESCRIPTION
@Throne3d and I thought that, as long as we make sure updated_at is touched, this would spare us processing time (hi Effulgence) and memory usage for no loss of functionality.