### PR TITLE
Upgrade Dockerfile chromium to 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     nodejs \
     postgresql-client-11 \
-    chromium=79.* \
+    chromium=80.* \
   && apt-get clean
 
 ARG bundler_version=2.0.2


### PR DESCRIPTION
`chromium=79.*` no longer installs correctly for Buster.

We should maybe take the version constraint off this – not sure it matters too much which version we constrain to, and maybe we should just set a lower bound or something (though that doesn't look straightforward with apt).