### PR TITLE
Use safe_join (and html_safe) in author_links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -234,7 +234,7 @@ module ApplicationHelper
     authors = post.authors.reject(&:deleted?).sort_by{|a| a.username.downcase}
     num_deleted = total - authors.size
     deleted = 'deleted user'.pluralize(num_deleted)
-    return "(#{deleted})".html_safe if authors.empty?
+    return "(#{deleted})" if authors.empty?
 
     if total < 4
       links = authors.map { |author| linked ? user_link(author, colored: colored) : author.username }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -234,18 +234,19 @@ module ApplicationHelper
     authors = post.authors.reject(&:deleted?).sort_by{|a| a.username.downcase}
     num_deleted = total - authors.size
     deleted = 'deleted user'.pluralize(num_deleted)
-    return "(#{deleted})" if authors.empty?
+    return "(#{deleted})".html_safe if authors.empty?
 
     if total < 4
       links = authors.map { |author| linked ? user_link(author, colored: colored) : author.username }
-      return links.join(', ') if num_deleted.zero?
-      return links.join(', ') + " and #{num_deleted} #{deleted}"
+      joined_links = safe_join(links, ', ')
+      return joined_links if num_deleted.zero?
+      return safe_join([joined_links, "#{num_deleted} #{deleted}"], ' and ')
     end
 
     first_author = post.user.deleted? ? authors.first : post.user
     first_link = linked ? user_link(first_author, colored: colored) : first_author.username
     others = linked ? link_to("#{total-1} others", stats_post_path(post)) : "#{total-1} others"
-    first_link + ' and ' + others
+    safe_join([first_link, others], ' and ')
   end
 
   def allowed_boards(obj, user)

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -42,7 +42,7 @@
               = link_to index, post_path(post, page: index)
   - unless local_assigns[:hide_continuity]
     %td.post-board.vtop{class: klass}= link_to post.board_name, anchored_board_path(post)
-  %td.post-authors.vtop{class: klass}= author_links(post).html_safe
+  %td.post-authors.vtop{class: klass}= author_links(post)
   %td.width-70.post-replies.vtop{class: klass}= link_to replies_count, stats_post_path(post)
   - if logged_in? && local_assigns[:show_unread_count]
     %td.width-70.vtop{class: klass}

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -48,7 +48,7 @@
               %br
               %span.details= sanitize_simple_link_text(post.description)
           %td.vtop.post-board{class: klass}= link_to post.board_name, board_path(post.board_id)
-          %td.vtop.post-authors{class: klass}= author_links(post, colored: true).html_safe
+          %td.vtop.post-authors{class: klass}= author_links(post, colored: true)
           %td.vtop.centered.post-replies{class: klass}= link_to post.reply_count, stats_post_path(post)
           %td.vtop.centered.post-replies{class: klass}= link_to @reply_counts[post.id].to_i, post_or_reply_mem_link(**@link_targets[post.id].except(:created_at))
           %td.vtop.centered.post-time{class: klass}= @link_targets[post.id][:created_at].strftime("%l:%M %p")

--- a/spec/helpers/writable_helper_spec.rb
+++ b/spec/helpers/writable_helper_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe WritableHelper do
         post = create(:post)
         post.user.update!(deleted: true)
         expect(helper.author_links(post)).to eq('(deleted user)')
-        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles only two deleted users" do
@@ -44,7 +43,6 @@ RSpec.describe WritableHelper do
         reply = create(:reply, post: post)
         reply.user.update!(deleted: true)
         expect(helper.author_links(post)).to eq('(deleted users)')
-        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles >4 deleted users" do
@@ -59,7 +57,6 @@ RSpec.describe WritableHelper do
         reply = create(:reply, post: post)
         reply.user.update!(deleted: true)
         expect(helper.author_links(post)).to eq('(deleted users)')
-        expect(helper.author_links(post)).to be_html_safe
       end
     end
 

