### PR TITLE
Add feature tests

### DIFF
--- a/spec/features/boards/edit_spec.rb
+++ b/spec/features/boards/edit_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.feature "Edit a single continuity", type: :feature do
+  scenario "Continuity can be edited" do
+    board = create(:board, name: "Test board")
+    login(board.creator, 'password')
+    visit continuity_path(board)
+    expect(page).to have_text("Test board")
+    click_link "Edit"
+    fill_in 'Continuity Name', with: 'Edited board'
+    click_button 'Save'
+    expect(page).to have_no_selector('.error')
+    expect(page).to have_selector('.success', text: 'Continuity saved!')
+    expect(page).to have_text("Edited board")
+  end
+end

--- a/spec/features/characters/add_alias_spec.rb
+++ b/spec/features/characters/add_alias_spec.rb
@@ -1,0 +1,15 @@
+RSpec.feature "Adding a character alias", type: :feature do
+  scenario "Adding successfully" do
+    user = login
+    character = create(:character, user: user)
+    visit characters_path
+    click_link character.name
+    click_link "Edit Character"
+    expect(page).not_to have_text("AnAlias")
+    click_link "New Alias"
+    fill_in "Alias", with: "AnAlias"
+    click_button 'Save'
+    expect(page).to have_selector('.success', text: 'Alias created.')
+    expect(page).to have_text("AnAlias")
+  end
+end


### PR DESCRIPTION
I'll probably add more tests later but my route issue on board#edit passed tests because we had no feature tests for it, so the answer is to add feature tests for it. Also adds tests for aliases#new.

Relates to #1097