### PR TITLE
Order API docs and reset IDs between examples

### DIFF
--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -1072,10 +1072,10 @@
       "response_data": {
         "id": 1,
         "subject": "test subject 8",
-        "created_at": "2019-12-29T21:32:20.967Z",
+        "created_at": "2019-12-25T21:34:56.000Z",
         "status": 0,
         "description": "",
-        "tagged_at": "2019-12-29T21:32:20.967Z",
+        "tagged_at": "2019-12-25T21:34:56.000Z",
         "board": {
           "id": 1,
           "name": "test board 20"
@@ -1156,8 +1156,8 @@
         {
           "id": 1,
           "content": "test content 1",
-          "created_at": "2019-12-29T21:32:22.882Z",
-          "updated_at": "2019-12-29T21:32:22.882Z",
+          "created_at": "2019-12-25T21:34:56.000Z",
+          "updated_at": "2019-12-25T21:34:56.000Z",
           "character_name": null,
           "character": null,
           "icon": null,
@@ -1169,8 +1169,8 @@
         {
           "id": 2,
           "content": "test content 2",
-          "created_at": "2019-12-29T21:32:22.947Z",
-          "updated_at": "2019-12-29T21:32:22.947Z",
+          "created_at": "2019-12-25T21:34:56.000Z",
+          "updated_at": "2019-12-25T21:34:56.000Z",
           "character_name": null,
           "character": null,
           "icon": null,
@@ -1182,8 +1182,8 @@
         {
           "id": 3,
           "content": "test content 3",
-          "created_at": "2019-12-29T21:32:22.995Z",
-          "updated_at": "2019-12-29T21:32:22.995Z",
+          "created_at": "2019-12-25T21:34:56.000Z",
+          "updated_at": "2019-12-25T21:34:56.000Z",
           "character_name": "TestAlias3",
           "character": {
             "id": 2,
@@ -1529,10 +1529,10 @@
           {
             "id": 1,
             "subject": "test subject 31",
-            "created_at": "2019-12-29T21:32:25.196Z",
+            "created_at": "2019-12-25T21:34:56.000Z",
             "status": 0,
             "description": "",
-            "tagged_at": "2019-12-29T21:32:25.196Z",
+            "tagged_at": "2019-12-25T21:34:56.000Z",
             "board": {
               "id": 1,
               "name": "test board 29"

--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -8,33 +8,6 @@
       ],
       "query": null,
       "request_data": {
-        "ordered_section_ids": [
-          "88",
-          "86",
-          "89",
-          "87"
-        ]
-      },
-      "response_data": {
-        "section_ids": [
-          88,
-          86,
-          89,
-          87
-        ]
-      },
-      "code": "200",
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "POST",
-      "path": "/api/v1/board_sections/reorder",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
       },
       "response_data": {
         "errors": [
@@ -56,16 +29,43 @@
       "query": null,
       "request_data": {
         "ordered_section_ids": [
-          "93",
-          "91"
+          "3",
+          "1",
+          "4",
+          "2"
         ]
       },
       "response_data": {
         "section_ids": [
-          93,
-          91,
-          92,
-          94
+          3,
+          1,
+          4,
+          2
+        ]
+      },
+      "code": "200",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/api/v1/board_sections/reorder",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "ordered_section_ids": [
+          "3",
+          "1"
+        ]
+      },
+      "response_data": {
+        "section_ids": [
+          3,
+          1,
+          2,
+          4
         ]
       },
       "code": "200",
@@ -83,13 +83,18 @@
       "query": "",
       "request_data": null,
       "response_data": {
-        "errors": [
+        "results": [
           {
-            "message": "Invalid parameter 'page' value 'b': Must be a number."
+            "id": 1,
+            "name": "baa"
+          },
+          {
+            "id": 5,
+            "name": "BAAc"
           }
         ]
       },
-      "code": "422",
+      "code": "200",
       "show_in_doc": 1,
       "recorded": true
     },
@@ -102,18 +107,13 @@
       "query": "",
       "request_data": null,
       "response_data": {
-        "results": [
+        "errors": [
           {
-            "id": 259,
-            "name": "baa"
-          },
-          {
-            "id": 263,
-            "name": "BAAc"
+            "message": "Invalid parameter 'page' value 'b': Must be a number."
           }
         ]
       },
-      "code": "200",
+      "code": "422",
       "show_in_doc": 1,
       "recorded": true
     }
@@ -140,7 +140,7 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/boards/256/posts",
+      "path": "/api/v1/boards/1/posts",
       "versions": [
         "1.0"
       ],
@@ -149,25 +149,25 @@
       "response_data": {
         "results": [
           {
-            "id": 330,
-            "subject": "test subject 29",
+            "id": 1,
+            "subject": "test subject 1",
             "created_at": "2019-01-02T03:04:05.000Z",
             "status": 0,
             "description": "",
             "tagged_at": "2019-01-02T03:04:05.000Z",
             "board": {
-              "id": 256,
-              "name": "test board 26"
+              "id": 1,
+              "name": "test board 11"
             },
             "section": {
-              "id": 100,
-              "name": "TestSection15",
+              "id": 1,
+              "name": "TestSection13",
               "order": 0
             },
             "authors": [
               {
-                "id": 833,
-                "username": "JohnDoe92"
+                "id": 2,
+                "username": "JohnDoe14"
               }
             ],
             "num_replies": 0
@@ -201,24 +201,24 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/boards/258",
+      "path": "/api/v1/boards/1",
       "versions": [
         "1.0"
       ],
       "query": "",
       "request_data": null,
       "response_data": {
-        "id": 258,
-        "name": "test board 28",
+        "id": 1,
+        "name": "test board 10",
         "board_sections": [
           {
-            "id": 102,
-            "name": "TestSection17",
+            "id": 2,
+            "name": "TestSection12",
             "order": 0
           },
           {
-            "id": 101,
-            "name": "TestSection16",
+            "id": 1,
+            "name": "TestSection11",
             "order": 1
           }
         ]
@@ -238,9 +238,50 @@
       "query": "",
       "request_data": null,
       "response_data": {
+        "results": [
+          {
+            "id": 1,
+            "name": "test character 1",
+            "screenname": null,
+            "selector_name": "test character 1"
+          }
+        ]
+      },
+      "code": "200",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "GET",
+      "path": "/api/v1/characters",
+      "versions": [
+        "1.0"
+      ],
+      "query": "",
+      "request_data": null,
+      "response_data": {
         "errors": [
           {
             "message": "Post could not be found."
+          }
+        ]
+      },
+      "code": "422",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "GET",
+      "path": "/api/v1/characters",
+      "versions": [
+        "1.0"
+      ],
+      "query": "",
+      "request_data": null,
+      "response_data": {
+        "errors": [
+          {
+            "message": "Template could not be found."
           }
         ]
       },
@@ -278,25 +319,6 @@
       "response_data": {
         "errors": [
           {
-            "message": "You do not have permission to perform this action."
-          }
-        ]
-      },
-      "code": "403",
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "GET",
-      "path": "/api/v1/characters",
-      "versions": [
-        "1.0"
-      ],
-      "query": "",
-      "request_data": null,
-      "response_data": {
-        "errors": [
-          {
             "message": "Invalid parameter 'includes' value ['invalid']: Must be an array of ['default_icon', 'aliases', 'template_name']"
           }
         ]
@@ -316,65 +338,16 @@
       "response_data": {
         "errors": [
           {
-            "message": "Template could not be found."
+            "message": "You do not have permission to perform this action."
           }
         ]
       },
-      "code": "422",
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "GET",
-      "path": "/api/v1/characters",
-      "versions": [
-        "1.0"
-      ],
-      "query": "",
-      "request_data": null,
-      "response_data": {
-        "results": [
-          {
-            "id": 77,
-            "name": "test character 6",
-            "screenname": null,
-            "selector_name": "test character 6"
-          }
-        ]
-      },
-      "code": "200",
+      "code": "403",
       "show_in_doc": 1,
       "recorded": true
     }
   ],
   "characters#reorder": [
-    {
-      "verb": "POST",
-      "path": "/api/v1/characters/reorder",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "ordered_characters_gallery_ids": [
-          "53",
-          "51",
-          "54",
-          "52"
-        ]
-      },
-      "response_data": {
-        "characters_gallery_ids": [
-          53,
-          51,
-          54,
-          52
-        ]
-      },
-      "code": "200",
-      "show_in_doc": 1,
-      "recorded": true
-    },
     {
       "verb": "POST",
       "path": "/api/v1/characters/reorder",
@@ -404,16 +377,43 @@
       "query": null,
       "request_data": {
         "ordered_characters_gallery_ids": [
-          "58",
-          "56"
+          "3",
+          "1",
+          "4",
+          "2"
         ]
       },
       "response_data": {
         "characters_gallery_ids": [
-          58,
-          56,
-          57,
-          59
+          3,
+          1,
+          4,
+          2
+        ]
+      },
+      "code": "200",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/api/v1/characters/reorder",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "ordered_characters_gallery_ids": [
+          "3",
+          "1"
+        ]
+      },
+      "response_data": {
+        "characters_gallery_ids": [
+          3,
+          1,
+          2,
+          4
         ]
       },
       "code": "200",
@@ -422,76 +422,6 @@
     }
   ],
   "characters#show": [
-    {
-      "verb": "GET",
-      "path": "/api/v1/characters/78",
-      "versions": [
-        "1.0"
-      ],
-      "query": "",
-      "request_data": null,
-      "response_data": {
-        "errors": [
-          {
-            "message": "You do not have permission to perform this action."
-          }
-        ]
-      },
-      "code": "403",
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "GET",
-      "path": "/api/v1/characters/79",
-      "versions": [
-        "1.0"
-      ],
-      "query": "",
-      "request_data": null,
-      "response_data": {
-        "id": 79,
-        "name": "test character 8",
-        "screenname": null,
-        "default_icon": null,
-        "aliases": [
-          {
-            "id": 9,
-            "name": "TestAlias1"
-          }
-        ],
-        "galleries": [
-          {
-            "name": "test gallery 2",
-            "icons": [
-              {
-                "id": 49,
-                "url": "http://www.fakeicon.com",
-                "keyword": "totally fake 2"
-              },
-              {
-                "id": 50,
-                "url": "http://www.fakeicon.com",
-                "keyword": "totally fake 3"
-              }
-            ]
-          },
-          {
-            "name": "test gallery 3",
-            "icons": [
-              {
-                "id": 51,
-                "url": "http://www.fakeicon.com",
-                "keyword": "totally fake 4"
-              }
-            ]
-          }
-        ]
-      },
-      "code": "200",
-      "show_in_doc": 1,
-      "recorded": true
-    },
     {
       "verb": "GET",
       "path": "/api/v1/characters/-1",
@@ -513,26 +443,49 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/characters/80",
+      "path": "/api/v1/characters/1",
       "versions": [
         "1.0"
       ],
       "query": "",
       "request_data": null,
       "response_data": {
-        "id": 80,
-        "name": "test character 9",
+        "id": 1,
+        "name": "test character 7",
         "screenname": null,
-        "alias_id_for_post": 10,
         "default_icon": null,
         "aliases": [
           {
-            "id": 10,
-            "name": "TestAlias2"
+            "id": 1,
+            "name": "TestAlias1"
           }
         ],
         "galleries": [
-
+          {
+            "name": "test gallery 1",
+            "icons": [
+              {
+                "id": 1,
+                "url": "http://www.fakeicon.com",
+                "keyword": "totally fake 1"
+              },
+              {
+                "id": 2,
+                "url": "http://www.fakeicon.com",
+                "keyword": "totally fake 2"
+              }
+            ]
+          },
+          {
+            "name": "test gallery 2",
+            "icons": [
+              {
+                "id": 3,
+                "url": "http://www.fakeicon.com",
+                "keyword": "totally fake 3"
+              }
+            ]
+          }
         ]
       },
       "code": "200",
@@ -541,7 +494,7 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/characters/81",
+      "path": "/api/v1/characters/1",
       "versions": [
         "1.0"
       ],
@@ -557,44 +510,15 @@
       "code": "422",
       "show_in_doc": 1,
       "recorded": true
-    }
-  ],
-  "characters#update": [
-    {
-      "verb": "PUT",
-      "path": "/api/v1/characters/82",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "character": {
-          "default_icon_id": "53"
-        }
-      },
-      "response_data": {
-        "name": "test character 11",
-        "id": 82,
-        "screenname": null,
-        "default_icon": {
-          "id": 53,
-          "url": "http://www.fakeicon.com",
-          "keyword": "totally fake 6"
-        }
-      },
-      "code": "200",
-      "show_in_doc": 1,
-      "recorded": true
     },
     {
-      "verb": "PUT",
-      "path": "/api/v1/characters/83",
+      "verb": "GET",
+      "path": "/api/v1/characters/1",
       "versions": [
         "1.0"
       ],
-      "query": null,
-      "request_data": {
-      },
+      "query": "",
+      "request_data": null,
       "response_data": {
         "errors": [
           {
@@ -606,6 +530,36 @@
       "show_in_doc": 1,
       "recorded": true
     },
+    {
+      "verb": "GET",
+      "path": "/api/v1/characters/1",
+      "versions": [
+        "1.0"
+      ],
+      "query": "",
+      "request_data": null,
+      "response_data": {
+        "id": 1,
+        "name": "test character 10",
+        "screenname": null,
+        "alias_id_for_post": 1,
+        "default_icon": null,
+        "aliases": [
+          {
+            "id": 1,
+            "name": "TestAlias2"
+          }
+        ],
+        "galleries": [
+
+        ]
+      },
+      "code": "200",
+      "show_in_doc": 1,
+      "recorded": true
+    }
+  ],
+  "characters#update": [
     {
       "verb": "PUT",
       "path": "/api/v1/characters/-1",
@@ -648,14 +602,60 @@
     },
     {
       "verb": "PUT",
-      "path": "/api/v1/characters/84",
+      "path": "/api/v1/characters/1",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+      },
+      "response_data": {
+        "errors": [
+          {
+            "message": "You do not have permission to perform this action."
+          }
+        ]
+      },
+      "code": "403",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "PUT",
+      "path": "/api/v1/characters/1",
       "versions": [
         "1.0"
       ],
       "query": null,
       "request_data": {
         "character": {
-          "default_icon_id": "55",
+          "default_icon_id": "2"
+        }
+      },
+      "response_data": {
+        "name": "test character 12",
+        "id": 1,
+        "screenname": null,
+        "default_icon": {
+          "id": 2,
+          "url": "http://www.fakeicon.com",
+          "keyword": "totally fake 5"
+        }
+      },
+      "code": "200",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "PUT",
+      "path": "/api/v1/characters/1",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "character": {
+          "default_icon_id": "2",
           "name": "",
           "user_id": ""
         }
@@ -682,12 +682,13 @@
       "query": "",
       "request_data": null,
       "response_data": {
-        "name": "Galleryless",
-        "icons": [
-
+        "errors": [
+          {
+            "message": "Gallery user could not be found."
+          }
         ]
       },
-      "code": "200",
+      "code": "422",
       "show_in_doc": 1,
       "recorded": true
     },
@@ -700,13 +701,12 @@
       "query": "",
       "request_data": null,
       "response_data": {
-        "errors": [
-          {
-            "message": "Gallery user could not be found."
-          }
+        "name": "Galleryless",
+        "icons": [
+
         ]
       },
-      "code": "422",
+      "code": "200",
       "show_in_doc": 1,
       "recorded": true
     },
@@ -731,19 +731,19 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/galleries/61",
+      "path": "/api/v1/galleries/1",
       "versions": [
         "1.0"
       ],
       "query": "",
       "request_data": null,
       "response_data": {
-        "name": "test gallery 1",
+        "name": "test gallery 13",
         "icons": [
           {
-            "id": 48,
+            "id": 1,
             "url": "http://www.fakeicon.com",
-            "keyword": "totally fake 1"
+            "keyword": "totally fake 8"
           }
         ]
       },
@@ -801,23 +801,7 @@
       ],
       "query": null,
       "request_data": {
-        "s3_key": "users/860/icons/nonsense-fakeimg-1.png"
-      },
-      "response_data": {
-      },
-      "code": "200",
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "POST",
-      "path": "/api/v1/icons/s3_delete",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "s3_key": "users/8611/icons/hash_name.png"
+        "s3_key": "users/11/icons/hash_name.png"
       },
       "response_data": {
         "errors": [
@@ -838,7 +822,7 @@
       ],
       "query": null,
       "request_data": {
-        "s3_key": "users/862/icons/nonsense-fakeimg-2.png"
+        "s3_key": "users/1/icons/nonsense-fakeimg-1.png"
       },
       "response_data": {
         "errors": [
@@ -848,6 +832,22 @@
         ]
       },
       "code": "422",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/api/v1/icons/s3_delete",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "s3_key": "users/1/icons/nonsense-fakeimg-2.png"
+      },
+      "response_data": {
+      },
+      "code": "200",
       "show_in_doc": 1,
       "recorded": true
     }
@@ -864,8 +864,8 @@
       "response_data": {
         "results": [
           {
-            "id": 325,
-            "subject": "search"
+            "id": 1,
+            "subject": "test subject 6"
           }
         ]
       },
@@ -884,8 +884,8 @@
       "response_data": {
         "results": [
           {
-            "id": 327,
-            "subject": "test subject 26"
+            "id": 1,
+            "subject": "search"
           }
         ]
       },
@@ -924,19 +924,71 @@
       "query": null,
       "request_data": {
         "ordered_post_ids": [
-          "307",
-          "305",
-          "308",
-          "306"
+          "3",
+          "1",
+          "4",
+          "2"
+        ]
+      },
+      "response_data": {
+        "post_ids": [
+          3,
+          1,
+          4,
+          2
+        ]
+      },
+      "code": "200",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/api/v1/posts/reorder",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "ordered_post_ids": [
+          "3",
+          "1"
+        ]
+      },
+      "response_data": {
+        "post_ids": [
+          3,
+          1,
+          2,
+          4
+        ]
+      },
+      "code": "200",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "POST",
+      "path": "/api/v1/posts/reorder",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "ordered_post_ids": [
+          "3",
+          "1",
+          "4",
+          "2"
         ],
-        "section_id": "96"
+        "section_id": "1"
       },
       "response_data": {
         "post_ids": [
-          307,
-          305,
-          308,
-          306
+          3,
+          1,
+          4,
+          2
         ]
       },
       "code": "200",
@@ -952,69 +1004,17 @@
       "query": null,
       "request_data": {
         "ordered_post_ids": [
-          "312",
-          "310"
+          "3",
+          "1"
         ],
-        "section_id": "98"
+        "section_id": "1"
       },
       "response_data": {
         "post_ids": [
-          312,
-          310,
-          311,
-          313
-        ]
-      },
-      "code": "200",
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "POST",
-      "path": "/api/v1/posts/reorder",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "ordered_post_ids": [
-          "317",
-          "315",
-          "318",
-          "316"
-        ]
-      },
-      "response_data": {
-        "post_ids": [
-          317,
-          315,
-          318,
-          316
-        ]
-      },
-      "code": "200",
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "POST",
-      "path": "/api/v1/posts/reorder",
-      "versions": [
-        "1.0"
-      ],
-      "query": null,
-      "request_data": {
-        "ordered_post_ids": [
-          "322",
-          "320"
-        ]
-      },
-      "response_data": {
-        "post_ids": [
-          322,
-          320,
-          321,
-          323
+          3,
+          1,
+          2,
+          4
         ]
       },
       "code": "200",
@@ -1023,25 +1023,6 @@
     }
   ],
   "posts#show": [
-    {
-      "verb": "GET",
-      "path": "/api/v1/posts/328",
-      "versions": [
-        "1.0"
-      ],
-      "query": "",
-      "request_data": null,
-      "response_data": {
-        "errors": [
-          {
-            "message": "You do not have permission to perform this action."
-          }
-        ]
-      },
-      "code": "403",
-      "show_in_doc": 1,
-      "recorded": true
-    },
     {
       "verb": "GET",
       "path": "/api/v1/posts/0",
@@ -1063,42 +1044,61 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/posts/329",
+      "path": "/api/v1/posts/1",
       "versions": [
         "1.0"
       ],
       "query": "",
       "request_data": null,
       "response_data": {
-        "id": 329,
-        "subject": "test subject 28",
-        "content": "test content",
-        "created_at": "2019-12-29T02:35:53.472Z",
+        "errors": [
+          {
+            "message": "You do not have permission to perform this action."
+          }
+        ]
+      },
+      "code": "403",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "GET",
+      "path": "/api/v1/posts/1",
+      "versions": [
+        "1.0"
+      ],
+      "query": "",
+      "request_data": null,
+      "response_data": {
+        "id": 1,
+        "subject": "test subject 8",
+        "created_at": "2019-12-29T21:32:20.967Z",
         "status": 0,
         "description": "",
-        "tagged_at": "2019-12-29T02:35:53.472Z",
-        "character": {
-          "id": 91,
-          "name": "test character 20",
-          "screenname": null
-        },
-        "icon": {
-          "id": 58,
-          "url": "http://www.fakeicon.com",
-          "keyword": "totally fake 11"
-        },
+        "tagged_at": "2019-12-29T21:32:20.967Z",
         "board": {
-          "id": 255,
-          "name": "test board 25"
+          "id": 1,
+          "name": "test board 20"
         },
         "section": null,
         "authors": [
           {
-            "id": 824,
-            "username": "JohnDoe83"
+            "id": 1,
+            "username": "JohnDoe61"
           }
         ],
-        "num_replies": 0
+        "num_replies": 0,
+        "content": "test content",
+        "character": {
+          "id": 1,
+          "name": "test character 18",
+          "screenname": null
+        },
+        "icon": {
+          "id": 1,
+          "url": "http://www.fakeicon.com",
+          "keyword": "totally fake 11"
+        }
       },
       "code": "200",
       "show_in_doc": 1,
@@ -1127,68 +1127,7 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/posts/303/replies",
-      "versions": [
-        "1.0"
-      ],
-      "query": "",
-      "request_data": null,
-      "response_data": [
-        {
-          "id": 13,
-          "content": "test content 1",
-          "created_at": "2019-12-29T02:35:52.695Z",
-          "updated_at": "2019-12-29T02:35:52.695Z",
-          "character_name": null,
-          "character": null,
-          "icon": null,
-          "user": {
-            "id": 775,
-            "username": "JohnDoe34"
-          }
-        },
-        {
-          "id": 14,
-          "content": "test content 2",
-          "created_at": "2019-12-29T02:35:52.714Z",
-          "updated_at": "2019-12-29T02:35:52.714Z",
-          "character_name": null,
-          "character": null,
-          "icon": null,
-          "user": {
-            "id": 775,
-            "username": "JohnDoe34"
-          }
-        },
-        {
-          "id": 15,
-          "content": "test content 3",
-          "created_at": "2019-12-29T02:35:52.732Z",
-          "updated_at": "2019-12-29T02:35:52.732Z",
-          "character_name": "TestAlias3",
-          "character": {
-            "id": 90,
-            "name": "test character 19",
-            "screenname": null
-          },
-          "icon": {
-            "id": 57,
-            "url": "http://www.fakeicon.com",
-            "keyword": "totally fake 10"
-          },
-          "user": {
-            "id": 777,
-            "username": "JohnDoe36"
-          }
-        }
-      ],
-      "code": "200",
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "GET",
-      "path": "/api/v1/posts/304/replies",
+      "path": "/api/v1/posts/1/replies",
       "versions": [
         "1.0"
       ],
@@ -1202,6 +1141,67 @@
         ]
       },
       "code": "403",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "GET",
