### PR TITLE
Improve Permissible

### DIFF
--- a/app/concerns/permissible.rb
+++ b/app/concerns/permissible.rb
@@ -1,4 +1,6 @@
 module Permissible
+  extend ActiveSupport::Concern
+
   ADMIN = 1
   MOD = 2
   IMPORTER = 3
@@ -14,27 +16,29 @@ module Permissible
     # :edit_continuities
   ]
 
-  def has_permission?(permission)
-    return false unless role_id
-    return true if admin?
-    return true if importer? && permission == :import_posts
-    return false unless mod?
-    MOD_PERMS.include?(permission)
-  end
+  included do
+    def has_permission?(permission)
+      return false unless role_id
+      return true if admin?
+      return true if importer? && permission == :import_posts
+      return false unless mod?
+      MOD_PERMS.include?(permission)
+    end
 
-  def admin?
-    role_id == ADMIN
-  end
+    def admin?
+      role_id == ADMIN
+    end
 
-  def mod?
-    role_id == MOD
-  end
+    def mod?
+      role_id == MOD
+    end
 
-  def importer?
-    role_id == IMPORTER
-  end
+    def importer?
+      role_id == IMPORTER
+    end
 
-  def suspended?
-    role_id == SUSPENDED
+    def suspended?
+      role_id == SUSPENDED
+    end
   end
 end

--- a/app/concerns/permissible.rb
+++ b/app/concerns/permissible.rb
@@ -1,15 +1,22 @@
 module Permissible
   extend ActiveSupport::Concern
 
