### PR TITLE
Redo Post::Status to use the Rails enum builtins

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -193,7 +193,7 @@ class Post < ApplicationRecord
 
     # testing for case where the post was changed in status more recently than the last reply
     audits_exist = audits.where('created_at > ?', most_recent.created_at).where(action: 'update')
-    audits_exist = audits_exist.where("(audited_changes -> 'status' ->> 1)::integer = ?", Post::Status::COMPLETE)
+    audits_exist = audits_exist.where("(audited_changes -> 'status' ->> 1)::integer = ?", Post.statuses[:complete])
     return most_recent.updated_at unless audits_exist.exists?
     self.edited_at
   end
@@ -207,7 +207,7 @@ class Post < ApplicationRecord
 
   def taggable_by?(user)
     return false unless user
-    return false if completed? || abandoned?
+    return false if complete? || abandoned?
     return false unless user.writes_in?(board)
     return true unless authors_locked?
     author_ids.include?(user.id)
@@ -303,7 +303,7 @@ class Post < ApplicationRecord
     return if skip_edited
     self.edited_at = self.updated_at
     return if skip_tagged
-    return if replies.exists? && (!status_changed? || status != Post::Status::COMPLETE)
+    return if replies.exists? && (!status_changed? || !complete?)
     self.tagged_at = self.updated_at
   end
 

--- a/app/models/post/status.rb
+++ b/app/models/post/status.rb
@@ -1,36 +1,16 @@
 module Post::Status
   extend ActiveSupport::Concern
 
-  ACTIVE = 0
-  COMPLETE = 1
-  HIATUS = 2
-  ABANDONED = 3
-
   included do
-    def completed?
-      status == COMPLETE
-    end
+    enum status: {
+      active: 0,
+      complete: 1,
+      hiatus: 2,
+      abandoned: 3,
+    }
 
     def on_hiatus?
-      marked_hiatus? || (active? && tagged_at < 1.month.ago)
+      hiatus? || (active? && tagged_at < 1.month.ago)
     end
-
-    def marked_hiatus?
-      status == HIATUS
-    end
-
-    def active?
-      status == ACTIVE
-    end
-
-    def abandoned?
-      status == ABANDONED
-    end
-  end
-
-  def self.get_status(param)
-    statuses = ['Active', 'Complete', 'Hiatus', 'Abandoned'].map(&:upcase)
-    raise NameError unless statuses.include?(param)
-    const_get(param)
   end
 end

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -66,7 +66,7 @@ class Reply < ApplicationRecord
     return if post.last_reply_id != id || skip_post_update
     return if (saved_changes.keys - Post::NON_TAGGED_ATTRS - ['updated_at']).empty?
     post.tagged_at = updated_at
-    post.status = Post::Status::ACTIVE if post.on_hiatus?
+    post.status = 'active' if post.on_hiatus?
     post.save
   end
 

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -66,7 +66,7 @@ class Reply < ApplicationRecord
     return if post.last_reply_id != id || skip_post_update
     return if (saved_changes.keys - Post::NON_TAGGED_ATTRS - ['updated_at']).empty?
     post.tagged_at = updated_at
-    post.status = 'active' if post.on_hiatus?
+    post.status = :active if post.on_hiatus?
     post.save
   end
 

--- a/app/services/post_importer.rb
+++ b/app/services/post_importer.rb
@@ -3,7 +3,7 @@ class PostImporter < Object
     @url = url
   end
 
-  def import(board_id, importer_id, section_id: nil, status: Post::Status::COMPLETE, threaded: false)
+  def import(board_id, importer_id, section_id: nil, status: Post.statuses[:complete], threaded: false)
     validate_url!
     validate_duplicate!(board_id) unless threaded
     validate_usernames!

--- a/app/services/post_scraper.rb
+++ b/app/services/post_scraper.rb
@@ -26,7 +26,7 @@ class PostScraper < Object
   def initialize(url, board_id=nil, section_id=nil, status=nil, threaded_import=false, console_import=false, subject=nil)
     @board_id = board_id || SANDBOX_ID
     @section_id = section_id
-    @status = status || Post::Status::COMPLETE
+    @status = status || Post.statuses[:complete]
     url += (url.include?('?') ? '&' : '?') + 'style=site' unless url.include?('style=site')
     url += '&view=flat' unless url.include?('view=flat') || threaded_import
     @url = url

