### PR TITLE
Rename board(s)_path routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
   def logout_required
     if logged_in?
       flash[:error] = "You are already logged in."
-      redirect_to boards_path
+      redirect_to continuities_path
     end
   end
 

--- a/app/controllers/board_sections_controller.rb
+++ b/app/controllers/board_sections_controller.rb
@@ -13,7 +13,7 @@ class BoardSectionsController < ApplicationController
     @board_section = BoardSection.new(section_params)
     unless @board_section.board.nil? || @board_section.board.editable_by?(current_user)
       flash[:error] = "You do not have permission to edit this continuity."
-      redirect_to boards_path and return
+      redirect_to continuities_path and return
     end
 
     begin
@@ -27,7 +27,7 @@ class BoardSectionsController < ApplicationController
       render :new
     else
       flash[:success] = "New section, #{@board_section.name}, has successfully been created for #{@board_section.board.name}."
-      redirect_to edit_board_path(@board_section.board)
+      redirect_to edit_continuity_path(@board_section.board)
     end
   end
 
@@ -76,7 +76,7 @@ class BoardSectionsController < ApplicationController
       redirect_to board_section_path(@board_section)
     else
       flash[:success] = "Section deleted."
-      redirect_to edit_board_path(@board_section.board)
+      redirect_to edit_continuity_path(@board_section.board)
     end
   end
 
@@ -86,7 +86,7 @@ class BoardSectionsController < ApplicationController
     @board_section = BoardSection.find_by_id(params[:id])
     unless @board_section
       flash[:error] = "Section not found."
-      redirect_to boards_path and return
+      redirect_to continuities_path and return
     end
   end
 
@@ -94,7 +94,7 @@ class BoardSectionsController < ApplicationController
     board = @board_section.try(:board) || Board.find_by_id(params[:board_id])
     if board && !board.editable_by?(current_user)
       flash[:error] = "You do not have permission to edit this continuity."
-      redirect_to boards_path and return
+      redirect_to continuities_path and return
     end
   end
 

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -181,7 +181,7 @@ class BoardsController < ApplicationController
     desc = [metadata.join(' – ')]
     desc << generate_short(@board.description) if @board.description.present?
     {
-      url: board_url(@board),
+      url: continuity_url(@board),
       title: @board.name,
       description: desc.join("\n"),
     }

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -49,7 +49,7 @@ class BoardsController < ApplicationController
       render :new
     else
       flash[:success] = "Continuity created!"
-      redirect_to boards_path
+      redirect_to continuities_path
     end
   end
 
@@ -89,7 +89,7 @@ class BoardsController < ApplicationController
       render :edit
     else
       flash[:success] = "Continuity saved!"
-      redirect_to board_path(@board)
+      redirect_to continuity_path(@board)
     end
   end
 
@@ -101,10 +101,10 @@ class BoardsController < ApplicationController
         message: "Continuity could not be deleted.",
         array: @board.errors.full_messages
       }
-      redirect_to board_path(@board)
+      redirect_to continuity_path(@board)
     else
       flash[:success] = "Continuity deleted."
-      redirect_to boards_path
+      redirect_to continuities_path
     end
   end
 
@@ -159,14 +159,14 @@ class BoardsController < ApplicationController
   def find_board
     unless (@board = Board.find_by_id(params[:id]))
       flash[:error] = "Continuity could not be found."
-      redirect_to boards_path and return
+      redirect_to continuities_path and return
     end
   end
 
   def require_permission
     unless @board.editable_by?(current_user)
       flash[:error] = "You do not have permission to edit that continuity."
-      redirect_to board_path(@board) and return
+      redirect_to continuity_path(@board) and return
     end
   end
 

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -33,9 +33,9 @@ class FavoritesController < ApplicationController
     elsif params[:board_id].present?
       unless (favorite = Board.find_by_id(params[:board_id]))
         flash[:error] = "Continuity could not be found."
-        redirect_to boards_path and return
+        redirect_to continuities_path and return
       end
-      fav_path = board_path(favorite)
+      fav_path = continuity_path(favorite)
     elsif params[:post_id].present?
       unless (favorite = Post.find_by_id(params[:post_id]))
         flash[:error] = "Post could not be found."
@@ -47,7 +47,7 @@ class FavoritesController < ApplicationController
       fav_path = post_path(favorite, params)
     else
       flash[:error] = "No favorite specified."
-      redirect_to boards_path and return
+      redirect_to continuities_path and return
     end
 
     fav = Favorite.new