+      "path": "/api/v1/posts/1/replies",
+      "versions": [
+        "1.0"
+      ],
+      "query": "",
+      "request_data": null,
+      "response_data": [
+        {
+          "id": 1,
+          "content": "test content 1",
+          "created_at": "2019-12-29T21:32:22.882Z",
+          "updated_at": "2019-12-29T21:32:22.882Z",
+          "character_name": null,
+          "character": null,
+          "icon": null,
+          "user": {
+            "id": 1,
+            "username": "JohnDoe89"
+          }
+        },
+        {
+          "id": 2,
+          "content": "test content 2",
+          "created_at": "2019-12-29T21:32:22.947Z",
+          "updated_at": "2019-12-29T21:32:22.947Z",
+          "character_name": null,
+          "character": null,
+          "icon": null,
+          "user": {
+            "id": 1,
+            "username": "JohnDoe89"
+          }
+        },
+        {
+          "id": 3,
+          "content": "test content 3",
+          "created_at": "2019-12-29T21:32:22.995Z",
+          "updated_at": "2019-12-29T21:32:22.995Z",
+          "character_name": "TestAlias3",
+          "character": {
+            "id": 2,
+            "name": "test character 20",
+            "screenname": null
+          },
+          "icon": {
+            "id": 2,
+            "url": "http://www.fakeicon.com",
+            "keyword": "totally fake 13"
+          },
+          "user": {
+            "id": 3,
+            "username": "JohnDoe91"
+          }
+        }
+      ],
+      "code": "200",
       "show_in_doc": 1,
       "recorded": true
     }
