### PR TITLE
Remove stray &nbsp; in characters#show

### DIFF
--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -42,7 +42,7 @@
       %td.centered{class: cycle('even', 'odd')}
         = link_to character_path(@character, view: 'galleries') do
           = image_tag "icons/photos.png"
-          &nbsp;Galleries
+          Galleries
     %tr
       %td.centered{class: cycle('even', 'odd')}
         = link_to character_path(@character, view: 'posts') do


### PR DESCRIPTION
Currently:
![image](https://user-images.githubusercontent.com/19716939/70403889-d5a4f780-19fd-11ea-9b6d-9c1a55b40fc6.png)

Fixed:
![image](https://user-images.githubusercontent.com/19716939/70403852-c160fa80-19fd-11ea-8238-9f2e57d1c81a.png)
