### PR TITLE
Seed uploaded image URLs with a random string in the Javascript 2: The Seedening

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,10 @@
 //= require jquery-ui/widgets/button
 //= require jquery-ui/widgets/dialog
 //= require jquery-fileupload/basic
+//= require jquery-fileupload/vendor/load-image.all.min
+//= require jquery-fileupload/vendor/canvas-to-blob
+//= require jquery-fileupload/jquery.fileupload-process
+//= require jquery-fileupload/jquery.fileupload-image
 //= require bootstrap.min
 //= require tinymce-jquery
 //= require select2

--- a/app/assets/javascripts/galleries/uploader.js
+++ b/app/assets/javascripts/galleries/uploader.js
@@ -20,6 +20,10 @@ $(document).ready(function() {
   });
 });
 
+function randomString() {
+  return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+}
+
 function bindFileInput(fileInput, form, submitButton, formData) {
   var uploadArgs = {
     fileInput: fileInput,
@@ -46,6 +50,12 @@ function bindFileInput(fileInput, form, submitButton, formData) {
 
       formData["Content-Type"] = fileType;
       data.formData = formData;
+
+      // seed the AWS key with a random string here, not serverside, so each upload has a unique string
+      var pieces = data.formData.key.split('$');
+      var newKey = pieces[0] + randomString() + '_$' + pieces[1];
+      data.formData.key = newKey;
+
       data.submit();
       fileInput.val('');
     },

--- a/app/assets/javascripts/galleries/uploader.js
+++ b/app/assets/javascripts/galleries/uploader.js
@@ -1,6 +1,7 @@
 /* global addUploadedIcon, setLoadingIcon, addCallback, failCallback */
 
 var uploadedIcons = {};
+var formKey = '';
 
 $(document).ready(function() {
   var form = $('form.icon-upload');
@@ -52,7 +53,8 @@ function bindFileInput(fileInput, form, submitButton, formData) {
       data.formData = formData;
 
       // seed the AWS key with a random string here, not serverside, so each upload has a unique string
-      var pieces = data.formData.key.split('$');
+      if (formKey === '') formKey = data.formData.key;
+      var pieces = formKey.split('$');
       var newKey = pieces[0] + randomString() + '_$' + pieces[1];
       data.formData.key = newKey;
 

--- a/app/assets/javascripts/galleries/uploader.js
+++ b/app/assets/javascripts/galleries/uploader.js
@@ -35,6 +35,9 @@ function bindFileInput(fileInput, form, submitButton, formData) {
     paramName: 'file', // S3 does not like nested name fields i.e. name="user[avatar_url]"
     dataType: 'XML', // S3 returns XML if success_action_status is set to 201
     replaceFileInput: false,
+    disableImageResize: false,
+    imageMaxWidth: 400,
+    imageMaxHeight: 400,
 
     add: function(e, data) {
       var fileType = data.files[0].type;
@@ -58,7 +61,12 @@ function bindFileInput(fileInput, form, submitButton, formData) {
       var newKey = pieces[0] + randomString() + '_$' + pieces[1];
       data.formData.key = newKey;
 
-      data.submit();
+      var uploader = $(this);
+      data.process(function() {
+        return uploader.fileupload('process', data);
+      }).done(function() {
+        data.submit();
+      });
       fileInput.val('');
     },
     start: function() {

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -153,7 +153,7 @@ class GalleriesController < UploadingController
       icon = Icon.new(icon_params(icon.except('filename', 'file')))
       icon.user = current_user
       unless icon.valid?
-        @icons[index]['url'] = '' if icon.errors.messages[:url]&.include?('has already been taken')
+        @icons[index]['url'] = @icons[index]['s3_key'] = '' if icon.errors.messages[:url]&.include?('is invalid')
         flash.now[:error] ||= {}
         flash.now[:error][:array] ||= []
         flash.now[:error][:array] += icon.errors.full_messages.map{|m| "Icon "+(index+1).to_s+": "+m.downcase}

--- a/app/controllers/uploading_controller.rb
+++ b/app/controllers/uploading_controller.rb
@@ -12,7 +12,7 @@ class UploadingController < ApplicationController
     end
 
     @s3_direct_post = S3_BUCKET.presigned_post(
-      key: "users/#{current_user.id}/icons/#{SecureRandom.uuid}_${filename}",
+      key: "users/#{current_user.id}/icons/${filename}",
       success_action_status: '201',
       acl: 'public-read',
       content_type_starts_with: 'image/',

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -60,7 +60,8 @@ class Icon < ApplicationRecord
 
   def uploaded_url_yours
     return unless uploaded?
-    return if url.include?("users%2F#{user_id}%2Ficons%2F")
+    return if url.include?("users%2F#{user_id}%2Ficons%2F") && \
+              s3_key.starts_with?("users/#{user_id}/icons/")
 
     self.url = url_was
     self.s3_key = s3_key_was

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -661,9 +661,9 @@ RSpec.describe GalleriesController do
         expect(response).to render_template(:add)
         expect(flash[:error][:message]).to eq('Your icons could not be saved.')
         expect(assigns(:icons).length).to eq(icons.length-1) # removes blank icons
-        expect(assigns(:icons).first[:url]).to be_empty # removes duplicate uploaded icon URLs
+        expect(assigns(:icons).first[:url]).to be_empty # removes not-yours uploaded icon URLs
         expect(flash.now[:error][:array]).to match_array([
-          "Icon 1: url has already been taken",
+          "Icon 1: url is invalid",
           "Icon 2: keyword can't be blank",
           "Icon 3: url can't be blank",
           "Icon 3: url must be an actual fully qualified url (http://www.example.com)",

--- a/spec/models/icon_spec.rb
+++ b/spec/models/icon_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe Icon do
       expect(icon).not_to be_valid
     end
 
-    context "#uploaded_url_not_in_use" do
+    context "#uploaded_url_yours" do
       it "should set the url back to its previous url on create" do
         icon = create(:uploaded_icon)
-        dupe_icon = build(:icon, url: icon.url, s3_key: icon.s3_key)
+        dupe_icon = build(:icon, url: icon.url, s3_key: icon.s3_key, user: create(:user))
         expect(dupe_icon).not_to be_valid
         expect(dupe_icon.url).to be nil
       end
@@ -42,6 +42,7 @@ RSpec.describe Icon do
         old_url = dupe_icon.url
         dupe_icon.url = icon.url
         dupe_icon.s3_key = icon.s3_key
+        dupe_icon.user_id = create(:user)
         expect(dupe_icon.save).to be false
         expect(dupe_icon.url).to eq(old_url)
       end
@@ -107,17 +108,8 @@ RSpec.describe Icon do
     it "deletes uploaded on new uploaded update" do
       icon = create(:uploaded_icon)
       old_key = icon.s3_key
-      icon.url = "https://d1anwqy6ci9o1i.cloudfront.net/users/#{icon.user.id}/icons/nonsense-fakeimg2.png"
-      icon.s3_key = "/users/#{icon.user.id}/icons/nonsense-fakeimg2.png"
-      icon.save!
-      expect(DeleteIconFromS3Job).to have_been_enqueued.with(old_key).on_queue('high')
-    end
-
-    it "deletes uploaded on new non-uploaded update" do
-      icon = create(:uploaded_icon)
-      old_key = icon.s3_key
-      icon.url = "https://fake.com/nonsense-fakeimg2.png"
-      icon.s3_key = "/users/#{icon.user.id}/icons/nonsense-fakeimg2.png"
+      icon.url = "https://d1anwqy6ci9o1i.cloudfront.net/users%2F#{icon.user.id}%2Ficons%2Fnonsense-fakeimg2.png"
+      icon.s3_key = "users/#{icon.user.id}/icons/nonsense-fakeimg2.png"
       icon.save!
       expect(DeleteIconFromS3Job).to have_been_enqueued.with(old_key).on_queue('high')
     end
@@ -137,29 +129,32 @@ RSpec.describe Icon do
 
     it "does nothing unless asset host is present" do
       ENV['ICON_HOST'] = nil
-      icon = build(:icon)
+      icon = build(:icon, user: create(:user))
+      url = "https://glowfic-bucket.s3.amazonaws.com/users%2F#{icon.user.id}%2Ficons%2Ffake_test.png"
       icon.s3_key = 'users/1/icons/fake_test.png'
-      icon.url = 'https://glowfic-bucket.s3.amazonaws.com/users%2F1%2Ficons%2Ffake_test.png'
+      icon.url = url
       icon.save!
-      expect(icon.reload.url).to eq('https://glowfic-bucket.s3.amazonaws.com/users%2F1%2Ficons%2Ffake_test.png')
+      expect(icon.reload.url).to eq(url)
     end
 
     it "does nothing unless the icon is uploaded" do
       ENV['ICON_HOST'] = asset_host
-      icon = build(:icon)
+      icon = build(:icon, user: create(:user))
+      url = "https://glowfic-bucket.s3.amazonaws.com/users%2F#{icon.user.id}%2Ficons%2Ffake_test.png"
       icon.s3_key = nil
-      icon.url = 'https://glowfic-bucket.s3.amazonaws.com/users%2F1%2Ficons%2Ffake_test.png'
+      icon.url = url
       icon.save!
-      expect(icon.reload.url).to eq('https://glowfic-bucket.s3.amazonaws.com/users%2F1%2Ficons%2Ffake_test.png')
+      expect(icon.reload.url).to eq(url)
     end
 
     it "does nothing unless the icon already has the asset host domain in it" do
       ENV['ICON_HOST'] = asset_host
-      icon = build(:icon)
+      icon = build(:icon, user: create(:user))
+      url = "#{asset_host}/users%2F#{icon.user_id}%2Ficons%2Ffake_test.png"
       icon.s3_key = 'users/1/icons/fake_test.png'
-      icon.url = asset_host + '/users%2F1%2Ficons%2Ffake_test.png'
+      icon.url = url
       icon.save!
-      expect(icon.reload.url).to eq(asset_host + '/users%2F1%2Ficons%2Ffake_test.png')
+      expect(icon.reload.url).to eq(url)
     end
 
     it "handles weird URL-less AWS edge case" do
@@ -170,11 +165,11 @@ RSpec.describe Icon do
 
     it "updates the s3 domain to the asset host domain" do
       ENV['ICON_HOST'] = asset_host
-      icon = build(:icon)
+      icon = build(:icon, user: create(:user))
+      icon.url = "https://glowfic-bucket.s3.amazonaws.com/users%2F#{icon.user_id}%2Ficons%2Ffake_test.png"
       icon.s3_key = 'users/1/icons/fake_test.png'
-      icon.url = 'https://glowfic-bucket.s3.amazonaws.com/users%2F1%2Ficons%2Ffake_test.png'
       icon.save!
-      expect(icon.reload.url).to eq(asset_host + '/users%2F1%2Ficons%2Ffake_test.png')
+      expect(icon.reload.url).to eq("#{asset_host}/users%2F#{icon.user_id}%2Ficons%2Ffake_test.png")
     end
   end
 end

--- a/spec/models/icon_spec.rb
+++ b/spec/models/icon_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe Icon do
         expect(dupe_icon.save).to be false
         expect(dupe_icon.url).to eq(old_url)
       end
+
+      it "does not allow url/s3_key mismatch" do
+        icon = build(:icon, user: create(:user))
+        icon.url = "https://d1anwqy6ci9o1i.cloudfront.net/users%2F#{icon.user.id}%2Ficons%2Fnonsense-fakeimg2.png"
+        icon.s3_key = "users/#{icon.user.id + 1}/icons/nonsense-fakeimg2.png"
+        expect(icon.save).to be false
+        expect(icon.url).to be_nil
+      end
     end
   end
 
@@ -131,7 +139,7 @@ RSpec.describe Icon do
       ENV['ICON_HOST'] = nil
       icon = build(:icon, user: create(:user))
       url = "https://glowfic-bucket.s3.amazonaws.com/users%2F#{icon.user.id}%2Ficons%2Ffake_test.png"
-      icon.s3_key = 'users/1/icons/fake_test.png'
+      icon.s3_key = "users/#{icon.user_id}/icons/fake_test.png"
       icon.url = url
       icon.save!
       expect(icon.reload.url).to eq(url)
@@ -151,7 +159,7 @@ RSpec.describe Icon do
       ENV['ICON_HOST'] = asset_host
       icon = build(:icon, user: create(:user))
       url = "#{asset_host}/users%2F#{icon.user_id}%2Ficons%2Ffake_test.png"
-      icon.s3_key = 'users/1/icons/fake_test.png'
+      icon.s3_key = "users/#{icon.user_id}/icons/fake_test.png"
       icon.url = url
       icon.save!
       expect(icon.reload.url).to eq(url)
@@ -167,7 +175,7 @@ RSpec.describe Icon do
       ENV['ICON_HOST'] = asset_host
       icon = build(:icon, user: create(:user))
       icon.url = "https://glowfic-bucket.s3.amazonaws.com/users%2F#{icon.user_id}%2Ficons%2Ffake_test.png"
-      icon.s3_key = 'users/1/icons/fake_test.png'
+      icon.s3_key = "users/#{icon.user_id}/icons/fake_test.png"
       icon.save!
       expect(icon.reload.url).to eq("#{asset_host}/users%2F#{icon.user_id}%2Ficons%2Ffake_test.png")
     end


### PR DESCRIPTION
Reverts Marri/glowfic#1158

Properly seeds image URLs with a random hash in the browser, since seeding per-file rather than at the server level on page load helps prevent the thing where users experience issues if they accidentally upload the same file twice and then delete one.

Also incidentally added image resizing to ensure images are resized down to 400x400 before uploading, since... why not?

Also-also fixed the "uploaded URL is yours" validation, which wasn't working at blocking what we actually wanted it to block and also was doing an unindexed db query.