### PR TITLE
Fix minor rubocop lints

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,7 +4,7 @@ class ApplicationRecord < ActiveRecord::Base
   def audited_user_id
     user = ::Audited.store[:audited_user] # from as_user
     user ||= ::Audited.store[:current_user].call if ::Audited.store[:current_user].respond_to?(:call) # from controller method
-    return nil if user.nil? && Rails.env != 'test' # for debugging purposes this should fail loudly in tests
+    return nil if user.nil? && !Rails.env.test? # for debugging purposes this should fail loudly in tests
     user.id
   end
 end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -13,9 +13,9 @@ class Board < ApplicationRecord
 
   has_many :board_authors, inverse_of: :board, dependent: :destroy
   has_many :authors, class_name: 'User', through: :board_authors, source: :user, dependent: :destroy
-  has_many :board_writers, -> { where(cameo: false) }, class_name: 'BoardAuthor', inverse_of: :board
+  has_many :board_writers, -> { where(cameo: false) }, class_name: 'BoardAuthor', inverse_of: :board, dependent: :destroy
   has_many :writers, class_name: 'User', through: :board_writers, source: :user, dependent: :destroy
-  has_many :board_cameos, -> { where(cameo: true) }, class_name: 'BoardAuthor', inverse_of: :board
+  has_many :board_cameos, -> { where(cameo: true) }, class_name: 'BoardAuthor', inverse_of: :board, dependent: :destroy
   has_many :cameos, class_name: 'User', through: :board_cameos, source: :user, dependent: :destroy
   has_many :coauthors, ->(board) { where.not(id: board.creator_id) }, class_name: 'User', through: :board_writers, source: :user, dependent: :destroy
 

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require ::File.expand_path('config/environment', __dir__)
 run Rails.application

--- a/script/post_split.rb
+++ b/script/post_split.rb
@@ -118,7 +118,7 @@ def update_caches(post, last_reply)
   end
 
   puts "updating post columns: #{cached_data}"
-  post.update_columns(cached_data)
+  post.update_columns(cached_data) # rubocop:disable Rails/SkipsModelValidations
 end
 
 split_post if $PROGRAM_NAME == __FILE__

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -1000,6 +1000,7 @@ RSpec.describe CharactersController do
 
     context "with audits enabled" do
       before(:each) { Reply.auditing_enabled = true }
+
       after(:each) { Reply.auditing_enabled = false }
 
       it "succeeds with valid other character" do

--- a/spec/features/posts/show_spec.rb
+++ b/spec/features/posts/show_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Viewing posts", :type => :feature do
 
     scenario "when user has content warnings turned off" do
       user = login
-      user.update(hide_warnings: true)
+      user.update!(hide_warnings: true)
       visit post_path(post)
       expect(page).not_to have_selector('.error')
     end

--- a/spec/lib/presentable_spec.rb
+++ b/spec/lib/presentable_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Presentable do
       4
     end
   end
+
   class ExampleWith
     include Presentable
   end
@@ -40,6 +41,7 @@ RSpec.describe Presentable do
       1
     end
   end
+
   class ExampleWithSuper
     include Presentable
     def as_json(_options={})


### PR DESCRIPTION
- Adds whitespace
- Uses update! in tests
- Disables warning on post split script
- Uses expand_path __dir__ pattern
- Declares `dependent: :destroy` on board writers and cameos
- Uses `Rails.env.test?` rather than `Rails.env == 'test'`