--- a/app/views/posts/_import.haml
+++ b/app/views/posts/_import.haml
@@ -11,7 +11,7 @@
       = select_tag :section_id, options_from_collection_for_select(BoardSection.where(board_id: params[:board_id]).ordered, :id, :name, params[:section_id]), include_blank: '— Choose Section —', id: 'post_section_id'
     %br
     = label_tag :status, "Status", style: "width: 150px; display: inline-block;"
-    = select_tag :status, options_for_select([['In Progress', Post::Status::ACTIVE], ['Complete', Post::Status::COMPLETE], ['On Hiatus', Post::Status::HIATUS], ['Abandoned', Post::Status::ABANDONED]], params[:status] || Post::Status::COMPLETE), style: 'margin-top: 5px;'
+    = select_tag :status, options_for_select(Post.statuses.map{|k,v| [k.titlecase, v]}, params[:status] || Post.statuses[:complete]), style: 'margin-top: 5px;'
     %br
     = label_tag :threaded, "Threaded?", style: "width: 150px; display: inline-block;"
     = check_box_tag :threaded, "1", params[:threaded].present?

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -1,8 +1,8 @@
 %tr
   - klass = cycle('even', 'odd')
   - replies_count = post.reply_count
-  %td.post-completed.vtop{class: [klass, (post.completed? ? 'post-complete' : 'post-incomplete')]}
-    - if post.completed?
+  %td.post-completed.vtop{class: [klass, (post.complete? ? 'post-complete' : 'post-incomplete')]}
+    - if post.complete?
       = image_tag "icons/book.png", class: 'vmid', title: "Thread Complete", alt: 'Complete'
     - elsif post.on_hiatus?
       = image_tag "icons/hourglass.png", class: 'vmid', title: "Thread On Hiatus", alt: 'Hiatused'

--- a/app/views/posts/show.haml
+++ b/app/views/posts/show.haml
@@ -74,12 +74,12 @@
             = image_tag "icons/star_add.png".freeze, class: 'vmid'.freeze, style: 'margin-bottom: 3px;'.freeze, alt: ''
             Favorite
       - if @post.metadata_editable_by?(current_user)
-        - unless @post.completed?
+        - unless @post.complete?
           = link_to post_path(@post, status: 'complete'.freeze), method: :put do
             %div
               = image_tag "icons/book.png".freeze, alt: ''
               Mark Complete
-        - unless @post.marked_hiatus?
+        - unless @post.hiatus?
           = link_to post_path(@post, status: 'hiatus'.freeze), method: :put do
             %div
               = image_tag "icons/hourglass.png".freeze, alt: ''
@@ -144,7 +144,7 @@
 - if @replies.present?
   = render 'posts/paginator', paginated: @replies
 = render partial: 'replies/single', collection: @replies, as: :reply
-- if @post.completed? && (@replies.empty? || (@replies.last.id == @post.last_reply_id))
+- if @post.complete? && (@replies.empty? || (@replies.last.id == @post.last_reply_id))
   .post-ender Here Ends This Thread
   - if @prev_post || @next_post
     .post-navheader

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -28,17 +28,16 @@
     %tr
       %th.sub.width-150 Status
       %td{class: cycle('odd', 'even')}
-        - case @post.status
-        - when Post::Status::ACTIVE
-          = image_tag "icons/book_open.png", class: 'vmid', title: 'In Progress', alt: ''
-          In Progress
-        - when Post::Status::COMPLETE
-          = image_tag "icons/book.png", class: 'vmid', title: 'Complete', alt: ''
-          Complete
-        - when Post::Status::HIATUS
+        - if @post.on_hiatus?
           = image_tag "icons/hourglass.png", class: 'vmid', title: 'On Hiatus', alt: ''
           On Hiatus
-        - when Post::Status::ABANDONED
+        - elsif @post.active?
+          = image_tag "icons/book_open.png", class: 'vmid', title: 'In Progress', alt: ''
+          In Progress
+        - elsif @post.complete?
+          = image_tag "icons/book.png", class: 'vmid', title: 'Complete', alt: ''
+          Complete
+        - elsif @post.abandoned?
           = image_tag "icons/book_grey.png", class: 'vmid', title: 'Abandoned', alt: ''
           Abandoned
     %tr

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -25,8 +25,8 @@
         %tr
           - klass = [cycle('even', 'odd')]
           - klass << 'post-ignored' if ignored?(post)
