### PR TITLE
Upgrade Rubocop to 1.15

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -300,9 +300,6 @@ Rails/HasManyOrHasOneDependent:
 Rails/HelperInstanceVariable:
   Enabled: false
 
-Rails/HttpStatus:
-  Enabled: false
-
 Rails/MailerName:
   Enabled: true
 
@@ -359,8 +356,11 @@ Rails/WhereNot:
 
 ################## RSpec #################################
 
-Capybara/FeatureMethods:
+RSpec/Capybara/FeatureMethods:
   EnabledMethods: [feature, scenario]
+
+RSpec/Rails/HttpStatus:
+  Enabled: false
 
 RSpec/AnyInstance:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -278,6 +278,9 @@ Rails/DynamicFindBy:
     - find_by_sql
     - find_by_id
 
+Rails/EnvironmentVariableAccess: # (new in 2.10)
+  Enabled: false
+
 Rails/FilePath:
   EnforcedStyle: 'arguments'
 
@@ -335,6 +338,9 @@ Rails/ShortI18n:
 
 Rails/SquishedSQLHeredocs:
   Enabled: true
+
+Rails/TimeZoneAssignment: # (new in 2.10)
+  Enabled: false
 
 Rails/UniqueValidationWithoutIndex:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,9 +22,6 @@ Rails:
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/BeginEndAlignment:
-  Enabled: true
-
 Layout/CaseIndentation:
   EnforcedStyle: 'end'
   IndentOneStep: true
@@ -83,9 +80,6 @@ Layout/ParameterAlignment:
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: 'no_space'
 
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
 Layout/SpaceAroundOperators:
   Enabled: false
 
@@ -110,87 +104,22 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*'
 
-Lint/BinaryOperatorWithIdenticalOperands:
-  Enabled: true
-
 Lint/ConstantDefinitionInBlock:
-  Enabled: true
   Exclude:
     - 'spec/lib/presentable_spec.rb'
 
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/DuplicateElsifCondition:
-  Enabled: true
-
-Lint/DuplicateRequire:
-  Enabled: true
-
-Lint/DuplicateRescueException:
-  Enabled: true
-
-Lint/EmptyConditionalBody:
-  Enabled: true
-
-Lint/EmptyFile:
-  Enabled: true
-
-Lint/FloatComparison:
-  Enabled: true
-
-Lint/HashCompareByIdentity:
-  Enabled: true
-
-Lint/IdentityComparison:
-  Enabled: true
-
 Lint/MissingSuper:
-  Enabled: true
   Exclude:
     - 'app/services/daily_report.rb'
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/OutOfRangeRegexpRef:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
 
 Lint/ParenthesesAsGroupedExpression:
   Exclude:
     - 'spec/**/*'
 
-Lint/RedundantSafeNavigation:
-  Enabled: true
-
-Lint/SelfAssignment:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
-
 Lint/SuppressedException:
   Exclude:
     - 'spec/jobs/application_job_spec.rb'
     - 'spec/jobs/generate_flat_post_job_spec.rb'
-
-Lint/TopLevelReturnWithArgument:
-  Enabled: true
-
-Lint/TrailingCommaInAttributeDeclaration:
-  Enabled: true
-
-Lint/UnreachableLoop:
-  Enabled: true
-
-Lint/UselessMethodDefinition:
-  Enabled: true
-
-Lint/UselessTimes:
-  Enabled: true
 
 ###################### Metrics ####################################
 
@@ -441,16 +370,10 @@ RSpec/StubbedMock:
 Style/AndOr:
   EnforcedStyle: 'conditionals'
 
-Style/AccessorGrouping:
-  Enabled: true
-
 Style/AsciiComments:
   Enabled: false
 
 Style/AutoResourceCleanup:
-  Enabled: true
-
-Style/BisectedAttrAccessor:
   Enabled: true
 
 Style/BlockDelimiters:
