### PR TITLE
Create gallery editor partial

### DIFF
--- a/app/views/galleries/_editor.haml
+++ b/app/views/galleries/_editor.haml
@@ -1,0 +1,6 @@
+%tr
+  %th.sub Name
+  %td{class: cycle('even', 'odd')}= f.text_field :name, placeholder: "Gallery Name", class: 'text'
+%tr
+  %th.vtop.sub Groups
+  %td{class: cycle('even', 'odd')}= tag_select(gallery, f, :gallery_groups)

--- a/app/views/galleries/edit.haml
+++ b/app/views/galleries/edit.haml
@@ -9,17 +9,12 @@
   %table.form-table.gallery-edit-form
     %thead
       %tr
-        %th.editor-title{colspan: 3}
+        %th.editor-title{colspan: 2}
           Edit Gallery
     %tbody.gallery-editor
+      = render 'editor', f: f, gallery: @gallery
       %tr
-        %th.sub Name
-        %td{class: cycle('even', 'odd'), colspan: 2}= f.text_field :name, placeholder: "Gallery Name", class: 'text'
-      %tr
-        %th.vtop.sub Groups
-        %td{class: cycle('even', 'odd'), colspan: 2}= tag_select(@gallery, f, :gallery_groups)
-      %tr
-        %th.subber{colspan: 3} Edit Icons
+        %th.subber{colspan: 2} Edit Icons
   .gallery-icons-edit
     = f.fields_for :galleries_icons, @gallery.galleries_icons.joins(:icon).order(Arel.sql('LOWER(keyword)')) do |gif|
       .gallery-icon-editor

--- a/app/views/galleries/new.haml
+++ b/app/views/galleries/new.haml
@@ -5,12 +5,7 @@
       %tr
         %th.editor-title{colspan: 2}New Gallery
     %tbody
-      %tr
-        %th.vtop.sub Name
-        %td{class: cycle('even', 'odd')}= f.text_field :name, placeholder: "Gallery Name", class: 'text'
-      %tr
-        %th.vtop.sub Groups
-        %td{class: cycle('even', 'odd')}= tag_select(@gallery, f, :gallery_groups)
+      = render 'editor', f: f, gallery: @gallery
       - if icons_present
         %tr
           %th.vtop.sub Icons


### PR DESCRIPTION
A very minimal one, but, nonetheless, the code is shared, so. Fixes #1195 

Also fixes some legacy colspan behavior from when we had the icon editing as subtables.