### PR TITLE
Upgrade rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
-  gem 'rubocop', '~> 0.73.0', require: false
+  gem 'rubocop', '~> 0.74.0', require: false
   gem 'rubocop-performance', '~> 1.4.0', require: false
   gem 'rubocop-rails', '~> 2.2.1', require: false
   gem 'traceroute'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,14 +355,14 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.73.0)
+    rubocop (0.74.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-performance (1.4.0)
+    rubocop-performance (1.4.1)
       rubocop (>= 0.71.0)
     rubocop-rails (2.2.1)
       rack (>= 1.1)
@@ -520,7 +520,7 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails
-  rubocop (~> 0.73.0)
+  rubocop (~> 0.74.0)
   rubocop-performance (~> 1.4.0)
   rubocop-rails (~> 2.2.1)
   sanitize


### PR DESCRIPTION
* Upgrades rubocop from 0.73 to 0.74 ([Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0740-2019-07-31))
* Upgrades rubocop-performance from 1.4.0 to 1.4.1 ([Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md#141-2019-07-29))