### PR TITLE
Improve timeout behavior (Rack::Timeout and PG statement_timeout)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'will_paginate', '~> 3.1.8' # pin will_paginate until we deal with breaking 
 group :production do
   gem 'puma'
   gem 'rack-cors'
-  gem 'rack-timeout'
+  gem 'rack-timeout', '>= 0.6.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rack-timeout (0.5.2)
+    rack-timeout (0.6.0)
     rails (5.2.3)
       actioncable (= 5.2.3)
       actionmailer (= 5.2.3)
@@ -447,7 +447,7 @@ DEPENDENCIES
   rack-cors
   rack-mini-profiler
   rack-pratchett
-  rack-timeout
+  rack-timeout (>= 0.6.0)
   rails (~> 5.2.0)
   rails-controller-testing
   rake (~> 12.0)

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: env RACK_TIMEOUT_TERM_ON_TIMEOUT=1 bundle exec puma -C config/puma.rb
+web: env RACK_TIMEOUT_TERM_ON_TIMEOUT=1 STATEMENT_TIMEOUT=10s bundle exec puma -C config/puma.rb
 worker: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=7 QUEUES=mailer,notifier,high,* bundle exec rake resque:work

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec puma -C config/puma.rb
+web: env RACK_TIMEOUT_TERM_ON_TIMEOUT=1 bundle exec puma -C config/puma.rb
 worker: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=7 QUEUES=mailer,notifier,high,* bundle exec rake resque:work

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,3 +19,5 @@ production:
   <<: *default
   database: db/production.sqlite3
   pool: <%= ENV["DB_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  variables:
+    statement_timeout: <%= ENV["STATEMENT_TIMEOUT"] %>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,6 +23,8 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
+# Should be greater than 1 to allow RACK_TIMEOUT_TERM_ON_TIMEOUT to work appropriately.
+#
 workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.


### PR DESCRIPTION
References for these changes:

- SIGTERMing Puma workers that hit Timeouts (summary: Rack::Timeout can break application state, like database pools, so we should use multiple Puma workers – as we currently do in prod – and trash the whole process when we hit into an issue that could break our state):
  * https://github.com/sharpstone/rack-timeout/pull/157
  * https://www.schneems.com/2017/02/21/the-oldest-bug-in-ruby-why-racktimeout-might-hose-your-server/
  * https://github.com/ankane/the-ultimate-guide-to-ruby-timeouts/blob/a72ea3234e732942bd855735c1f8efa40e23de57/README.md#rack-timeout
- Using a PostgreSQL statement_timeout instead of relying on Rack::Timeout (only applying to the `web` process, in prod, and set to 10s to make it significantly less than Rack::Timeout while still being reasonable for web-facing queries):
  * https://github.com/sharpstone/rack-timeout/blob/3fbc469640a93512e43ab534221dea174e8c2c4a/doc/risks.md#timing-out-is-inherently-unsafe
  * https://github.com/ankane/the-ultimate-guide-to-ruby-timeouts/blob/a72ea3234e732942bd855735c1f8efa40e23de57/README.md#postgresql