### PR TITLE
Clean up rubocop lints

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -59,11 +59,11 @@ class Board < ApplicationRecord
     # this should ONLY be called by an admin for emergency fixes
     board_sections.ordered.each_with_index do |section, index|
       next if section.section_order == index
-      section.update_columns(section_order: index)
+      section.update_columns(section_order: index) # rubocop:disable Rails/SkipsModelValidations
     end
     posts.where(section_id: nil).ordered_in_section.each_with_index do |post, index|
       next if post.section_order == index
-      post.update_columns(section_order: index)
+      post.update_columns(section_order: index) # rubocop:disable Rails/SkipsModelValidations
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -320,7 +320,7 @@ class Post < ApplicationRecord
   end
 
   def reset_warnings(_warning)
-    Post::View.where(post_id: id).update_all(warnings_hidden: false)
+    Post::View.where(post_id: id).update_all(warnings_hidden: false) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def notify_followers

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -72,6 +72,7 @@ class Tag < ApplicationRecord
 
   def merge_with(other_tag)
     transaction do
+      # rubocop:disable Rails/SkipsModelValidations
       PostTag.where(tag_id: other_tag.id).where(post_id: post_tags.select(:post_id).distinct.pluck(:post_id)).delete_all
       PostTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
       CharacterTag.where(tag_id: other_tag.id).where(character_id: character_tags.select(:character_id).distinct.pluck(:character_id)).delete_all
@@ -83,6 +84,7 @@ class Tag < ApplicationRecord
       Tag::SettingTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
       Tag::SettingTag.where(tagged_id: other_tag.id).update_all(tagged_id: self.id)
       other_tag.destroy
+      # rubocop:enable Rails/SkipsModelValidations
     end
   end
 end

--- a/spec/controllers/api/api_controller_spec.rb
+++ b/spec/controllers/api/api_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Api::ApiController do
       end
 
       it "displays an error if an expired token is provided" do
-        cur_time = Time.now
+        cur_time = Time.zone.now
         Timecop.freeze(cur_time) { api_login }
         Timecop.freeze(cur_time + Authentication::EXPIRY + 3.days) do
           get :show, params: {id: 1}
@@ -48,7 +48,7 @@ RSpec.describe Api::ApiController do
       end
 
       it "displays an error if an expired token is provided" do
-        cur_time = Time.now
+        cur_time = Time.zone.now
         Timecop.freeze(cur_time) { api_login }
         Timecop.freeze(cur_time + Authentication::EXPIRY + 3.days) do
           get :index

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Api::V1::PostsController do
       patch :update, params: { id: post.id, private_note: 'Shiny new note' }
 
       expect(response).to have_http_status(200)
-      expect(response.json['private_note']).to eq("<p>Shiny new note</p>");
+      expect(response.json['private_note']).to eq("<p>Shiny new note</p>")
       expect(post.author_for(user).private_note).to eq('Shiny new note')
     end
   end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -3430,6 +3430,7 @@ RSpec.describe PostsController do
     context "when logged out" do
       include_examples "logged out post list"
     end
+
     context "when logged in" do
       include_examples "logged in post list"
     end
@@ -3453,6 +3454,7 @@ RSpec.describe PostsController do
     context "when logged out" do
       include_examples "logged out post list"
     end
+
     context "when logged in" do
       include_examples "logged in post list"
     end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1,5 +1,81 @@
 RSpec.describe PostsController do