@@ -464,9 +387,6 @@ Style/ClassAndModuleChildren:
 
 Style/ClassEqualityComparison:
   Enabled: false
-
-Style/CombinableLoops:
-  Enabled: true
 
 Style/CommentAnnotation:
   Enabled: false
@@ -505,20 +425,8 @@ Style/GuardClause:
 Style/HashAsLastArrayItem:
   Enabled: false
 
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashLikeCase:
-  Enabled: true
-
 Style/HashSyntax:
   Enabled: false
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
 
 Style/KeywordParametersOrder:
   Enabled: false
@@ -550,45 +458,21 @@ Style/Proc:
 Style/RaiseArgs:
   Enabled: false
 
-Style/RedundantAssignment:
-  Enabled: true
-
 Style/RedundantBegin:
   Enabled: false
 
 Style/RedundantException:
   Enabled: false
 
-Style/RedundantFetchBlock:
-  Enabled: true
-
-Style/RedundantFileExtensionInRequire:
-  Enabled: true
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: true
-
 Style/RedundantSelf:
   Enabled: false
-
-Style/RedundantSelfAssignment:
-  Enabled: true
 
 Style/RegexpLiteral:
   EnforcedStyle: 'slashes'
   AllowInnerSlashes: true
 
-Style/SingleArgumentDig:
-  Enabled: true
-
 Style/SlicingWithRange:
   Enabled: false
-
-Style/SoleNestedConditional:
-  Enabled: true
 
 Style/StringConcatenation:
   Enabled: false
@@ -604,7 +488,6 @@ Style/TernaryParentheses:
   Enabled: false
 
 Style/TrailingCommaInArguments:
-  Enabled: true
   EnforcedStyleForMultiline: 'comma'
 
 Style/TrailingCommaInArrayLiteral:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,10 @@ Layout/SpaceAroundOperators:
 Layout/SpaceBeforeBlockBraces:
   Enabled: false
 
+Layout/SpaceBeforeBrackets: # (new in 1.7)
+  Enabled: false
+  # problems with false positives
+
 Layout/SpaceInLambdaLiteral:
   Enabled: false
 
@@ -100,6 +104,9 @@ Layout/SpaceInsideRangeLiteral:
 
 #################### Lint ################################
 
+Lint/AmbiguousAssignment: # (new in 1.7)
+  Enabled: true
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*'
@@ -108,9 +115,24 @@ Lint/ConstantDefinitionInBlock:
   Exclude:
     - 'spec/lib/presentable_spec.rb'
 
+Lint/DuplicateBranch: # (new in 1.3)
+  Enabled: true
+
+Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
+  Enabled: true
+
+Lint/EmptyBlock: # (new in 1.1)
+  Enabled: true
+
+Lint/EmptyClass: # (new in 1.3)
+  Enabled: true
+
 Lint/MissingSuper:
   Exclude:
     - 'app/services/daily_report.rb'
+
+Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
+  Enabled: true
 
 Lint/ParenthesesAsGroupedExpression:
   Exclude:
@@ -120,6 +142,15 @@ Lint/SuppressedException:
   Exclude:
     - 'spec/jobs/application_job_spec.rb'
     - 'spec/jobs/generate_flat_post_job_spec.rb'
+
+Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: true
+
+Lint/UnexpectedBlockArity: # (new in 1.5)
+  Enabled: true
+
+Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
+  Enabled: true
 
 ###################### Metrics ####################################
 
@@ -500,3 +531,27 @@ Style/TrailingCommaInHashLiteral:
 
 Style/WordArray:
   Enabled: false
+
+Style/ArgumentsForwarding: # (new in 1.1)
+  Enabled: true
+
+Style/CollectionCompact: # (new in 1.2)
+  Enabled: true
+
+Style/DocumentDynamicEvalDefinition: # (new in 1.1)
+  Enabled: true
+
+Style/HashExcept: # (new in 1.7)
+  Enabled: true
+
+Style/NegatedIfElseCondition: # (new in 1.2)
+  Enabled: true
+
+Style/NilLambda: # (new in 1.3)
+  Enabled: true
+
+Style/RedundantArgument: # (new in 1.4)
+  Enabled: false
+
+Style/SwapValues: # (new in 1.1)
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,11 @@ require:
 Rails:
   Enabled: true
 
