### PR TITLE
Use Newest First as the default sort order for reply search links

### DIFF
--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -50,7 +50,7 @@
           Posts
     %tr
       %td.centered{class: cycle('even', 'odd')}
-        = link_to search_replies_path(commit: true, character_id: @character.id) do
+        = link_to search_replies_path(commit: true, character_id: @character.id, sort: :created_new) do
           = image_tag "icons/table_multiple.png", alt: ''
           Replies
     - if @character.editable_by?(current_user)

--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -47,7 +47,7 @@
         Posts
   %tr
     %td.centered{class: cycle('even', 'odd')}
-      = link_to search_replies_path(commit: true, icon_id: @icon.id) do
+      = link_to search_replies_path(commit: true, icon_id: @icon.id, sort: :created_new) do
         = image_tag "icons/table_multiple.png", alt: ''
         Replies
   - if @icon.user_id == current_user.try(:id)

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -55,7 +55,7 @@
             %li
               = link_to character.name, character_path(character)
               = surround '(', ')' do
-                = link_to "#{count} times", search_replies_path(post_id: @post.id, character_id: character.id, commit: true)
+                = link_to "#{count} times", search_replies_path(post_id: @post.id, character_id: character.id, commit: true, sort: :created_new)
 
     - if @post.settings.present?
       %tr


### PR DESCRIPTION
Searching replies without specifying text means we should specify a sort (here newest first) since 'best match' relies on pgsearch data that won't exist. Currently only fixes various relevant links to reply sort, but possibly we should make the search page itself smarter at some point.