### PR TITLE
Delete history

### DIFF
--- a/app/concerns/orderable.rb
+++ b/app/concerns/orderable.rb
@@ -50,6 +50,7 @@ module Orderable
 
     def autofill_order
       return unless new_record? || order_change?(false)
+      return if self.order.present?
       self.order = ordered_items.count
     end
 

--- a/app/concerns/orderable.rb
+++ b/app/concerns/orderable.rb
@@ -50,7 +50,7 @@ module Orderable
 
     def autofill_order
       return unless new_record? || order_change?(false)
-      return if self.order.present?
+      return if new_record? && self.order.present?
       self.order = ordered_items.count
     end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -162,12 +162,18 @@ class PostsController < WritableController
   end
 
   def delete_history
-    @audits = @post.associated_audits.where(action: 'destroy').paginate(per_page: 1, page: page)
-    @audit = @audits.first
-    @deleted = Reply.new(@audit.audited_changes)
-    @preceding = @post.replies.where('id < ?', @audit.auditable_id).order(id: :desc).limit(2)
-    @preceding = [@post] unless @preceding.present?
-    @following = @post.replies.where('id > ?', @audit.auditable_id).order(id: :asc).limit(2)
+    audit_ids = @post.associated_audits.where(action: 'destroy').where(auditable_type: 'Reply') # all destroyed replies
+    audit_ids = audit_ids.joins('LEFT JOIN replies ON replies.id = audits.auditable_id').where('replies.id IS NULL') # not restored
+    audit_ids = audit_ids.group(:auditable_id).pluck(Arel.sql('MAX(audits.id)')) # only most recent per reply
+    @audits = Audited::Audit.where(id: audit_ids).paginate(per_page: 1, page: page)
+
+    if @audits.present?
+      @audit = @audits.first
+      @deleted = Reply.new(@audit.audited_changes)
+      @preceding = @post.replies.where('id < ?', @audit.auditable_id).order(id: :desc).limit(2).reverse
+      @preceding = [@post] unless @preceding.present?
+      @following = @post.replies.where('id > ?', @audit.auditable_id).order(id: :asc).limit(2)
+    end
   end
 
   def stats

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -225,7 +225,7 @@ class RepliesController < WritableController
     new_reply = Reply.new(audit.audited_changes)
     unless new_reply.editable_by?(current_user)
       flash[:error] = "You do not have permission to modify this post."
-      redirect_to post_path(new_reply.post) # TODO test this
+      redirect_to post_path(new_reply.post) and return # TODO test this
     end
 
     new_reply.is_import = true

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -237,7 +237,7 @@ class RepliesController < WritableController
     new_reply.reply_order = following_replies.first&.reply_order
 
     Reply.transaction do
-      following_replies.update_all('reply_order = reply_order + 1')
+      following_replies.update_all('reply_order = reply_order + 1') # rubocop:disable Rails/SkipsModelValidations
       new_reply.save!
     end
 

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -225,7 +225,7 @@ class RepliesController < WritableController
     new_reply = Reply.new(audit.audited_changes)
     unless new_reply.editable_by?(current_user)
       flash[:error] = "You do not have permission to modify this post."
-      redirect_to post_path(new_reply.post) and return # TODO test this
+      redirect_to post_path(new_reply.post) and return
     end
 
     new_reply.is_import = true

--- a/app/views/posts/delete_history.haml
+++ b/app/views/posts/delete_history.haml
@@ -11,15 +11,20 @@
 = render 'posts/paginator', paginated: @audits
 %br
 
-.sub Preceding context
-= render partial: 'replies/single', collection: @preceding, as: :reply
-%br
+- if @audits.present?
+  .subber Preceding context
+  = render partial: 'replies/single', collection: @preceding, as: :reply
+  %br
 
