### PR TITLE
Fix character gallery display bug

### DIFF
--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -162,7 +162,7 @@ function findGalleryInGroups(galleryId) {
 }
 
 function displayGallery(newId) {
-  $.authenticatedGet('/api/v1/galleries/'+newId, function(resp) {
+  $.authenticatedGet('/api/v1/galleries/'+newId, {}, function(resp) {
     var galleryObj = $("<div>").attr({id: 'gallery'+newId}).data('id', newId);
     galleryObj.append("<br />");
     galleryObj.append($("<b>").attr({class: 'gallery-name'}).append(resp.name));


### PR DESCRIPTION
In which $.get() is considerably more forgiving than my $.authenticatedGet()

$.get seems to have accepted arguments of (url, success) as well as (url, data, success) for ?some reason? but $.authenticatedGet expects strictly (url, data, success). Since this call omitted the data argument, it was passing the success function as the data and therefore the function was not in fact being called upon success.