### PR TITLE
Add model uniqueness constraints

### DIFF
--- a/app/models/board_author.rb
+++ b/app/models/board_author.rb
@@ -2,5 +2,5 @@ class BoardAuthor < ApplicationRecord
   belongs_to :board, optional: false
   belongs_to :user, optional: false
 
-  validates :user_id, uniqueness: { scope: :board_id }
+  validates :user, uniqueness: { scope: :board }
 end

--- a/app/models/character_tag.rb
+++ b/app/models/character_tag.rb
@@ -4,6 +4,8 @@ class CharacterTag < ApplicationRecord
   belongs_to :setting, foreign_key: :tag_id, inverse_of: :character_tags, optional: true
   belongs_to :gallery_group, foreign_key: :tag_id, inverse_of: :character_tags, optional: true
 
+  validates :character, uniqueness: { scope: :tag }
+
   after_create :add_galleries_to_character
   after_destroy :remove_galleries_from_character
 

--- a/app/models/characters_gallery.rb
+++ b/app/models/characters_gallery.rb
@@ -5,6 +5,8 @@ class CharactersGallery < ApplicationRecord
   before_create :autofill_order
   after_destroy :reorder_others
 
+  validates :character, uniqueness: { scope: :gallery }
+
   scope :ordered, -> { order(section_order: :asc) }
 
   def reorder_others

--- a/app/models/flat_post.rb
+++ b/app/models/flat_post.rb
@@ -1,6 +1,8 @@
 class FlatPost < ApplicationRecord
   belongs_to :post, inverse_of: :flat_post, optional: false
 
+  validates :post, uniqueness: true
+
   def self.regenerate_all(before=nil, override=true)
     # uses Post instead of FlatPost in case any are missing
     Post.includes(:flat_post).find_each do |post|

--- a/app/models/galleries_icon.rb
+++ b/app/models/galleries_icon.rb
@@ -5,7 +5,7 @@ class GalleriesIcon < ApplicationRecord
 
   after_create :set_has_gallery
   after_destroy :unset_has_gallery
-  validates :gallery_id, uniqueness: { scope: :icon_id }
+  validates :gallery, uniqueness: { scope: :icon }
 
   def unset_has_gallery
     return if icon.galleries.present?

--- a/app/models/gallery_tag.rb
+++ b/app/models/gallery_tag.rb
@@ -3,6 +3,8 @@ class GalleryTag < ApplicationRecord
   belongs_to :tag, inverse_of: :gallery_tags, optional: true # TODO: This is required, fix bug around validation if it is set as such
   belongs_to :gallery_group, foreign_key: :tag_id, inverse_of: :gallery_tags, optional: false # This is currently required but may not continue to be
 
+  validates :gallery, uniqueness: { scope: :tag }
+
   after_create :add_gallery_to_characters
   after_destroy :remove_gallery_from_characters
 

--- a/app/models/news_view.rb
+++ b/app/models/news_view.rb
@@ -1,4 +1,6 @@
 class NewsView < ApplicationRecord
   belongs_to :user, optional: false
   belongs_to :news, optional: false
+
+  validates :user, uniqueness: { scope: :news }
 end

--- a/app/models/post_author.rb
+++ b/app/models/post_author.rb
@@ -2,5 +2,5 @@ class PostAuthor < ApplicationRecord
   belongs_to :post, optional: false
   belongs_to :user, optional: false
 
-  validates :user_id, uniqueness: { scope: :post_id }
+  validates :user, uniqueness: { scope: :post }
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -4,4 +4,6 @@ class PostTag < ApplicationRecord
   belongs_to :setting, foreign_key: :tag_id, inverse_of: :post_tags, optional: true
   belongs_to :content_warning, foreign_key: :tag_id, inverse_of: :post_tags, optional: true
   belongs_to :label, foreign_key: :tag_id, inverse_of: :post_tags, optional: true
+
+  validates :post, uniqueness: { scope: :tag }
 end

--- a/app/models/post_viewer.rb
+++ b/app/models/post_viewer.rb
@@ -2,6 +2,8 @@ class PostViewer < ApplicationRecord
   belongs_to :post, optional: false
   belongs_to :user, optional: false
 
+  validates :post, uniqueness: { scope: :user }
+
   after_commit :invalidate_cache
 
   CACHE_VERSION = 1

--- a/app/models/reply_draft.rb
+++ b/app/models/reply_draft.rb
@@ -3,6 +3,8 @@ class ReplyDraft < ApplicationRecord
 
   belongs_to :post, inverse_of: :reply_drafts, optional: false
 
