### PR TITLE
Add replies.post_id to reply_order index

### DIFF
--- a/db/migrate/20200201234346_add_post_reply_order_index_to_replies.rb
+++ b/db/migrate/20200201234346_add_post_reply_order_index_to_replies.rb
@@ -1,0 +1,8 @@
+class AddPostReplyOrderIndexToReplies < ActiveRecord::Migration[5.2]
+  # cannot change indexes concurrently inside transactions
+  self.disable_ddl_transaction!
+
+  def change
+    add_index :replies, [:post_id, :reply_order], algorithm: :concurrently
+  end
+end

--- a/db/migrate/20200201234427_remove_reply_index_from_replies.rb
+++ b/db/migrate/20200201234427_remove_reply_index_from_replies.rb
@@ -1,0 +1,8 @@
+class RemoveReplyIndexFromReplies < ActiveRecord::Migration[5.2]
+  # cannot change indexes concurrently inside transactions
+  self.disable_ddl_transaction!
+
+  def change
+    remove_index :replies, column: :reply_order, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_08_101015) do
+ActiveRecord::Schema.define(version: 2020_02_01_234427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -365,8 +365,8 @@ ActiveRecord::Schema.define(version: 2020_01_08_101015) do
     t.index ["character_id"], name: "index_replies_on_character_id"
     t.index ["created_at"], name: "index_replies_on_created_at"
     t.index ["icon_id"], name: "index_replies_on_icon_id"
+    t.index ["post_id", "reply_order"], name: "index_replies_on_post_id_and_reply_order"
     t.index ["post_id"], name: "index_replies_on_post_id"
-    t.index ["reply_order"], name: "index_replies_on_reply_order"
     t.index ["thread_id"], name: "index_replies_on_thread_id"
     t.index ["user_id"], name: "index_replies_on_user_id"
   end


### PR DESCRIPTION
I've set it to use `algorithm: :concurrently` as the replies table is pretty large – this way, we should be good to run it whenever. Unfortunately, this does mean disabling transactions for the statements (`CREATE INDEX CONCURRENTLY` requires transactions itself, so can't run inside one). Accordingly, so it rolls back appropriately if either of the commands fail, I've separated them into two migration files.

The motivation for this is that `SELECT id FROM replies WHERE post_id = ? ORDER BY reply_order DESC LIMIT 1` is a pretty common query that ends up taking a long time on the replies table (~500ms). `EXPLAIN` did in fact indicate it filtering by post_id first, then doing an index scan to find the right reply_order, but since we're not looking for reply_order except in the context of a post, it seems best to turn this into a composite index, as here.