-.sub
-  Reply deleted #{pretty_time(@audit.created_at)} by #{user_link(@audit.user)}
-  = link_to 'Restore', restore_reply_path(id: @audit.auditable_id), method: :post
-= render 'replies/single', reply: @deleted
-%br
+  .subber
+    Reply deleted #{pretty_time(@audit.created_at)} by #{user_link(@audit.user)}
+    - if @deleted.editable_by?(current_user)
+      = link_to restore_reply_path(id: @audit.auditable_id), method: :post do
+        %button{style: 'float: right; margin: 0;'} Restore
+        .clear
+  = render 'replies/single', reply: @deleted
+  %br
 
-.sub Following context
-= render partial: 'replies/single', collection: @following, as: :reply
+  - if @following.present?
+    .subber Following context
+    = render partial: 'replies/single', collection: @following, as: :reply

--- a/app/views/posts/delete_history.haml
+++ b/app/views/posts/delete_history.haml
@@ -1,0 +1,25 @@
+- content_for :breadcrumbs do
+  = link_to "Continuities", boards_path
+  &raquo;
+  = link_to @post.board.name, board_path(@post.board)
+  &raquo;
+  = link_to @post.subject, post_path(@post)
+  &raquo;
+  %b Delete History
+
+.content-header History of Deleted Replies
+= render 'posts/paginator', paginated: @audits
+%br
+
+.sub Preceding context
+= render partial: 'replies/single', collection: @preceding, as: :reply
+%br
+
+.sub
+  Reply deleted #{pretty_time(@audit.created_at)} by #{user_link(@audit.user)}
+  = link_to 'Restore', restore_reply_path(id: @audit.auditable_id), method: :post
+= render 'replies/single', reply: @deleted
+%br
+
+.sub Following context
+= render partial: 'replies/single', collection: @following, as: :reply

--- a/app/views/posts/show.haml
+++ b/app/views/posts/show.haml
@@ -115,6 +115,10 @@
             %div
               = image_tag "icons/bell_add.png".freeze
               Show in Replies Owed
+        = link_to delete_history_post_path(@post) do
+          %div
+            = image_tag 'icons/cross.png'.freeze
+            Deleted Replies
       -# TODO need more dynos
       -#= link_to users_path do
       -#  %div

--- a/app/views/writable/_history.haml
+++ b/app/views/writable/_history.haml
@@ -27,12 +27,17 @@
         %td{class: cycle('even', 'odd')}
           - if audit.version == 1
             (Original)
+          - elsif audit.action == 'destroy'
+            = image_tag 'icons/cross.png', alt: 'X', class: 'vmid'
+            Deleted
+          - elsif audit.action == 'create'
+            Restored
           - else
             = audit.audited_changes.keys.map(&:humanize).join(', ').capitalize
       %tr
         %th.sub Updated
         %td{class: cycle('even', 'odd')}= pretty_time(audit.created_at)
-      - if audit.version > 1 && audit.audited_changes.key?('board_id')
+      - if audit.action == 'update' && audit.audited_changes.key?('board_id')
         %tr
           %th.sub Continuity
           %td{class: cycle('even', 'odd')}
@@ -46,7 +51,7 @@
               %b= link_to cur.board.name, board_path(cur.board)
             - else
               %b [Deleted]
-      - if audit.version > 1 && audit.audited_changes.key?('privacy')
+      - if audit.action == 'update' && audit.audited_changes.key?('privacy')
         %tr
           %th.sub Privacy
           %td{colspan: 3, class: cycle('even', 'odd')}
@@ -54,7 +59,7 @@
             %b= privacy_state(audit.audited_changes['privacy'][0])
             to
             %b= privacy_state(cur.privacy)
-      - if audit.version == 1 || (audit.audited_changes.keys & %w(character_alias_id character_id content description icon_id subject)).present?
+      - if audit.action != 'destroy' && (audit.action == 'create' || (audit.audited_changes.keys & %w(character_alias_id character_id content description icon_id subject)).present?)
         %tr
           %th.sub.vtop Content
           %td{class: cycle('even', 'odd')}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
   resources :posts do
     member do
       get :history
+      get :delete_history
       get :stats
       post :warnings
     end
@@ -91,7 +92,10 @@ Rails.application.routes.draw do
     end
   end
   resources :replies, except: [:index, :new] do