+  shared_examples "logged out post list" do
+    it "does not show user-only posts" do
+      posts = create_list(:post, 2)
+      create_list(:post, 2, privacy: :registered)
+      get controller_action, params: params
+      expect(response.status).to eq(200)
+      expect(Post.all.count).to eq(4)
+      expect(assigns(assign_variable)).to match_array(posts)
+    end
+  end
+
+  shared_examples "logged in post list" do
+    let(:user) { create(:user) }
+    let(:posts) { create_list(:post, 3) }
+
+    before(:each) {
+      login_as(user)
+      posts
+    }
+
+    it "does not show access-locked or private threads" do
+      create(:post, privacy: :private)
+      create(:post, privacy: :access_list)
+      get controller_action, params: params
+      expect(response.status).to eq(200)
+      expect(assigns(assign_variable)).to match_array(posts)
+    end
+
+    it "shows access-locked and private threads if you have access" do
+      posts << create(:post, user: user, privacy: :private)
+      posts << create(:post, user: user, privacy: :access_list)
+      get controller_action, params: params
+      expect(response.status).to eq(200)
+      expect(assigns(assign_variable)).to match_array(posts)
+    end
+
+    it "does not show posts with blocked or blocking authors" do
+      post1 = create(:post, authors_locked: true)
+      post2 = create(:post, authors_locked: true)
+      create(:block, blocking_user: user, blocked_user: post1.user, hide_them: :posts)
+      create(:block, blocking_user: post2.user, blocked_user: user, hide_me: :posts)
+      get controller_action, params: params
+      expect(response.status).to eq(200)
+      expect(assigns(assign_variable)).to match_array(posts)
+    end
+
+    it "shows posts with a blocked (but not blocking) author with show_blocked" do
+      post1 = create(:post, authors_locked: true)
+      post2 = create(:post, authors_locked: true)
+      create(:block, blocking_user: user, blocked_user: post1.user, hide_them: :posts)
+      create(:block, blocking_user: post2.user, blocked_user: user, hide_me: :posts)
+      params[:show_blocked] = true
+      posts << post1
+      get controller_action, params: params
+      expect(response.status).to eq(200)
+      expect(assigns(assign_variable)).to match_array(posts)
+    end
+
+    it "shows your own posts with blocked or but not blocking authors" do
+      post1 = create(:post, authors_locked: true, author_ids: [user.id])
+      create(:reply, post: post1, user: user)
+      post2 = create(:post, authors_locked: true, author_ids: [user.id])
+      create(:reply, post: post2, user: user)
+      create(:block, blocking_user: user, blocked_user: post1.user, hide_them: :posts)
+      create(:block, blocking_user: post2.user, blocked_user: user, hide_me: :posts)
+      posts << post2
+      get controller_action, params: params
+      expect(response.status).to eq(200)
+      expect(assigns(assign_variable)).to match_array(posts)
+    end
+  end
+
   describe "GET index" do
+    let(:controller_action) { "index" }
+    let(:params) { { } }
+    let(:assign_variable) { :posts }
+
     it "has a 200 status code" do
       get :index
       expect(response.status).to eq(200)
@@ -53,6 +129,14 @@ RSpec.describe PostsController do
         expect(response.body).to include('title="A &amp; B do a thing"')
       end
     end
+
+    context "when logged out" do
+      include_examples "logged out post list"
+    end
+
+    context "when logged in" do
+      include_examples "logged in post list"
+    end
   end
 
   describe "GET search" do
@@ -74,6 +158,10 @@ RSpec.describe PostsController do
     end
 
     context "searching" do
+      let(:controller_action) { "search" }
+      let(:params) { { commit: true } }
+      let(:assign_variable) { :search_results }
+
       it "finds all when no arguments given" do
         create_list(:post, 4)
         get :search, params: { commit: true }
@@ -175,6 +263,14 @@ RSpec.describe PostsController do
         create(:reply, post: posts[1])
         get :search, params: { commit: true }
         expect(assigns(:search_results)).to eq([posts[1], posts[2], posts[3], posts[0]])
+      end
+
+      context "when logged out" do
+        include_examples "logged out post list"
+      end
+
+      context "when logged in" do
+        include_examples "logged in post list"
       end
     end
   end
@@ -2888,6 +2984,10 @@ RSpec.describe PostsController do
   end
 
   describe "GET unread" do
+    let(:controller_action) { "unread" }
+    let(:params) { { } }
+    let(:assign_variable) { :posts }
+
     it "requires login" do
       get :unread
       expect(response).to redirect_to(root_url)
@@ -3056,6 +3156,10 @@ RSpec.describe PostsController do
         expect(assigns(:posts)).to match_array([opened_post1, opened_post2])
         expect(assigns(:hide_quicklinks)).to eq(true)
       end
+    end
+
+    context "when logged in" do
+      include_examples "logged in post list"
     end
   end
 
@@ -3347,116 +3451,6 @@ RSpec.describe PostsController do
       login
       post :unhide
       expect(response).to redirect_to(hidden_posts_url)
