### PR TITLE
Preserve icon_id in reply search

### DIFF
--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -48,6 +48,7 @@
                 %td= label_tag :icon_id, 'Icon'
                 %td
                   = icon_tag @icon, class: 'preview-icon search-icon-preview'
+                  = hidden_field_tag :icon_id, @icon.id
                   %span.search-icon-keyword= @icon.keyword
             %tr
               %td= label_tag :condensed, 'Condensed'


### PR DESCRIPTION
That way users can search within uses of the icon rather than losing the icon filter as soon as they submit the form. Fixes the bug reported by Manya.