-          %td.vtop.post-completed{class: klass.dup.push(post.completed? ? 'post-complete' : 'post-incomplete')}
-            - if post.completed?
+          %td.vtop.post-completed{class: klass.dup.push(post.complete? ? 'post-complete' : 'post-incomplete')}
+            - if post.complete?
               = image_tag "icons/book.png", class: 'vmid', title: "Thread Complete", alt: 'Complete'
             - elsif post.on_hiatus?
               = image_tag "icons/hourglass.png", class: 'vmid', title: "Thread On Hiatus", alt: 'Hiatused'

--- a/db/seeds/post.rb
+++ b/db/seeds/post.rb
@@ -521,7 +521,7 @@ Post.create!([
     so she's the one who fetches Miles Vorkosigan, watches over his transformation into Miles Naismith, and accompanies the latter to his destination, pretending this time to be business partners (she Sales And Marketing, he eccentrically Development, product Top Secret).<br><br>Currently they're sliding back into their ranks and uniforms - she's got her Dendarii pants on already and lovely scarlet accessories to turn them into shiny silver fashion statements.  But before they fully reintegrate with their outfit and she dons the rest of <em>her</em> outfit there is a hospital visit to make.<br><br>The survivors of the incident, such as they are, aren't in great shape.  Miles knows how the dead-and-irrecoverable wanted to be disposed of; he knows his obligations to the crippled, likewise, and he discharges them with all the gravity and generosity that could be wished.  Quinn wants his job, so she watches him do it, even this least lovely part.  Reminds her a little of the news that her face was getting artistically replaced.  But that doesn't mean she doesn't wonder why he has to get that up close and personal with Aziz, who after all probably can't understand a word he says.<br><br>Miles demurs with something about a fascinated fear of the loss of mind, and Elli lets it go.<br><br>They get good news about Marilac, about the value of their work there.<br><br>They split up so that he can shower, and she can get into her greys, and then there's going to be the usual meeting.",
     created_at: "2015-07-22 17:44:00",
     updated_at: "2019-06-22 18:40:31",
-    status: Post::Status::ABANDONED,
+    status: 'abandoned',
     section_order: 0,
     edited_at: "2019-06-22 18:40:31",
     tagged_at: "2015-07-23 00:59:00",

--- a/db/seeds/post.rb
+++ b/db/seeds/post.rb
@@ -521,7 +521,7 @@ Post.create!([
     so she's the one who fetches Miles Vorkosigan, watches over his transformation into Miles Naismith, and accompanies the latter to his destination, pretending this time to be business partners (she Sales And Marketing, he eccentrically Development, product Top Secret).<br><br>Currently they're sliding back into their ranks and uniforms - she's got her Dendarii pants on already and lovely scarlet accessories to turn them into shiny silver fashion statements.  But before they fully reintegrate with their outfit and she dons the rest of <em>her</em> outfit there is a hospital visit to make.<br><br>The survivors of the incident, such as they are, aren't in great shape.  Miles knows how the dead-and-irrecoverable wanted to be disposed of; he knows his obligations to the crippled, likewise, and he discharges them with all the gravity and generosity that could be wished.  Quinn wants his job, so she watches him do it, even this least lovely part.  Reminds her a little of the news that her face was getting artistically replaced.  But that doesn't mean she doesn't wonder why he has to get that up close and personal with Aziz, who after all probably can't understand a word he says.<br><br>Miles demurs with something about a fascinated fear of the loss of mind, and Elli lets it go.<br><br>They get good news about Marilac, about the value of their work there.<br><br>They split up so that he can shower, and she can get into her greys, and then there's going to be the usual meeting.",
     created_at: "2015-07-22 17:44:00",
     updated_at: "2019-06-22 18:40:31",
-    status: 'abandoned',
+    status: :abandoned,
     section_order: 0,
     edited_at: "2019-06-22 18:40:31",
     tagged_at: "2015-07-23 00:59:00",

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PostsController do
       create_list(:post, 26)
       oldest = Post.ordered_by_id.first
       next_oldest = Post.ordered_by_id.second
-      oldest.update!(status: Post.statuses[:complete])
+      oldest.update!(status: :complete)
       get :index
       ids_fetched = controller.instance_variable_get('@posts').map(&:id)
       expect(ids_fetched.count).to eq(25)
@@ -166,7 +166,7 @@ RSpec.describe PostsController do
 
       it "filters by completed" do
         create(:post)
-        post = create(:post, status: Post.statuses[:complete])
+        post = create(:post, status: :complete)
         get :search, params: { commit: true, completed: true }
         expect(assigns(:search_results)).to match_array(post)
       end
@@ -1571,14 +1571,14 @@ RSpec.describe PostsController do
       end
 
       it "handles unexpected failure" do
-        post = create(:post, status: Post.statuses[:active])
+        post = create(:post, status: :active)
         login_as(post.user)
         post.update_columns(board_id: 0) # rubocop:disable Rails/SkipsModelValidations
         expect(post.reload).not_to be_valid
         put :update, params: { id: post.id, status: 'abandoned' }
         expect(response).to redirect_to(post_url(post))
         expect(flash[:error][:message]).to eq('Status could not be updated.')
-        expect(post.reload.status).not_to eq(Post.statuses[:abandoned])
+        expect(post.reload.status).not_to eq(:abandoned)
       end
 
       it "marks read after completed" do
@@ -2606,7 +2606,7 @@ RSpec.describe PostsController do
       it "shows hiatused posts" do
         post = create(:post, user: user)
         create(:reply, post: post, user: other_user)
-        post.update!(status: Post.statuses[:hiatus])
+        post.update!(status: :hiatus)
 
         get :owed, params: {view: 'hiatused'}
         expect(response.status).to eq(200)
@@ -2667,17 +2667,17 @@ RSpec.describe PostsController do
       it "hides completed and abandoned threads" do
         create(:reply, post_id: post.id, user_id: other_user.id)
 
-        post.update!(status: Post.statuses[:complete])
+        post.update!(status: :complete)
         get :owed
         expect(response.status).to eq(200)
         expect(assigns(:posts)).to be_empty
 
-        post.update!(status: Post.statuses[:active])
+        post.update!(status: :active)
         get :owed
         expect(response.status).to eq(200)
         expect(assigns(:posts)).to match_array([post])
 
-        post.update!(status: Post.statuses[:abandoned])
+        post.update!(status: :abandoned)
         get :owed
         expect(response.status).to eq(200)
         expect(assigns(:posts)).to be_empty
@@ -2685,7 +2685,7 @@ RSpec.describe PostsController do
 
       it "show hiatused threads by default" do
         create(:reply, post_id: post.id, user_id: other_user.id)
-        post.update!(status: Post.statuses[:hiatus])
+        post.update!(status: :hiatus)
 
         get :owed
         expect(response.status).to eq(200)
@@ -2694,7 +2694,7 @@ RSpec.describe PostsController do
 
       it "optionally hides hiatused threads" do
         create(:reply, post_id: post.id, user_id: other_user.id)
-        post.update!(status: Post.statuses[:hiatus])
+        post.update!(status: :hiatus)
 
         user.hide_hiatused_tags_owed = true
         user.save!

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -1074,12 +1074,11 @@ RSpec.describe RepliesController do
       create(:reply, post: rpost, user: rpost.user)
       reply.destroy!
 
-      rpost.status = Post::Status::HIATUS
-      rpost.save!
+      rpost.update!(status: :hiatus)
       login_as(rpost.user)
       post :restore, params: { id: reply.id }
       expect(flash[:success]).to eq("Reply has been restored!")
-      expect(Post.find(rpost.id).status).to eq(Post::Status::HIATUS)
+      expect(Post.find(rpost.id)).to be_hiatus
     end
   end
 

--- a/spec/jobs/scrape_post_job_spec.rb
+++ b/spec/jobs/scrape_post_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ScrapePostJob do
     stub_fixture(url, 'scrape_no_replies')
     board = create(:board)
     create(:character, screenname: 'wild_pegasus_appeared')
-    ScrapePostJob.perform_now(url, board.id, nil, Post::Status::COMPLETE, false, board.creator_id)
+    ScrapePostJob.perform_now(url, board.id, nil, Post.statuses[:complete], false, board.creator_id)
     expect(Message.count).to eq(1)
     expect(Message.first.subject).to eq("Post import succeeded")
     expect(Post.count).to eq(1)
@@ -32,11 +32,11 @@ RSpec.describe ScrapePostJob do
 
     expect(ScrapePostJob).to receive(:notify_exception).with(
       an_instance_of(UnrecognizedUsernameError),
-      url, board.id, nil, Post::Status::COMPLETE, false, board.creator_id
+      url, board.id, nil, Post.statuses[:complete], false, board.creator_id
     ).and_call_original
 
     begin
-      ScrapePostJob.perform_now(url, board.id, nil, Post::Status::COMPLETE, false, board.creator_id)
+      ScrapePostJob.perform_now(url, board.id, nil, Post.statuses[:complete], false, board.creator_id)
     rescue UnrecognizedUsernameError
       expect(Message.count).to eq(1)
       expect(Message.first.subject).to eq("Post import failed")
@@ -57,11 +57,11 @@ RSpec.describe ScrapePostJob do
 
     expect(ScrapePostJob).to receive(:notify_exception).with(
       an_instance_of(AlreadyImportedError),
-      url, board.id, nil, Post::Status::COMPLETE, false, board.creator_id
+      url, board.id, nil, Post.statuses[:complete], false, board.creator_id
     ).and_call_original
 
     begin
-      ScrapePostJob.perform_now(url, board.id, nil, Post::Status::COMPLETE, false, board.creator_id)
+      ScrapePostJob.perform_now(url, board.id, nil, Post.statuses[:complete], false, board.creator_id)
     rescue AlreadyImportedError
       expect(Message.count).to eq(1)
       expect(Message.first.subject).to eq("Post import failed")

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Post do
 
       it "should update edited_at and tagged_at when status edited" do
         Timecop.freeze(time) do
-          post.update!(status: 'complete')
+          post.update!(status: :complete)
         end
         expect(post.tagged_at).to be > old_tagged_at
         expect(post.edited_at).to be > old_edited_at
@@ -73,7 +73,7 @@ RSpec.describe Post do
 
       it "should update edited_at and tagged_at when status edited" do
         Timecop.freeze(time) do
-          post.update!(status: 'complete')
+          post.update!(status: :complete)
         end
         expect(post.tagged_at).to be > old_tagged_at
         expect(post.edited_at).to be > old_edited_at
@@ -637,7 +637,7 @@ RSpec.describe Post do
         expect(post.read_time_for(post.replies)).to be_the_same_time_as(unread.created_at)
 
         Timecop.freeze(unread.created_at + 1.day) do
-          post.update!(status: 'complete')
+          post.update!(status: :complete)
 
           post.description = 'new description to add another audit'
           post.save!

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Post do
 
       it "should update edited_at and tagged_at when status edited" do
         Timecop.freeze(time) do
-          post.update!(status: Post::Status::COMPLETE)
+          post.update!(status: 'complete')
         end
         expect(post.tagged_at).to be > old_tagged_at
         expect(post.edited_at).to be > old_edited_at
@@ -73,7 +73,7 @@ RSpec.describe Post do
 
       it "should update edited_at and tagged_at when status edited" do
         Timecop.freeze(time) do
-          post.update!(status: Post::Status::COMPLETE)
+          post.update!(status: 'complete')
         end
         expect(post.tagged_at).to be > old_tagged_at
         expect(post.edited_at).to be > old_edited_at
@@ -637,8 +637,7 @@ RSpec.describe Post do
         expect(post.read_time_for(post.replies)).to be_the_same_time_as(unread.created_at)
 
         Timecop.freeze(unread.created_at + 1.day) do
-          post.status = Post::Status::COMPLETE
-          post.save!
+          post.update!(status: 'complete')
 
           post.description = 'new description to add another audit'
           post.save!


### PR DESCRIPTION
Open question which I have absolutely used mixed values for here and should consistentize: do we want to use:
`post.update(status: 'complete')`
or
`post.update(status: :complete)`
or
`post.update(status: Post.statuses[:complete])`

I lean towards 2 but am open to opinions.

I believe this fixes an incidental bug in the post metadata page around how we display posts that are active-but-old-enough-to-display-hiatuses, but perhaps that was on purpose?