### PR TITLE
Set the preload directive in the HSTS header

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,6 +48,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+  config.ssl_options = { hsts: { preload: true } }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Fixes #1347 

As detailed in https://blog.bigbinary.com/2016/08/24/rails-5-adds-more-control-to-fine-tuning-ssl-usage.html Rails will automatically set the HSTS preload directives if we add it to our configuration file. Once this is deployed we should submit ourselves to the list at https://hstspreload.org/ as well.