### PR TITLE
Reply indicator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ backstop/reports/*
 /.gems
 /.envrc
 dump.rdb
+.claude/

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -273,6 +273,7 @@ class UsersController < ApplicationController
       :show_user_in_switcher,
       :default_hide_edit_delete_buttons,
       :default_hide_add_bookmark_button,
+      :replies_owed_indicator,
     )
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -122,4 +122,21 @@ module ApplicationHelper
     return '(deleted user)'.html_safe if deleted
     link_to username, user_path(user_id)
   end
+
+  # Count of posts the user owes a reply to. Mirrors the logic in
+  # PostsController#owed but returns just the count; used to render the
+  # badge next to the "Replies Owed" nav link when the user has opted
+  # into the indicator.
+  def replies_owed_count(user)
+    return 0 unless user
+    ids = Post::Author.where(user_id: user.id, can_owe: true).group(:post_id).pluck(:post_id)
+    drafts = ReplyDraft.where(post_id: ids, user: user).pluck(:post_id)
+    solo = Post::Author.where(post_id: ids).group(:post_id).having('count(post_id) < 2').pluck(:post_id)
+    posts = Post.where(id: ids)
+      .where.not(last_user: user)
+      .or(Post.where(id: (drafts + solo).uniq))
+      .where.not(status: [:complete, :abandoned])
+    posts = posts.where.not(status: :hiatus).where('tagged_at > ?', 1.month.ago) if user.hide_hiatused_tags_owed?
+    posts.count
+  end
 end

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -123,7 +123,12 @@
             - if logged_in?
               %li= link_to 'Unread', unread_posts_path
               - unless current_user.read_only?
-                %li= link_to 'Replies Owed', owed_posts_path
+                %li
+                  = link_to 'Replies Owed', owed_posts_path
+                  - if current_user.replies_owed_indicator
+                    - owed_count = replies_owed_count(current_user)
+                    - if owed_count > 0
+                      %span.badge.badge-primary= owed_count
             %li= link_to 'Tags', tags_path
             - day = DailyReport.unread_date_for(current_user)
             - daybadge = DailyReport.badge_for(day)

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -62,6 +62,9 @@
       .checkbox-field{class: cycle('even', 'odd')}
         = f.check_box :hide_hiatused_tags_owed
         = f.label :hide_hiatused_tags_owed, "Hide hiatused threads"
+        %br
+        = f.check_box :replies_owed_indicator
+        = f.label :replies_owed_indicator, "Show count in top menu bar"
     %div
       .sub Daily Report
       .checkbox-field{class: cycle('even', 'odd')}

--- a/db/migrate/20260518010000_add_replies_owed_indicator_to_users.rb
+++ b/db/migrate/20260518010000_add_replies_owed_indicator_to_users.rb
@@ -1,0 +1,5 @@
+class AddRepliesOwedIndicatorToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :replies_owed_indicator, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_24_202900) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_18_010000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -489,6 +489,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_24_202900) do
     t.boolean "visible_unread", default: false
     t.boolean "show_user_in_switcher", default: true
     t.boolean "ignore_unread_daily_report", default: false
+    t.boolean "replies_owed_indicator", default: false, null: false
     t.boolean "favorite_notifications", default: true
     t.string "default_character_split", default: "template"
     t.integer "role_id"


### PR DESCRIPTION
Closes #1154. This will have performance impact, probably better to merge after postgres is moved. To mitigate somewhat, the indicator is defaulted to off.