### PR TITLE
Upgrade from ruby 2.6.3 to ruby 2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
- - 2.6.3
+ - 2.6.5
 env:
 - CI=true
 services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.3
+FROM ruby:2.6.5
 
 WORKDIR /code
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.6.3'
+ruby '2.6.5'
 
 gem 'api-pagination'
 gem 'apipie-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -500,7 +500,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-*   [Ruby](https://www.ruby-lang.org/en/) 2.6.3
+*   [Ruby](https://www.ruby-lang.org/en/) 2.6.5
 *   [Rails](http://rubyonrails.org/) 5.2
 *   [Redis](https://redis.io/topics/quickstart)
 *   [PostgreSQL](https://www.postgresql.org/) (guide to set this up [later](#setting-up-postgresql))
@@ -97,7 +97,7 @@ First, go to the glowfic folder and download the latest code:
 *   `git pull`
 
 Then look at this README again, to make sure the version of Ruby hasn't changed; alternatively, in case this file is not up to date, look at the top of the `Gemfile` file, where it states the version of ruby.
-As of writing, this is `ruby '2.6.3'`.
+As of writing, this is `ruby '2.6.5'`.
 If it has changed, you can rebuild the glowfic image with:
 
 *   `docker-compose stop`


### PR DESCRIPTION
[Ruby 2.6.4 Changelog](https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-6-4-released/)
[Ruby 2.6.5 Changelog](https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/)

Mostly security vulnerabilities that shouldn't affect us afaict but nonetheless.

(also haml-lint was complaining that it expected 2.6.5 and got 2.6.3 xD)