### PR TITLE
Optimize daily report to make less database calls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -140,13 +140,19 @@ class ApplicationController < ActionController::Base
 
   def post_or_reply_link(reply)
     return unless reply.id.present?
-    if reply.is_a?(Reply)
-      reply_path(reply, anchor: "reply-#{reply.id}")
-    else
-      post_path(reply)
-    end
+    post_or_reply_mem_link(id: reply.id, klass: reply.class)
   end
   helper_method :post_or_reply_link
+
+  def post_or_reply_mem_link(id: nil, klass: nil)
+    return if id.nil?
+    if klass == Reply
+      reply_path(id, anchor: "reply-#{id}")
+    else
+      post_path(id)
+    end
+  end
+  helper_method :post_or_reply_mem_link
 
   def posts_from_relation(relation, no_tests: true, with_pagination: true, select: '', max: false)
     if max

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -29,6 +29,10 @@ class ReportsController < ApplicationController
     if @report_type == 'daily'
       @posts = DailyReport.new(@day).posts(sort)
       @posts = posts_from_relation(@posts, max: true)
+      replies_on_day = Reply.where(created_at: @day.beginning_of_day..@day.end_of_day)
+      @reply_counts = replies_on_day.group(:post_id).count
+      first_for_day = replies_on_day.order(post_id: :asc, created_at: :asc).select('DISTINCT ON (post_id) replies.*')
+      @link_targets = @posts.to_h{ |post| [post.id, linked_for(post, first_for_day[post.id])] }
     end
   end
 
@@ -63,13 +67,11 @@ class ReportsController < ApplicationController
   end
   helper_method :ignored?
 
-  def linked_for(day, post, replies=nil)
-    return post if post.created_at.to_date == day.to_date
-    replies ||= post.replies.where(created_at: day.beginning_of_day .. day.end_of_day).order('created_at asc')
-    return post if replies.empty?
-    replies.first
+  def linked_for(post, reply)
+    return post if post.created_at.to_date == @day.to_date
+    return post if reply.nil?
+    reply
   end
-  helper_method :linked_for
 
   def sort
     @sort ||= case params[:sort]

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -50,8 +50,8 @@
           %td.vtop.post-board{class: klass}= link_to post.board_name, board_path(post.board_id)
           %td.vtop.post-authors{class: klass}= author_links(post, colored: true).html_safe
           %td.vtop.centered.post-replies{class: klass}= link_to post.reply_count, stats_post_path(post)
-          %td.vtop.centered.post-replies{class: klass}= link_to @reply_counts[post.id].to_i, post_or_reply_link(@link_targets[post.id])
-          %td.vtop.centered.post-time{class: klass}= @link_targets[post.id].created_at.strftime("%l:%M %p")
+          %td.vtop.centered.post-replies{class: klass}= link_to @reply_counts[post.id].to_i, post_or_reply_mem_link(**@link_targets[post.id].except(:created_at))
+          %td.vtop.centered.post-time{class: klass}= @link_targets[post.id][:created_at].strftime("%l:%M %p")
     %tfoot
       %tr
         %td{colspan: 7}= render 'posts/paginator', paginated: @posts

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -25,8 +25,6 @@
         %tr
           - klass = [cycle('even', 'odd')]
           - klass << 'post-ignored' if ignored?(post)
-          - replies_today = post.replies.where(created_at: @day.beginning_of_day .. @day.end_of_day).order('created_at asc')
-          - linked = linked_for(@day, post, replies_today)
           %td.vtop.post-completed{class: klass.dup.push(post.completed? ? 'post-complete' : 'post-incomplete')}
             - if post.completed?
               = image_tag "icons/book.png", class: 'vmid', title: "Thread Complete"
@@ -52,8 +50,8 @@
           %td.vtop.post-board{class: klass}= link_to post.board_name, board_path(post.board_id)
           %td.vtop.post-authors{class: klass}= author_links(post, colored: true).html_safe
           %td.vtop.centered.post-replies{class: klass}= link_to post.reply_count, stats_post_path(post)
-          %td.vtop.centered.post-replies{class: klass}= link_to replies_today.count, post_or_reply_link(linked)
-          %td.vtop.centered.post-time{class: klass}= linked.created_at.strftime("%l:%M %p")
+          %td.vtop.centered.post-replies{class: klass}= link_to @reply_counts[post.id], post_or_reply_link(@link_targets[post.id])
+          %td.vtop.centered.post-time{class: klass}= @link_targets[post.id].created_at.strftime("%l:%M %p")
     %tfoot
       %tr
         %td{colspan: 7}= render 'posts/paginator', paginated: @posts

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -50,7 +50,7 @@
           %td.vtop.post-board{class: klass}= link_to post.board_name, board_path(post.board_id)
           %td.vtop.post-authors{class: klass}= author_links(post, colored: true).html_safe
           %td.vtop.centered.post-replies{class: klass}= link_to post.reply_count, stats_post_path(post)
-          %td.vtop.centered.post-replies{class: klass}= link_to @reply_counts[post.id], post_or_reply_link(@link_targets[post.id])
+          %td.vtop.centered.post-replies{class: klass}= link_to @reply_counts[post.id].to_i, post_or_reply_link(@link_targets[post.id])
           %td.vtop.centered.post-time{class: klass}= @link_targets[post.id].created_at.strftime("%l:%M %p")
     %tfoot
       %tr


### PR DESCRIPTION
It currently checks the reply count for the day and finds the earliest reply *per post*, which is sub-optimal when we can instead do this.