### PR TITLE
Test JS with selenium-webdriver and capybara (and geckodriver)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ branches:
 addons:
   code_climate:
     repo_token: 1e0c6dba9930e839038860b6d73301226c821937f57ed35d06fc0e4b7bddf5f6
+  chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ branches:
 addons:
   code_climate:
     repo_token: 1e0c6dba9930e839038860b6d73301226c821937f57ed35d06fc0e4b7bddf5f6
-  chrome: stable
+  firefox: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update
 RUN apt-get install -y curl
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
 RUN apt-get install -y nodejs postgresql-client-9.4
-RUN apt-get install -y chromium-driver
+RUN apt-get install -y firefox-esr
 
 RUN gem install bundler -v 1.15.2
 RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update
 RUN apt-get install -y curl
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
 RUN apt-get install -y nodejs postgresql-client-9.4
+RUN apt-get install -y chromium-driver
 
 RUN gem install bundler -v 1.15.2
 RUN bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,9 @@ group :test do
   gem 'json'
   gem 'rails-controller-testing'
   gem 'resque_spec'
+  gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'timecop'
+  gem 'webdrivers', '~> 4.0'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
+    childprocess (1.0.1)
+      rake (< 13.0)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -371,6 +373,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.13.1)
       sexp_processor (~> 4.9)
+    rubyzip (1.2.3)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
     safe_yaml (1.0.5)
@@ -403,6 +406,9 @@ GEM
       activesupport (>= 4)
     select2-rails (4.0.3)
       thor (~> 0.14)
+    selenium-webdriver (3.142.3)
+      childprocess (>= 0.5, < 2.0)
+      rubyzip (~> 1.2, >= 1.2.2)
     sexp_processor (4.12.0)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -456,6 +462,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -527,6 +537,7 @@ DEPENDENCIES
   sassc-rails
   seed_dump (~> 3.2)
   select2-rails
+  selenium-webdriver
   simplecov
   test-unit (~> 3.0)
   thin
@@ -535,6 +546,7 @@ DEPENDENCIES
   traceroute
   uglifier
   web-console (~> 3.0)
+  webdrivers (~> 4.0)
   webmock
   will_paginate
 

--- a/app/assets/javascripts/galleries/expander_old.js
+++ b/app/assets/javascripts/galleries/expander_old.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
   $('.gallery-minmax').click(function(event) {
-    var elem = $(this);
-    var id = elem.data('id');
+    var elem = $('a', this);
+    var id = $(this).data('id');
     if (elem.html().trim() === '-') {
       $('.gallery-data-' + id).hide();
       elem.html('+');

--- a/app/assets/javascripts/galleries/expander_old.js
+++ b/app/assets/javascripts/galleries/expander_old.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-  $('.gallery-minmax').click(function() {
+  $('.gallery-minmax').click(function(event) {
     var elem = $(this);
     var id = elem.data('id');
     if (elem.html().trim() === '-') {
@@ -9,5 +9,6 @@ $(document).ready(function() {
       $('.gallery-data-' + id).show();
       elem.html('-');
     }
+    event.preventDefault();
   });
 });

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -20,7 +20,8 @@
           = link_to gallery_path(gallery), method: :delete, data: { confirm: 'Are you sure you want to delete this gallery? (This will not delete the icons.)' }, class: 'gallery-delete' do
             .link-box.action-delete x Delete Gallery
       - unless local_assigns[:hide_minmax]
-        .gallery-box.float-right.gallery-minmax{data: {id: gallery.id}} -
+        .gallery-box.float-right.gallery-minmax{data: {id: gallery.id}}
+          = link_to '-', '#'
       - if local_assigns[:character_gallery] && (is_owner || current_user.try(:admin?))
         .float-right
           = image_tag "icons/arrow_up.png", class: "section-up disabled-arrow"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -201,7 +201,6 @@ end
 
 require 'webmock/rspec'
 allowed_sites = lambda do |uri|
-  p uri.to_s
   uri.to_s.start_with?("https://github.com:443/mozilla/geckodriver/") ||
     uri.host == "github-production-release-asset-2e65be.s3.amazonaws.com"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,36 @@ require 'rails_helper'
 require 'support/spec_test_helper'
 require 'support/spec_feature_helper'
 
+require 'webdrivers'
+require 'selenium/webdriver'
+
+Capybara.register_driver :headless_firefox do |app|
+  profile = Selenium::WebDriver::Firefox::Profile.new
+  options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
+
+  options.add_argument('-headless')
+  options.add_argument('--window-size=1366,768')
+
+  Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
+end
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.register_driver :headless_chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+
+  options.add_argument('--headless')
+  # options.add_argument('--no-sandbox')
+  # options.add_argument('--disable-popup-blocking')
+  options.add_argument('--window-size=1366,768')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.javascript_driver = :headless_chrome
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,8 @@ require 'support/spec_feature_helper'
 require 'webdrivers'
 require 'selenium/webdriver'
 
+Webdrivers.logger.level = :DEBUG
+
 Capybara.register_driver :headless_firefox do |app|
   profile = Selenium::WebDriver::Firefox::Profile.new
   options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
@@ -70,7 +72,7 @@ Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
-Capybara.javascript_driver = :headless_chrome
+Capybara.javascript_driver = :headless_firefox
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,8 +45,6 @@ require 'support/spec_feature_helper'
 require 'webdrivers'
 require 'selenium/webdriver'
 
-Webdrivers.logger.level = :DEBUG
-
 Capybara.register_driver :headless_firefox do |app|
   profile = Selenium::WebDriver::Firefox::Profile.new
   options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
@@ -202,9 +200,14 @@ module ActionDispatch
 end
 
 require 'webmock/rspec'
+allowed_sites = lambda do |uri|
+  p uri.to_s
+  uri.to_s.start_with?("https://github.com:443/mozilla/geckodriver/") ||
+    uri.host == "github-production-release-asset-2e65be.s3.amazonaws.com"
+end
 WebMock.disable_net_connect!(
   allow_localhost: true,
-  allow: "chromedriver.storage.googleapis.com",
+  allow: allowed_sites,
 )
 
 # disable auditing by default unless specifically turned on for a test

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,7 +63,7 @@ Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
 
   options.add_argument('--headless')
-  # options.add_argument('--no-sandbox')
+  options.add_argument('--no-sandbox')
   # options.add_argument('--disable-popup-blocking')
   options.add_argument('--window-size=1366,768')
 
@@ -200,7 +200,10 @@ module ActionDispatch
 end
 
 require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: "chromedriver.storage.googleapis.com",
+)
 
 # disable auditing by default unless specifically turned on for a test
 Post.auditing_enabled = false


### PR DESCRIPTION
Modification of #1146. Uses geckodriver and firefox. The Dockerfile uses firefox-esr because buster (the Debian release) doesn't have the other one directly, but I figure we should test on the latest so I stuck Travis at latest. `allowed_sites` is a bit ugly on this one – the download has some redirects.