### PR TITLE
Fix Docker postgres

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.6.5
 
 WORKDIR /code
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >> /etc/apt/sources.list.d/postgres.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
 RUN apt-get update


### PR DESCRIPTION
PostgreSQL Apt Repository documentation now specifies a different filename to add source to, see https://www.postgresql.org/download/linux/debian/