@@ -92,7 +92,7 @@ class FavoritesController < ApplicationController
       elsif fav.favorite_type == Post.to_s
         redirect_to post_path(fav.favorite)
       else
-        redirect_to board_path(fav.favorite)
+        redirect_to continuity_path(fav.favorite)
       end
     end
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -242,7 +242,7 @@ class PostsController < WritableController
       redirect_to post_path(@post)
     else
       flash[:success] = "Post deleted."
-      redirect_to boards_path
+      redirect_to continuities_path
     end
   end
 
@@ -409,12 +409,12 @@ class PostsController < WritableController
 
     unless @post
       flash[:error] = "Post could not be found."
-      redirect_to boards_path and return
+      redirect_to continuities_path and return
     end
 
     unless @post.visible_to?(current_user)
       flash[:error] = "You do not have permission to view this post."
-      redirect_to boards_path and return
+      redirect_to continuities_path and return
     end
 
     @page_title = @post.subject

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -214,7 +214,7 @@ class RepliesController < WritableController
     audit = Audited::Audit.where(action: 'destroy').order(id: :desc).find_by(auditable_id: params[:id])
     unless audit
       flash[:error] = "Reply could not be found."
-      redirect_to boards_path and return
+      redirect_to continuities_path and return
     end
 
     if audit.auditable
@@ -252,13 +252,13 @@ class RepliesController < WritableController
 
     unless @reply
       flash[:error] = "Post could not be found."
-      redirect_to boards_path and return
+      redirect_to continuities_path and return
     end
 
     @post = @reply.post
     unless @post.visible_to?(current_user)
       flash[:error] = "You do not have permission to view this post."
-      redirect_to boards_path and return
+      redirect_to continuities_path and return
     end
 
     @page_title = @post.subject

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -34,7 +34,7 @@ class SessionsController < ApplicationController
       session[:user_id] = user.id
       cookies.permanent.signed[:user_id] = cookie_hash(user.id) if params[:remember_me].present?
       @current_user = user
-      redirect_to boards_path and return if session[:previous_url] == '/login'
+      redirect_to continuities_path and return if session[:previous_url] == '/login'
     else
       flash[:error] = "You have entered an incorrect password."
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -143,7 +143,7 @@ class UsersController < ApplicationController
   def require_own_user
     unless params[:id] == current_user.id.to_s
       flash[:error] = "You do not have permission to edit that user."
-      redirect_to(boards_path)
+      redirect_to(continuities_path)
     end
   end
 

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -11,9 +11,9 @@ module WritableHelper
     post_path(post, page: 'unread', anchor: 'unread', **kwargs)
   end
 
-  def anchored_board_path(post)
-    return board_path(post.board_id) unless post.section_id.present?
-    board_path(post.board_id, anchor: "section-#{post.section_id}")
+  def anchored_continuity_path(post)
+    return continuity_path(post.board_id) unless post.section_id.present?
+    continuity_path(post.board_id, anchor: "section-#{post.section_id}")
   end
 
   def dropdown_icons(item, galleries=nil)

--- a/app/views/board_sections/edit.haml
+++ b/app/views/board_sections/edit.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
-  = link_to "Continuities", boards_path
+  = link_to "Continuities", continuities_path
   &raquo;
-  = link_to @board_section.board.name, board_path(@board_section.board)
+  = link_to @board_section.board.name, continuity_path(@board_section.board)
   &raquo;
   = link_to @board_section.name, board_section_path(@board_section)
   &raquo;

--- a/app/views/board_sections/show.haml
+++ b/app/views/board_sections/show.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
-  = link_to "Continuities", boards_path
+  = link_to "Continuities", continuities_path
   &raquo;
-  = link_to @board_section.board.name, board_path(@board_section.board)
+  = link_to @board_section.board.name, continuity_path(@board_section.board)
   &raquo;
   %b= @board_section.name
 

--- a/app/views/boards/_list_item.haml
+++ b/app/views/boards/_list_item.haml
@@ -1,6 +1,6 @@
 %tr
   - klass = cycle('even', 'odd')
-  %td.padding-10.board-title{class: klass}= link_to board.name, board_path(board)
+  %td.padding-10.board-title{class: klass}= link_to board.name, continuity_path(board)
   %td.padding-10.board-authors{class: klass}
     - if board.authors_locked?
       = safe_join(board.writers.where.not(deleted: true).ordered.map { |u| user_link(u) }, ', ')

--- a/app/views/boards/edit.haml
+++ b/app/views/boards/edit.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
-  = link_to "Continuities", boards_path
+  = link_to "Continuities", continuities_path
   &raquo;
