### PR TITLE
Make sure GenerateFlatPostJob will create a flat post

### DIFF
--- a/app/jobs/generate_flat_post_job.rb
+++ b/app/jobs/generate_flat_post_job.rb
@@ -27,8 +27,7 @@ class GenerateFlatPostJob < ApplicationJob
         .left_outer_joins(:icon)
         .ordered
 
-      flat_post = post.flat_post
-      flat_post = post.build_flat_post unless flat_post
+      flat_post = post.flat_post || post.build_flat_post
       flat_post.content = PostsController.render :_generate_flat, layout: false, locals: {replies: replies}
       flat_post.save!
 

--- a/app/jobs/generate_flat_post_job.rb
+++ b/app/jobs/generate_flat_post_job.rb
@@ -28,6 +28,7 @@ class GenerateFlatPostJob < ApplicationJob
         .ordered
 
       flat_post = post.flat_post
+      flat_post = post.build_flat_post unless flat_post
       flat_post.content = PostsController.render :_generate_flat, layout: false, locals: {replies: replies}
       flat_post.save!
 

--- a/spec/jobs/generate_flat_post_job_spec.rb
+++ b/spec/jobs/generate_flat_post_job_spec.rb
@@ -81,5 +81,14 @@ RSpec.describe GenerateFlatPostJob do
 
       GenerateFlatPostJob.perform_now(post.id)
     end
+
+    it "builds a FlatPost object if one does not exist" do
+      post = create(:post)
+      expect(post.flat_post).not_to be_nil
+      post.flat_post.destroy!
+
+      GenerateFlatPostJob.perform_now(post.id)
+      expect(FlatPost.find_by(post: post)).not_to be_nil
+    end
   end
 end


### PR DESCRIPTION
We need to create a new FlatPost if the Post is missing one, so we can regenerate them after a db migration