### PR TITLE
Fix character editor invalid html

### DIFF
--- a/app/views/characters/_editor.haml
+++ b/app/views/characters/_editor.haml
@@ -23,8 +23,9 @@
   - if @character.user == current_user
     %tr#create_template{class: ('hidden' unless params[:new_template])}
       %th.sub &#8627; Name
-      = f.fields_for :template do |ff|
-        %td{class: klass}= ff.text_field :name, placeholder: "Template Name", class: 'text'
+      %td{class: klass}
+        = f.fields_for :template do |ff|
+          = ff.text_field :name, placeholder: "Template Name", class: 'text'
   - if @character.user.galleries.present?
     %tr
       %th.sub Galleries


### PR DESCRIPTION
There's a hidden input tag that afaict the form_for is generating, which was winding up outside the td