-  = link_to @board.name, board_path(@board)
+  = link_to @board.name, continuity_path(@board)
   &raquo;
   %b Edit
 

--- a/app/views/boards/index.haml
+++ b/app/views/boards/index.haml
@@ -12,11 +12,11 @@
       %th.table-title{colspan: 3}
         = @page_title
         - if logged_in? && (@user.nil? || @user.id == current_user.id)
-          = link_to new_board_path do
+          = link_to new_continuity_path do
             .link-box.action-new + New Continuity
     %tr
       %th.subber.padding-10{colspan: 3}
-        = form_tag search_boards_path, method: :get do
+        = form_tag search_continuities_path, method: :get do
           = label_tag :name, 'Search by name:'
           = text_field_tag :name, params[:name], style: 'margin: 0px 5px;', id: :name
           = submit_tag "Search", class: 'button'

--- a/app/views/boards/new.haml
+++ b/app/views/boards/new.haml
@@ -1,4 +1,4 @@
-= form_for @board, url: boards_path, method: :post do |f|
+= form_for @board, url: continuities_path, method: :post do |f|
   %table.form-table
     %thead
       %tr

--- a/app/views/boards/search.haml
+++ b/app/views/boards/search.haml
@@ -13,7 +13,7 @@
   %tbody
     %tr
       %td.search-box
-        = form_tag search_boards_path, method: :get do
+        = form_tag search_continuities_path, method: :get do
           %table.search-form
             %tr
               %td.width-70= label_tag :name, 'Name'

--- a/app/views/boards/show.haml
+++ b/app/views/boards/show.haml
@@ -1,5 +1,5 @@
 - content_for :breadcrumbs do
-  = link_to "Continuities", boards_path
+  = link_to "Continuities", continuities_path
   &raquo;
   %b= @board.name
 
@@ -12,11 +12,11 @@
     - if @board.editable_by?(current_user)
       = link_to new_board_section_path params: {board_id: @board.id} do
         .link-box.action-new + New Section
-      = link_to edit_board_path(@board) do
+      = link_to edit_continuity_path(@board) do
         .link-box.action-edit
           = image_tag "icons/pencil.png", alt: ''
           Edit
-      = link_to board_path(@board), method: :delete, data: { confirm: 'Are you sure you want to delete this continuity?' } do
+      = link_to continuity_path(@board), method: :delete, data: { confirm: 'Are you sure you want to delete this continuity?' } do
         .link-box.action-delete x Delete
     - if (fav = Favorite.between(current_user, @board))
       = link_to favorite_path(fav), method: :delete do

--- a/app/views/favorites/index.haml
+++ b/app/views/favorites/index.haml
@@ -24,7 +24,7 @@
             - if favorite_rec.favorite.is_a? User
               = user_link(favorite_rec.favorite)
             - elsif favorite_rec.favorite.is_a? Board
-              = link_to favorite_rec.favorite.name, board_path(favorite_rec.favorite)
+              = link_to favorite_rec.favorite.name, continuity_path(favorite_rec.favorite)
             - else
               = link_to favorite_rec.favorite.subject, post_path(favorite_rec.favorite)
           %td{class: klass}= favorite_rec.favorite_type == 'Board' ? 'Continuity' : favorite_rec.favorite_type

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -103,7 +103,7 @@
                   = link_to "Forgot Password?", new_password_reset_path
         #nav-bottom
           %ul
-            %li= link_to 'Continuities', boards_path
+            %li= link_to 'Continuities', continuities_path
             %li= link_to 'Recently Updated', posts_path
             %li= link_to 'Search', search_posts_path
             %li= link_to 'Users', users_path

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -41,7 +41,7 @@
             - (total_pages-2).upto(total_pages) do |index|
               = link_to index, post_path(post, page: index)
   - unless local_assigns[:hide_continuity]
-    %td.post-board.vtop{class: klass}= link_to post.board_name, anchored_board_path(post)
+    %td.post-board.vtop{class: klass}= link_to post.board_name, anchored_continuity_path(post)
   %td.post-authors.vtop{class: klass}= author_links(post)
   %td.width-70.post-replies.vtop{class: klass}= link_to replies_count, stats_post_path(post)
   - if logged_in? && local_assigns[:show_unread_count]

--- a/app/views/posts/delete_history.haml
+++ b/app/views/posts/delete_history.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
-  = link_to "Continuities", boards_path
+  = link_to "Continuities", continuities_path
   &raquo;
