### PR TITLE
asterisms/mobile-unread-patch

### DIFF
--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -520,6 +520,13 @@ div.post-subheader { width: 100%; }
     vertical-align: middle;
   }
 }
+@media (pointer: coarse) {
+  .mobile-target {
+    display: inline-block;
+    padding-bottom: 8px;
+    padding-right: 8px;
+  }
+}
 
 /* Unread marker on posts */
 .unread-marker-container { position: relative; }

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -16,10 +16,10 @@
     - if logged_in?
       - if unread_post?(post, unread_ids) || (@show_unread && !opened_post?(post, opened_ids))
         = link_to unread_path(post) do
-          = image_tag unread_img, class: 'vmid', title: 'First Unread', alt: 'First Unread'
+          = image_tag unread_img, class: 'vmid mobile-target', title: 'First Unread', alt: 'First Unread'
       - elsif @show_unread
         = link_to unread_path(post) do
-          = image_tag lastlink_img, class: 'vmid', title: 'First Unread', alt: 'Jump To End'
+          = image_tag lastlink_img, class: 'vmid mobile-target', title: 'First Unread', alt: 'Jump To End'
     - if logged_in? && @opened_ids.present? && !@opened_ids.include?(post.id)
       %b= link_to post.subject, post_path(post), title: strip_tags(post.description)&.html_safe
     - else

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -54,7 +54,7 @@
           %td.post-subject{class: klass}
             - if has_unread?(post)
               = link_to unread_path(post) do
-                = image_tag unread_img, class: 'vmid', title: 'First Unread'
+                = image_tag unread_img, class: 'vmid mobile-target', title: 'First Unread'
             - if never_read?(post)
               %b= link_to post.subject, post_path(post)
             - else


### PR DESCRIPTION
Quick and dirty fix for #849.

Desktop (unchanged, platform is Firefox on Windows 10):
![image](https://user-images.githubusercontent.com/1367322/92356582-3485c300-f09b-11ea-8d89-0f1a42f01064.png)

Mobile (note space around the unread marker, platform is Firefox on Android):
![image](https://user-images.githubusercontent.com/1367322/92356641-49625680-f09b-11ea-87bf-9db1f672db1b.png)