+#################### Gemspec ##############################
+
+Gemspec/DateAssignment: # (new in 1.10)
+  Enabled: true
+
 #################### Layout ##############################
 
 Layout/ArgumentAlignment:
@@ -115,6 +120,9 @@ Lint/ConstantDefinitionInBlock:
   Exclude:
     - 'spec/lib/presentable_spec.rb'
 
+Lint/DeprecatedConstants: # (new in 1.8)
+  Enabled: true
+
 Lint/DuplicateBranch: # (new in 1.3)
   Enabled: true
 
@@ -127,6 +135,9 @@ Lint/EmptyBlock: # (new in 1.1)
 Lint/EmptyClass: # (new in 1.3)
   Enabled: true
 
+Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
+  Enabled: true
+
 Lint/MissingSuper:
   Exclude:
     - 'app/services/daily_report.rb'
@@ -134,16 +145,31 @@ Lint/MissingSuper:
 Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
   Enabled: true
 
+Lint/NumberedParameterAssignment: # (new in 1.9)
+  Enabled: true
+
+Lint/OrAssignmentToConstant: # (new in 1.9)
+  Enabled: true
+
 Lint/ParenthesesAsGroupedExpression:
   Exclude:
     - 'spec/**/*'
+
+Lint/RedundantDirGlobSort: # (new in 1.8)
+  Enabled: true
 
 Lint/SuppressedException:
   Exclude:
     - 'spec/jobs/application_job_spec.rb'
     - 'spec/jobs/generate_flat_post_job_spec.rb'
 
+Lint/SymbolConversion: # (new in 1.9)
+  Enabled: true
+
 Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: true
+
+Lint/TripleQuotes: # (new in 1.9)
   Enabled: true
 
 Lint/UnexpectedBlockArity: # (new in 1.5)
@@ -550,7 +576,16 @@ Style/CollectionCompact: # (new in 1.2)
 Style/DocumentDynamicEvalDefinition: # (new in 1.1)
   Enabled: true
 
+Style/EndlessMethod: # (new in 1.8)
+  Enabled: true
+
+Style/HashConversion: # (new in 1.10)
+  Enabled: true
+
 Style/HashExcept: # (new in 1.7)
+  Enabled: true
+
+Style/IfWithBooleanLiteralBranches: # (new in 1.9)
   Enabled: true
 
 Style/NegatedIfElseCondition: # (new in 1.2)
@@ -561,6 +596,9 @@ Style/NilLambda: # (new in 1.3)
 
 Style/RedundantArgument: # (new in 1.4)
   Enabled: false
+
+Style/StringChars: # (new in 1.12)
+  Enabled: true
 
 Style/SwapValues: # (new in 1.1)
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -220,6 +220,9 @@ Performance/CollectionLiteralInLoop:
 Performance/ConstantRegexp:
   Enabled: true
 
+Performance/MapCompact: # (new in 1.11)
+  Enabled: true
+
 Performance/MethodObjectAsBlock:
   Enabled: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ group :development do
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
   gem 'rubocop', '~> 1.7.0', require: false
-#  gem 'rubocop-performance', '~> 1.10.2', require: false
+  gem 'rubocop-performance', '~> 1.11.3', require: false
   gem 'rubocop-rails', '~> 2.10.1', require: false
 #  gem 'rubocop-rspec', '~> 1.44.1', require: false
   gem 'traceroute'

--- a/Gemfile
+++ b/Gemfile
@@ -59,9 +59,9 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
-  gem 'rubocop', '1.7.0', require: false
+  gem 'rubocop', '~> 1.7.0', require: false
 #  gem 'rubocop-performance', '~> 1.10.2', require: false
