### PR TITLE
Clean up tests in preparation for splitting post content into replies

### DIFF
--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe RepliesController do
         }
       }
 
-      reply = Reply.first
+      reply = Reply.order(:id).last
       expect(reply).not_to be_nil
       expect(response).to redirect_to(reply_url(reply, anchor: "reply-#{reply.id}"))
       expect(flash[:success]).to eq("Posted!")
@@ -246,7 +246,7 @@ RSpec.describe RepliesController do
       expect(Reply.count).to eq(0)
 
       post :create, params: { reply: {post_id: reply_post.id, content: 'test content!'} }
-      reply = Reply.first
+      reply = Reply.order(:id).last
       expect(response).to redirect_to(reply_url(reply, anchor: "reply-#{reply.id}"))
       expect(reply).not_to be_nil
       expect(flash[:success]).to eq('Posted!')
@@ -262,7 +262,7 @@ RSpec.describe RepliesController do
       expect(Reply.count).to eq(0)
 
       post :create, params: { reply: {post_id: reply_post.id, content: 'test content again!'} }
-      reply = Reply.first
+      reply = Reply.order(:id).last
       expect(response).to redirect_to(reply_url(reply, anchor: "reply-#{reply.id}"))
       expect(reply).not_to be_nil
       expect(flash[:success]).to eq('Posted!')

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Post do
     it "should update when multiple fields are changed" do
       post = create(:post)
       expect(post.edited_at).to eq(post.created_at)
-      post.content = 'new content now'
+      post.subject = 'new subject'
       post.description = 'description'
       post.save!
       expect(post.edited_at).not_to eq(post.created_at)
@@ -748,7 +748,7 @@ RSpec.describe Post do
     end
 
     it "does not reset on update" do
-      post.content = 'new content'
+      post.description = 'new description'
       post.save!
       expect(post.reload).not_to be_show_warnings_for(user)
     end
@@ -920,7 +920,7 @@ RSpec.describe Post do
       post = nil
       Audited.audit_class.as_user(user) do
         post = create(:post, content: 'original', user: user)
-        1.upto(5) { |i| post.update!(content: 'message' + i.to_s) }
+        1.upto(5) { |i| post.update!(description: 'message' + i.to_s) }
       end
       expect(post.reload.has_edit_audits?).to eq(true)
     end
@@ -928,10 +928,10 @@ RSpec.describe Post do
     it "is true if post has been edited by moderator" do
       post = nil
       Audited.audit_class.as_user(user) do
-        post = create(:post, content: 'original')
+        post = create(:post, description: 'original')
       end
       Audited.audit_class.as_user(create(:mod_user)) do
-        post.update!(content: 'blah')
+        post.update!(description: 'blah')
       end
       expect(post.reload.has_edit_audits?).to eq(true)
     end


### PR DESCRIPTION
Makes tests of changing post fields use metadata rather than content
Clarifies reply selection

(Obviously, extracted from #705)