### PR TITLE
Prevent hiatusing of threads from updating tagged_at

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -307,6 +307,7 @@ class Post < ApplicationRecord
     self.edited_at = self.updated_at
     return if skip_tagged
     return if replies.exists? && !status_changed?
+    return if marked_hiatus?
     self.tagged_at = self.updated_at
   end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -76,6 +76,15 @@ RSpec.describe Post do
         end
       end
 
+      it "should update edited_at but not tagged_at when hiatused" do
+        Timecop.freeze(time) do
+          post.status = Post::STATUS_HIATUS
+          post.save!
+          expect(post.tagged_at).to eq(old_tagged_at)
+          expect(post.edited_at).to be > old_edited_at
+        end
+      end
+
       it "should not update on invalid edit" do
         Timecop.freeze(time) do
           post.section_order = post.section_order + 1


### PR DESCRIPTION
Widely requested (along with making abandoned do the same, but that seemed like it might require community input). This will prevent marking threads hiatused bumping them on Recently Updated and Unread.