### PR TITLE
Expire flat post locks after 30 minutes

### DIFF
--- a/spec/jobs/generate_flat_post_job_spec.rb
+++ b/spec/jobs/generate_flat_post_job_spec.rb
@@ -4,64 +4,84 @@ RSpec.describe GenerateFlatPostJob do
   include ActiveJob::TestHelper
   before(:each) { clear_enqueued_jobs }
 
-  it "does nothing with invalid post id" do
-    expect($redis).not_to receive(:set)
-    GenerateFlatPostJob.perform_now(-1)
-  end
+  describe ".enqueue" do
+    it "enqueues post when there's no lock" do
+      $redis.del("lock.generate_flat_posts.0")
 
-  it "quits if lock present" do
-    post = create(:post)
-    $redis.set(GenerateFlatPostJob.lock_key(post.id), true)
-    create(:reply)
-    expect(GenerateFlatPostJob).not_to have_queued(post.id).in(:high)
-  end
-
-  it "deletes key when retry gives up" do
-    exc = StandardError.new
-    $redis.set(GenerateFlatPostJob.lock_key(2), true)
-    GenerateFlatPostJob.notify_exception(exc, 2)
-    expect($redis.get(GenerateFlatPostJob.lock_key(2))).to be_nil
-  end
-
-  it "regenerates content" do
-    post = create(:post)
-    expect(post.flat_post.content).to be_nil
-
-    GenerateFlatPostJob.perform_now(post.id)
-
-    expect(post.flat_post.reload.content).not_to be_nil
-    expect($redis.get(GenerateFlatPostJob.lock_key(post.id))).to be_nil
-  end
-
-  it "unsets key even if error is raised" do
-    post = create(:post)
-    $redis.set(GenerateFlatPostJob.lock_key(post.id), true)
-
-    exc = StandardError
-    expect_any_instance_of(FlatPost).to receive(:save!).and_raise(exc)
-    expect(ApplicationJob).to receive(:notify_exception).with(exc, post.id).and_call_original
-    clear_enqueued_jobs
-
-    begin
-      GenerateFlatPostJob.perform_now(post.id)
-    rescue StandardError
-    else
-      raise "Error should be handled"
+      expect {
+        GenerateFlatPostJob.enqueue(0)
+      }.to have_enqueued_job.with(0)
+      expect($redis.get("lock.generate_flat_posts.0")).to eq("true")
     end
 
-    expect($redis.get(GenerateFlatPostJob.lock_key(post.id))).to be_nil
+    it "does not enqueue post if already locked" do
+      $redis.set("lock.generate_flat_posts.0", true)
+      expect {
+        GenerateFlatPostJob.enqueue(0)
+      }.not_to have_enqueued_job
+    end
   end
 
-  it "retries if resque is terminated" do
-    post = create(:post)
-    $redis.set(GenerateFlatPostJob.lock_key(post.id), true)
+  describe "#perform" do
+    it "does nothing with invalid post id" do
+      expect($redis).not_to receive(:set)
+      GenerateFlatPostJob.perform_now(-1)
+    end
 
-    exc = Resque::TermException.new("SIGTERM")
-    expect_any_instance_of(FlatPost).to receive(:save!).and_raise(exc)
-    clear_enqueued_jobs
+    it "quits if lock present" do
+      post = create(:post)
+      $redis.set(GenerateFlatPostJob.lock_key(post.id), true)
+      create(:reply)
+      expect(GenerateFlatPostJob).not_to have_queued(post.id).in(:high)
+    end
 
-    expect_any_instance_of(GenerateFlatPostJob).to receive(:retry_job)
+    it "deletes key when retry gives up" do
+      exc = StandardError.new
+      $redis.set(GenerateFlatPostJob.lock_key(2), true)
+      GenerateFlatPostJob.notify_exception(exc, 2)
+      expect($redis.get(GenerateFlatPostJob.lock_key(2))).to be_nil
+    end
 
-    GenerateFlatPostJob.perform_now(post.id)
+    it "regenerates content" do
+      post = create(:post)
+      expect(post.flat_post.content).to be_nil
+
+      GenerateFlatPostJob.perform_now(post.id)
+
+      expect(post.flat_post.reload.content).not_to be_nil
+      expect($redis.get(GenerateFlatPostJob.lock_key(post.id))).to be_nil
+    end
+
+    it "unsets key even if error is raised" do
+      post = create(:post)
+      $redis.set(GenerateFlatPostJob.lock_key(post.id), true)
+
+      exc = StandardError
+      expect_any_instance_of(FlatPost).to receive(:save!).and_raise(exc)
+      expect(ApplicationJob).to receive(:notify_exception).with(exc, post.id).and_call_original
+      clear_enqueued_jobs
+
+      begin
+        GenerateFlatPostJob.perform_now(post.id)
+      rescue StandardError
+      else
+        raise "Error should be handled"
+      end
+
+      expect($redis.get(GenerateFlatPostJob.lock_key(post.id))).to be_nil
+    end
+
+    it "retries if resque is terminated" do
+      post = create(:post)
+      $redis.set(GenerateFlatPostJob.lock_key(post.id), true)
+
+      exc = Resque::TermException.new("SIGTERM")
+      expect_any_instance_of(FlatPost).to receive(:save!).and_raise(exc)
+      clear_enqueued_jobs
+
+      expect_any_instance_of(GenerateFlatPostJob).to receive(:retry_job)
+
+      GenerateFlatPostJob.perform_now(post.id)
+    end
   end
 end


### PR DESCRIPTION
We recently encountered a situation where a lock wasn't properly being expired on a post's flat post generation. This limits the impact of that situation, so that it can't extend for more than 10 minutes. Future work might investigate a bit more thoroughly the behavior of the job under SIGTERM, since misbehavior there is probably what left the key hanging around.

~~Ten~~ Thirty minutes seems like a comfortable time for the job to successfully process, which is why I picked this. In usual behavior, we'll never hit an expiry, but if we somehow lose the job that should be unlocking this key, it'll only hold the lock for 30 minutes. In the case that our flat post jobs back up significantly, this at least limits them to one job per 30 minutes of queue time, and only if tags are continually made, so there should be no significant adverse behavior the other way of things.

I also make the lock getting atomic, by using Redis's `NX` – per [the documentation](https://redis.io/commands/set), this returns `OK` (converted to `true` by `redis-rb`) only if the key didn't already exist, so here we condense the GET and SET of the key into one command.

**Edit**: Moved from 10 minutes to 30 minutes, since that seems safer.