### PR TITLE
Auto refresh the API token

### DIFF
--- a/app/concerns/authentication/web.rb
+++ b/app/concerns/authentication/web.rb
@@ -40,7 +40,12 @@ module Authentication::Web
     def set_user
       @current_user ||= User.find_by_id(session[:user_id])
       return unless @current_user
-      session[:api_token] = nil if Time.zone.now > session[:api_token].try(:[], "expires").to_i
+      set_user_token
+    end
+
+    def set_user_token
+      expiration = session[:api_token].try(:[], "expires").to_i
+      session[:api_token] = nil if Time.zone.now.to_i > expiration
       session[:api_token] ||= {
         value: Authentication.generate_api_token(@current_user),
         expires: Authentication::EXPIRY.from_now.to_i

--- a/app/concerns/authentication/web.rb
+++ b/app/concerns/authentication/web.rb
@@ -40,7 +40,11 @@ module Authentication::Web
     def set_user
       @current_user ||= User.find_by_id(session[:user_id])
       return unless @current_user
-      session[:api_token] ||= Authentication.generate_api_token(@current_user)
+      session[:api_token] = nil if Time.zone.now > session[:api_token].try(:[], "expires").to_i
+      session[:api_token] ||= {
+        value: Authentication.generate_api_token(@current_user),
+        expires: Authentication::EXPIRY.from_now.to_i
+      }
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -184,7 +184,7 @@ class ApplicationController < ActionController::Base
 
   def set_login_gon
     gon.logged_in = logged_in?
-    gon.api_token = session[:api_token] if logged_in?
+    gon.api_token = session[:api_token]["value"] if logged_in?
   end
 
   def set_timezone(&block)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,7 +16,10 @@ class SessionsController < ApplicationController
       user = auth.user
       flash[:success] = "You are now logged in as #{user.username}. Welcome back!"
       session[:user_id] = user.id
-      session[:api_token] = auth.api_token
+      session[:api_token] = {
+        value: auth.api_token,
+        expires: Authentication::EXPIRY.from_now.to_i
+      }
       cookies.permanent.signed[:user_id] = cookie_hash(user.id) if params[:remember_me].present?
       @current_user = user
       redirect_to continuities_path and return if session[:previous_url] == '/login'


### PR DESCRIPTION
So that all your javascript doesn't cease working every 30 days.

Considerations:
- I investigated building true refresh tokens, but they are expected to be stored somewhere secure, and our method of passing token values through `gon` did not seem secure enough to qualify. Not that we can't build one later for regular API users, but didn't make sense for our views.
- The Rails code could have pulled the expiration date from the token itself rather than sticking it in session, but that seemed like an awful lot of unnecessary decoding for very little gain.