### PR TITLE
Paginate the template-grouped character list view page

### DIFF
--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -51,10 +51,15 @@
           %th.sub{colspan: colspan} Ungrouped Characters
         = render 'group', characters: @user.characters.where(character_group_id: nil), skip_grouped_templates: true, page_view: page_view
     - elsif @user.characters.exists?
-      - @user.templates.ordered.each do |template|
+      - paginated_templates = @user.templates.ordered.paginate(page: page, per_page: 5)
+      - paginated_templates.each do |template|
         = render partial_type, name: template, characters: template.characters.ordered
-      - if @user.characters.where(template_id: nil).exists?
+      - if paginated_templates.next_page.nil? && @user.characters.where(template_id: nil).exists?
         = render partial_type, name: "No Template", characters: @user.characters.where(template_id: nil).ordered, show_new_character_button: @user.id == current_user&.id
+      - if paginated_templates.total_pages > 1
+        %tfoot
+          %tr
+            %td{colspan: colspan}= render 'posts/paginator', paginated: paginated_templates
     - else
       %tr
         %td.centered.padding-5{class: cycle('even', 'odd'), colspan: colspan} — No characters yet —

--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -51,7 +51,7 @@
           %th.sub{colspan: colspan} Ungrouped Characters
         = render 'group', characters: @user.characters.where(character_group_id: nil), skip_grouped_templates: true, page_view: page_view
     - elsif @user.characters.exists?
-      - paginated_templates = @user.templates.ordered.paginate(page: page, per_page: 5)
+      - paginated_templates = @user.templates.ordered.paginate(page: page, per_page: 10)
       - paginated_templates.each do |template|
         = render partial_type, name: template, characters: template.characters.ordered
       - if paginated_templates.next_page.nil? && @user.characters.where(template_id: nil).exists?


### PR DESCRIPTION
A small, time-limited chunk of memory optimization: paginate the template-grouped list view.

* Does not cover icon view
* Does not cover viewing a single character group
* Does not cover a user with character groups
* Does not cover ungrouped templates (ungrouped list view is already paginated, so this really is just icon view again)