### PR TITLE
Disable audit display on replies#search

### DIFF
--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -86,7 +86,7 @@ class RepliesController < WritableController
 
     @search_results = @search_results.where.not(post_id: current_user.hidden_posts) if logged_in? && !params[:show_blocked]
 
-    @audits = Audited::Audit.where(auditable_id: @search_results.map(&:id)).group(:auditable_id).count
+    @audits = []
 
     unless params[:condensed]
       @search_results = @search_results

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -1285,7 +1285,7 @@ RSpec.describe RepliesController do
         expect(assigns(:search_results)).to eq([reply, reply2])
       end
 
-      it "calculates audits" do
+      it "does not include audits" do
         Reply.auditing_enabled = true
         user = create(:user)
 
@@ -1303,10 +1303,8 @@ RSpec.describe RepliesController do
           replies[5].update!(content: 'new content')
         end
 
-        counts = replies.map(&:id).zip([1, 1, 2, 2, 6, 2]).to_h
-
         get :search, params: { commit: true, sort: 'created_old' }
-        expect(assigns(:audits)).to eq(counts)
+        expect(assigns(:audits)).to be_empty
         Reply.auditing_enabled = false
       end
     end


### PR DESCRIPTION
Until we have audit count caching, at least

(This also disables display of updated_at on reply#search)