### PR TITLE
Upgrade TinyMCE to the latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'sassc-rails'
 gem 'select2-rails'
 gem 'sprockets', '~> 3.7' # pin sprockets until we deal with its major upgrade
 gem 'test-unit', '~> 3.0' # required by Heroku for production console
-gem 'tinymce-rails', '~> 4.6.7'
+gem 'tinymce-rails'
 gem 'uglifier'
 gem 'will_paginate', '~> 3.1.8' # pin will_paginate until we deal with breaking WillPaginate::ViewHelpers::LinkRenderer change
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
-    builder (3.2.3)
+    builder (3.2.4)
     byebug (11.0.1)
     capybara (3.29.0)
       addressable
@@ -186,7 +186,7 @@ GEM
     listen (3.2.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.3.1)
+    loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -212,7 +212,7 @@ GEM
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
     nio4r (2.5.2)
-    nokogiri (1.10.5)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.1)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -403,7 +403,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.1)
-    tinymce-rails (4.6.7)
+    tinymce-rails (5.1.4)
       railties (>= 3.1.1)
     traceroute (0.8.0)
       rails (>= 3.0.0)
@@ -497,7 +497,7 @@ DEPENDENCIES
   test-unit (~> 3.0)
   thin
   timecop
-  tinymce-rails (~> 4.6.7)
+  tinymce-rails
   traceroute
   uglifier
   web-console (~> 3.0)

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -1,4 +1,4 @@
-/* global gon, tinymce, tinyMCE, resizeScreenname, createTagSelect */
+/* global gon, tinyMCE, resizeScreenname, createTagSelect */
 var tinyMCEInit = false, shownIcons = [];
 var PRIVACY_ACCESS = 2; // TODO don't hardcode
 var iconSelectBox;
@@ -292,31 +292,22 @@ function setupTinyMCE() {
       selector: selector,
       menubar: false,
       toolbar: ["bold italic underline strikethrough | link image | blockquote hr bullist numlist | undo redo"],
-      plugins: "image,hr,link,autoresize,paste",
+      branding: false,
+      plugins: "wordcount,image,hr,link,autoresize,paste",
       paste_as_text: true,
       custom_undo_redo_levels: 10,
       content_css: gon.tinymce_css_path,
       statusbar: true,
       elementpath: false,
-      theme_advanced_resizing: true,
-      theme_advanced_resize_horizontal: false,
-      autoresize_bottom_margin: 15,
-      autoresize_min_height: height,
+      resize: true,
+      autoresize_bottom_margin: 5,
+      min_height: height,
       browser_spellcheck: true,
       relative_urls: false,
       remove_script_host: true,
       document_base_url: gon.base_url,
       body_class: gon.editor_class,
-      setup: function(ed) {
-        ed.on('init', function() {
-          var rawContent = tinymce.activeEditor.getContent({format: 'raw'});
-          var content = tinymce.activeEditor.getContent();
-          // TODO fix hack
-          if (rawContent === '<p>&nbsp;<br></p>' && content === '') {
-            tinymce.activeEditor.setContent('');
-          }
-        });
-      }
+      contextmenu: false,
     });
     tinyMCEInit = true;
   }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -505,3 +505,9 @@ The copy box can't be invisible/hidden or copy fails but opacity works
   font-size: $font_size_smaller;
   text-align: right;
 }
+
+#content .tox-toolbar {
+  background-color: $bg_color_mce_panel;
+  border-bottom: 1px solid #CCCCCC;
+  .tox-tbtn { height: 30px; width: 30px; }
+}

--- a/app/assets/stylesheets/layouts/_dark_themes_selectors.scss
+++ b/app/assets/stylesheets/layouts/_dark_themes_selectors.scss
@@ -105,25 +105,36 @@
 }
 
 /* RTF post editor – see tinymce.css for styling of the iframe itself */
-/* border: */
-#content .mce-panel { border-color: $border_color_input; }
-#content .mce-edit-area { border-top-color: $border_color_input; }
-#content .mce-statusbar { border-top-color: $border_color_input; }
-/* header & buttons: */
-/* - default */
-#content .mce-panel, #content .mce-btn { background-color: $bg_color_mce_panel; }
-#content .mce-ico { color: $font_color_input; }
-
-/* footer: 'powered by' text */
-#content .mce-branding-powered-by {
+#content .tox-toolbar, #content .tox-statusbar {
   background-color: $bg_color_mce_panel;
   border-color: $border_color_input;
+  .tox-toolbar__group { border-color: $border_color_input; }
 }
-
-#content .mce-label {
-  color: rgba($font_color_input, $opacity_mce_label);
-  text-shadow: none;
+#content .tox-statusbar__wordcount { color: $font_color_input; }
+#content .tox-statusbar__resize-handle svg { fill: $font_color_input; }
+#content .tox .tox-tbtn {
+  box-sizing: content-box;
+  svg {
+    fill: $font_color_input;
+    &:hover {
+      background-color: $bg_color_input;
+      border: 1px solid $font_color_input;
+    }
+  }
+  &:hover { background-color: $bg_color_input; }
+  &.tox-tbtn--disabled {
+    svg {
+      fill: $font_color_input;
+      opacity: 0.5;
+      &:hover {
+        border: 0;
+        background-color: transparent;
+      }
+    }
+    &:hover { background-color: transparent; }
+  }
 }
+#content .tox-tinymce { border-color: $border_color_input; }
 
 #footer {
   background-color: $bg_color_header_middle;

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -270,7 +270,7 @@ div.post-subheader { width: 100%; }
   background-repeat: no-repeat;
 }
 
-#reply_content, .mce-panel { box-sizing: content-box; }
+#reply_content { box-sizing: content-box; }
 #post-editor { position: relative; }
 
 #post_form {


### PR DESCRIPTION
- Upgrades TinyMCE from 4.6.7 to 5.1.4
- Disables the Powered By text
- Adds a word counter to the bottom bar
- `theme_advanced_resizing` is now just `resize`
- `autoresize_min_height` is now just `min_height`
- A smaller bottom_margin looks nicer imaltho
- The function to avoid spam paragraphs when flipping between rich text and html editors seems to have become unnecessary somewhere
- `contextmenu` disables the Fancy Custom Right Click Menu they make that we don't want
- they renamed all their DOM elements so much CSS rebuilding occurred

![Screenshot from 2019-12-21 20-35-50](https://user-images.githubusercontent.com/735954/71316222-fd4e8380-2431-11ea-9451-d581ed53ce03.png)
![Screenshot from 2019-12-21 20-35-32](https://user-images.githubusercontent.com/735954/71316223-fd4e8380-2431-11ea-89c6-33cf50d2be6e.png)
![Screenshot from 2019-12-21 20-35-02](https://user-images.githubusercontent.com/735954/71316224-fde71a00-2431-11ea-84da-15c5ef2a67f7.png)
