### PR TITLE
Fix font-size bug

### DIFF
--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -255,7 +255,6 @@ div.post-subheader { width: 100%; }
 #post_content, #reply_content {
   width: 100%;
   display: block;
-  font-size: $font_size_small;
 }
 
 #reply_content { height: 130px; }

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -255,6 +255,7 @@ div.post-subheader { width: 100%; }
 #post_content, #reply_content {
   width: 100%;
   display: block;
+  font-size: $font_size_small;
 }
 
 #reply_content { height: 130px; }

--- a/app/assets/stylesheets/tinymce.scss
+++ b/app/assets/stylesheets/tinymce.scss
@@ -1,8 +1,6 @@
 @import 'variables';
 
 body {
-  font-family: Helvetica, sans-serif;
-  font-size: $font_size_small;
   background-color: $bg_color_input;
 
   blockquote {

--- a/app/assets/stylesheets/tinymce.scss
+++ b/app/assets/stylesheets/tinymce.scss
@@ -2,6 +2,7 @@
 
 body {
   background-color: $bg_color_input;
+  font-size: 87.5%;
 
   blockquote {
     background-color: calculate-transparent-color($bg_color_input, #EAEAEA, 0.2);


### PR DESCRIPTION
Declaring font-size for the RTF editor in rem is confusing it into sometimes adding unnecessary font-size spans. Using percent instead fixes it. Why? WHO KNOWS.

Also, to make things consistent, we now use just sans-serif in the RTF editor like the rest of the site instead of Helvetica, sans-serif.