### PR TITLE
Set up rubocop cops that duplicate codeclimate checks 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,7 +117,7 @@ Metrics/BlockNesting:
   Max: 4
 
 Metrics/ClassLength:
-  Enabled: false
+  Max: 250
 
 Metrics/CyclomaticComplexity:
   Enabled: false
@@ -126,13 +126,21 @@ Metrics/LineLength:
   Enabled: false
 
 Metrics/MethodLength:
-  Enabled: false
+  Max: 25
+  Exclude:
+    - 'db/**/*'
+    - 'script/**/*'
+    - 'spec/**/*'
 
 Metrics/ModuleLength:
-  Enabled: false
+  Max: 250
 
 Metrics/ParameterLists:
-  Enabled: false
+  Max: 4
+  Exclude:
+    - 'db/**/*'
+    - 'script/**/*'
+    - 'spec/**/*'
 
 Metrics/PerceivedComplexity:
   Enabled: false


### PR DESCRIPTION
To increase chances of detecting something it'll object to beforehand