### PR TITLE
Add Resque worker to docker-compose.yml

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -78,4 +78,8 @@ Rails.application.configure do
 
   # raise an error if assets aren't found
   config.assets.unknown_asset_fallback = false
+
+  # enable Resque logging
+  Resque.logger       = Logger.new(STDOUT)
+  Resque.logger.level = Logger::INFO
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,37 @@
-version: "3"
+version: "3.7"
+
+x-env: &env
+  REDIS_URL: redis://redis
+  GLOWFIC_DATABASE_HOST: postgres
+  GLOWFIC_DATABASE_USER: postgres
+  GLOWFIC_DATABASE_PASS: postgres
+x-svc: &svc
+  build: .
+  image: glowfic
+  links:
+    - redis
+    - postgres
+  volumes:
+    - .:/code
+    - bundler-volume:/usr/local/bundle
+
 services:
   web:
-    build: .
+    <<: *svc
     ports:
       - "3000:3000"
-    volumes:
-      - .:/code
-      - bundler-volume:/usr/local/bundle
-    links:
-      - redis
-      - postgres
-    working_dir: /code
     command: bin/rails s
     environment:
-      - REDIS_URL=redis://redis
-      - GLOWFIC_DATABASE_HOST=postgres
-      - GLOWFIC_DATABASE_USER=postgres
-      - GLOWFIC_DATABASE_PASS=postgres
-      - BIND_HOST=0.0.0.0
+      <<: *env
+      BIND_HOST: 0.0.0.0
+  worker:
+    <<: *svc
+    command: bundle exec rake resque:work
+    environment:
+      <<: *env
+      TERM_CHILD: 1
+      RESQUE_TERM_TIMEOUT: 7
+      QUEUES: mailer,notifier,high,*
   redis:
     image: redis:4.0-alpine
   postgres:


### PR DESCRIPTION
This way we can use Docker and get background jobs to run!

Also adds a configuration to the dev environment to make Resque print output. Otherwise, it seems to eat everything, but still runs. See [the docs](https://github.com/resque/resque/wiki/Logging) for more info.