### PR TITLE
Improve .travis.yml (use Bionic, updated Bundler, and Postgres 10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
 env:
   global:
     - CC_TEST_REPORTER_ID=1e0c6dba9930e839038860b6d73301226c821937f57ed35d06fc0e4b7bddf5f6
-    - PGPORT=5433
 services:
   - redis-server
   - postgresql
@@ -27,8 +26,4 @@ branches:
   only:
     - master
 addons:
-  postgresql: 11
-  apt:
-    packages:
-      - postgresql-11
-      - postgresql-client-11
+  postgresql: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
 env:
   global:
     - CC_TEST_REPORTER_ID=1e0c6dba9930e839038860b6d73301226c821937f57ed35d06fc0e4b7bddf5f6
+    - PGPORT=5433
 services:
   - redis-server
   - postgresql
@@ -25,3 +26,9 @@ after_script:
 branches:
   only:
     - master
+addons:
+  postgresql: 11
+  apt:
+    packages:
+      - postgresql-11
+      - postgresql-client-11

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ services:
   - postgresql
 cache: bundler
 before_install:
-  - gem install bundler -v 1.15.2
+  - gem install bundler -v 1.17.3
+  - echo "Using bundler:" $(bundle --version)
 before_script:
   - psql -c 'create database glowfic_test;' -U postgres
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: bionic
 language: ruby
 rvm:
- - 2.6.5
+  - 2.6.5
 env:
   global:
     - CC_TEST_REPORTER_ID=1e0c6dba9930e839038860b6d73301226c821937f57ed35d06fc0e4b7bddf5f6
@@ -10,10 +10,10 @@ services:
   - postgresql
 cache: bundler
 before_install:
+  - psql -c 'create database glowfic_test;' -U postgres
   - gem install bundler -v 1.17.3
   - echo "Using bundler:" $(bundle --version)
 before_script:
-  - psql -c 'create database glowfic_test;' -U postgres
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
@@ -24,4 +24,4 @@ after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 branches:
   only:
-  - master
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: ruby
 rvm:
  - 2.6.5


### PR DESCRIPTION
Exists, according to https://docs.travis-ci.com/user/reference/bionic. I'd prefer to use it rather than an image that's THREE AND A HALF years out of date (16.04).

This also updates Bundler to 1.17.3 - oops - and Postgres to 10. I tried updating Postgres to 11, but it ended up taking 5 minutes to boot each run, which seems pretty awful, so I think we should wait until it's better supported.