### PR TITLE
Set the WillPaginate per_page default to 25

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,7 +92,7 @@ class ApplicationController < ActionController::Base
 
   def posts_from_relation(relation, no_tests: true, with_pagination: true, select: '', max: false)
     posts = posts_list_relation(relation, no_tests: no_tests, select: select, max: max)
-    posts = posts.paginate(page: page, per_page: 25) if with_pagination
+    posts = posts.paginate(page: page) if with_pagination
     calculate_view_status(posts) if logged_in?
     posts
   end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -23,7 +23,7 @@ class BoardsController < ApplicationController
       @cameo_boards = Board.where(id: BoardAuthor.where(user_id: @user.id, cameo: true).select(:board_id).distinct.pluck(:board_id)).ordered
     else
       @page_title = 'Continuities'
-      @boards = Board.ordered.paginate(page: page, per_page: 25)
+      @boards = Board.ordered.paginate(page: page)
     end
   end
 

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -305,7 +305,7 @@ class CharactersController < ApplicationController
       @search_results = @search_results.where(where_calc.join(' OR '), *(['%' + params[:name].to_s + '%'] * where_calc.length))
     end
 
-    @search_results = @search_results.ordered.paginate(page: page, per_page: 25)
+    @search_results = @search_results.ordered.paginate(page: page)
   end
 
   private

--- a/app/controllers/indexes_controller.rb
+++ b/app/controllers/indexes_controller.rb
@@ -7,7 +7,7 @@ class IndexesController < ApplicationController
 
   def index
     @page_title = "Indexes"
-    @indexes = Index.order('id asc').paginate(per_page: 25, page: page)
+    @indexes = Index.order('id asc').paginate(page: page)
   end
 
   def new

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -14,7 +14,7 @@ class MessagesController < ApplicationController
       from_table = current_user.messages.where(visible_inbox: true).ordered_by_thread.select('distinct on (thread_id) messages.*')
       from_table = from_table.where.not(sender_id: blocked_ids).left_outer_joins(:sender).where('users.deleted IS NULL OR users.deleted = false')
     end
-    @messages = Message.from(from_table).select('*').order('subquery.id desc').paginate(per_page: 25, page: page)
+    @messages = Message.from(from_table).select('*').order('subquery.id desc').paginate(page: page)
     @view = @page_title.downcase
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -282,7 +282,7 @@ class PostsController < WritableController
       post_ids = Reply.where(character_id: params[:character_id]).select(:post_id).distinct.pluck(:post_id)
       @search_results = @search_results.where(character_id: params[:character_id]).or(@search_results.where(id: post_ids))
     end
-    @search_results = posts_from_relation(@search_results).paginate(page: page, per_page: 25)
+    @search_results = posts_from_relation(@search_results).paginate(page: page)
   end
 
   def warnings

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -82,7 +82,7 @@ class RepliesController < WritableController
       .joins(:user)
       .left_outer_joins(:character)
       .with_edit_audit_counts
-      .paginate(page: page, per_page: 25)
+      .paginate(page: page)
       .includes(:post)
 
     unless params[:condensed]

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -27,7 +27,7 @@ class TagsController < ApplicationController
     if @view == 'posts'
       @posts = posts_from_relation(@tag.posts.ordered)
     elsif @view == 'characters'
-      @characters = @tag.characters.includes(:user, :template).ordered.paginate(per_page: 25, page: page)
+      @characters = @tag.characters.includes(:user, :template).ordered.paginate(page: page)
     elsif @view == 'galleries'
       @galleries = @tag.galleries.with_icon_count.ordered_by_name
       use_javascript('galleries/expander')

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
 
   def index
     @page_title = 'Users'
-    @users = User.active.ordered.paginate(page: page, per_page: 25)
+    @users = User.active.ordered.paginate(page: page)
   end
 
   def show
@@ -116,7 +116,7 @@ class UsersController < ApplicationController
     @page_title = 'Search Users'
     return unless params[:commit].present?
     username = '%' + params[:username].to_s + '%'
-    @search_results = User.active.where("username LIKE ?", username).ordered.paginate(per_page: 25, page: page)
+    @search_results = User.active.where("username LIKE ?", username).ordered.paginate(page: page)
   end
 
   def output

--- a/app/services/board/searcher.rb
+++ b/app/services/board/searcher.rb
@@ -6,7 +6,7 @@ class Board::Searcher < Object
   def search(params, page:)
     search_authors(params[:author_id]) if params[:author_id].present?
     @search_results = @search_results.where("name LIKE ?", "%#{params[:name]}%") if params[:name].present?
-    @search_results.ordered.paginate(per_page: 25, page: page)
+    @search_results.ordered.paginate(page: page)
   end
 
   def search_authors(author_ids)

--- a/app/services/tag_searcher.rb
+++ b/app/services/tag_searcher.rb
@@ -10,7 +10,7 @@ class TagSearcher < Object
     @qs = @qs.where(type: tag_type) if tag_type.present?
     @qs = @qs.includes(:user) if tag_type == 'Setting'
     @qs = @qs.where.not(type: 'GalleryGroup') unless tag_type == 'GalleryGroup'
-    @qs.with_character_counts.paginate(per_page: 25, page: page)
+    @qs.with_character_counts.paginate(page: page)
   end
 
   def validate_type!(tag_type)

--- a/app/views/writable/_history.haml
+++ b/app/views/writable/_history.haml
@@ -1,7 +1,7 @@
 .content-header Edit History (Oldest to Newest)
 %table
   %tbody
-    - audits = audited.audits.paginate(per_page: 25, page: page)
+    - audits = audited.audits.paginate(page: page)
     - if audits.total_pages > 1
       %tr
         %td{colspan: 2}= render 'posts/paginator', paginated: audits

--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -49,3 +49,5 @@ module WillPaginate
     end
   end
 end
+
+WillPaginate.per_page = 25


### PR DESCRIPTION
We specify it all over the place because it would otherwise default to 30. Didn't touch any of the stuff using user.per_page, just things that explicitly said "always and only use 25".*

*Except the API, which uses a different pagination gem, which does not presently seem to admit of sensible defaults but I can check on that more later.