-    end
-  end
-
-  shared_examples "logged out post list" do
-    it "does not show user-only posts" do
-      posts = create_list(:post, 2)
-      create_list(:post, 2, privacy: :registered)
-      get controller_action, params: params
-      expect(response.status).to eq(200)
-      expect(Post.all.count).to eq(4)
-      expect(assigns(assign_variable)).to match_array(posts)
-    end
-  end
-
-  shared_examples "logged in post list" do
-    let(:user) { create(:user) }
-    let(:posts) { create_list(:post, 3) }
-
-    before(:each) {
-      login_as(user)
-      posts
-    }
-
-    it "does not show access-locked or private threads" do
-      create(:post, privacy: :private)
-      create(:post, privacy: :access_list)
-      get controller_action, params: params
-      expect(response.status).to eq(200)
-      expect(assigns(assign_variable)).to match_array(posts)
-    end
-
-    it "shows access-locked and private threads if you have access" do
-      posts << create(:post, user: user, privacy: :private)
-      posts << create(:post, user: user, privacy: :access_list)
-      get controller_action, params: params
-      expect(response.status).to eq(200)
-      expect(assigns(assign_variable)).to match_array(posts)
-    end
-
-    it "does not show posts with blocked or blocking authors" do
-      post1 = create(:post, authors_locked: true)
-      post2 = create(:post, authors_locked: true)
-      create(:block, blocking_user: user, blocked_user: post1.user, hide_them: :posts)
-      create(:block, blocking_user: post2.user, blocked_user: user, hide_me: :posts)
-      get controller_action, params: params
-      expect(response.status).to eq(200)
-      expect(assigns(assign_variable)).to match_array(posts)
-    end
-
-    it "shows posts with a blocked (but not blocking) author with show_blocked" do
-      post1 = create(:post, authors_locked: true)
-      post2 = create(:post, authors_locked: true)
-      create(:block, blocking_user: user, blocked_user: post1.user, hide_them: :posts)
-      create(:block, blocking_user: post2.user, blocked_user: user, hide_me: :posts)
-      params[:show_blocked] = true
-      posts << post1
-      get controller_action, params: params
-      expect(response.status).to eq(200)
-      expect(assigns(assign_variable)).to match_array(posts)
-    end
-
-    it "shows your own posts with blocked or but not blocking authors" do
-      post1 = create(:post, authors_locked: true, author_ids: [user.id])
-      create(:reply, post: post1, user: user)
-      post2 = create(:post, authors_locked: true, author_ids: [user.id])
-      create(:reply, post: post2, user: user)
-      create(:block, blocking_user: user, blocked_user: post1.user, hide_them: :posts)
-      create(:block, blocking_user: post2.user, blocked_user: user, hide_me: :posts)
-      posts << post2
-      get controller_action, params: params
-      expect(response.status).to eq(200)
-      expect(assigns(assign_variable)).to match_array(posts)
-    end
-  end
-
-  context "GET index" do
-    let(:controller_action) { "index" }
-    let(:params) { { } }
-    let(:assign_variable) { :posts }
-
-    context "when logged out" do
-      include_examples "logged out post list"
-    end
-
-    context "when logged in" do
-      include_examples "logged in post list"
-    end
-  end
-
-  context "GET unread" do
-    let(:controller_action) { "unread" }
-    let(:params) { { } }
-    let(:assign_variable) { :posts }
-
-    context "when logged in" do
-      include_examples "logged in post list"
-    end
-  end
-
-  context "GET search" do
-    let(:controller_action) { "search" }
-    let(:params) { { commit: true } }
-    let(:assign_variable) { :search_results }
-
-    context "when logged out" do
-      include_examples "logged out post list"
-    end
-
-    context "when logged in" do
-      include_examples "logged in post list"
     end
   end
 end

--- a/spec/models/daily_report_spec.rb
+++ b/spec/models/daily_report_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe DailyReport do
       Time.use_zone('America/New_York') do
         report = DailyReport.new("2020-05-21".to_date)
         posts = report.posts({first_updated_at: :desc})
-        expect(posts.to_a.count).to eq(1)
+        expect(posts.to_a.size).to eq(1)
         expect(posts[0].first_updated_at).to be_the_same_time_as(mismatch_time + 6.hours)
       end
     end

--- a/spec/models/post/view_spec.rb
+++ b/spec/models/post/view_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Post::View do
     it "does not update message if read" do
       post = make_post
       notification = user.messages.first
-      notification.update_attributes(unread: false)
+      notification.update!(unread: false)
       post.mark_read(user)
       expect(user.messages.first.unread).to eq(false)
     end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -608,7 +608,7 @@ RSpec.describe Post do
         coauthor = create(:user)
         post = create(:post, authors_locked: true, author_ids: [coauthor.id])
         create(:reply, post: post, user: coauthor)
-        block = create(:block, blocking_user: post.user, blocked_user: coauthor, hide_me: :posts)
+        create(:block, blocking_user: post.user, blocked_user: coauthor, hide_me: :posts)
         expect(post.reload).to be_visible_to(coauthor)
       end
     end


### PR DESCRIPTION
* Disables rubocop on more update_all statements
* Uses Time.zone.now rather than Time.zone
* Improves some whitespace
* Uses size rather than count
* Uses update! rather than update_attributes
* Removes unused assignment
* Merges repeated example groups in PostsController tests 