### PR TITLE
Upgrade dev redis to 4.0 to match prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - GLOWFIC_DATABASE_PASS=postgres
       - BIND_HOST=0.0.0.0
   redis:
-    image: redis:3.2-alpine
+    image: redis:4.0-alpine
   postgres:
     environment:
       - POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
Prod redis is currently 4.0.14! This helps get our docker-compose commands more in line with prod.