### PR TITLE
Remove RACK_TIMEOUT env vars from Procfile, move to Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: env RACK_TIMEOUT_TERM_ON_TIMEOUT=1 STATEMENT_TIMEOUT=10s bundle exec puma -C config/puma.rb
+web: env STATEMENT_TIMEOUT=10s bundle exec puma -C config/puma.rb
 worker: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=7 QUEUES=mailer,notifier,high,* bundle exec rake resque:work


### PR DESCRIPTION
Instead of setting these variables in our Procfile,
we should consistently set them in Heroku, as we
sort of already partially do.

Current values including those on Heroku and defaults:

```
RACK_TIMEOUT_TERM_ON_TIMEOUT=1
RACK_TIMEOUT_SERVICE_TIMEOUT=25
(RACK_TIMEOUT_WAIT_TIMEOUT=30)
```

Values I intend to set on Heroku before we release this:

```
RACK_TIMEOUT_TERM_ON_TIMEOUT=1
RACK_TIMEOUT_SERVICE_TIMEOUT=25
RACK_TIMEOUT_WAIT_TIMEOUT=25
```

## Prerequisites

Note that I should change the figures on Heroku first, so we can test them independently of this change, and then merge this if they're shown to be fine.

## Context

The different settings are described at https://github.com/sharpstone/rack-timeout/blob/master/doc/settings.md. Currently, when we receive prolonged app downtimes after having rack timeout issues, _most_ of our error emails come with errors along the lines of "Request waited (>25000)ms, then ran for longer than (<5000)ms, sending SIGTERM to process (PID)." This indicates that our app isn't starting in a timely manner to process requests, and Rack::Timeout is being overly trigger-happy. Reducing `wait_timeout` will help here: if a request has already waited more than these 25 seconds, it will not even be sent to the Rails app for processing, instead being more immediately rejected so we can handle requests appropriately.

Typically, service_timeout is a much lower value (15s) than wait_timeout (30s), which gives a request at most 15s to be processed once it's already entered Rack, but 30s overall from entering Heroku (if it waits 15 seconds before we process it, we get the full 15 seconds, but if it waits, e.g., 25 seconds, we only get 5 seconds to process it). Our service_timeout is higher – I think because we sometimes have long requests – but this shouldn't negatively impact this change, and shouldn't overall be a significant issue to our system, except insofar as we can be held up for up to 25 seconds (rather than just 15) processing some strangely slow request.