+  validates :post, uniqueness: { scope: :user }
+
   def self.draft_for(post_id, user_id)
     self.find_by(post_id: post_id, user_id: user_id)
   end

--- a/app/models/report_view.rb
+++ b/app/models/report_view.rb
@@ -1,3 +1,5 @@
 class ReportView < ApplicationRecord
   belongs_to :user, optional: false
+
+  validates :user, uniqueness: true
 end

--- a/app/models/tag_tag.rb
+++ b/app/models/tag_tag.rb
@@ -1,4 +1,6 @@
 class TagTag < ApplicationRecord
   belongs_to :child_setting, class_name: 'Setting', foreign_key: :tagged_id, inverse_of: :child_setting_tags, optional: true
   belongs_to :parent_setting, class_name: 'Setting', foreign_key: :tag_id, inverse_of: :parent_setting_tags, optional: true
+
+  validates :child_setting, uniqueness: { scope: :parent_setting }
 end

--- a/spec/models/characters_gallery_spec.rb
+++ b/spec/models/characters_gallery_spec.rb
@@ -31,4 +31,33 @@ RSpec.describe CharactersGallery do
     cg = CharactersGallery.create!(character: character, gallery: gallery)
     expect(cg.section_order).to eq(2)
   end
+
+  it "should prevent duplicate joins for the same character and gallery" do
+    character = create(:character)
+    gallery = create(:gallery, user: character.user)
+    character.galleries << gallery
+    cg = character.characters_galleries.create(gallery: gallery)
+    expect(cg.persisted?).to be(false)
+    expect(cg).not_to be_valid
+    expect(cg.errors.messages).to eq({character: ['has already been taken']})
+  end
+
+  it "should allow multiple galleries on the same character" do
+    character = create(:character)
+    character.galleries << create(:gallery, user: character.user)
+    gallery2 = create(:gallery, user: character.user)
+    cg = character.characters_galleries.create(gallery: gallery2)
+    expect(cg.persisted?).to be(true)
+    expect(cg).to be_valid
+  end
+
+  it "should allow multiple characters to have the same gallery" do
+    character = create(:character)
+    gallery = create(:gallery, user: character.user)
+    character.galleries << gallery
+    character2 = create(:character, user: character.user)
+    cg = character2.characters_galleries.create(gallery: gallery)
+    expect(cg.persisted?).to be(true)
+    expect(cg).to be_valid
+  end
 end

--- a/spec/models/flat_post_spec.rb
+++ b/spec/models/flat_post_spec.rb
@@ -3,6 +3,24 @@ require "spec_helper"
 RSpec.describe FlatPost do
   include ActiveJob::TestHelper
 
+  describe "validations" do
+    it "is limited to one per post" do
+      post = create(:post)
+      expect(post.flat_post).to be_present
+      flatpost = FlatPost.create(post: post)
+      expect(flatpost.persisted?).to be(false)
+      expect(flatpost).not_to be_valid
+      expect(flatpost.errors.messages).to eq({post: ['has already been taken']})
+    end
+
+    it "can have multiple on different posts" do
+      create(:post)
+      expect(FlatPost.count).to eq(1)
+      post = create(:post)
+      expect(post.flat_post).to be_valid
+    end
+  end
+
   describe ".regenerate_all" do
     def delete_lock(post)
       lock_key = GenerateFlatPostJob.lock_key(post.id)

--- a/spec/models/reply_draft_spec.rb
+++ b/spec/models/reply_draft_spec.rb
@@ -22,6 +22,29 @@ RSpec.describe ReplyDraft do
       expect(draft).not_to be_valid
     end
 
+    it "is limited to one per user per post" do
+      post = create(:post)
+      user = create(:user)
+      create(:reply_draft, user: user, post: post)
+      draft = build(:reply_draft, post: post, user: user)
+      expect(draft).not_to be_valid
+      expect(draft.errors.messages).to eq({post: ['has already been taken']})
+    end
+
+    it "allows multiple drafts by different users on the same post" do
+      post = create(:post)
+      create(:reply_draft, post: post)
+      draft = build(:reply_draft, post: post)
+      expect(draft).to be_valid
+    end
+
+    it "allows multiple drafts by the same user on different posts" do
+      user = create(:user)
+      create(:reply_draft, user: user)
+      draft = build(:reply_draft, user: user)
+      expect(draft).to be_valid
+    end
+
     it "works when valid" do
       user = create(:user)
       icon = create(:icon, user: user)


### PR DESCRIPTION
Add constraints to join tables which lack them (except IndexPost)
Standarize on `:model, uniqueness: { scope: :other_model }` rather than
ids
Add uniqueness constraints to FlatPost and ReportView