### PR TITLE
Combine apt-get update and apt-get install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,11 @@ WORKDIR /code
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
-RUN apt-get update
-RUN apt-get install -y curl nodejs postgresql-client-11
+RUN apt-get update && apt-get install -y \
+    curl \
+    nodejs \
+    postgresql-client-11 \
+  && apt-get clean
 
 ARG bundler_version=1.17.3
 


### PR DESCRIPTION
Per https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get:

> Always combine `RUN apt-get update` with `apt-get install`
> in the same `RUN` statement.

> Using `apt-get update` alone in a `RUN` statement causes
> caching issues and subsequent `apt-get install`
> instructions fail.

I'm guessing this is what caused the Postgres 11 installation to fail for you when it worked for me @Marri.

I'm also adding `apt-get clean`  to the end just to be sure that our image is clearing the cache of `apt-get update`. Official images should do it already, apparently, but this way we also have all the backslashes consistent.