### PR TITLE
Upgrade bundler to 2.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     postgresql-client-11 \
   && apt-get clean
 
-ARG bundler_version=1.17.3
+ARG bundler_version=2.0.2
 
 RUN gem install bundler -v $bundler_version
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,4 +508,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.3
+   2.0.2


### PR DESCRIPTION
Doesn't seem to add much, but it's looking like this is the path that Bundler is heading (they have a bunch of bug fixes on this version, and are releasing 2.1 and maybe 3.0 soon!).

Heroku already supports this version: <https://github.com/heroku/heroku-buildpack-ruby/blob/master/CHANGELOG.md#v201-6232019>

And we can see what version they support at the following file (make sure to change to the master branch in the future, though!): https://github.com/heroku/heroku-buildpack-ruby/blob/1a30c5a0a4c189201a979d6d97bfb38a1aca2572/lib/language_pack/helpers/bundler_wrapper.rb#L40