### PR TITLE
Add section order to posts in the /boards/:id/posts API

### DIFF
--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -19,7 +19,7 @@ class PostPresenter
   end
 
   def includeless_json(post)
-    attrs = %w(id subject description created_at tagged_at status)
+    attrs = %w(id subject description created_at tagged_at status section_order)
     post_json = post.as_json_without_presenter(only: attrs)
     post_json.merge({
       board: post.board,

--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -153,6 +153,7 @@
             "subject": "test subject 1",
             "created_at": "2019-01-02T03:04:05.000Z",
             "status": 0,
+            "section_order": 0,
             "description": "",
             "tagged_at": "2019-01-02T03:04:05.000Z",
             "board": {
@@ -1074,6 +1075,7 @@
         "subject": "test subject 8",
         "created_at": "2019-12-25T21:34:56.000Z",
         "status": 0,
+        "section_order": 0,
         "description": "",
         "tagged_at": "2019-12-25T21:34:56.000Z",
         "board": {
@@ -1540,6 +1542,7 @@
             "subject": "test subject 31",
             "created_at": "2019-12-25T21:34:56.000Z",
             "status": 0,
+            "section_order": 0,
             "description": "",
             "tagged_at": "2019-12-25T21:34:56.000Z",
             "board": {


### PR DESCRIPTION
Builds on #1286 for a more readable docs diff.