-  = link_to @post.board.name, board_path(@post.board)
+  = link_to @post.board.name, continuity_path(@post.board)
   &raquo;
   = link_to @post.subject, post_path(@post)
   &raquo;

--- a/app/views/posts/edit.haml
+++ b/app/views/posts/edit.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
-  = link_to "Continuities", boards_path
+  = link_to "Continuities", continuities_path
   &raquo;
-  = link_to @post.board.name, board_path(@post.board)
+  = link_to @post.board.name, continuity_path(@post.board)
   - if @post.section
     &raquo;
     = link_to @post.section.name, board_section_path(@post.section)

--- a/app/views/posts/hidden.haml
+++ b/app/views/posts/hidden.haml
@@ -14,7 +14,7 @@
           - klass = cycle('even, odd')
           %td.padding-10{class: klass}
           %td.padding-10{class: klass, colspan: 5}
-            = link_to view.board.name, board_path(view.board)
+            = link_to view.board.name, continuity_path(view.board)
           %td{class: klass}= check_box_tag :"unhide_boards[]", view.board_id, params[:unhide_boards].try(:include?, view.board_id.to_s), class: 'no-margin'
       - if @hidden_boardviews.empty?
         %tr

--- a/app/views/posts/history.haml
+++ b/app/views/posts/history.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
-  = link_to "Continuities", boards_path
+  = link_to "Continuities", continuities_path
   &raquo;
-  = link_to @post.board.name, board_path(@post.board)
+  = link_to @post.board.name, continuity_path(@post.board)
   &raquo;
   = link_to @post.subject, post_path(@post)
   &raquo;

--- a/app/views/posts/show.haml
+++ b/app/views/posts/show.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
-  = link_to "Continuities".freeze, boards_path
+  = link_to "Continuities".freeze, continuities_path
   &raquo;
-  = link_to @post.board.name, board_path(@post.board)
+  = link_to @post.board.name, continuity_path(@post.board)
   - if @post.section
     &raquo;
     = link_to @post.section.name, board_section_path(@post.section)

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
-  = link_to "Continuities", boards_path
+  = link_to "Continuities", continuities_path
   &raquo;
-  = link_to @post.board.name, board_path(@post.board)
+  = link_to @post.board.name, continuity_path(@post.board)
   - if @post.section
     &raquo;
     = link_to @post.section.name, board_section_path(@post.section)

--- a/app/views/posts/unread.haml
+++ b/app/views/posts/unread.haml
@@ -23,7 +23,7 @@
           = submit_tag "Mark Read", class: 'button'
 %br
 
-= form_tag mark_boards_path, :method => :post do
+= form_tag mark_continuities_path, :method => :post do
   %table.float-left.form-table{style: 'margin-bottom: 10px;'}
     %thead
       %tr

--- a/app/views/replies/history.haml
+++ b/app/views/replies/history.haml
@@ -1,7 +1,7 @@
 - content_for :breadcrumbs do
-  = link_to "Continuities", boards_path
+  = link_to "Continuities", continuities_path
   &raquo;
-  = link_to @reply.post.board.name, board_path(@reply.post.board)
+  = link_to @reply.post.board.name, continuity_path(@reply.post.board)
   &raquo;
   = link_to @reply.post.subject, post_path(@reply.post)
   &raquo;

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -57,7 +57,7 @@
             - if post.description.present?
               %br
               %span.details= sanitize_simple_link_text(post.description)
-          %td.vtop.post-board{class: klass}= link_to post.board_name, board_path(post.board_id)
+          %td.vtop.post-board{class: klass}= link_to post.board_name, continuity_path(post.board_id)
           %td.vtop.post-authors{class: klass}= author_links(post, colored: true)
           %td.vtop.centered.post-replies{class: klass}= link_to post.reply_count, stats_post_path(post)
           %td.vtop.centered.post-replies{class: klass}= link_to @reply_counts[post.id].to_i, post_or_reply_mem_link(**@link_targets[post.id].except(:created_at))

--- a/app/views/search/_breadcrumbs.haml
+++ b/app/views/search/_breadcrumbs.haml
@@ -13,4 +13,4 @@
     |
     = link_to_unless_current "Users", search_users_path
     |
-    = link_to_unless_current "Continuities", search_boards_path
+    = link_to_unless_current "Continuities", search_continuities_path

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -33,7 +33,7 @@
     -# TODO tags
     %tr
       %td.centered{class: cycle('even', 'odd')}
-        = link_to user_boards_path(@user) do
+        = link_to user_continuities_path(@user) do
           = image_tag "icons/table.png", class: 'vmid', alt: ''
           Continuities
     %tr

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -33,7 +33,7 @@
     -# TODO tags
     %tr
       %td.centered{class: cycle('even', 'odd')}