-#  gem 'rubocop-rails', '~> 2.9.1', require: false
+  gem 'rubocop-rails', '~> 2.10.1', require: false
 #  gem 'rubocop-rspec', '~> 1.44.1', require: false
   gem 'traceroute'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -59,10 +59,10 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
-  gem 'rubocop', '~> 0.93.1', require: false
-  gem 'rubocop-performance', '~> 1.10.2', require: false
-  gem 'rubocop-rails', '~> 2.9.1', require: false
-  gem 'rubocop-rspec', '~> 1.44.1', require: false
+  gem 'rubocop', '1.0.0', require: false
+#  gem 'rubocop-performance', '~> 1.10.2', require: false
+#  gem 'rubocop-rails', '~> 2.9.1', require: false
+#  gem 'rubocop-rspec', '~> 1.44.1', require: false
   gem 'traceroute'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
-  gem 'rubocop', '~> 1.7.0', require: false
+  gem 'rubocop', '~> 1.15.0', require: false
   gem 'rubocop-performance', '~> 1.11.3', require: false
   gem 'rubocop-rails', '~> 2.10.1', require: false
   gem 'rubocop-rspec', '~> 2.3.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'rack-mini-profiler'
-  gem 'rubocop', '1.0.0', require: false
+  gem 'rubocop', '1.7.0', require: false
 #  gem 'rubocop-performance', '~> 1.10.2', require: false
 #  gem 'rubocop-rails', '~> 2.9.1', require: false
 #  gem 'rubocop-rspec', '~> 1.44.1', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :development do
   gem 'rubocop', '~> 1.7.0', require: false
   gem 'rubocop-performance', '~> 1.11.3', require: false
   gem 'rubocop-rails', '~> 2.10.1', require: false
-#  gem 'rubocop-rspec', '~> 1.44.1', require: false
+  gem 'rubocop-rspec', '~> 2.3.0', require: false
   gem 'traceroute'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,9 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
+    rubocop-rspec (2.3.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.2)
     ruby_parser (3.15.0)
@@ -476,6 +479,7 @@ DEPENDENCIES
   rubocop (~> 1.7.0)
   rubocop-performance (~> 1.11.3)
   rubocop-rails (~> 2.10.1)
