### PR TITLE
Require HTTP basic auth for the Resque web console

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,3 +1,5 @@
+require 'resque/server'
+
 Resque.before_fork do
   defined?(ActiveRecord::Base) and ActiveRecord::Base.connection.disconnect!
 end
@@ -15,6 +17,12 @@ Resque::Mailer.error_handler = lambda { |mailer, message, error, action, args|
   end
 }
 Resque::Mailer.excluded_environments = [] # I explicitly want this to run in tests; don't exclude them.
+
+Resque::Server.use(Rack::Auth::Basic) do |user, password|
+  username = ENV['RESQUE_WEB_HTTP_BASIC_AUTH_USER'] || 'user'
+  pw = ENV['RESQUE_WEB_HTTP_BASIC_AUTH_PASSWORD'] || 'secret'
+  [user, password] == [username, pw]
+end
 
 # only logs Resque failures when they are not retried
 # require 'resque/failure/redis'

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -18,10 +18,12 @@ Resque::Mailer.error_handler = lambda { |mailer, message, error, action, args|
 }
 Resque::Mailer.excluded_environments = [] # I explicitly want this to run in tests; don't exclude them.
 
-Resque::Server.use(Rack::Auth::Basic) do |user, password|
-  username = ENV['RESQUE_WEB_HTTP_BASIC_AUTH_USER'] || 'user'
-  pw = ENV['RESQUE_WEB_HTTP_BASIC_AUTH_PASSWORD'] || 'secret'
-  [user, password] == [username, pw]
+if Rails.env.production?
+  Resque::Server.use(Rack::Auth::Basic) do |user, password|
+    username = ENV['RESQUE_WEB_HTTP_BASIC_AUTH_USER'] || 'user'
+    pw = ENV['RESQUE_WEB_HTTP_BASIC_AUTH_PASSWORD'] || 'secret'
+    [user, password] == [username, pw]
+  end
 end
 
 # only logs Resque failures when they are not retried


### PR DESCRIPTION
We used to have this, it went away when we moved from the resque_web gem to the built-in server that comes with the resque gem, this puts it back. Production has these ENV variables already set to reasonable values.