### PR TITLE
Fix summary display

### DIFF
--- a/app/assets/stylesheets/normalize.scss
+++ b/app/assets/stylesheets/normalize.scss
@@ -30,6 +30,8 @@ body {
  * Correct `block` display not defined for `main` in IE 11.
  */
 
+/* summary removed from this list due to display: block causing issues with some browsers. */
+
 article,
 aside,
 details,
@@ -41,8 +43,7 @@ hgroup,
 main,
 menu,
 nav,
-section,
-summary {
+section {
   display: block;
 }
 


### PR DESCRIPTION
Firefox does Dumb Things with how `display: block` affects summary 
elements, which we do not want it to do, therefore I have told normalize 
not to set it on summaries. See 
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary#Default_style

Fixes #1390

I recognize that this edits normalize, which is why I commented the relevant line rather than deleting it, but ~~our normalize is really outdated anyway~~ I think this is important to fix