### PR TITLE
Rewrite status code

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -327,22 +327,16 @@ class PostsController < WritableController
   end
 
   def change_status
+    @post.status = params[:status]
     begin
-      new_status = Post.const_get('STATUS_'+params[:status].upcase)
-    rescue NameError
-      flash[:error] = "Invalid status selected."
+      @post.save!
+    rescue ActiveRecord::RecordInvalid
+      flash[:error] = {
+        message: "Status could not be updated.",
+        array: @post.errors.full_messages
+      }
     else
-      @post.status = new_status
-      begin
-        @post.save!
-      rescue ActiveRecord::RecordInvalid
-        flash[:error] = {
-          message: "Status could not be updated.",
-          array: @post.errors.full_messages
-        }
-      else
-        flash[:success] = "Post has been marked #{params[:status]}."
-      end
+      flash[:success] = "Post has been marked #{helpers.status_state(params[:status].to_i, only_text: true).downcase}."
     end
     redirect_to post_path(@post)
   end

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -55,6 +55,22 @@ module WritableHelper
     image_tag("icons/#{img}.png", class: 'vmid', title: name)
   end
 
+  STATUS_MAP = {
+    Post::STATUS_ACTIVE    => ['In Progress', 'book_open'],
+    Post::STATUS_COMPLETE  => ['Complete', 'book'],
+    Post::STATUS_HIATUS    => ['On Hiatus', 'hourglass'],
+    Post::STATUS_ABANDONED => ['Abandoned', 'book_grey'],
+  }
+
+  def status_state(status, only_icon: false, only_text: false, short_title: false)
+    name = STATUS_MAP[status][0]
+    img = STATUS_MAP[status][1]
+    return name if only_text
+    icon = image_tag("icons/#{img}.png", class: 'vmid', title: "#{'Thread' unless short_title} #{name}")
+    return icon if only_icon
+    [icon, name].join(' ')
+  end
+
   def menu_img
     return 'icons/menu.png' unless current_user.try(:layout).to_s.start_with?('starry')
     'icons/menugray.png'

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -70,7 +70,7 @@ module WritableHelper
     return name if only_text
     icon = image_tag("icons/#{img}.png", class: 'vmid', title: "#{'Thread' unless short_title} #{name}")
     return icon if only_icon
-    [icon, name].join(' ')
+    [icon, name].safe_join(' ')
   end
 
   def menu_img

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -63,8 +63,10 @@ module WritableHelper
   }
 
   def status_state(status, only_icon: false, only_text: false, short_title: false)
-    name = STATUS_MAP[status][0]
-    img = STATUS_MAP[status][1]
+    raise ArgumentError("Invalid status: #{status}") unless STATUS_MAP.key?(status)
+    status_info = STATUS_MAP[status]
+    name = status_info[0]
+    img = status_info[1]
     return name if only_text
     icon = image_tag("icons/#{img}.png", class: 'vmid', title: "#{'Thread' unless short_title} #{name}")
     return icon if only_icon

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -38,6 +38,7 @@ class Post < ApplicationRecord
 
   validates :subject, presence: true
   validates :description, length: { maximum: 255 }
+  validates :status, inclusion: { in: (0..3), message: 'is invalid' }
   validate :valid_board, :valid_board_section
 
   before_create :build_initial_flat_post, :set_timestamps

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -2,12 +2,8 @@
   - klass = cycle('even', 'odd')
   - replies_count = post.reply_count
   %td.post-completed.vtop{class: [klass, (post.completed? ? 'post-complete' : 'post-incomplete')]}
-    - if post.completed?
-      = image_tag "icons/book.png", class: 'vmid', title: "Thread Complete"
-    - elsif post.on_hiatus?
-      = image_tag "icons/hourglass.png", class: 'vmid', title: "Thread On Hiatus"
-    - elsif post.abandoned?
-      = image_tag "icons/book_grey.png", class: 'vmid', title: "Thread Abandoned"
+    - if [Post::STATUS_COMPLETE, Post::STATUS_HIATUS, Post::STATUS_ABANDONED].include?(post.status)
+      = status_state(post.status, only_icon: true)
     - if post.access_list? || post.private?
       = privacy_icon(post.privacy)
     - if !current_user.try(:hide_warnings) && post.has_content_warnings?

--- a/app/views/posts/show.haml
+++ b/app/views/posts/show.haml
@@ -75,22 +75,22 @@
             Favorite
       - if @post.metadata_editable_by?(current_user)
         - unless @post.completed?
-          = link_to post_path(@post, status: 'complete'.freeze), method: :put do
+          = link_to post_path(@post, status: Post::STATUS_COMPLETE), method: :put do
             %div
               = image_tag "icons/book.png".freeze
               Mark Complete
         - unless @post.marked_hiatus?
-          = link_to post_path(@post, status: 'hiatus'.freeze), method: :put do
+          = link_to post_path(@post, status: Post::STATUS_HIATUS), method: :put do
             %div
               = image_tag "icons/hourglass.png".freeze
               Mark On Hiatus
         - unless @post.active?
-          = link_to post_path(@post, status: 'active'.freeze), method: :put do
+          = link_to post_path(@post, status: Post::STATUS_ACTIVE), method: :put do
             %div
               = image_tag "icons/book_open.png".freeze
               Mark In Progress
         - unless @post.abandoned?
-          = link_to post_path(@post, status: 'abandoned'.freeze), method: :put do
+          = link_to post_path(@post, status: Post::STATUS_ABANDONED), method: :put do
             %div
               = image_tag "icons/book_grey.png".freeze
               Mark Abandoned

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -28,7 +28,7 @@
     %tr
       %th.sub.width-150 Status
       %td{class: cycle('odd', 'even')}
-        =status_state(@post.status, short_title: true)
+        = status_state(@post.status, short_title: true)
     %tr
       %th.sub.width-150 Audience
       %td{class: cycle('odd', 'even')}

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -28,19 +28,7 @@
     %tr
       %th.sub.width-150 Status
       %td{class: cycle('odd', 'even')}
-        - case @post.status
-        - when Post::STATUS_ACTIVE
-          = image_tag "icons/book_open.png", class: 'vmid', title: "In Progress"
-          In Progress
-        - when Post::STATUS_COMPLETE
-          = image_tag "icons/book.png", class: 'vmid', title: "In Progress"
-          Complete
-        - when Post::STATUS_HIATUS
-          = image_tag "icons/hourglass.png", class: 'vmid', title: "In Progress"
-          On Hiatus
-        - when Post::STATUS_ABANDONED
-          = image_tag "icons/book_grey.png", class: 'vmid', title: "In Progress"
-          Abandoned
+        =status_state(@post.status, short_title: true)
     %tr
       %th.sub.width-150 Audience
       %td{class: cycle('odd', 'even')}


### PR DESCRIPTION
* Makes `params[:status]` an int rather than a string
* Creates `status_state` helper
* Adds a status validation on the post model