### PR TITLE
Fix reports#daily to use subqueries rather than Ruby

### DIFF
--- a/app/services/daily_report.rb
+++ b/app/services/daily_report.rb
@@ -7,10 +7,10 @@ class DailyReport < Report
 
   def posts(sort='')
     range = day.beginning_of_day .. day.end_of_day
-    created_no_replies = Post.where(last_reply_id: nil, created_at: range).pluck(:id)
-    by_replies = Reply.where(created_at: range).pluck(:post_id)
-    all_post_ids = created_no_replies + by_replies
-    Post.where(id: all_post_ids.uniq)
+    created_no_replies = Post.where(last_reply_id: nil, created_at: range)
+    by_replies = Post.where(id: Reply.where(created_at: range).distinct.select(:post_id))
+    all_posts = created_no_replies.or(by_replies)
+    all_posts
       .select(ActiveRecord::Base.sanitize_sql_array([
         "posts.*,
         case


### PR DESCRIPTION
This removes some really staggeringly-large queries when lots of posts (or replies) were created in a single day. I managed to load 5000 posts on a single report day and it took 300ms of controller time, so assuming this is still logically correct, this is a very good improvement! On master it only took about 500ms, anyway, so this isn't too bad, but it presumably helps some with memory usage.