### PR TITLE
Don't redefine the ordered_manually scope

### DIFF
--- a/app/concerns/orderable.rb
+++ b/app/concerns/orderable.rb
@@ -6,7 +6,7 @@ module Orderable
     after_save :reorder_others_after
     after_destroy :reorder_others_before
 
-    scope :ordered_manually, -> { order('section_order asc') }
+    scope :ordered_manually, -> { order('section_order asc') } unless respond_to?(:ordered_manually)
 
     def order
       section_order

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -2,6 +2,9 @@ class Reply < ApplicationRecord
   include Presentable
   include Writable
   include PgSearch::Model
+
+  scope :ordered, -> { order(reply_order: :asc) }
+  scope :ordered_manually, -> { ordered }
   include Orderable
 
   belongs_to :post, inverse_of: :replies, optional: false
@@ -24,10 +27,6 @@ class Reply < ApplicationRecord
   scope :with_edit_audit_counts, -> {
     select("(SELECT COUNT(*) FROM audits WHERE audits.auditable_id = replies.id AND audits.auditable_type = 'Reply') > 1 AS has_edit_audits")
   }
-
-  scope :ordered, -> { order(reply_order: :asc) }
-
-  scope :ordered_manually, -> { ordered }
 
   scope :visible_to, ->(user) { where(post_id: Post.visible_to(user).select(:id)) }
 

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -3,6 +3,7 @@ class Reply < ApplicationRecord
   include Writable
   include PgSearch::Model
 
+  # define this scope here or Orderable will redefine it
   scope :ordered, -> { order(reply_order: :asc) }
   scope :ordered_manually, -> { ordered }
   include Orderable


### PR DESCRIPTION
Causes Orderable not to define ordered_manually if the class has already defined it, which should keep us from getting those 'scope already defined' warnings.