### PR TITLE
Add slow log on certain Rails events

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, :email]

--- a/config/initializers/slow_log.rb
+++ b/config/initializers/slow_log.rb
@@ -1,0 +1,32 @@
+# log excessively slow events to make debugging & optimization easier.
+# ideally this will be replaced by proper metrics at some future point.
+
+ActiveSupport::Notifications.subscribe("process_action.action_controller") do |*args|
+  event = ActiveSupport::Notifications::Event.new *args
+  next unless event.duration > 5000
+
+  # hide most headers as they significantly clutter logs
+  headers = event.payload.delete(:headers).to_h
+  event.payload[:partial_headers] = headers.slice("HTTP_USER_AGENT", "REMOTE_ADDR")
+  Rails.logger.warn "[process_action.action_controller] SLOW: action took longer than 5 seconds: #{event.payload}"
+end
+
+ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+  event = ActiveSupport::Notifications::Event.new *args
+  next unless event.duration > 1000
+
+  # convert activerecord binds into more readable parameters
+  event.payload[:binds] = event.payload[:binds].map { |x| [x.name, x.value] }
+  Rails.logger.warn "[sql.active_record] SLOW: sql took longer than 1 second: #{event.payload}"
+end
+
+ActiveSupport::Notifications.subscribe("instantiation.active_record") do |*args|
+  event = ActiveSupport::Notifications::Event.new *args
+  detail_string = "#{event.payload[:class_name]}, #{event.payload[:record_count]}"
+  if event.payload[:record_count] > 70
+    Rails.logger.warn "[instantiation.active_record] SLOW: many records created: #{detail_string}"
+  end
+  if event.duration > 1000
+    Rails.logger.warn "[instantiation.active_record] SLOW: instantiation took more than 1 second: #{detail_string}"
+  end
+end


### PR DESCRIPTION
Uses https://guides.rubyonrails.org/active_support_instrumentation.html to track slow queries and log them to console. This may not be as good as NewRelic in terms of range of details, but it might allow us to better target what we want and see individual details for that that we provide.

Example logs:

```
[process_action.action_controller] SLOW: action took longer than 5 seconds: {:controller=>"CharactersController", :action=>"index", :params=>{"controller"=>"characters", "action"=>"index", "user_id"=>"1"}, :format=>:html, :method=>"GET", :path=>"/users/1/characters", :status=>200, :view_runtime=>1741.1696999988635, :db_runtime=>58.8822000008804, :partial_headers=>{"HTTP_USER_AGENT"=>"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36", "REMOTE_ADDR"=>"::1"}}

[sql.active_record] SLOW: sql took longer than 1 second: {:sql=>"SELECT  \"news_views\".* FROM \"news_views\" WHERE \"news_views\".\"user_id\" = $1 LIMIT $2", :name=>"NewsView Load", :binds=>[["user_id", 5], ["LIMIT", 1]], :type_casted_binds=>[5, 1], :statement_name=>"a6", :connection_id=>50877520}

[instantiation.active_record] SLOW: many records created: NewsView, 0

[instantiation.active_record] SLOW: instantiation took more than 1 second: NewsView, 0
```

Unfortunately the last two aren't super useful for actual debug in practice, _but_ they may help point out where we're being slow (and in combination with surrounding logs should be good enough for our purposes). The events don't have additional details that we could use, unfortunately.