### PR TITLE
Feature spec sessions#new and sessions#destroy

### DIFF
--- a/spec/features/sessions/destroy_spec.rb
+++ b/spec/features/sessions/destroy_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.feature "Logging out", :type => :feature do
+  scenario "Log out while correctly logged in" do
+    user = login
+    expect(page).to have_selector('#user-info', text: user.username)
+    # TODO: Use js:true and logout button, rather than manually submitting a DELETE.
+    page.driver.submit(:delete, logout_path, {})
+
+    expect(page).to have_selector('.flash.success', text: 'You have been logged out.')
+    expect(page).to have_no_selector('#user-info')
+    expect(page).to have_current_path(root_path)
+
+    # make sure we're still logged out after navigating somewhere else
+    visit boards_path
+    expect(page).to have_no_selector('.flash')
+    expect(page).to have_no_selector('#user-info')
+  end
+end

--- a/spec/features/sessions/destroy_spec.rb
+++ b/spec/features/sessions/destroy_spec.rb
@@ -1,11 +1,10 @@
 require "spec_helper"
 
 RSpec.feature "Logging out", :type => :feature do
-  scenario "Log out while correctly logged in" do
+  scenario "Log out while correctly logged in", js: true do
     user = login
     expect(page).to have_selector('#user-info', text: user.username)
-    # TODO: Use js:true and logout button, rather than manually submitting a DELETE.
-    page.driver.submit(:delete, logout_path, {})
+    click_button "Log out"
 
     expect(page).to have_selector('.flash.success', text: 'You have been logged out.')
     expect(page).to have_no_selector('#user-info')

--- a/spec/features/sessions/new_spec.rb
+++ b/spec/features/sessions/new_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+# Sessions#new is primarily for mobile logins.
+# The other flow is tested (implicitly) everywhere that uses the login method.
+RSpec.feature "Logging in", :type => :feature do
+  scenario "Log in with invalid details" do
+    visit login_path
+    expect(page).to have_no_selector('.flash')
+    within('.form-table') do
+      fill_in 'Username', with: 'Invalid user'
+      fill_in 'Password', with: 'failed password'
+      click_on 'Sign In'
+    end
+
+    expect(page).to have_selector('.flash.error', text: 'That username does not exist.')
+    expect(page).to have_current_path(login_path)
+
+    username = 'Valid user'
+    create(:user, username: username)
+    within('.form-table') do
+      fill_in 'Username', with: username
+      fill_in 'Password', with: 'failed password'
+      click_on 'Sign In'
+    end
+
+    expect(page).to have_selector('.flash.error', text: 'You have entered an incorrect password.')
+    expect(page).to have_current_path(login_path)
+  end
+
+  scenario "Log in with valid details" do
+    username = 'Test user'
+    password = 'my password1234@'
+    create(:user, username: username, password: password)
+    visit login_path
+    expect(page).to have_no_selector('.flash')
+
+    expect(page).to have_selector('.form-table')
+    within('.form-table') do
+      fill_in 'Username', with: username
+      fill_in 'Password', with: password
+      click_on 'Sign In'
+    end
+
+    expect(page).to have_current_path(boards_path)
+    expect(page).to have_no_selector('.flash.error')
+    expect(page).to have_selector('.flash.success', text: 'You are now logged in as Test user. Welcome back!')
+    expect(page).to have_no_selector('#username')
+    expect(page).to have_selector('#user-username', text: username)
+
+    # make sure we're still logged in after navigating somewhere else
+    visit root_path
+    expect(page).to have_no_selector('.flash')
+    expect(page).to have_no_selector('#username')
+    expect(page).to have_selector('#user-username', text: username)
+  end
+
+  scenario "Error while already logged in" do
+    login
+
+    visit login_path
+    expect(page).to have_current_path(boards_path)
+    expect(page).to have_selector('.flash.error', text: 'You are already logged in.')
+    expect(page).to have_no_selector('#username')
+  end
+end


### PR DESCRIPTION
~~Currently does destroy in a relatively ugly way: since we require the `DELETE` verb, and Rails hacks that in by using JavaScript, the button fails in our (JS-disabled) RackTest driver. Accordingly, I'm using `page.driver.submit` to directly force RackTest to submit `DELETE` to the logout route, rather than actually testing it in a more integrational way. There's a TODO to make sure we add that if/when #1146 is finished and merged.~~ Uses the new selenium-webdriver of #1146 to test logging out, since that requires the `DELETE` verb!