### PR TITLE
Prevent update_board_cameos from trying to create duplicate board cameos

### DIFF
--- a/app/concerns/owable.rb
+++ b/app/concerns/owable.rb
@@ -53,9 +53,10 @@ module Owable
 
       # adjust for the fact that the associations are managed separately
       all_authors = authors + unjoined_authors + joined_authors + tagging_authors
-      new_cameos = all_authors.uniq - board.authors
+      # check board authors rather than authors to avoid issues with weird association caching
+      new_cameos = all_authors.uniq.map(&:id) - board.board_authors.map(&:user_id)
       return if new_cameos.empty?
-      board.cameos += new_cameos
+      new_cameos.each { |author| board.board_authors.create!(user_id: author, cameo: true) }
     end
   end
 end


### PR DESCRIPTION
Okay the edge case where the weird caching happened was in #705 but this fix, unlike most of that branch, doesn't _need_ to be in there, and also other things could trigger that edge case.