### PR TITLE
Remove unused gems from production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'aws-sdk-rails', '~> 2'
 gem 'aws-sdk-s3', '~> 1'
 gem 'aws-sdk-ses', '~> 1'
 gem 'bootstrap'
-gem 'coffee-rails'
 gem 'exception_notification'
 gem 'gon', '~> 6.2.1'
 gem 'haml-rails'
@@ -27,7 +26,6 @@ gem 'rails', '~> 5.2.0'
 gem 'redis', '~> 4.0'
 gem 'redis-rails'
 gem 'resque'
-gem 'resque-scheduler'
 gem 'resque_mailer'
 gem 'sanitize'
 gem 'sassc', '~> 2.1' # pin sassc until it stops causing schema:load problems (potentially related to https://github.com/sass/sassc-ruby/issues/146)
@@ -43,7 +41,6 @@ group :production do
   gem 'puma'
   gem 'rack-cors'
   gem 'rack-timeout'
-  gem 'rails_12factor'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,13 +90,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    coffee-rails (5.0.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 5.2.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -111,8 +104,6 @@ GEM
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     erubis (2.7.0)
-    et-orbi (1.2.2)
-      tzinfo
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
@@ -126,9 +117,6 @@ GEM
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
     ffi (1.11.2)
-    fugit (1.3.3)
-      et-orbi (~> 1.1, >= 1.1.8)
-      raabro (~> 1.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     gon (6.2.1)
@@ -228,7 +216,6 @@ GEM
     public_suffix (4.0.1)
     puma (4.3.1)
       nio4r (~> 2.0)
-    raabro (1.1.6)
     rack (2.0.8)
     rack-cors (1.0.6)
       rack (>= 1.6.0)
@@ -262,11 +249,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.2.3)
       actionpack (= 5.2.3)
       activesupport (= 5.2.3)
@@ -306,11 +288,6 @@ GEM
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    resque-scheduler (4.4.0)
-      mono_logger (~> 1.0)
-      redis (>= 3.3)
-      resque (>= 1.26)
-      rufus-scheduler (~> 3.2)
     resque_mailer (2.4.3)
       actionmailer (>= 3.0)
       activesupport (>= 3.0)
@@ -353,8 +330,6 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_parser (3.14.1)
       sexp_processor (~> 4.9)
-    rufus-scheduler (3.6.0)
-      fugit (~> 1.1, >= 1.1.6)
     safe_yaml (1.0.5)
     sanitize (5.1.0)
       crass (~> 1.0.2)
@@ -446,7 +421,6 @@ DEPENDENCIES
   bootstrap
   byebug
   capybara
-  coffee-rails
   database_cleaner
   dotenv-rails
   exception_notification
@@ -474,12 +448,10 @@ DEPENDENCIES
   rack-timeout
   rails (~> 5.2.0)
   rails-controller-testing
-  rails_12factor
   rake (~> 12.0)
   redis (~> 4.0)
   redis-rails
   resque
-  resque-scheduler
   resque_mailer
   resque_spec
   rspec-rails

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -1,5 +1,4 @@
 require 'resque/tasks'
-require 'resque/scheduler/tasks'
 
 task "resque:setup" => :environment do
   ENV['QUEUE'] = '*'


### PR DESCRIPTION
- rails_12factor is handled natively by Rails 5 and the correct variables are set in production
- we do not schedule Resque jobs
- we do not write coffeescript