-  MOD_PERMS = [
+  PERMS = [
     :edit_posts,
     :edit_replies,
     :edit_characters,
     :import_posts,
-    # :edit_tags,
-    # :delete_tags,
-    # :edit_continuities
+    # admin-only permissions start here
+    :delete_replies,
+    :edit_tags,
+    :delete_tags,
+    :edit_continuities,
+    :edit_indexes,
+    :edit_news,
+    :delete_news
   ]
+
+  MOD_PERMS = PERMS[0..3]
 
   included do
     enum role_id: {
@@ -21,6 +28,7 @@ module Permissible
 
     def has_permission?(permission)
       return false unless role_id
+      return false unless PERMS.include?(permission)
       return true if admin?
       return true if importer? && permission == :import_posts
       return false unless mod?

--- a/app/concerns/permissible.rb
+++ b/app/concerns/permissible.rb
@@ -6,6 +6,7 @@ module Permissible
     :edit_replies,
     :edit_characters,
     :import_posts,
+    :create_news,
     # admin-only permissions start here
     :delete_replies,
     :edit_tags,
@@ -16,7 +17,7 @@ module Permissible
     :delete_news
   ]
 
-  MOD_PERMS = PERMS[0..3]
+  MOD_PERMS = PERMS[0..4]
 
   included do
     enum role_id: {

--- a/app/concerns/permissible.rb
+++ b/app/concerns/permissible.rb
@@ -1,11 +1,6 @@
 module Permissible
   extend ActiveSupport::Concern
 
-  ADMIN = 1
-  MOD = 2
-  IMPORTER = 3
-  SUSPENDED = 4
-
   MOD_PERMS = [
     :edit_posts,
     :edit_replies,
@@ -17,28 +12,19 @@ module Permissible
   ]
 
   included do
+    enum role_id: {
+      admin: 1,
+      mod: 2,
+      importer: 3,
+      suspended: 4
+    }
+
     def has_permission?(permission)
       return false unless role_id
       return true if admin?
       return true if importer? && permission == :import_posts
       return false unless mod?
       MOD_PERMS.include?(permission)
-    end
-
-    def admin?
-      role_id == ADMIN
-    end
-
-    def mod?
-      role_id == MOD
-    end
-
-    def importer?
-      role_id == IMPORTER
-    end
-
-    def suspended?
-      role_id == SUSPENDED
     end
   end
 end

--- a/app/concerns/permissible.rb
+++ b/app/concerns/permissible.rb
@@ -20,7 +20,7 @@ module Permissible
   MOD_PERMS = PERMS[0..4]
 
   included do
-    enum role_id: {
+    enum role: {
       admin: 1,
       mod: 2,
       importer: 3,
@@ -28,7 +28,7 @@ module Permissible
     }
 
     def has_permission?(permission)
-      return false unless role_id
+      return false unless role
       return false unless PERMS.include?(permission)
       return true if admin?
       return true if importer? && permission == :import_posts

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 class NewsController < ApplicationController
   before_action :login_required, except: [:index, :show]
-  before_action :require_staff, except: [:index, :show]
   before_action :find_model, only: [:show, :edit, :update, :destroy]
-  before_action :require_permission, only: [:edit, :update]
+  before_action :require_create_permission, only: [:new, :create]
+  before_action :require_edit_permission, only: [:edit, :update]
 
   def index
     @page_title = 'Site News'
@@ -88,14 +88,14 @@ class NewsController < ApplicationController
     end
   end
 
-  def require_staff
-    unless current_user.admin? || current_user.mod?
+  def require_create_permission
+    unless current_user.has_permission?(:create_news)
       flash[:error] = "You do not have permission to manage news posts."
       redirect_to news_index_path and return
     end
   end
 
-  def require_permission
+  def require_edit_permission
     unless @news.editable_by?(current_user)
       flash[:error] = "You do not have permission to edit that news post."
       redirect_to news_index_path and return

--- a/db/migrate/20210712193922_rename_role_id.rb
+++ b/db/migrate/20210712193922_rename_role_id.rb
@@ -1,0 +1,5 @@
+class RenameRoleId < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :users, :role_id, :role
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_16_173619) do
+ActiveRecord::Schema.define(version: 2021_07_12_193922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -452,7 +452,7 @@ ActiveRecord::Schema.define(version: 2020_04_16_173619) do
     t.boolean "ignore_unread_daily_report", default: false
     t.boolean "favorite_notifications", default: true
     t.string "default_character_split", default: "template"
-    t.integer "role_id"
+    t.integer "role"
     t.integer "tos_version"
     t.boolean "deleted", default: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,14 +6,14 @@ puts "Seeding database..."
 
 puts "Creating users..."
 marri = User.create!(username: 'Marri', password: 'nikari', email: "dummy1@example.com", default_editor: 'html', unread_opened: true,
-                    role_id: Permissible::ADMIN, default_view: 'list', layout: 'starrylight', moiety_name: 'Red', moiety: 'AA0000', hide_warnings: true,
+                    role_id: :admin, default_view: 'list', layout: 'starrylight', moiety_name: 'Red', moiety: 'AA0000', hide_warnings: true,
                     ignore_unread_daily_report: true, visible_unread: true, created_at: "2015-10-05 19:39:00")
 alicorn = User.create!(username: 'Alicorn', password: 'alicorn', email: "dummy2@example.com", created_at: "2015-10-05 19:39:00")
-kappa = User.create!(username: 'Kappa', password: 'pythbox', email: "dummy3@example.com", role_id: Permissible::IMPORTER,
+kappa = User.create!(username: 'Kappa', password: 'pythbox', email: "dummy3@example.com", role_id: :importer,
                     visible_unread: true, created_at: "2015-10-05 19:39:00")
 aestrix = User.create!(username: 'Aestrix', password: 'aestrix', email: "dummy4@example.com", created_at: "2015-11-26 7:59:00")
-throne = User.create!(username: 'Throne3d', password: 'throne3d', email: "dummy5@example.com", role_id: Permissible::MOD, created_at: "2016-02-22 14:48:00")
-teceler = User.create!(username: 'Teceler', password: 'teceler', email: "dummy6@example.com", role_id: Permissible::MOD, default_editor: 'html',
+throne = User.create!(username: 'Throne3d', password: 'throne3d', email: "dummy5@example.com", role_id: :mod, created_at: "2016-02-22 14:48:00")
+teceler = User.create!(username: 'Teceler', password: 'teceler', email: "dummy6@example.com", role_id: :mod, default_editor: 'html',
                     layout: 'starrydark', ignore_unread_daily_report: true, created_at: "2015-12-17 19:48:00")
 
 User.update_all(tos_version: 20181109)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,14 +6,14 @@ puts "Seeding database..."
 
 puts "Creating users..."
 marri = User.create!(username: 'Marri', password: 'nikari', email: "dummy1@example.com", default_editor: 'html', unread_opened: true,
-                    role_id: :admin, default_view: 'list', layout: 'starrylight', moiety_name: 'Red', moiety: 'AA0000', hide_warnings: true,
+                    role: :admin, default_view: 'list', layout: 'starrylight', moiety_name: 'Red', moiety: 'AA0000', hide_warnings: true,
                     ignore_unread_daily_report: true, visible_unread: true, created_at: "2015-10-05 19:39:00")
 alicorn = User.create!(username: 'Alicorn', password: 'alicorn', email: "dummy2@example.com", created_at: "2015-10-05 19:39:00")
-kappa = User.create!(username: 'Kappa', password: 'pythbox', email: "dummy3@example.com", role_id: :importer,
+kappa = User.create!(username: 'Kappa', password: 'pythbox', email: "dummy3@example.com", role: :importer,
                     visible_unread: true, created_at: "2015-10-05 19:39:00")
 aestrix = User.create!(username: 'Aestrix', password: 'aestrix', email: "dummy4@example.com", created_at: "2015-11-26 7:59:00")
-throne = User.create!(username: 'Throne3d', password: 'throne3d', email: "dummy5@example.com", role_id: :mod, created_at: "2016-02-22 14:48:00")
-teceler = User.create!(username: 'Teceler', password: 'teceler', email: "dummy6@example.com", role_id: :mod, default_editor: 'html',
+throne = User.create!(username: 'Throne3d', password: 'throne3d', email: "dummy5@example.com", role: :mod, created_at: "2016-02-22 14:48:00")
+teceler = User.create!(username: 'Teceler', password: 'teceler', email: "dummy6@example.com", role: :mod, default_editor: 'html',
                     layout: 'starrydark', ignore_unread_daily_report: true, created_at: "2015-12-17 19:48:00")
 
 User.update_all(tos_version: 20181109)

--- a/spec/controllers/api/v1/sessions_controller_spec.rb
+++ b/spec/controllers/api/v1/sessions_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::V1::SessionsController do
     end
 
     it "requires unsuspended user" do
-      user = create(:user, role_id: Permissible::SUSPENDED)
+      user = create(:user, role_id: :suspended)
       post :create, params: { username: user.username }
       expect(response).to have_http_status(401)
       expect(response.json['errors'][0]['message']).to eq("You could not be logged in.")

--- a/spec/controllers/api/v1/sessions_controller_spec.rb
+++ b/spec/controllers/api/v1/sessions_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::V1::SessionsController do
     end
 
     it "requires unsuspended user" do
-      user = create(:user, role_id: :suspended)
+      user = create(:user, role: :suspended)
       post :create, params: { username: user.username }
       expect(response).to have_http_status(401)
       expect(response.json['errors'][0]['message']).to eq("You could not be logged in.")

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -432,7 +432,7 @@ RSpec.describe ApplicationController do
     end
 
     it "logs out suspended" do
-      user.update!(role_id: :suspended)
+      user.update!(role: :suspended)
       get :index
       expect(response.json['logged_in']).to eq(false)
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -416,6 +416,10 @@ RSpec.describe ApplicationController do
   end
 
   describe "#check_forced_logout" do
+    let(:user) { create(:user) }
+
+    before(:each) { login_as(user) }
+
     controller do
       def index
         render json: {logged_in: current_user.present?}
@@ -423,26 +427,18 @@ RSpec.describe ApplicationController do
     end
 
     it "does not log out unsuspended undeleted" do
-      user = create(:user)
-      login_as(user)
       get :index
       expect(response.json['logged_in']).to be(true)
     end
 
     it "logs out suspended" do
-      user = create(:user)
-      login_as(user)
-      user.role_id = Permissible::SUSPENDED
-      user.save!
+      user.update!(role_id: :suspended)
       get :index
       expect(response.json['logged_in']).to eq(false)
     end
 
     it "logs out deleted" do
-      user = create(:user)
-      login_as(user)
-      user.deleted = true
-      user.save!
+      user.update!(deleted: true)
       get :index
       expect(response.json['logged_in']).to eq(false)
     end

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe NewsController do
       login
       get :edit, params: {id: create(:news).id}
       expect(response).to redirect_to(news_index_url)
-      expect(flash[:error]).to eq("You do not have permission to manage news posts.")
+      expect(flash[:error]).to eq("You do not have permission to edit that news post.")
     end
 
     it "errors if wrong mod" do
@@ -189,7 +189,7 @@ RSpec.describe NewsController do
       login
       patch :update, params: {id: create(:news).id}
       expect(response).to redirect_to(news_index_url)
-      expect(flash[:error]).to eq("You do not have permission to manage news posts.")
+      expect(flash[:error]).to eq("You do not have permission to edit that news post.")
     end
 
     it "errors if wrong mod" do
@@ -245,7 +245,7 @@ RSpec.describe NewsController do
       login
       delete :destroy, params: {id: create(:news).id}
       expect(response).to redirect_to(news_index_url)
-      expect(flash[:error]).to eq("You do not have permission to manage news posts.")
+      expect(flash[:error]).to eq("You do not have permission to edit that news post.")
     end
 
     it "errors if wrong mod" do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe SessionsController do
     end
 
     it "requires unsuspended user" do
-      user = create(:user, role_id: Permissible::SUSPENDED)
+      user = create(:user, role_id: :suspended)
       post :create, params: { username: user.username }
       expect(flash[:error]).to eq("You could not be logged in.")
       expect(controller.send(:logged_in?)).not_to eq(true)

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe SessionsController do
     end
 
     it "requires unsuspended user" do
-      user = create(:user, role_id: :suspended)
+      user = create(:user, role: :suspended)
       post :create, params: { username: user.username }
       expect(flash[:error]).to eq("You could not be logged in.")
       expect(controller.send(:logged_in?)).not_to eq(true)

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -279,14 +279,6 @@ RSpec.describe TagsController do
       get :edit, params: { id: tag.id }
       expect(response.status).to eq(200)
     end
-
-    it "allows mod to edit the tag" do
-      stub_const("Permissible::MOD_PERMS", [:edit_tags])
-      tag = create(:label)
-      login_as(create(:mod_user))
-      get :edit, params: { id: tag.id }
-      expect(response.status).to eq(200)
-    end
   end
 
   describe "PUT update" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,15 +10,15 @@ FactoryBot.define do
     tos_version { User::CURRENT_TOS_VERSION }
 
     factory :admin_user do
-      role_id { 1 }
+      role_id { :admin }
     end
 
     factory :mod_user do
-      role_id { 2 }
+      role_id { :mod }
     end
 
     factory :importing_user do
-      role_id { 3 }
+      role_id { :importer }
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,15 +10,15 @@ FactoryBot.define do
     tos_version { User::CURRENT_TOS_VERSION }
 
     factory :admin_user do
-      role_id { :admin }
+      role { :admin }
     end
 
     factory :mod_user do
-      role_id { :mod }
+      role { :mod }
     end
 
     factory :importing_user do
-      role_id { :importer }
+      role { :importer }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -297,4 +297,73 @@ RSpec.describe User do
       end
     end
   end
+
+  describe "#has_permission?" do
+    shared_examples 'all' do
+      it "returns false for regular users" do
+        user = create(:user)
+        expect(user.has_permission?(permission)).to eq(false)
+      end
+
+      it "returns false for suspended users" do
+        user = create(:user, role: :suspended)
+        expect(user.has_permission?(permission)).to eq(false)
+      end
+
+      it "returns true for admins" do
+        user = create(:admin_user)
+        expect(user.has_permission?(permission)).to eq(true)
+      end
+    end
+
+    shared_examples 'mod permissions' do
+      include_examples 'all'
+
+      it "returns true for mods" do
+        user = create(:mod_user)
+        expect(user.has_permission?(permission)).to eq(true)
+      end
+    end
+
+    shared_examples 'importers' do
+      it "returns false for importers" do
+        user = create(:importing_user)
+        expect(user.has_permission?(permission)).to eq(false)
+      end
+    end
+
+    (Permissible::MOD_PERMS - [:import_posts]).each do |permission|
+      context permission.to_s do
+        let(:permission) { permission }
+
+        include_examples 'mod permissions'
+        include_examples 'importers'
+      end
+    end
+
+    Permissible::PERMS[5..].each do |permission|
+      context permission.to_s do
+        let(:permission) { permission }
+
+        include_examples 'all'
+        include_examples 'importers'
+
+        it "returns false for mods" do
+          user = create(:mod_user)
+          expect(user.has_permission?(permission)).to eq(false)
+        end
+      end
+    end
+
+    context 'import_posts' do
+      let(:permission) { :import_posts }
+
+      include_examples 'mod permissions'
+
+      it "returns true for importers" do
+        user = create(:importing_user)
+        expect(user.has_permission?(:import_posts)).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Transitions Permissible to using the Concern framework
* Transfers `role_id` meaning to an enum rather than constants
* Renames `role_id` to `role`
* Lists all permissions on Permissible
* Restricts `has_permission?` to known permissions
* Adds `:create_news` permission and uses that rather than checking staff
* Tests `has_permission?`
* Removes mods can edit tag test