### PR TITLE
Fix alternating colors on flat posts when description is present

### DIFF
--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -174,7 +174,7 @@ div.post-subheader { width: 100%; }
 }
 
 /* Post-specific content & editor */
-#content > .post-container {
+#content > .post-container, .flat-post-replies .post-container {
   padding: 0;
   overflow: auto;
 }

--- a/app/views/posts/flat.haml
+++ b/app/views/posts/flat.haml
@@ -54,4 +54,4 @@
               - if @post.created_at.to_i != @post.last_updated.to_i
                 = precede ' | Updated ' do
                   %span.post-updated=pretty_time(@post.last_updated, ApplicationHelper::TIME_FORMAT)
-      = @post.flat_post.content.try(:html_safe)
+      .flat-post-replies= @post.flat_post.content.try(:html_safe)


### PR DESCRIPTION
Right now, because they are done with nth-child(even), adding the description row causes our count to be off by one and makes the top post and first reply use the same background and incorrectly bleed into each other. This fixes that with the extremely simplistic hack of "put all the replies in a wrapping div so they count within that wrapping div and ignore the existence of the post's description entirely". This then for some reason broke the replies' padding, because they were no longer in content > post-container, so that CSS class has been extended to apply to the flat post reply wrapper div as well.