### PR TITLE
Live-in-page editor for private post notes

### DIFF
--- a/app/assets/javascripts/posts/edit_notes.js
+++ b/app/assets/javascripts/posts/edit_notes.js
@@ -1,0 +1,88 @@
+var originalValue = '';
+var submittedButton = '';
+
+$(document).ready(function() {
+  originalValue = $("#post_private_note").val();
+
+  $(".edit-private-notes").click(function() {
+    $(".private-note").toggle();
+    $(".private-note-editor").toggle();
+    return false;
+  });
+
+  $(".save-private-note").click(function() {
+    saveNoteChanges();
+    return false;
+  });
+
+  $(".discard-private-note").click(function() {
+    if (confirm('Are you sure you wish to discard your changes?')) {
+      $("#post_private_note").val(originalValue);
+    }
+    return false;
+  });
+
+  $("#dialog-confirm").dialog({
+    resizable: false,
+    autoOpen: false,
+    height: "auto",
+    width: 400,
+    modal: true,
+    dialogClass: "no-close",
+    buttons: {
+      "Save Changes": function() {
+        $(this).dialog("close");
+        saveNoteChanges(function() { $(submittedButton).click(); });
+      },
+      "Discard Changes": function() {
+        $(this).dialog("close");
+        $("#post_private_note").val(originalValue);
+        $(submittedButton).click();
+      },
+      "Cancel": function() {
+        $(this).dialog("close");
+      }
+    }
+  });
+
+  var formButtons = $("#submit_button, #draft_button, #preview_button");
+  formButtons.click(function() {
+    submittedButton = "#" + $(this).attr('id');
+    formButtons.not(this).prop('disabled', true);
+    if ($("#post_private_note").val() === originalValue) { return true; }
+    formButtons.not(this).prop('disabled', false);
+    $("#dialog-confirm").dialog("open");
+    return false;
+  });
+});
+
+function noteFromData(note, encodedNote) {
+  if (note) { return decodeURI(encodedNote); }
+  return $("<em>").html("(You haven't written a note yet!)");
+}
+
+function saveNoteChanges(success) {
+  $(".loading").show();
+
+  var newNote = $("#post_private_note").val();
+  var postID = $("#reply_post_id").val();
+
+  $.authenticatedAjax({
+    url: '/api/v1/posts/'+postID,
+    type: 'PATCH',
+    data: {'private_note': newNote},
+    success: function(data) {
+      originalValue = newNote;
+      $(".loading").hide();
+      $(".private-note").html(noteFromData(newNote, data.private_note));
+      $(".private-note-editor").hide();
+      $(".private-note").show();
+      $(".saveconf").show().delay(2000).fadeOut();
+      if (typeof success !== 'undefined') { success(); }
+    },
+    error: function() {
+      $(".loading").hide();
+      $(".saveerror").show();
+    }
+  });
+}

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -1,4 +1,6 @@
+//= require posts/edit_notes
 /* global gon, tinyMCE, resizeScreenname, createTagSelect, createSelect2 */
+
 var tinyMCEInit = false, shownIcons = [];
 var PRIVACY_ACCESS = 2; // TODO don't hardcode
 var iconSelectBox;
@@ -6,11 +8,6 @@ var iconSelectBox;
 $(document).ready(function() {
   setupMetadataEditor();
   iconSelectBox = $('#reply-icon-selector');
-
-  var formButtons = $("#submit_button, #draft_button, #preview_button");
-  formButtons.click(function() {
-    formButtons.not(this).data('disable-with', '').prop('disabled', true);
-  });
 
   if ($("#post-editor .view-button").length > 0) setupWritableEditor();
 });

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -526,3 +526,7 @@ The copy box can't be invisible/hidden or copy fails but opacity works
   th.sub { width: 150px; }
   textarea { height: 400px; }
 }
+
+.no-close .ui-dialog-titlebar-close {
+  display: none;
+}

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -305,6 +305,20 @@ div.post-subheader { width: 100%; }
   }
 }
 
