### PR TITLE
Use a virtual volume for Postgres Docker data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,8 @@ services:
       - POSTGRES_PASSWORD=postgres
     image: postgres:11-alpine
     volumes:
-      - "./db/storage/:/var/lib/postgresql/data"
+      - postgres-data:/var/lib/postgresql/data
 
 volumes:
   bundler-volume:
+  postgres-data:


### PR DESCRIPTION
I don't remember why we saved it on disk in `db/storage` - did we need to access it from the host, for some reason?

If not, we can just use a virtual directory instead. This helps with some permission errors I was getting using Postgres under Docker (Toolbox) for Windows.