-    member { get :history }
+    member do
+      get :history
+      post :restore
+    end
     collection { get :search }
   end
   resources :tags, except: [:new, :create]

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1179,6 +1179,76 @@ RSpec.describe PostsController do
     end
   end
 
+  describe "GET delete_history" do
+    before(:each) { Reply.auditing_enabled = true }
+    after(:each) { Reply.auditing_enabled = false }
+
+    it "requires login" do
+      get :delete_history, params: { id: -1 }
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to eq("You must be logged in to view that page.")
+    end
+
+    it "requires post" do
+      login
+      get :delete_history, params: { id: -1 }
+      expect(response).to redirect_to(boards_url)
+      expect(flash[:error]).to eq("Post could not be found.")
+    end
+
+    it "requires permission" do
+      login
+      post = create(:post)
+      get :delete_history, params: { id: post.id }
+      expect(response).to redirect_to(post_url(post))
+      expect(flash[:error]).to eq("You do not have permission to modify this post.")
+    end
+
+    it "sets correct variables" do
+      post = create(:post)
+      login_as(post.user)
+      reply = create(:reply, post: post)
+      reply.destroy
+      get :delete_history, params: { id: post.id }
+      expect(response).to have_http_status(200)
+      expect(assigns(:audit).auditable_id).to eq(reply.id)
+    end
+
+    it "ignores restored replies" do
+      post = create(:post)
+      login_as(post.user)
+      reply = create(:reply, post: post)
+      reply.destroy
+      restore(reply)
+      get :delete_history, params: { id: post.id }
+      expect(assigns(:audits).count).to eq(0)
+    end
+
+    it "only selects more recent restore" do
+      post = create(:post)
+      login_as(post.user)
+      reply = create(:reply, post: post, content: 'old content')
+      reply.destroy
+      restore(reply)
+      reply = Reply.find_by_id(reply.id)
+      reply.content = 'new content'
+      reply.save
+      reply.destroy
+      get :delete_history, params: { id: post.id }
+      expect(assigns(:audits).count).to eq(1)
+      expect(assigns(:audit).audited_changes['content']).to eq('new content')
+    end
+
+    def restore(reply)
+      audit = Audited::Audit.where(action: 'destroy', auditable_id: reply.id).last
+      new_reply = Reply.new(audit.audited_changes)
+      new_reply.is_import = true
+      new_reply.skip_notify = true
+      new_reply.id = audit.auditable_id
+      new_reply.save!
+    end
+  end
+
   describe "GET stats" do
     it "requires post" do
       login

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -1020,6 +1020,17 @@ RSpec.describe RepliesController do
     end
 
     it "does not update post status" do
+      rpost = create(:post)
+      reply = create(:reply, post: rpost, user: rpost.user)
+      create(:reply, post: rpost, user: rpost.user)
+      reply.destroy
+
+      rpost.status = Post::STATUS_HIATUS
+      rpost.save
+      login_as(rpost.user)
+      post :restore, params: { id: reply.id }
+      expect(flash[:success]).to eq("Reply has been restored!")
+      expect(Post.find(rpost.id).status).to eq(Post::STATUS_HIATUS)
     end
   end
 


### PR DESCRIPTION
Things to confirm we're okay with:
- [x] If you restore the last reply in a post, it will move a manually-hiatused thread to active. 
- [x] If you restore the last reply in a post, it will tag the post.
- [x] Any post author can view the delete history
- [x] Only the reply's author can restore a deleted reply
- [ ] Does not gracefully handle reply_order not matching id order, like, at all
- [x] When you restore a reply, it preserves the created_at but bumps the updated_at

View of reply#history with deletes and restores:
![Screenshot from 2019-11-09 17-02-30](https://user-images.githubusercontent.com/735954/68539150-ea756900-0333-11ea-88d4-fcb299bf7f20.png)

View of post#delete_history:
![Screenshot from 2019-12-08 05-14-34](https://user-images.githubusercontent.com/735954/70387958-b8c6e080-1979-11ea-99a9-1c338071c0dc.png)
