### PR TITLE
Test the password reset flow

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -21,6 +21,10 @@ plugins:
   rubocop:
     enabled: true
     channel: rubocop-0-74
+checks:
+  return-statements:
+    config:
+      threshold: 5
 exclude_patterns:
 - config/
 - db/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -131,7 +131,7 @@ class ApplicationController < ActionController::Base
     return true if request.xhr?
     return true unless request.get?
     return true if params[:tos_check].present?
-    return true if ['about', 'sessions'].include?(params[:controller])
+    return true if ['about', 'sessions', 'password_resets'].include?(params[:controller])
     return true if params[:controller] == 'users' && params[:action] == 'new'
 
     tos_version = logged_in? ? current_user.tos_version : cookies[:accepted_tos]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,8 +92,7 @@ class ApplicationController < ActionController::Base
   helper_method :page_view
 
   def store_location
-    return unless request.get?
-    return if request.xhr?
+    return unless standard_request?
     session[:previous_url] = request.fullpath
   end
 
@@ -105,8 +104,7 @@ class ApplicationController < ActionController::Base
 
   def require_glowfic_domain
     return unless Rails.env.production? || params[:force_domain] # for testability
-    return unless request.get?
-    return if request.xhr?
+    return unless standard_request?
     return if request.host.include?('glowfic.com')
     return if request.host.include?('glowfic-staging.herokuapp.com')
     glowfic_url = root_url(host: ENV['DOMAIN_NAME'], protocol: 'https')[0...-1] + request.fullpath # strip double slash
@@ -128,8 +126,7 @@ class ApplicationController < ActionController::Base
 
   def tos_skippable?
     return true if Rails.env.test? && params[:force_tos].nil?
-    return true if request.xhr?
-    return true unless request.get?
+    return true unless standard_request?
     return true if params[:tos_check].present?
     return true if ['about', 'sessions', 'password_resets'].include?(params[:controller])
     return true if params[:controller] == 'users' && params[:action] == 'new'
@@ -212,4 +209,10 @@ class ApplicationController < ActionController::Base
     short_msg[0...73] + '…' # make the absolute max length 75 characters
   end
   helper_method :generate_short
+
+  private
+
+  def standard_request?
+    request.get? && !request.xhr?
+  end
 end

--- a/spec/features/password_reset_spec.rb
+++ b/spec/features/password_reset_spec.rb
@@ -1,0 +1,24 @@
+RSpec.feature "Resetting password", :type => :feature do
+  scenario "Resetting your password" do
+    # request reset
+    user = create(:user)
+    visit new_password_reset_path
+    expect(page).to have_selector("th.editor-title", exact_text: "Request Password Reset")
+    within(".form-table") do
+      fill_in "Username" , with: user.username
+      fill_in "Email address", with: user.email
+      click_button "Reset Password"
+    end
+    expect(page).to have_selector('.success', exact_text: 'A password reset link has been emailed to you.')
+
+    # complete reset request
+    reset = PasswordReset.last
+    visit password_reset_path(reset.auth_token)
+    expect(page).to have_selector("th.editor-title", exact_text: "Change Password")
+    fill_in "New Password", with: 'anewpass'
+    fill_in "Confirm Password", with: 'anewpass'
+    click_button "Save"
+    expect(page).to have_selector('.success', exact_text: "Password successfully changed.")
+    expect(user.reload.authenticate('anewpass')).to be true
+  end
+end


### PR DESCRIPTION
Also do not show the TOS prompt on the password reset page.

Of the eight issues fixed by this PR in CodeClimate:
- Two are the thing I was trying to change by upping the return max, so that's fine
- One is in fact below the original 4 by adding the new `standard_request?` method so that's fine
- Two should really be fixed with services, but still have Cognitive Complexity issues outstanding so we're not losing any information
- One is post.visible_to? which is legible just fine even with five returns so I'm fine with it chilling on that one
- Two are from methods with six returns, so now instead of two "too many return" issues we just have one, so we're just closing duplicates.

Related to #1097 