-        = link_to user_continuities_path(@user) do
+        = link_to user_boards_path(@user) do
           = image_tag "icons/table.png", class: 'vmid', alt: ''
           Continuities
     %tr

--- a/app/views/writable/_history.haml
+++ b/app/views/writable/_history.haml
@@ -43,12 +43,12 @@
           %td{class: cycle('even', 'odd')}
             Changed from
             - if (board = Board.find_by_id(audit.audited_changes['board_id'][0]))
-              %b= link_to board.name, board_path(board)
+              %b= link_to board.name, continuity_path(board)
             - else
               %b [Deleted]
             to
             - if cur.board
-              %b= link_to cur.board.name, board_path(cur.board)
+              %b= link_to cur.board.name, continuity_path(cur.board)
             - else
               %b [Deleted]
       - if audit.action == 'update' && audit.audited_changes.key?('privacy')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
   end
 
   # Forums
-  resources :boards do
+  resources :boards, as: :continuities do
     collection do
       post :mark
       get :search

--- a/spec/controllers/board_sections_controller_spec.rb
+++ b/spec/controllers/board_sections_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BoardSectionsController do
       login_as(user)
 
       get :new, params: { board_id: board.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to edit this continuity.")
     end
 
@@ -49,7 +49,7 @@ RSpec.describe BoardSectionsController do
       login_as(user)
 
       post :create, params: { board_section: {board_id: board.id} }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to edit this continuity.")
     end
 
@@ -76,7 +76,7 @@ RSpec.describe BoardSectionsController do
       login_as(board.creator)
       section_name = 'ValidSection'
       post :create, params: { board_section: {board_id: board.id, name: section_name} }
-      expect(response).to redirect_to(edit_board_url(board))
+      expect(response).to redirect_to(edit_continuity_url(board))
       expect(flash[:success]).to eq("New section, #{section_name}, has successfully been created for #{board.name}.")
       expect(assigns(:board_section).name).to eq(section_name)
     end
@@ -85,7 +85,7 @@ RSpec.describe BoardSectionsController do
   describe "GET show" do
     it "requires valid section" do
       get :show, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Section not found.")
     end
 
@@ -156,7 +156,7 @@ RSpec.describe BoardSectionsController do
     it "requires valid section" do
       login
       get :edit, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Section not found.")
     end
 
@@ -164,7 +164,7 @@ RSpec.describe BoardSectionsController do
       section = create(:board_section)
       login
       get :edit, params: { id: section.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to edit this continuity.")
     end
 
@@ -192,7 +192,7 @@ RSpec.describe BoardSectionsController do
       expect(board_section.board).not_to be_editable_by(user)
 
       put :update, params: { id: board_section.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to edit this continuity.")
     end
 
@@ -226,7 +226,7 @@ RSpec.describe BoardSectionsController do
     it "requires valid section" do
       login
       delete :destroy, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Section not found.")
     end
 
@@ -234,7 +234,7 @@ RSpec.describe BoardSectionsController do
       section = create(:board_section)
       login
       delete :destroy, params: { id: section.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to edit this continuity.")
     end
 
@@ -242,7 +242,7 @@ RSpec.describe BoardSectionsController do
       section = create(:board_section)
       login_as(section.board.creator)
       delete :destroy, params: { id: section.id }
-      expect(response).to redirect_to(edit_board_url(section.board))
+      expect(response).to redirect_to(edit_continuity_url(section.board))
       expect(flash[:success]).to eq("Section deleted.")
       expect(BoardSection.find_by_id(section.id)).to be_nil
     end

--- a/spec/controllers/boards_controller_spec.rb
+++ b/spec/controllers/boards_controller_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe BoardsController do
           cameo_ids: [user3.id]
         }
       }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:success]).to eq("Continuity created!")
       expect(Board.count).to eq(1)
 
@@ -196,7 +196,7 @@ RSpec.describe BoardsController do
   describe "GET show" do
     it "requires valid board" do
       get :show, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Continuity could not be found.")
     end
 
@@ -263,7 +263,7 @@ RSpec.describe BoardsController do
 
       meta_og = assigns(:meta_og)
       expect(meta_og.keys).to match_array([:url, :title, :description])
-      expect(meta_og[:url]).to eq(board_url(board))
+      expect(meta_og[:url]).to eq(continuity_url(board))
       expect(meta_og[:title]).to eq('board')
       expect(meta_og[:description]).to eq("Jane Doe, John Doe – 1 post\nsample board")
     end
