### PR TITLE
Use Node 10 in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /code
 
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >> /etc/apt/sources.list.d/postgres.list
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
 RUN apt-get update
 RUN apt-get install -y curl nodejs postgresql-client-9.4
 


### PR DESCRIPTION
Node 8 expires this December, per <https://github.com/nodejs/Release>. Since Node 10 is the active LTS, I suggest we move to that (supported until 2021!).