### PR TITLE
Update chromium to new buster-provided version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     nodejs \
     postgresql-client-11 \
-    chromium=78.* \
+    chromium=79.* \
   && apt-get clean
 
 ARG bundler_version=2.0.2


### PR DESCRIPTION
The docker image is failing to build for me without this change! Probably doesn't fail for anyone with a docker cache from before this update, and this will trigger a rebuild.