### PR TITLE
Use Docker for PostgreSQL & Redis dependencies by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ This will set up the database and add some sample information – currently thes
 
 If you encounter an error involving the 'citext' extension:
 
-*   Execute `sudo -u postgres bin-docker/psql`, and then in the prompt that appears:
+*   Ensure the postgres container is running, with `docker-compose up postgres &`
+*   Execute `docker-compose exec postgres psql`, and then in the prompt that appears:
 *   `CREATE EXTENSION IF NOT EXISTS citext;`
 
 You will need to re-run `bin-docker/rake db:migrate`.

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,8 +1,8 @@
 default: &default
   adapter: postgresql
   host: <%= ENV['GLOWFIC_DATABASE_HOST'] || 'localhost' %>
-  username: <%= ENV['GLOWFIC_DATABASE_USER'] %>
-  password: <%= ENV['GLOWFIC_DATABASE_PASS'] %>
+  username: <%= ENV['GLOWFIC_DATABASE_USER'] || 'postgres' %>
+  password: <%= ENV['GLOWFIC_DATABASE_PASS'] || 'postgres' %>
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,12 +35,19 @@ services:
       QUEUES: mailer,notifier,high,*
   redis:
     image: redis:4.0-alpine
+    ports:
+      - 6379:6379
   postgres:
     environment:
+      - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+      - PGUSER=postgres
+      - PGPASSWORD=postgres
     image: postgres:11-alpine
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
 
 volumes:
   bundler-volume:


### PR DESCRIPTION
Upgrade route:

- Docker-only users: nothing should change, `docker-compose up` as normal
- Users of Docker for dependencies only: you are now able to run the server with `docker-compose up postgres redis &` then `rails s`
- Users of local PostgreSQL & Redis: first, run `echo -e "GLOWFIC_DATABASE_USER=\nGLOWFIC_DATABASE_PASS=" > .env`, then `rails s` as normal

For those using a local PostgreSQL & Redis, this `.env` file will be read by the application and override the new defaults, causing the application to try to connect to your database with your Unix username and whatever password you set inside `~/.pgpass`. Redis requires no changes.