### PR TITLE
Reorder Dockerfile commands for cache reuse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 FROM ruby:2.6.3
 
-ADD Gemfile* /code/
-
 WORKDIR /code
 
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >> /etc/apt/sources.list.d/postgres.list
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN apt-get update
-RUN apt-get install -y curl
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
-RUN apt-get install -y nodejs postgresql-client-9.4
+RUN apt-get update
+RUN apt-get install -y curl nodejs postgresql-client-9.4
 
 RUN gem install bundler -v 1.17.2
+
+ADD Gemfile* /code/
 RUN bundle install


### PR DESCRIPTION
RSpec runs fine locally after this change, so I'm happy with it.