+.private-note-editor {
+  #post_private_note {
+    width: 100%;
+    height: calc(100% - 50px);
+  }
+}
+
+.loading {
+  width: 16px;
+  height: 16px;
+}
+
+.post-note-editor { margin: 5px; }
+
 .details {
   display: inline;
   font-size: $font_size_smaller;

--- a/app/controllers/api/v1/index_posts_controller.rb
+++ b/app/controllers/api/v1/index_posts_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::IndexPostsController < Api::ApiController
   before_action :login_required
   resource_description do
+    name 'Index Posts'
     description 'Viewing and editing index posts'
   end
 

--- a/app/views/replies/_write.haml
+++ b/app/views/replies/_write.haml
@@ -26,14 +26,31 @@
       = submit_tag "Preview", class: 'button', id: 'preview_button', name: 'button_preview', data: { disable_with: 'Previewing...' }
       - if reply.new_record?
         = submit_tag "Save Draft", class: 'button', id: 'draft_button', data: { disable_with: 'Drafting...' }, name: 'button_draft'
-    - if reply.post.author_for(current_user)&.private_note.present?
+    - if reply.post.author_for(current_user).present?
       %hr.clear
-      %b Your Post Notes
-      &nbsp;
-      = link_to edit_post_path(reply.post, anchor: 'post-notes') do
-        = image_tag "icons/pencil.png".freeze, title: 'Edit', alt: 'Edit'
-      %br
-      = sanitize_written_content(reply.post.author_for(current_user).private_note)
+      .post-note-editor
+        .loading.float-right.hidden
+          = image_tag 'icons/loading.gif', title: 'Loading...', class: 'vmid', alt: 'Loading...'
+        .saveerror.float-right.hidden
+          = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: ''
+          Error, please try again
+        .saveconf.float-right.hidden
+          = image_tag "icons/accept.png", title: 'Saved', class: 'vmid', alt: ''
+          Saved
+        %b Your Author Notes
+        = image_tag "icons/pencil.png".freeze, title: 'Edit', alt: 'Edit', class: 'edit-private-notes pointer'
+        %br
+        .private-note
+          - if (note = reply.post.author_for(current_user).private_note).present?
+            = sanitize_written_content(note)
+          - else
+            %em (You haven't written a note yet!)
+        .private-note-editor.hidden
+          = text_area_tag :private_note, params[:private_note] || reply.post.author_for(current_user).private_note, id: 'post_private_note'
+          = submit_tag 'Save', class: 'save-private-note button'
+          = submit_tag 'Discard Changes', class: 'discard-private-note button'
+        #dialog-confirm{title: "Your author note has unsaved changes!"}
+          %p What would you like to do with your unsaved changes?
     - else
       %br
     = render 'posts/editor_help'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,7 +130,7 @@ Rails.application.routes.draw do
       resources :index_sections, only: [] do
         collection { post :reorder }
       end
-      resources :posts, only: [:index, :show] do
+      resources :posts, only: [:index, :show, :update] do
         resources :replies, only: :index
         collection { post :reorder }
       end

--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -152,7 +152,7 @@
             "id": 1,
             "subject": "test subject 1",
             "created_at": "2019-01-02T03:04:05.000Z",
-            "status": 0,
+            "status": "active",
             "section_order": 0,
             "description": "",
             "tagged_at": "2019-01-02T03:04:05.000Z",
@@ -1276,7 +1276,7 @@
         "id": 1,
         "subject": "test subject 28",
         "created_at": "2019-12-25T21:34:56.000Z",
-        "status": 0,
+        "status": "active",
         "section_order": 0,
         "description": "",
         "tagged_at": "2019-12-25T21:34:56.000Z",
@@ -1303,6 +1303,105 @@
           "url": "http://www.fakeicon.com",
           "keyword": "totally fake 11"
         }
+      },
+      "code": "200",
+      "show_in_doc": 1,
+      "recorded": true
+    }
+  ],
+  "posts#update": [
+    {
+      "verb": "PATCH",
+      "path": "/api/v1/posts/0",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+      },
+      "response_data": {
+        "errors": [
+          {
+            "message": "You must be logged in to view that page."
+          }
+        ]
+      },
+      "code": "401",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "PATCH",
+      "path": "/api/v1/posts/0",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+      },
+      "response_data": {
+        "errors": [
+          {
+            "message": "Post could not be found."
+          }
+        ]
+      },
+      "code": "404",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "PATCH",
+      "path": "/api/v1/posts/1",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+      },
+      "response_data": {
+        "errors": [
+          {
+            "message": "You do not have permission to perform this action."
+          }
+        ]
+      },
+      "code": "403",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "PATCH",
+      "path": "/api/v1/posts/1",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+      },
+      "response_data": {
+        "errors": [
+          {
+            "message": "Missing parameter private_note"
+          }
+        ]
+      },
+      "code": "422",
+      "show_in_doc": 1,
+      "recorded": true
+    },
+    {
+      "verb": "PATCH",
+      "path": "/api/v1/posts/1",
+      "versions": [
+        "1.0"
+      ],
+      "query": null,
+      "request_data": {
+        "private_note": "Shiny new note"
+      },
+      "response_data": {
+        "private_note": "<p>Shiny new note</p>"
       },
       "code": "200",
       "show_in_doc": 1,
@@ -1367,7 +1466,7 @@
           "icon": null,
           "user": {
             "id": 1,
-            "username": "JohnDoe135"
+            "username": "JohnDoe144"
           }
         },
         {
@@ -1380,7 +1479,7 @@
           "icon": null,
           "user": {
             "id": 1,
-            "username": "JohnDoe135"
+            "username": "JohnDoe144"
           }
         },
         {
@@ -1401,7 +1500,7 @@
           },
           "user": {
             "id": 3,
-            "username": "JohnDoe137"
+            "username": "JohnDoe146"
           }
         }
       ],
