### PR TITLE
Update Dockerfile chromium version to 83

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     nodejs \
     postgresql-client-11 \
-    chromium=80.* \
+    chromium=83.* \
   && apt-get clean
 
 ARG bundler_version=2.0.2


### PR DESCRIPTION
This is the current version available for buster, and fixes Dockerfile builds: https://packages.debian.org/pt-br/buster/chromium