### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+log/
+tmp/


### PR DESCRIPTION
Since we don't use any of the given files in our Docker images, and they're huge, let's remove them from Docker's context sending.

This makes docker build much faster. (Instead of sending like 300+MB of context for the huge .git I have locally, this will only send more like 20MB.)