### PR TITLE
Generate emailless users with nil email for tests

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe User do
 
   describe "emails" do
     def generate_emailless_user
-      user = build(:user, email: '')
+      user = build(:user, email: nil)
       user.send(:encrypt_password)
       user.save!(validate: false)
       user


### PR DESCRIPTION
Postgres unique indexes will only ignore duplicate nil
values, not duplicate blank string values.

Extracted from #1391