@@ -279,7 +279,7 @@ RSpec.describe BoardsController do
     it "requires valid board" do
       login
       get :edit, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Continuity could not be found.")
     end
 
@@ -289,7 +289,7 @@ RSpec.describe BoardsController do
       board = create(:board)
       expect(board).not_to be_editable_by(user)
       get :edit, params: { id: board.id }
-      expect(response).to redirect_to(board_url(board))
+      expect(response).to redirect_to(continuity_url(board))
       expect(flash[:error]).to eq("You do not have permission to edit that continuity.")
     end
 
@@ -324,7 +324,7 @@ RSpec.describe BoardsController do
     it "requires valid board" do
       login
       put :update, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Continuity could not be found.")
     end
 
@@ -334,7 +334,7 @@ RSpec.describe BoardsController do
       board = create(:board)
       expect(board).not_to be_editable_by(user)
       put :update, params: { id: board.id }
-      expect(response).to redirect_to(board_url(board))
+      expect(response).to redirect_to(continuity_url(board))
       expect(flash[:error]).to eq("You do not have permission to edit that continuity.")
     end
 
@@ -364,7 +364,7 @@ RSpec.describe BoardsController do
           cameo_ids: [user3.id]
         }
       }
-      expect(response).to redirect_to(board_url(board))
+      expect(response).to redirect_to(continuity_url(board))
       expect(flash[:success]).to eq("Continuity saved!")
       board.reload
       expect(board.name).to eq(name + 'edit')
@@ -384,7 +384,7 @@ RSpec.describe BoardsController do
     it "requires valid board" do
       login
       delete :destroy, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Continuity could not be found.")
     end
 
@@ -394,7 +394,7 @@ RSpec.describe BoardsController do
       board = create(:board)
       expect(board).not_to be_editable_by(user)
       delete :destroy, params: { id: board.id }
-      expect(response).to redirect_to(board_url(board))
+      expect(response).to redirect_to(continuity_url(board))
       expect(flash[:error]).to eq("You do not have permission to edit that continuity.")
     end
 
@@ -402,7 +402,7 @@ RSpec.describe BoardsController do
       board = create(:board)
       login_as(board.creator)
       delete :destroy, params: { id: board.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:success]).to eq("Continuity deleted.")
     end
 
@@ -415,7 +415,7 @@ RSpec.describe BoardsController do
       perform_enqueued_jobs(only: UpdateModelJob) do
         delete :destroy, params: { id: board.id }
       end
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:success]).to eq('Continuity deleted.')
       post.reload
       expect(post.board_id).to eq(3)
@@ -429,7 +429,7 @@ RSpec.describe BoardsController do
       login_as(board.creator)
       expect_any_instance_of(Board).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed, 'fake error')
       delete :destroy, params: { id: board.id }
-      expect(response).to redirect_to(board_url(board))
+      expect(response).to redirect_to(continuity_url(board))
       expect(flash[:error]).to eq({message: "Continuity could not be deleted.", array: []})
       expect(post.reload.board).to eq(board)
     end

--- a/spec/controllers/favorites_controller_spec.rb
+++ b/spec/controllers/favorites_controller_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe FavoritesController do
       login_as(user)
       post :create, params: { board_id: board.id }
       expect(Favorite.between(user, board)).not_to be_nil
-      expect(response).to redirect_to(board_url(board))
+      expect(response).to redirect_to(continuity_url(board))
       expect(flash[:success]).to eq("Your favorite has been saved.")
     end
   end
@@ -237,7 +237,7 @@ RSpec.describe FavoritesController do
       favorite = create(:favorite, favorite: create(:board))
       login_as(favorite.user)
       delete :destroy, params: { id: favorite.id }
-      expect(response).to redirect_to(board_url(favorite.favorite))
+      expect(response).to redirect_to(continuity_url(favorite.favorite))
       expect(flash[:success]).to eq("Favorite removed.")
     end
 

--- a/spec/controllers/favorites_controller_spec.rb
+++ b/spec/controllers/favorites_controller_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe FavoritesController do
     it "requires a valid param" do
       login
       post :create
-      expect(response).to redirect_to(boards_path)
+      expect(response).to redirect_to(continuities_path)
       expect(flash[:error]).to eq('No favorite specified.')
     end
 
@@ -149,7 +149,7 @@ RSpec.describe FavoritesController do
     it "requires valid board if given" do
       login
       post :create, params: { board_id: -1 }
