### PR TITLE
Posts with post views should still respect continuity hide-from-unread

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -49,11 +49,12 @@ class PostsController < WritableController
     # I am so very sorry I cannot make this more legible. I blame Rails? Posts are unread when:
     #   post view does not exist and (board view does not exist or post has updated since non-ignored board view read_at)
     #   or
-    #   post view exists and post has updated since non-ignored post view read_at
+    #   post view exists and post has updated since non-ignored post view read_at and (board view does not exist or is not ignored)
     @posts = @posts.where("(\
       post_views.user_id IS NULL AND (\
         board_views.user_id IS NULL OR ((board_views.read_at IS NULL OR (date_trunc('second', board_views.read_at) < date_trunc('second', posts.tagged_at))) AND board_views.ignored = '0')))\
       OR (post_views.user_id IS NOT NULL AND (\
+        board_views.user_id IS NULL OR board_views.ignored = '0') AND (\
         (post_views.read_at IS NULL OR (date_trunc('second', post_views.read_at) < date_trunc('second', posts.tagged_at))) AND post_views.ignored = '0'))")
 
     @posts = posts_from_relation(@posts.ordered, with_pagination: false)

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -2666,6 +2666,11 @@ RSpec.describe PostsController do
       both_read_post.mark_read(user)
       both_read_post.board.mark_read(user)
 
+      # board ignored
+      board_ignored = create(:post)
+      board_ignored.mark_read(user, both_unread_post.created_at - 1.second, true)
+      board_ignored.board.ignore(user)
+
       login_as(user)
       get :unread
       expect(assigns(:posts)).to match_array([unread_post, post_unread_post, board_unread_post, both_unread_post, both_board_read_post])


### PR DESCRIPTION
Pedro had a bunch of posts reappear in his Unread, because he had read them and marked the continuity hidden and the post view was taking precedence