+  rubocop-rspec (~> 2.3.0)
   sanitize
   sassc-rails
   seed_dump (~> 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,6 +331,9 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (1.5.0)
       parser (>= 3.0.1.1)
+    rubocop-performance (1.11.3)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
     rubocop-rails (2.10.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -471,6 +474,7 @@ DEPENDENCIES
   resque_spec
   rspec-rails
   rubocop (~> 1.7.0)
+  rubocop-performance (~> 1.11.3)
   rubocop-rails (~> 2.10.1)
   sanitize
   sassc-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,7 +320,7 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
-    rubocop (0.93.1)
+    rubocop (1.0.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
@@ -331,16 +331,6 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (1.5.0)
       parser (>= 3.0.1.1)
-    rubocop-performance (1.10.2)
-      rubocop (>= 0.90.0, < 2.0)
-      rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.9.1)
-      activesupport (>= 4.2.0)
-      rack (>= 1.1)
-      rubocop (>= 0.90.0, < 2.0)
-    rubocop-rspec (1.44.1)
-      rubocop (~> 0.87)
-      rubocop-ast (>= 0.7.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.2)
     ruby_parser (3.15.0)
@@ -476,10 +466,7 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails
-  rubocop (~> 0.93.1)
-  rubocop-performance (~> 1.10.2)
-  rubocop-rails (~> 2.9.1)
-  rubocop-rspec (~> 1.44.1)
+  rubocop (= 1.0.0)
   sanitize
   sassc-rails
   seed_dump (~> 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,15 +320,15 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
-    rubocop (1.7.0)
+    rubocop (1.15.0)
       parallel (~> 1.10)
-      parser (>= 2.7.1.5)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.2.0, < 2.0)
+      rubocop-ast (>= 1.5.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.5.0)
       parser (>= 3.0.1.1)
     rubocop-performance (1.11.3)
@@ -406,7 +406,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.0.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
     webdrivers (4.4.1)
@@ -476,7 +476,7 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails
-  rubocop (~> 1.7.0)
+  rubocop (~> 1.15.0)
   rubocop-performance (~> 1.11.3)
   rubocop-rails (~> 2.10.1)
   rubocop-rspec (~> 2.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,6 +331,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (1.5.0)
       parser (>= 3.0.1.1)
+    rubocop-rails (2.10.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.2)
     ruby_parser (3.15.0)
@@ -466,7 +470,8 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails
-  rubocop (= 1.7.0)
+  rubocop (~> 1.7.0)
+  rubocop-rails (~> 2.10.1)
   sanitize
   sassc-rails
   seed_dump (~> 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,13 +320,13 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
-    rubocop (1.0.0)
+    rubocop (1.7.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.6.0)
+      rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (1.5.0)
@@ -466,7 +466,7 @@ DEPENDENCIES
   resque_mailer
   resque_spec
   rspec-rails
-  rubocop (= 1.0.0)
+  rubocop (= 1.7.0)
   sanitize
   sassc-rails
   seed_dump (~> 3.2)

--- a/app/concerns/orderable.rb
+++ b/app/concerns/orderable.rb
@@ -27,9 +27,9 @@ module Orderable
         return unless board_checking.ordered?
       end
 
-      other_where = Hash[ordered_attributes.map do |atr|
+      other_where = ordered_attributes.to_h do |atr|
         [atr, is_after ? attribute_before_last_save(atr) : attribute_was(atr)]
-      end]
+      end
       others = self.class.where(other_where).ordered_manually
       return unless others.present?
 
@@ -62,7 +62,7 @@ module Orderable
     end
 
     def ordered_items
-      where_attr = Hash[ordered_attributes.map { |a| [a, self[a]] }]
+      where_attr = ordered_attributes.to_h { |a| [a, self[a]] }
       self.class.where(where_attr)
     end
   end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -193,7 +193,7 @@ class CharactersController < ApplicationController
         [alt.id, {url: view_context.image_path('icons/no-icon.png'), keyword: 'No Icon', aliases: alt.aliases.as_json}]
       end
     end
-    gon.gallery = Hash[icons]
+    gon.gallery = icons.to_h
     gon.gallery[''] = {url: view_context.image_path('icons/no-icon.png'), keyword: 'No Character'}
 
     @alt_dropdown = @alts.map do |alt|

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -93,7 +93,7 @@ class IconsController < UploadingController
     end
     @alts = all_icons.sort_by{|i| i.keyword.downcase }
     use_javascript('icons')
-    gon.gallery = Hash[all_icons.map { |i| [i.id, {url: i.url, keyword: i.keyword}] }]
+    gon.gallery = all_icons.to_h { |i| [i.id, {url: i.url, keyword: i.keyword}] }
     gon.gallery[''] = {url: view_context.image_path('icons/no-icon.png'), keyword: 'No Icon'}
 
     post_ids = Reply.where(icon_id: @icon.id).select(:post_id).distinct.pluck(:post_id)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -105,13 +105,13 @@ module ApplicationHelper
     # Layout identifiers (values in this hash) are expected to not include spaces,
     # so they are suitable as HTML classes for the TinyMCE editor
     layouts = {
-      'Default': nil,
-      'Dark': 'dark'.freeze,
-      'Iconless': 'iconless'.freeze,
-      'Starry': 'starry'.freeze,
+      Default: nil,
+      Dark: 'dark'.freeze,
+      Iconless: 'iconless'.freeze,
+      Starry: 'starry'.freeze,
       'Starry Dark' => 'starrydark'.freeze,
       'Starry Light' => 'starrylight'.freeze,
-      'Monochrome': 'monochrome'.freeze,
+      Monochrome: 'monochrome'.freeze,
       'Milky River' => 'river'.freeze,
     }
     options_for_select(layouts, default)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -232,7 +232,7 @@ class Post < ApplicationRecord
 
   # only returns for authors who have written in the post (it's zero for authors who have not joined)
   def author_word_counts
-    joined_authors.map { |author| [!author.deleted? ? author.username : '(deleted user)', word_count_for(author)] }.sort_by{|a| -a[1] }
+    joined_authors.map { |author| [author.deleted? ? '(deleted user)' : author.username, word_count_for(author)] }.sort_by{|a| -a[1] }
   end
 
   def character_appearance_counts

--- a/spec/controllers/api/api_controller_spec.rb
+++ b/spec/controllers/api/api_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::ApiController do
   describe "token handling" do
     context "with login_required" do
       it "displays an error if an invalid token is provided" do
-        request.headers.merge({'Authorization': "Bearer definitely-invalid"})
+        request.headers.merge({Authorization: "Bearer definitely-invalid"})
         get :show, params: {id: 1}
         expect(response).to have_http_status(422)
         expect(response.json['errors'][0]['message']).to eq("Authorization token is not valid.")
@@ -41,7 +41,7 @@ RSpec.describe Api::ApiController do
 
     context "without login_required but with mixed data" do
       it "displays an error if an invalid token is provided" do
-        request.headers.merge({'Authorization': "Bearer definitely-invalid"})
+        request.headers.merge({Authorization: "Bearer definitely-invalid"})
         get :index
         expect(response).to have_http_status(422)
         expect(response.json['errors'][0]['message']).to eq("Authorization token is not valid.")

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Favorite do
       expect(f2.save).to eq(true)
     end
 
-    it "should allow you to favorite multiple things" do
-    end
+    skip "should allow you to favorite multiple things"
   end
 end

--- a/spec/support/api_test_helper.rb
+++ b/spec/support/api_test_helper.rb
@@ -5,7 +5,7 @@ module ApiTestHelper
 
   def api_login_as(user)
     token = Authentication.generate_api_token(user)
-    request.headers.merge({'Authorization': "Bearer #{token}"})
+    request.headers.merge({Authorization: "Bearer #{token}"})
     user
   end
 end


### PR DESCRIPTION
Depends on #1518

- Upgrades rubocop to 1.15.0
- Upgrades rubocop-performance to 1.11.3
- Upgrades rubocop-rails to 2.10.1
- Upgrades rubocop-rspec to 2.3.0
&nbsp;

**New (enabled) cops:**
- Gemspec/DateAssignment
- ~~Layout/SpaceBeforeBrackets~~
- Lint/AmbiguousAssignment
- Lint/DeprecatedConstants
- Lint/DuplicateBranch
- Lint/DuplicateRegexpCharacterClassElement
- Lint/EmptyBlock
- Lint/EmptyClass
- Lint/LambdaWithoutLiteralBlock
- Lint/NoReturnInBeginEndBlocks
- Lint/NumberedParameterAssignment
- Lint/OrAssignmentToConstant
- Lint/RedundantDirGlobSort
- Lint/SymbolConversion
- Lint/ToEnumArguments
- Lint/TripleQuotes
- Lint/UnexpectedBlockArity
- Lint/UnmodifiedReduceAccumulator
- Style/ArgumentsForwarding
- Style/CollectionCompact
- Style/DocumentDynamicEvalDefinition
- Style/EndlessMethod
- Style/HashConversion
- Style/HashExcept
- Style/IfWithBooleanLiteralBranches
- Style/NegatedIfElseCondition
- Style/NilLambda
- ~~Style/RedundantArgument~~
- Style/StringChars
- Style/SwapValues
- Performance/MapCompact