-      expect(response).to redirect_to(boards_path)
+      expect(response).to redirect_to(continuities_path)
       expect(flash[:error]).to eq('Continuity could not be found.')
     end
 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -795,7 +795,7 @@ RSpec.describe PostsController do
     it "requires permission" do
       post = create(:post, privacy: Concealable::PRIVATE)
       get :show, params: { id: post.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
 
@@ -1207,7 +1207,7 @@ RSpec.describe PostsController do
     it "requires post" do
       login
       get :history, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
@@ -1236,7 +1236,7 @@ RSpec.describe PostsController do
     it "requires post" do
       login
       get :delete_history, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
@@ -1297,7 +1297,7 @@ RSpec.describe PostsController do
     it "requires post" do
       login
       get :stats, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
@@ -1323,7 +1323,7 @@ RSpec.describe PostsController do
     it "requires post" do
       login
       get :edit, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
@@ -1416,7 +1416,7 @@ RSpec.describe PostsController do
     it "requires valid post" do
       login
       put :update, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
@@ -1427,7 +1427,7 @@ RSpec.describe PostsController do
       expect(post.visible_to?(user)).not_to eq(true)
 
       put :update, params: { id: post.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
 
@@ -2436,14 +2436,14 @@ RSpec.describe PostsController do
   describe "POST warnings" do
     it "requires a valid post" do
       post :warnings, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
     it "requires permission" do
       warn_post = create(:post, privacy: Concealable::PRIVATE)
       post :warnings, params: { id: warn_post.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
 
@@ -2482,7 +2482,7 @@ RSpec.describe PostsController do
     it "requires valid post" do
       login
       delete :destroy, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
@@ -2500,7 +2500,7 @@ RSpec.describe PostsController do
       post = create(:post)
       login_as(post.user)
       delete :destroy, params: { id: post.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:success]).to eq("Post deleted.")
     end
 

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -424,7 +424,7 @@ RSpec.describe RepliesController do
   describe "GET show" do
     it "requires valid reply" do
       get :show, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
@@ -440,7 +440,7 @@ RSpec.describe RepliesController do
 
       login_as(reply.user)
       get :show, params: { id: reply.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
 
@@ -485,7 +485,7 @@ RSpec.describe RepliesController do
   describe "GET history" do
     it "requires valid reply" do
       get :history, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
@@ -501,7 +501,7 @@ RSpec.describe RepliesController do
 
       login_as(reply.user)
       get :history, params: { id: reply.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
 
@@ -529,7 +529,7 @@ RSpec.describe RepliesController do
     it "requires valid reply" do
       login
       get :edit, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
@@ -545,7 +545,7 @@ RSpec.describe RepliesController do
 
       login_as(reply.user)
       get :edit, params: { id: reply.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
 
@@ -595,7 +595,7 @@ RSpec.describe RepliesController do
     it "requires valid reply" do
       login
       put :update, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
@@ -611,7 +611,7 @@ RSpec.describe RepliesController do
 
       login_as(reply.user)
       put :update, params: { id: reply.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
 
@@ -796,7 +796,7 @@ RSpec.describe RepliesController do
     it "requires valid reply" do
       login
       delete :destroy, params: { id: -1 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Post could not be found.")
     end
 
@@ -812,7 +812,7 @@ RSpec.describe RepliesController do
 
       login_as(reply.user)
       delete :destroy, params: { id: reply.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You do not have permission to view this post.")
     end
 
@@ -932,7 +932,7 @@ RSpec.describe RepliesController do
       expect(Audited::Audit.find_by(auditable_id: 99)).to be_nil
       login
       post :restore, params: { id: 99 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Reply could not be found.")
     end
 
@@ -941,7 +941,7 @@ RSpec.describe RepliesController do
       Audited::Audit.where(action: 'create').find_by(auditable_id: reply.id).update!(action: 'destroy')
       login_as(reply.user)
       post :restore, params: { id: 99 }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("Reply could not be found.")
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SessionsController do
     it "redirects when logged in" do
       login
       get :new
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You are already logged in.")
     end
   end
@@ -52,7 +52,7 @@ RSpec.describe SessionsController do
     it "redirects when logged in" do
       login
       post :create
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You are already logged in.")
     end
 
@@ -142,7 +142,7 @@ RSpec.describe SessionsController do
     it "redirects when logged in" do
       login
       patch :confirm_tos
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq("You are already logged in.")
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe UsersController do
       user = create(:user)
       login
       get :edit, params: { id: user.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq('You do not have permission to edit that user.')
     end
 
@@ -276,7 +276,7 @@ RSpec.describe UsersController do
       user2 = create(:user)
       login_as(user1)
       put :update, params: { id: user2.id, user: {email: 'bademail@example.com'} }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq('You do not have permission to edit that user.')
       expect(user2.reload.email).not_to eq('bademail@example.com')
     end
@@ -359,7 +359,7 @@ RSpec.describe UsersController do
       user = create(:user)
       login
       put :password, params: { id: user.id }
-      expect(response).to redirect_to(boards_url)
+      expect(response).to redirect_to(continuities_url)
       expect(flash[:error]).to eq('You do not have permission to edit that user.')
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe UsersController do
     it "complains when logged in" do
       login
       post :create
-      expect(response).to redirect_to(boards_path)
+      expect(response).to redirect_to(continuities_path)
       expect(flash[:error]).to eq('You are already logged in.')
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe UsersController do
     it "complains when logged in" do
       login
       post :create
-      expect(response).to redirect_to(boards_path)
+      expect(response).to redirect_to(continuities_path)
       expect(flash[:error]).to eq('You are already logged in.')
     end
 

--- a/spec/features/boards/show_spec.rb
+++ b/spec/features/boards/show_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Show a single continuity", :type => :feature do
     board = create(:board, name: "Test board")
     create_list(:post, 5, board: board, user: board.creator)
 
-    visit board_path(board)
+    visit continuity_path(board)
 
     expect(page).to have_text("Test board")
     expect(page).to have_selector('.post-subject', count: 5)
@@ -18,7 +18,7 @@ RSpec.feature "Show a single continuity", :type => :feature do
     post2 = create(:post, board: board, user: board.creator)
     create_list(:reply, 4, post: post2)
 
-    visit board_path(board)
+    visit continuity_path(board)
 
     expect(page).to have_text("Author board")
     expect(page).to have_selector('.post-subject', count: 2)
@@ -49,7 +49,7 @@ RSpec.feature "Show a single continuity", :type => :feature do
     del_user1.archive
     del_user2.archive
 
-    visit board_path(board)
+    visit continuity_path(board)
 
     expect(page).to have_text("Test board")
     expect(page).to have_selector('.post-subject', count: 4)

--- a/spec/features/sessions/destroy_spec.rb
+++ b/spec/features/sessions/destroy_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Logging out", :type => :feature do
     expect(page).to have_current_path(root_path)
 
     # make sure we're still logged out after navigating somewhere else
-    visit boards_path
+    visit continuities_path
     expect(page).to have_no_selector('.flash')
     expect(page).to have_no_selector('#user-info')
   end

--- a/spec/features/sessions/new_spec.rb
+++ b/spec/features/sessions/new_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Logging in", :type => :feature do
       click_on 'Sign In'
     end
 
-    expect(page).to have_current_path(boards_path)
+    expect(page).to have_current_path(continuities_path)
     expect(page).to have_no_selector('.flash.error')
     expect(page).to have_selector('.flash.success', text: 'You are now logged in as Test user. Welcome back!')
     expect(page).to have_no_selector('#username')
@@ -58,7 +58,7 @@ RSpec.feature "Logging in", :type => :feature do
     login
 
     visit login_path
-    expect(page).to have_current_path(boards_path)
+    expect(page).to have_current_path(continuities_path)
     expect(page).to have_selector('.flash.error', text: 'You are already logged in.')
     expect(page).to have_no_selector('#username')
   end

--- a/spec/helpers/writable_helper_spec.rb
+++ b/spec/helpers/writable_helper_spec.rb
@@ -16,16 +16,16 @@ RSpec.describe WritableHelper do
     end
   end
 
-  describe "#anchored_board_path" do
+  describe "#anchored_continuity_path" do
     it "anchors for sectioned post" do
       section = create(:board_section)
       post = create(:post, board: section.board, section: section)
-      expect(helper.anchored_board_path(post)).to eq(board_path(post.board_id) + "#section-" + section.id.to_s)
+      expect(helper.anchored_continuity_path(post)).to eq(continuity_path(post.board_id) + "#section-" + section.id.to_s)
     end
 
     it "does not anchor for unsectioned post" do
       post = create(:post)
-      expect(helper.anchored_board_path(post)).to eq(board_path(post.board_id))
+      expect(helper.anchored_continuity_path(post)).to eq(continuity_path(post.board_id))
     end
   end
 


### PR DESCRIPTION
Uses `as: :continuities` to cause routes to be generated as `continuity_path` instead of `board_path`, etc. Does not change the actual URL scheme and is therefore not user facing. Step 1/? in renaming Board to Continuity like a sensible person.