### PR TITLE
Fix duplicate id errors on login page

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -87,7 +87,7 @@
                 %li= link_to "Post", new_post_path
               = link_to logout_path, method: :delete, id: :"header-logout" do
                 = button_tag "Log out", class: 'button'
-            - else
+            - elsif !current_page?(login_path)
               = form_tag login_path, method: :post, id: 'header-form' do
                 #header-forms
                   = text_field_tag :username, params[:username], placeholder: "Username"

--- a/app/views/sessions/new.haml
+++ b/app/views/sessions/new.haml
@@ -4,10 +4,10 @@
       %tr
         %th{colspan: 2} Sign In
     %tbody
-      %tr#username
+      %tr#username-row
         %th.sub.vtop Username
         %td.even= text_field_tag :username, params[:username], placeholder: "Username"
-      %tr#password
+      %tr#password-row
         %th.sub.vtop Password
         %td.odd
           = password_field_tag :password, params[:password], placeholder: "Password"


### PR DESCRIPTION
Currently it shows there, which gives duplicate id problems _and_ is redundant.

Looks like so, similar to how things display for mobile logged out viewers 
![image](https://user-images.githubusercontent.com/19716939/66724414-70f96200-edeb-11e9-9389-65ca6b4f4874.png)
