### PR TITLE
Reducing icon#show footprint

### DIFF
--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -55,6 +55,7 @@ class IconsController < UploadingController
       @times_used = (posts_using.count + replies_using.count)
       @posts_used = (posts_using.pluck(:id) + replies_using.select(:post_id).distinct.pluck(:post_id)).uniq.count
     end
+    @galleries = @icon.galleries.ordered_by_name
     @meta_og = og_data
   end
 
@@ -180,7 +181,7 @@ class IconsController < UploadingController
   end
 
   def og_data
-    galleries = @icon.galleries.pluck(:name)
+    galleries = @galleries.map(&:name)
     if galleries.present?
       desc = "Gallery".pluralize(galleries.count) + ": " + galleries.join(', ')
     else

--- a/app/views/galleries/_icon_view.haml
+++ b/app/views/galleries/_icon_view.haml
@@ -1,5 +1,5 @@
 = form_tag delete_multiple_icons_path, method: :delete do
-  = render partial: 'galleries/icon_item', collection: icons.pluck(:id, :keyword, :url), locals: {is_owner: is_owner, skip_forms: skip_forms}
+  = render partial: 'galleries/icon_item', collection: icons, locals: {is_owner: is_owner, skip_forms: skip_forms}
   - if is_owner && !skip_forms
     .clear.centered.icons-remove
       - if gallery

--- a/app/views/galleries/_list_item.haml
+++ b/app/views/galleries/_list_item.haml
@@ -1,4 +1,4 @@
-- icon_id, keyword, credit = list_item
+- icon_id, keyword, url, credit = list_item
 - klass = cycle('even', 'odd')
 %tr
   %td{class: klass}

--- a/app/views/galleries/_list_section.haml
+++ b/app/views/galleries/_list_section.haml
@@ -8,7 +8,7 @@
           %th.subber Times Used
           %th.subber Posts In
           %th.subber
-        = render partial: 'galleries/list_item', collection: icons.pluck(:id, :keyword, :credit), locals: {is_owner: is_owner, skip_forms: skip_forms}
+        = render partial: 'galleries/list_item', collection: icons, locals: {is_owner: is_owner, skip_forms: skip_forms}
         - if is_owner && !skip_forms
           %tr
             %th.form-table-ender{colspan: 5}

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -54,6 +54,7 @@
     %tr.gallery-subheader
       %th.sub Unsorted icons without a gallery will appear here. They can still be individually assigned to a character with no galleries.
   - icons ||= gallery ? gallery.icons : @user.galleryless_icons
+  - icons = icons.pluck(:id, :keyword, :url, :credit)
   - if page_view == 'list' && icons.present?
     = render partial_type, gallery: gallery, icons: icons, is_owner: is_owner, skip_forms: skip_forms
   - else

--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -7,8 +7,8 @@
       &raquo;
       = link_to "#{@icon.user.username}'s Galleries", user_galleries_path(@icon.user)
   &raquo;
-  - if @icon.galleries.count == 1
-    = link_to @icon.galleries.first.name, gallery_path(@icon.galleries.first)
+  - if @galleries.present?
+    = link_to @galleries.first.name, url_for(@galleries.first)
   - else
     = link_to_if params[:view] != 'galleries', "(#{@icon.galleries.count} Galleries)", icon_path(@icon, view: 'galleries')
   &raquo;
@@ -77,8 +77,8 @@
     %thead
       %tr
         %th.table-title Galleries
-    - if @icon.galleries.exists?
-      = render partial: 'galleries/single', collection: @icon.galleries.ordered_by_name, as: :gallery, locals: {klass: 'subber', skip_forms: true, is_owner: @icon.user == current_user}
+    - if @galleries.present?
+      = render partial: 'galleries/single', collection: @galleries, as: :gallery, locals: {klass: 'subber', skip_forms: true, is_owner: @icon.user == current_user}
     - else
       %tbody
         %tr


### PR DESCRIPTION
- We were plucking icon attributes slightly too late in galleries/_single, which meant the icons.present? line would load them into memory anyway. We have nice shiny low memory partials now and we should take advantage of this by not loading the icons into memory at all.

- We were querying Gallery up to five different times for icon#show, specifically:
  - Pluck on icon.galleries in name in og_data
  - Count on icon.galleries to determine whether to show a breadcrumb
  - [if previous check passed] Fetching icon.galleries to link to icon.galleries.first in breadcrumbs
  - icon.galleries.exist? to determine whether to render the galleries/single partial collection
  - [if previous check passed] Another icon.galleries fetch to actually render the collection, because this fetch used an order and so it would not reuse the association cache.