@@ -1218,7 +1218,7 @@
       "response_data": {
         "results": [
           {
-            "id": 17,
+            "id": 1,
             "text": "Tag1"
           }
         ]
@@ -1238,7 +1238,7 @@
       "response_data": {
         "results": [
           {
-            "id": 18,
+            "id": 1,
             "text": "Tag2"
           }
         ]
@@ -1258,7 +1258,7 @@
       "response_data": {
         "results": [
           {
-            "id": 19,
+            "id": 1,
             "text": "Tag3"
           }
         ]
@@ -1290,18 +1290,18 @@
   "tags#show": [
     {
       "verb": "GET",
-      "path": "/api/v1/tags/20",
+      "path": "/api/v1/tags/1",
       "versions": [
         "1.0"
       ],
       "query": "",
       "request_data": null,
       "response_data": {
-        "id": 20,
+        "id": 1,
         "text": "Tag4",
         "gallery_ids": [
-          74,
-          75
+          1,
+          2
         ]
       },
       "code": "200",
@@ -1340,32 +1340,12 @@
       "response_data": {
         "results": [
           {
-            "id": 41,
+            "id": 1,
             "name": "baa"
           },
           {
-            "id": 45,
+            "id": 5,
             "name": "BAAc"
-          }
-        ]
-      },
-      "code": "200",
-      "show_in_doc": 1,
-      "recorded": true
-    },
-    {
-      "verb": "GET",
-      "path": "/api/v1/templates",
-      "versions": [
-        "1.0"
-      ],
-      "query": "",
-      "request_data": null,
-      "response_data": {
-        "results": [
-          {
-            "id": 49,
-            "name": "test template 1"
           }
         ]
       },
@@ -1403,7 +1383,7 @@
       "response_data": {
         "errors": [
           {
-            "message": "User could not be found."
+            "message": "Invalid parameter 'user_id' value 'b': Must be a number."
           }
         ]
       },
@@ -1422,11 +1402,31 @@
       "response_data": {
         "errors": [
           {
-            "message": "Invalid parameter 'user_id' value 'b': Must be a number."
+            "message": "User could not be found."
           }
         ]
       },
       "code": "422",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "GET",
+      "path": "/api/v1/templates",
+      "versions": [
+        "1.0"
+      ],
+      "query": "",
+      "request_data": null,
+      "response_data": {
+        "results": [
+          {
+            "id": 1,
+            "name": "test template 1"
+          }
+        ]
+      },
+      "code": "200",
       "show_in_doc": 1,
       "recorded": true
     }
@@ -1443,11 +1443,11 @@
       "response_data": {
         "results": [
           {
-            "id": 849,
+            "id": 1,
             "username": "baa"
           },
           {
-            "id": 853,
+            "id": 5,
             "username": "BAAc"
           }
         ]
@@ -1486,7 +1486,7 @@
       "response_data": {
         "results": [
           {
-            "id": 858,
+            "id": 2,
             "username": "ali"
           }
         ]
@@ -1518,7 +1518,7 @@
     },
     {
       "verb": "GET",
-      "path": "/api/v1/users/845/posts",
+      "path": "/api/v1/users/1/posts",
       "versions": [
         "1.0"
       ],
@@ -1527,25 +1527,25 @@
       "response_data": {
         "results": [
           {
-            "id": 332,
+            "id": 1,
             "subject": "test subject 31",
-            "created_at": "2019-12-29T02:35:53.774Z",
+            "created_at": "2019-12-29T21:32:25.196Z",
             "status": 0,
             "description": "",
-            "tagged_at": "2019-12-29T02:35:53.774Z",
+            "tagged_at": "2019-12-29T21:32:25.196Z",
             "board": {
-              "id": 267,
+              "id": 1,
               "name": "test board 29"
             },
             "section": {
-              "id": 103,
+              "id": 1,
               "name": "TestSection18",
               "order": 0
             },
             "authors": [
               {
-                "id": 845,
-                "username": "JohnDoe104"
+                "id": 1,
+                "username": "JohnDoe108"
               }
             ],
             "num_replies": 0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -142,7 +142,7 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = :random
+  config.order = ENV['APIPIE_RECORD'] ? :defined : :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
@@ -158,6 +158,19 @@ RSpec.configure do |config|
       board.destroy
     end
     user.destroy
+  end
+
+  if ENV['APIPIE_RECORD']
+    config.before(:suite) do
+      DatabaseCleaner.strategy = :truncation
+      DatabaseCleaner.clean_with(:truncation)
+    end
+
+    config.around(:each) do |example|
+      DatabaseCleaner.cleaning do
+        example.run
+      end
+    end
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -167,8 +167,11 @@ RSpec.configure do |config|
     end
 
     config.around(:each) do |example|
+      time = Time.new(2019, 12, 25, 21, 34, 56, 0)
       DatabaseCleaner.cleaning do
-        example.run
+        Timecop.freeze(time) do
+          example.run
+        end
       end
     end
   end


### PR DESCRIPTION
This fixes most of the diffs in our doc/apipie_examples.json, but _doesn't_ fix created_at or updated_at. To fix that, we could maybe `Timecop.freeze` around all our examples? Not sure, but this helps with reading the diffs of this file!

This noticeably slows down doc generation, but I don't think it does it too badly!