### PR TITLE
Upgrade rubocop gems

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -19,7 +19,7 @@ plugins:
     enabled: true
   rubocop:
     enabled: true
-    channel: rubocop-0-71
+    channel: rubocop-0-74
 exclude_patterns:
 - config/
 - db/

--- a/Gemfile
+++ b/Gemfile
@@ -49,9 +49,9 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
-  gem 'rubocop', '~> 0.74.0', require: false
-  gem 'rubocop-performance', '~> 1.4.0', require: false
-  gem 'rubocop-rails', '~> 2.2.1', require: false
+  gem 'rubocop', '~> 0.75.0', require: false
+  gem 'rubocop-performance', '~> 1.5.0', require: false
+  gem 'rubocop-rails', '~> 2.3.2', require: false
   gem 'traceroute'
   gem 'web-console', '~> 3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,16 +335,16 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.74.0)
+    rubocop (0.75.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-performance (1.4.1)
+    rubocop-performance (1.5.0)
       rubocop (>= 0.71.0)
-    rubocop-rails (2.2.1)
+    rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
@@ -481,9 +481,9 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails
-  rubocop (~> 0.74.0)
-  rubocop-performance (~> 1.4.0)
-  rubocop-rails (~> 2.2.1)
+  rubocop (~> 0.75.0)
+  rubocop-performance (~> 1.5.0)
+  rubocop-rails (~> 2.3.2)
   sanitize
   sassc-rails
   seed_dump (~> 3.2)


### PR DESCRIPTION
* Upgrades rubocop from 0.74 to 0.75
* Upgrades rubocop-rails from 2.2.1 to 2.3.2
* Upgrades rubocop-performance from 1.4.0 to 1.5.0

Two new cops: [Lint/SendWithMixinArgument](https://rubocop.readthedocs.io/en/latest/cops_lint/#lintsendwithmixinargument) and [Rails/EnumHash](https://docs.rubocop.org/projects/rails/en/stable/cops_rails/#railsenumhash), neither of which have any complaints.

Also tells codeclimate to use rubocop 0.74, which is the latest version they support.