--- a/spec/helpers/writable_helper_spec.rb
+++ b/spec/helpers/writable_helper_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe WritableHelper do
         post = create(:post)
         post.user.update!(deleted: true)
         expect(helper.author_links(post)).to eq('(deleted user)')
+        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles only two deleted users" do
@@ -43,6 +44,7 @@ RSpec.describe WritableHelper do
         reply = create(:reply, post: post)
         reply.user.update!(deleted: true)
         expect(helper.author_links(post)).to eq('(deleted users)')
+        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles >4 deleted users" do
@@ -57,6 +59,7 @@ RSpec.describe WritableHelper do
         reply = create(:reply, post: post)
         reply.user.update!(deleted: true)
         expect(helper.author_links(post)).to eq('(deleted users)')
+        expect(helper.author_links(post)).to be_html_safe
       end
     end
 
@@ -66,6 +69,7 @@ RSpec.describe WritableHelper do
         post.user.update!(deleted: true)
         reply = create(:reply, post: post)
         expect(helper.author_links(post)).to eq(helper.user_link(reply.user) + ' and 1 deleted user')
+        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles two users with reply user deleted" do
@@ -73,6 +77,7 @@ RSpec.describe WritableHelper do
         reply = create(:reply, post: post)
         reply.user.update!(deleted: true)
         expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ' and 1 deleted user')
+        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles three users with one deleted" do
@@ -82,6 +87,7 @@ RSpec.describe WritableHelper do
         reply = create(:reply, post: post, user: create(:user, username: 'yyy'))
         links = [post.user, reply.user].map { |u| helper.user_link(u) }.join(', ')
         expect(helper.author_links(post)).to eq(links + ' and 1 deleted user')
+        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles three users with two deleted" do
@@ -91,6 +97,7 @@ RSpec.describe WritableHelper do
         reply = create(:reply, post: post)
         reply.user.update!(deleted: true)
         expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ' and 2 deleted users')
+        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles >4 users with post user first" do
@@ -102,6 +109,7 @@ RSpec.describe WritableHelper do
         create(:reply, post: post, user: create(:user, username: 'vvv'))
         stats_link = helper.link_to('4 others', stats_post_path(post))
         expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ' and ' + stats_link)
+        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles >4 users with alphabetical user first iff post user deleted" do
@@ -113,6 +121,7 @@ RSpec.describe WritableHelper do
         create(:reply, post: post, user: create(:user, username: 'vvv'))
         stats_link = helper.link_to('4 others', stats_post_path(post))
         expect(helper.author_links(post)).to eq(helper.user_link(reply.user) + ' and ' + stats_link)
+        expect(helper.author_links(post)).to be_html_safe
       end
     end
 
@@ -120,12 +129,14 @@ RSpec.describe WritableHelper do
       it "handles only one user" do
         post = create(:post)
         expect(helper.author_links(post)).to eq(helper.user_link(post.user))
+        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles two users with commas" do
         post = create(:post, user: create(:user, username: 'xxx'))
         reply = create(:reply, post: post, user: create(:user, username: 'yyy'))
         expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ', ' + helper.user_link(reply.user))
+        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles three users with commas and no and" do
@@ -134,6 +145,7 @@ RSpec.describe WritableHelper do
         users << create(:reply, post: post, user: create(:user, username: 'yyy')).user
         users << create(:reply, post: post, user: create(:user, username: 'xxx')).user
         expect(helper.author_links(post)).to eq(users.reverse.map { |u| helper.user_link(u) }.join(', '))
+        expect(helper.author_links(post)).to be_html_safe
       end
 
       it "handles >4 users with post user first" do
@@ -144,6 +156,7 @@ RSpec.describe WritableHelper do
         create(:reply, post: post, user: create(:user, username: 'vvv'))
         stats_link = helper.link_to('4 others', stats_post_path(post))
         expect(helper.author_links(post)).to eq(helper.user_link(post.user) + ' and ' + stats_link)
+        expect(helper.author_links(post)).to be_html_safe
       end
     end
   end


### PR DESCRIPTION
Mostly to avoid having to flag the output with html_safe