### PR TITLE
Seed uploaded image URLs with a random string in the Javascript

### DIFF
--- a/app/assets/javascripts/galleries/uploader.js
+++ b/app/assets/javascripts/galleries/uploader.js
@@ -20,6 +20,10 @@ $(document).ready(function() {
   });
 });
 
+function randomString() {
+  return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+}
+
 function bindFileInput(fileInput, form, submitButton, formData) {
   var uploadArgs = {
     fileInput: fileInput,
@@ -46,6 +50,12 @@ function bindFileInput(fileInput, form, submitButton, formData) {
 
       formData["Content-Type"] = fileType;
       data.formData = formData;
+
+      // seed the AWS key with a random string here, not serverside, so each upload has a unique string
+      var pieces = data.formData.key.split('$');
+      var newKey = pieces[0] + randomString() + '_$' + pieces[1];
+      data.formData.key = newKey;
+
       data.submit();
       fileInput.val('');
     },

--- a/app/controllers/uploading_controller.rb
+++ b/app/controllers/uploading_controller.rb
@@ -12,7 +12,7 @@ class UploadingController < ApplicationController
     end
 
     @s3_direct_post = S3_BUCKET.presigned_post(
-      key: "users/#{current_user.id}/icons/#{SecureRandom.uuid}_${filename}",
+      key: "users/#{current_user.id}/icons/${filename}",
       success_action_status: '201',
       acl: 'public-read',
       content_type_starts_with: 'image/',


### PR DESCRIPTION
Seeding per-file rather than at the server level on page load helps prevent the thing where users experience issues if they accidentally upload the same file twice and then delete one.