### PR TITLE
Fix minor model callback behaviors

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -22,7 +22,7 @@ class Board < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   after_create :add_creator_to_authors
-  after_destroy :move_posts_to_sandbox
+  after_destroy_commit :move_posts_to_sandbox
 
   scope :ordered, -> { order(pinned: :desc, name: :asc) }
 

--- a/app/models/board_section.rb
+++ b/app/models/board_section.rb
@@ -7,7 +7,7 @@ class BoardSection < ApplicationRecord
 
   validates :name, presence: true
 
-  after_destroy :clear_section_ids
+  after_destroy_commit :clear_section_ids
 
   scope :ordered, -> { order(section_order: :asc) }
 

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -28,7 +28,7 @@ class Character < ApplicationRecord
   attr_accessor :group_name
 
   before_validation :strip_spaces
-  after_destroy :clear_char_ids
+  after_destroy_commit :clear_char_ids
 
   scope :ordered, -> { order(name: :asc).order(Arel.sql('lower(screenname) asc'), created_at: :asc, id: :asc) }
   scope :with_name, -> (charname) { where("lower(concat_ws(' | ', name, nickname, screenname)) LIKE ?", "%#{charname.downcase}%") }

--- a/app/models/character_alias.rb
+++ b/app/models/character_alias.rb
@@ -2,7 +2,7 @@ class CharacterAlias < ApplicationRecord
   belongs_to :character, optional: false
   has_many :reply_drafts, dependent: :nullify
   validates :name, presence: true
-  after_destroy :clear_alias_ids
+  after_destroy_commit :clear_alias_ids
 
   scope :ordered, -> { order(Arel.sql('lower(name) asc'), created_at: :asc, id: :asc) }
 

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -22,7 +22,7 @@ class Icon < ApplicationRecord
   before_validation :use_icon_host
   before_save :use_https
   before_update :delete_from_s3
-  after_destroy :clear_icon_ids, :delete_from_s3
+  after_destroy_commit :clear_icon_ids, :delete_from_s3
 
   scope :ordered, -> { order(Arel.sql('lower(keyword) asc'), created_at: :asc, id: :asc) }
 

--- a/app/models/index_section.rb
+++ b/app/models/index_section.rb
@@ -14,9 +14,7 @@ class IndexSection < ApplicationRecord
   private
 
   def clear_index_post_values
-    IndexPost.where(index_section_id: id).find_each do |post|
-      post.update(index_section_id: nil)
-    end
+    UpdateModelJob.perform_later(IndexPost.to_s, {index_section_id: id}, {index_section_id: nil})
   end
 
   def ordered_attributes

--- a/app/models/index_section.rb
+++ b/app/models/index_section.rb
@@ -7,7 +7,7 @@ class IndexSection < ApplicationRecord
 
   validates :name, presence: true
 
-  after_destroy :clear_index_post_values
+  after_destroy_commit :clear_index_post_values
 
   scope :ordered, -> { order(section_order: :asc) }
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -10,7 +10,7 @@ class Message < ApplicationRecord
 
   before_validation :set_thread_id, :remove_deleted_recipient
   before_create :check_recipient
-  after_create :notify_recipient
+  after_create_commit :notify_recipient
 
   scope :ordered_by_id, -> { order(id: :asc) }
   scope :ordered_by_thread, -> { order(thread_id: :asc, id: :desc) }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -41,8 +41,8 @@ class Post < ApplicationRecord
   before_create :build_initial_flat_post, :set_timestamps
   before_update :set_timestamps
   before_validation :set_last_user, on: :create
-  after_commit :notify_followers, on: :create
-  after_commit :invalidate_caches, on: :update
+  after_create_commit :notify_followers
+  after_update_commit :invalidate_caches
 
   NON_EDITED_ATTRS = %w(id created_at updated_at edited_at tagged_at last_user_id last_reply_id section_order)
   NON_TAGGED_ATTRS = %w(icon_id character_alias_id character_id)

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -12,10 +12,11 @@ class Reply < ApplicationRecord
   validate :author_can_write_in_post, on: :create
   audited associated_with: :post, except: :reply_order, update_with_comment_only: false
 
-  after_create :notify_other_authors, :destroy_draft, :update_active_char, :set_last_reply, :update_post, :update_post_authors
-  after_save :update_flat_post
+  after_create :notify_other_authors, :destroy_draft, :update_active_char, :set_last_reply, :update_post
+  after_create_commit :update_post_authors # this can generate notification jobs
   after_update :update_post
   after_destroy :set_previous_reply_to_last, :remove_post_author
+  after_commit :update_flat_post
 
   attr_accessor :skip_notify, :skip_post_update, :is_import, :skip_regenerate
 


### PR DESCRIPTION
* Clearing IndexPost section ids will now use UpdateModelJob
* FlatPosts will now queue to regenerate immediately when replies are destroyed
* Various callbacks which queue jobs will only occur after the model is committed to the database