### PR TITLE
Fix notes

### DIFF
--- a/app/assets/javascripts/posts/edit_notes.js
+++ b/app/assets/javascripts/posts/edit_notes.js
@@ -5,7 +5,7 @@ $(document).ready(function() {
   originalValue = $("#post_private_note").val();
 
   // If not on the reply page or otherwise not live editing notes
-  if(!$(".edit-private-notes").length) return true;
+  if (!$(".edit-private-notes").length) return;
 
   $(".edit-private-notes").click(function() {
     $(".private-note").toggle();

--- a/app/assets/javascripts/posts/edit_notes.js
+++ b/app/assets/javascripts/posts/edit_notes.js
@@ -4,6 +4,9 @@ var submittedButton = '';
 $(document).ready(function() {
   originalValue = $("#post_private_note").val();
 
+  // If not on the reply page or otherwise not live editing notes
+  if(!$(".edit-private-notes").length) return true;
+
   $(".edit-private-notes").click(function() {
     $(".private-note").toggle();
     $(".private-note-editor").toggle();

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -78,7 +78,7 @@
     .even
       .details Notes written here are visible only to you. They will be displayed by the New Reply form.
       %br
-      = f.text_area :private_note, value: params[:private_note] || post.author_for(current_user)&.private_note
+      = f.text_area :private_note, value: params[:post].try(:[], :private_note) || post.author_for(current_user)&.private_note
 
   .subber Content
   - if post.id.present? && !post.editable_by?(current_user)


### PR DESCRIPTION
Fixes two small bugs:
- The post form was loading Javascript intended for the reply form, which would deactivate the submit button if you edited the post note (because it was waiting on AJAX save code that would never trigger)
- The post form would not persist changes to the post note upon failed saves because it was checking for the parameter `private_note` not `post[private_note]`