### PR TITLE
Correct some bugs in icon#edit

### DIFF
--- a/app/assets/javascripts/galleries/update_existing.js
+++ b/app/assets/javascripts/galleries/update_existing.js
@@ -1,13 +1,15 @@
 function addUploadedIcon(url, s3Key, _data, _fileInput) {
-  $("#icon_conf").show();
-  $("#icon_url_field").hide();
+  $(".icon_conf").show();
+  $(".icon_url_field").hide();
   $("#icon_url").hide().val(url);
   $("#icon_s3_key").val(s3Key);
-  $("#loading").hide();
-  $("#edit-icon").attr('src', url).show().removeClass('uploading-icon');
+  var iconID= $("#icon_id").val();
+  $("#loading-"+iconID).hide();
+  $("#icon-"+iconID).attr('src', url).show().removeClass('uploading-icon');
 }
 
 function setLoadingIcon(_fileInput) {
-  $("#edit-icon").hide().addClass('uploading-icon');
-  $("#loading").show();
+  var iconID= $("#icon_id").val();
+  $("#icon-"+iconID).hide().addClass('uploading-icon');
+  $("#loading-"+iconID).show();
 }

--- a/app/assets/stylesheets/galleries.scss
+++ b/app/assets/stylesheets/galleries.scss
@@ -30,6 +30,7 @@
 
 .icon-editor {
   display: inline-flex;
+  width: 400px;
   align-items: stretch;
   input { height: 23px; }
   input[type='text'], input[type='file'] { width: 209px; }
@@ -38,11 +39,14 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    width: 110px;
   }
+  .icon-edit-table { width: 290px; }
 }
 
 .gallery-icon-editor {
   @extend .icon-editor;
+  width: unset;
   margin: 18px 18px 0px 0px;
   border: solid $border_color_icon_editor;
   border-width: 15px 1.5px 5px 1.5px;
@@ -55,6 +59,7 @@
     align-items: center;
     justify-content: center;
   }
+  .icon-edit-table { width: unset; }
 }
 
 .gallery-editor #gallery_name { height: 23px; }
@@ -65,8 +70,6 @@
   display: flex;
   flex-flow: row wrap;
 }
-
-.form-table.icon-edit-table { width: unset; }
 
 /* Tiny buttons that hover over icons to allow deleting or selecting a checkbox for editing */
 .delete-button, .select-button {

--- a/app/assets/stylesheets/galleries.scss
+++ b/app/assets/stylesheets/galleries.scss
@@ -28,37 +28,36 @@
   vertical-align: top;
 }
 
-.icon-editor {
+%shared-editor {
   display: inline-flex;
-  width: 400px;
   align-items: stretch;
-  input { height: 23px; }
-  input[type='text'], input[type='file'] { width: 209px; }
 
+  input { height: 23px; }
   .icons-box {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 110px;
   }
+}
+
+.icon-editor {
+  @extend %shared-editor;
+  width: 400px;
+  input[type='text'], input[type='file'] { width: 209px; }
+
+  .icons-box { width: 110px; }
   .icon-edit-table { width: 290px; }
 }
 
 .gallery-icon-editor {
-  @extend .icon-editor;
-  width: unset;
+  @extend %shared-editor;
   margin: 18px 18px 0px 0px;
   border: solid $border_color_icon_editor;
   border-width: 15px 1.5px 5px 1.5px;
   background-color: $bg_color_icon_editor;
-  padding: 5px;
+  padding: 5px 5px 5px 0;
   input[type='text'], input[type='file'] { width: 225px; }
 
-  .icons-box {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
   .icon-edit-table { width: unset; }
 }
 

--- a/app/assets/stylesheets/galleries.scss
+++ b/app/assets/stylesheets/galleries.scss
@@ -31,8 +31,8 @@
 %shared-editor {
   display: inline-flex;
   align-items: stretch;
-
   input { height: 23px; }
+
   .icons-box {
     display: flex;
     align-items: center;
@@ -44,20 +44,18 @@
   @extend %shared-editor;
   width: 400px;
   input[type='text'], input[type='file'] { width: 209px; }
-
   .icons-box { width: 110px; }
   .icon-edit-table { width: 290px; }
 }
 
 .gallery-icon-editor {
   @extend %shared-editor;
-  margin: 18px 18px 0px 0px;
+  margin: 18px 18px 0 0;
   border: solid $border_color_icon_editor;
   border-width: 15px 1.5px 5px 1.5px;
   background-color: $bg_color_icon_editor;
   padding: 5px 5px 5px 0;
   input[type='text'], input[type='file'] { width: 225px; }
-
   .icon-edit-table { width: unset; }
 }
 

--- a/app/views/icons/_editor.haml
+++ b/app/views/icons/_editor.haml
@@ -32,10 +32,10 @@
         %td{class: cycle('even', 'odd'), colspan: 2}
           = gif.check_box :_destroy
           = gif.label :_destroy, 'Remove from Gallery'
-    %tr.gallery-icon-destroy
-      %td{class: cycle('even', 'odd'), colspan: 2}
-        = f.check_box :_destroy
-        = f.label :_destroy, 'Delete Icon'
+      %tr.gallery-icon-destroy
+        %td{class: cycle('even', 'odd'), colspan: 2}
+          = f.check_box :_destroy
+          = f.label :_destroy, 'Delete Icon'
   %tfoot
     - if gif.nil?
       %tr.submit-row


### PR DESCRIPTION
Partials are on occasion non-trivially the devil. Sneaky, sneaky devils.

- Editor width now matches title width
- URL box is now correctly replaced by the Uploaded box when replacing a
hotlinked image with an uploaded one
- The icon displayed is now replaced with a loading image during the
upload
- The loading icon is now replaced with the new image when upload
completes
- The icon box does not undersize itself to 20px wide while the loading
icon is present