### PR TITLE
Fix gallery tab of characters#show (and also some of icons#show)

### DIFF
--- a/app/assets/javascripts/characters/show.js
+++ b/app/assets/javascripts/characters/show.js
@@ -29,11 +29,10 @@ function bindArrows(orderBox, path, param) {
 
 // override standard reorder
 function reorderRows(orderBox) {
-  var arrowBox = $('tbody', orderBox);
-  var rows = $('.section-ordered', arrowBox);
+  var rows = $('.section-ordered', orderBox);
   var ordered = rows.sort(function(a, b) { return $(a).data('order') > $(b).data('order') ? 1 : -1; }).each(function() {
     var attaches = $(this).nextUntil('.section-ordered');
-    arrowBox.append(this, attaches.get());
+    orderBox.append(this, attaches.get());
   });
   return ordered;
 }

--- a/app/assets/javascripts/galleries/expander_old.js
+++ b/app/assets/javascripts/galleries/expander_old.js
@@ -3,12 +3,10 @@ $(document).ready(function() {
     var elem = $(this);
     var id = elem.data('id');
     if (elem.html().trim() === '-') {
-      $('#gallery' + id).hide();
-      $('#gallery-tags-' + id).hide();
+      $('.gallery-data-' + id).hide();
       elem.html('+');
     } else {
-      $('#gallery' + id).show();
-      $('#gallery-tags-' + id).show();
+      $('.gallery-data-' + id).show();
       elem.html('-');
     }
   });

--- a/app/assets/javascripts/icons.js
+++ b/app/assets/javascripts/icons.js
@@ -4,20 +4,6 @@ $(document).ready(function() {
   // respect up/down key selections in a dropdown as a valid change() trigger
   $("#icon_dropdown").change(function() { setIconFromId($(this).val()); });
   $("#icon_dropdown").keyup(function() { setIconFromId($(this).val()); });
-
-  $('.gallery-minmax').click(function() {
-    var elem = $(this);
-    var id = elem.data('id');
-    if (elem.html().trim() === '-') {
-      $('#gallery' + id).hide();
-      $('#gallery-tags-' + id).hide();
-      elem.html('+');
-    } else {
-      $('#gallery' + id).show();
-      $('#gallery-tags-' + id).show();
-      elem.html('-');
-    }
-  });
 });
 
 function setIconFromId(id) {

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -1,7 +1,11 @@
 - attrs = {}
-- attrs = {class: 'section-ordered', data: {id: character_gallery.id, order: character_gallery.section_order}} if local_assigns[:character_gallery]
-%tbody{class: ("gallery-title-#{gallery.id}" if gallery)}
-  %tr.gallery-header{**attrs}
+- gallery_klass = []
+- if local_assigns[:character_gallery]
+  - gallery_klass << 'section-ordered'
+  - attrs[:data] = {id: character_gallery.id, order: character_gallery.section_order}
+- gallery_klass << "gallery-title-#{gallery.id}" if gallery
+%tbody{class: gallery_klass, **attrs}
+  %tr.gallery-header
     %th.padding-10{class: (klass if defined? klass)}
       - link = gallery ? gallery_path(gallery) : user_gallery_path(id: 0, user_id: @user.id)
       = link_to gallery ? gallery.name : 'Galleryless icons', link, class: 'gallery-title'

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -1,6 +1,6 @@
 - attrs = {}
 - attrs = {class: 'section-ordered', data: {id: character_gallery.id, order: character_gallery.section_order}} if local_assigns[:character_gallery]
-%tbody
+%tbody{class: ("gallery-title-#{gallery.id}" if gallery)}
   %tr.gallery-header{**attrs}
     %th.padding-10{class: (klass if defined? klass)}
       - link = gallery ? gallery_path(gallery) : user_gallery_path(id: 0, user_id: @user.id)
@@ -21,7 +21,7 @@
         .float-right
           = image_tag "icons/arrow_up.png", class: "section-up disabled-arrow"
           = image_tag "icons/arrow_down.png", class: "section-down disabled-arrow"
-%tbody
+%tbody{class: ("gallery-data-#{gallery.id}" if gallery)}
   - groups = gallery.gallery_groups_data if gallery
   - if groups.present?
     %tr.gallery-tags

--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -77,10 +77,10 @@
     %thead
       %tr
         %th Galleries
-    %tbody
-      - if @icon.galleries.exists?
-        = render partial: 'galleries/single', collection: @icon.galleries.ordered_by_name, as: :gallery, locals: {klass: 'subber', skip_forms: true, is_owner: @icon.user == current_user}
-      - else
+    - if @icon.galleries.exists?
+      = render partial: 'galleries/single', collection: @icon.galleries.ordered_by_name, as: :gallery, locals: {klass: 'subber', skip_forms: true, is_owner: @icon.user == current_user}
+    - else
+      %tbody
         %tr
           %td.even.centered — No galleries yet —
 - elsif params[:view] == 'posts'


### PR DESCRIPTION
Since we moved the rows into `%tbody`s, we've had to relocate certain attributes and classes (and modify a small bit of JavaScript) to ensure the minmax & reordering function of character galleries work as expected.

We should try to feature spec this (in a spec with javascript enabled) if possible, to prevent regression.