### PR TITLE
Use visible_to scope for post previous/next

### DIFF
--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -79,21 +79,10 @@ class WritableController < ApplicationController
     use_javascript('paginator')
 
     if @post.board.ordered?
-      next_post = @post.next_post
-      9.times do
-        break unless next_post
-        break if next_post.visible_to?(current_user)
-        next_post = next_post.next_post
-      end
-      @next_post = next_post&.visible_to?(current_user) ? next_post : nil
+      posts = Post.where(board_id: @post.board_id, section_id: @post.section_id).visible_to(current_user).ordered_in_section
 
-      prev_post = @post.prev_post
-      9.times do
-        break unless prev_post
-        break if prev_post.visible_to?(current_user)
-        prev_post = prev_post.prev_post
-      end
-      @prev_post = prev_post&.visible_to?(current_user) ? prev_post : nil
+      @next_post = posts.find_by('section_order > ?', @post.section_order)
+      @prev_post = posts.reverse_order.find_by('section_order < ?', @post.section_order)
     end
 
     # show <link rel="canonical"> – for SEO stuff

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1145,16 +1145,16 @@ RSpec.describe PostsController do
       user = create(:user)
       board = create(:board, creator: user)
       section = create(:board_section, board: board)
-      create(:post, user: user, board: board, section: section)
+      prev = create(:post, user: user, board: board, section: section)
       create_list(:post, 10, board: board, section: section, privacy: Concealable::PRIVATE)
       post = create(:post, user: user, board: board, section: section)
       create_list(:post, 10, board: board, section: section, privacy: Concealable::PRIVATE)
-      create(:post, user: user, board: board, section: section)
+      nextp = create(:post, user: user, board: board, section: section)
 
       get :show, params: { id: post.id }
 
-      expect(assigns(:prev_post)).to be_nil
-      expect(assigns(:next_post)).to be_nil
+      expect(assigns(:prev_post)).to eq(prev)
+      expect(assigns(:next_post)).to eq(nextp)
     end
     # TODO WAY more tests
   end


### PR DESCRIPTION
* Uses visible to scope to check post visibility on the query rather sequentially loading individual posts
* Removes restriction of checking a limited number of previous/next posts