### PR TITLE
Use selector_name for alt dropdown on character replace

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -196,13 +196,7 @@ class CharactersController < ApplicationController
     gon.gallery = icons.to_h
     gon.gallery[''] = {url: view_context.image_path('icons/no-icon.png'), keyword: 'No Character'}
 
-    @alt_dropdown = @alts.map do |alt|
-      name = alt.name
-      name += ' | ' + alt.screenname if alt.screenname
-      name += ' | ' + alt.nickname if alt.nickname
-      name += ' | ' + alt.settings.pluck(:name).join(' & ') if alt.settings.present?
-      [name, alt.id]
-    end
+    @alt_dropdown = @alts.map { |alt| [alt.selector_name(include_settings: true), alt.id] }
     @alt = @alts.first
 
     reply_post_ids = Reply.where(character_id: @character.id).select(:post_id).distinct.pluck(:post_id)

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -66,8 +66,10 @@ class Character < ApplicationRecord
     @recent ||= Post.where(id: (post_ids + reply_ids).uniq).ordered
   end
 
-  def selector_name
-    [name, nickname, screenname].compact.join(' | ')
+  def selector_name(include_settings: false)
+    parts = [name, nickname, screenname]
+    parts << settings.pluck(:name).join(' & ') if include_settings
+    parts.reject(&:blank?).join(' | ')
   end
 
   def reorder_galleries(_gallery=nil)

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -323,6 +323,45 @@ RSpec.describe Character do
     end
   end
 
+  describe "#selector_name" do
+    let(:character) { create(:character) }
+    let(:screenname) { 'test_screename' }
+    let(:nickname) { 'test nickname' }
+
+    it "works with only name" do
+      expect(character.selector_name).to eq(character.name)
+    end
+
+    it "works with all names" do
+      character.update!(screenname: screenname, nickname: nickname)
+      expect(character.selector_name).to eq("#{character.name} | #{nickname} | #{screenname}")
+    end
+
+    context "with include_settings" do
+      let(:settings) { create_list(:setting, 2) }
+
+      it "works with no settings" do
+        expect(character.selector_name(include_settings: true)).to eq(character.name)
+      end
+
+      it "works with one setting" do
+        character.update!(settings: [settings[0]])
+        expect(character.selector_name(include_settings: true)).to eq("#{character.name} | #{settings[0].name}")
+      end
+
+      it "works with multiple settings" do
+        character.update!(settings: settings)
+        expect(character.selector_name(include_settings: true)).to eq("#{character.name} | #{settings[0].name} & #{settings[1].name}")
+      end
+
+      it "works with settings and names" do
+        character.update!(settings: settings, screenname: screenname, nickname: nickname)
+        string = "#{character.name} | #{nickname} | #{screenname} | #{settings[0].name} & #{settings[1].name}"
+        expect(character.selector_name(include_settings: true)).to eq(string)
+      end
+    end
+  end
+
   it "orders icons by default" do
     user = create(:user)
     char = create(:character, user: user)


### PR DESCRIPTION
* Replaces manually composed alt selector names + settings with selector_name call with additional parameter
* Adds include_settings parameter to selector_name
* Tests selector_name