### PR TITLE
Require PostScraper in ScrapePostJob tests

### DIFF
--- a/spec/jobs/scrape_post_job_spec.rb
+++ b/spec/jobs/scrape_post_job_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require Rails.root.join("app", "services", "post_scraper.rb")
 
 RSpec.describe ScrapePostJob do
   include ActiveJob::TestHelper


### PR DESCRIPTION
`ScrapePostJob sends messages on username exceptions` fails when called alone or when the file is called by itself (rather than as part of the test suite running in general) without this.