### PR TITLE
Fix consistency of logged_in method

### DIFF
--- a/app/concerns/authentication.rb
+++ b/app/concerns/authentication.rb
@@ -4,21 +4,25 @@ module Authentication
   included do
     protected
 
-    def check_permanent_user
-      return if logged_in?
-      session[:user_id] = cookies.signed[:user_id] if cookies.signed[:user_id].present?
+    before_action :set_session_from_cookie
+
+    def set_session_from_cookie
+      return if session[:user_id].present?
+      session[:user_id] = cookies.signed[:user_id]
     end
 
     def logged_in?
-      session[:user_id].present?
+      !!current_user
     end
     helper_method :logged_in?
 
     def current_user
-      return unless logged_in?
-      @current_user ||= User.find_by_id(session[:user_id])
       return @current_user if @current_user
-      logout # the user id stored in session does not exist, probably due to staging db reset
+      return nil unless session[:user_id].present?
+
+      user = User.find_by_id(session[:user_id])
+      logout unless user.present? # the user id stored in session does not exist, probably due to staging db reset
+      @current_user = user
     end
     helper_method :current_user
 

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -3,7 +3,6 @@ class Api::ApiController < ActionController::Base
   include Authentication
 
   protect_from_forgery with: :exception
-  before_action :check_permanent_user
   around_action :set_timezone
   around_action :handle_param_validation
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,6 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_token
 
   before_action :check_tos
-  before_action :check_permanent_user
   before_action :show_password_warning
   before_action :require_glowfic_domain
   before_action :set_login_gon

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -399,4 +399,14 @@ RSpec.describe ApplicationController do
       expect(response.json['logged_in']).to eq(false)
     end
   end
+
+  it "resets your session if your user was hard deleted" do
+    user_id = login
+    User.find_by(id: user_id).destroy!
+    get :index
+
+    expect(session[:user_id]).to be_nil
+    expect(controller.send(:logged_in?)).to eq(false)
+    expect(cookies.signed[:user_id]).to be_nil
+  end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -25,11 +25,10 @@ RSpec.describe SessionsController do
     it "logs out if user has become invalid" do
       user = create(:user)
       login_as(user)
-      expect(controller.send(:logged_in?)).to eq(true)
-      user.destroy
-      expect { get :index }.to raise_error(NoMethodError) # current_user will be cleared but then call functions on nil
-      get :index # subsequent loads will work
-      expect(controller.send(:logged_in?)).not_to eq(true)
+      user.destroy!
+      # reloading index should destroy the session
+      get :index
+      expect(controller.send(:logged_in?)).to eq(false)
     end
   end
 

--- a/spec/features/sessions/new_spec.rb
+++ b/spec/features/sessions/new_spec.rb
@@ -62,4 +62,22 @@ RSpec.feature "Logging in", :type => :feature do
     expect(page).to have_selector('.flash.error', text: 'You are already logged in.')
     expect(page).to have_no_selector('#username')
   end
+
+  scenario "Automatically logged out when user is destroyed" do
+    username = 'Test user'
+    password = 'my password1234@'
+    user = create(:user, username: username, password: password)
+    visit login_path
+
+    within('.form-table') do
+      fill_in 'Username', with: username
+      fill_in 'Password', with: password
+      click_on 'Sign In'
+    end
+
+    user.destroy!
+
+    visit root_path
+    expect(page).not_to have_text(username)
+  end
 end


### PR DESCRIPTION
We had some issues locally where `salt_uuid` methods got undefined when users got destroyed from the database. I think it's occasionally come up before that `logged_in?` and `current_user` can become inconsistent – and I think someone could fake a non-nil `session[:user_id]` that doesn't correspond to a user in production, even if they might have trouble finding a valid value (I don't know the details of how Rails protects sessions, but I hope it encrypts and signs them, which would make this impossible). Regardless, we often take `logged_in?` as indicating that `current_user` will be non-nil, so let's take this all the way: it now checks, explicitly, if current_user exists.

~~There are currently a few failures locally – I'll fix them if they're relevant to this, but they might just be a missing chromium binary.~~