@@ -1741,15 +1840,15 @@
         "results": [
           {
             "id": 1,
-            "subject": "test subject 51",
+            "subject": "test subject 54",
             "created_at": "2019-12-25T21:34:56.000Z",
-            "status": 0,
+            "status": "active",
             "section_order": 0,
             "description": "",
             "tagged_at": "2019-12-25T21:34:56.000Z",
             "board": {
               "id": 1,
-              "name": "test board 49"
+              "name": "test board 52"
             },
             "section": {
               "id": 1,
@@ -1759,7 +1858,7 @@
             "authors": [
               {
                 "id": 1,
-                "username": "JohnDoe154"
+                "username": "JohnDoe163"
               }
             ],
             "num_replies": 0

--- a/spec/features/replies/edit_spec.rb
+++ b/spec/features/replies/edit_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Creating replies", :type => :feature do
     expect(page).to have_no_selector('.post-container')
     within('#post-editor') do
       fill_in 'reply_content', with: 'other text'
-      click_button 'Save'
+      click_button 'submit_button'
     end
 
     expect(page).to have_no_selector('.error')
@@ -78,7 +78,7 @@ RSpec.feature "Creating replies", :type => :feature do
     within('#post-editor') do
       expect(page).to have_field('reply_content', with: 'other text')
       fill_in 'reply_content', with: 'third text'
-      click_button 'Save'
+      click_button 'submit_button'
     end
 
     expect(page).to have_no_selector('.error')


### PR DESCRIPTION
People should not go to edit their post notes and discover that they have lost everything they've written.

I considered a popup option to keep the editor more visibly separate from the reply editor. This was immediately vetoed by at least three people and was discarded as an option. But like, for posterity, if folks consider it.

~~Awaits #1384 so that we can properly authenticate the "save post notes" call in the page without reloading.~~

To do:
- [x] Show loading image after clicking Save
- [x] Show success image after successful save
- [x] Show error image if failed save
- [x] Some way to close the editor if you change your mind
- [x] Some way to discard your changes, with a confirmation
- [x] Better titles (and alt text?) on necessary icons
- [x] Generate API docs
- [x] Finish spec tests
- [x] All available error codes in API docs
- [x] Rename Post Notes to Author Notes
- [x] Some kind of warning before submitting or previewing reply with unsaved note