### PR TITLE
Enforce good practices and consistent style on tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -401,7 +401,7 @@ Rails/SquishedSQLHeredocs:
   Enabled: true
 
 Rails/TimeZoneAssignment: # (new in 2.10)
-  Enabled: false
+  Enabled: true
 
 Rails/UniqueValidationWithoutIndex:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -464,11 +464,12 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NestedGroups:
   Max: 5
 
+RSpec/StubbedMock:
+  Exclude:
+    - 'spec/script/post_split_spec.rb' # mocking multiple gets in order needs expect
+
 RSpec/SubjectDeclaration: # new in 2.5
   Enabled: true
-
-RSpec/StubbedMock:
-  Enabled: false
 
 ################## RSpec/Capybara ##############################
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -481,7 +481,7 @@ RSpec/Rails/AvoidSetupHook: # new in 2.4
   Enabled: true
 
 RSpec/Rails/HttpStatus:
-  Enabled: false
+  EnforcedStyle: numeric
 
 ################## Security ##############################
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -448,9 +448,6 @@ RSpec/HookArgument:
 RSpec/IdenticalEqualityAssertion: # new in 2.4
   Enabled: true
 
-RSpec/InstanceVariable:
-  Enabled: false
-
 RSpec/LeakyConstantDeclaration:
   Exclude:
     - 'spec/lib/presentable_spec.rb'

--- a/spec/controllers/api/v1/characters_controller_spec.rb
+++ b/spec/controllers/api/v1/characters_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::CharactersController do
       it "requires valid post id if provided", show_in_doc: in_doc do
         create(:character)
         get :index, params: { post_id: -1 }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(422)
         expect(response.json['errors'].size).to eq(1)
         expect(response.json['errors'][0]['message']).to eq("Post could not be found.")
       end
@@ -29,7 +29,7 @@ RSpec.describe Api::V1::CharactersController do
       it "requires valid template id if provided", show_in_doc: in_doc do
         create(:character)
         get :index, params: { template_id: 999 }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(422)
         expect(response.json['errors'].size).to eq(1)
         expect(response.json['errors'][0]['message']).to eq("Template could not be found.")
       end
@@ -37,7 +37,7 @@ RSpec.describe Api::V1::CharactersController do
       it "requires valid user id if provided", show_in_doc: in_doc do
         character = create(:character)
         get :index, params: { user_id: character.user.id + 1 }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(422)
         expect(response.json['errors'].size).to eq(1)
         expect(response.json['errors'][0]['message']).to eq("User could not be found.")
       end
@@ -45,7 +45,7 @@ RSpec.describe Api::V1::CharactersController do
       it "requires valid includes if provided", show_in_doc: in_doc do
         create(:character)
         get :index, params: { includes: ['invalid'] }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(422)
         expect(response.json['errors'].size).to eq(1)
         expected = "Invalid parameter 'includes' value ['invalid']: Must be an array of ['default_icon', 'aliases', 'nickname']"
         expect(response.json['errors'][0]['message']).to eq(expected)
@@ -54,7 +54,7 @@ RSpec.describe Api::V1::CharactersController do
       it "requires post with permission", show_in_doc: in_doc do
         post = create(:post, privacy: :private, with_character: true)
         get :index, params: { post_id: post.id }
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(403)
         expect(response.json['errors'].size).to eq(1)
         expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
       end
@@ -240,7 +240,7 @@ RSpec.describe Api::V1::CharactersController do
     it "requires post to have permission when provided a post_id", :show_in_doc do
       post = create(:post, privacy: :private, with_character: true)
       get :show, params: { id: post.character_id, post_id: post.id }
-      expect(response).to have_http_status(:forbidden)
+      expect(response).to have_http_status(403)
       expect(response.json['errors'].size).to eq(1)
       expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -341,35 +341,35 @@ RSpec.describe ApplicationController do
     it "redirects on valid requests" do
       ENV['DOMAIN_NAME'] ||= 'domaintest.host'
       get :index, params: { force_domain: true }
-      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to have_http_status(301)
       expect(response).to redirect_to('https://domaintest.host/anonymous?force_domain=true')
     end
 
     it "does not redirect on post requests" do
       post :create, params: { force_domain: true }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(200)
     end
 
     it "does not redirect unless forced" do
       get :index
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(200)
     end
 
     it "does not redirect API requests" do
       get :index, params: { force_domain: true }, xhr: true
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(200)
     end
 
     it "does not redirect glowfic.com requests" do
       request.host = 'glowfic.com'
       get :index, params: { force_domain: true }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(200)
     end
 
     it "does not redirect staging requests" do
       request.host = 'glowfic-staging.herokuapp.com'
       get :index, params: { force_domain: true }
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -1215,41 +1215,39 @@ RSpec.describe CharactersController do
       expect(assigns(:search_results)).to match_array([found])
     end
 
-    context "searching" do
-      before(:each) do
-        @name = create(:character, name: 'a', screenname: 'b', nickname: 'c')
-        @nickname = create(:character, name: 'b', screenname: 'c', nickname: 'a')
-        @screenname = create(:character, name: 'c', screenname: 'a', nickname: 'b')
-      end
+    context "with search" do
+      let!(:name) { create(:character, name: 'a', screenname: 'b', nickname: 'c') }
+      let!(:nickname) { create(:character, name: 'b', screenname: 'c', nickname: 'a') }
+      let!(:screenname) { create(:character, name: 'c', screenname: 'a', nickname: 'b') }
 
       it "searches names correctly" do
         get :search, params: { commit: true, name: 'a', search_name: true }
-        expect(assigns(:search_results)).to match_array([@name])
+        expect(assigns(:search_results)).to match_array([name])
       end
 
       it "searches screenname correctly" do
         get :search, params: { commit: true, name: 'a', search_screenname: true }
-        expect(assigns(:search_results)).to match_array([@screenname])
+        expect(assigns(:search_results)).to match_array([screenname])
       end
 
       it "searches nickname correctly" do
         get :search, params: { commit: true, name: 'a', search_nickname: true }
-        expect(assigns(:search_results)).to match_array([@nickname])
+        expect(assigns(:search_results)).to match_array([nickname])
       end
 
       it "searches name + screenname correctly" do
         get :search, params: { commit: true, name: 'a', search_name: true, search_screenname: true }
-        expect(assigns(:search_results)).to match_array([@name, @screenname])
+        expect(assigns(:search_results)).to match_array([name, screenname])
       end
 
       it "searches name + nickname correctly" do
         get :search, params: { commit: true, name: 'a', search_name: true, search_nickname: true }
-        expect(assigns(:search_results)).to match_array([@name, @nickname])
+        expect(assigns(:search_results)).to match_array([name, nickname])
       end
 
       it "searches nickname + screenname correctly" do
         get :search, params: { commit: true, name: 'a', search_nickname: true, search_screenname: true }
-        expect(assigns(:search_results)).to match_array([@nickname, @screenname])
+        expect(assigns(:search_results)).to match_array([nickname, screenname])
       end
 
       it "searches all correctly" do
@@ -1260,7 +1258,7 @@ RSpec.describe CharactersController do
           search_screenname: true,
           search_nickname: true,
         }
-        expect(assigns(:search_results)).to match_array([@name, @screenname, @nickname])
+        expect(assigns(:search_results)).to match_array([name, screenname, nickname])
       end
 
       it "orders results correctly" do

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe ApplicationJob do
 
     job = StubJob.new(2, :test)
     allow(job).to receive(:perform).and_raise(exc)
+    expect(job).to receive(:perform)
     begin
       job.perform_now
     rescue Exception # rubocop:disable Lint/RescueException

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ApplicationJob do
     expect(ExceptionNotifier).to receive(:notify_exception).with(exc, data: { job: StubJob.name, args: [2, :test] })
 
     job = StubJob.new(2, :test)
-    expect(job).to receive(:perform).and_raise(exc)
+    allow(job).to receive(:perform).and_raise(exc)
     begin
       job.perform_now
     rescue Exception # rubocop:disable Lint/RescueException

--- a/spec/models/daily_report_spec.rb
+++ b/spec/models/daily_report_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe DailyReport do
       zone = data.first
       dst_day_params = data.last
       context name do
-        before(:each) { Time.zone = zone }
-
-        after(:each) { Time.zone = default_zone }
+        around(:each) do |example|
+          Time.use_zone(zone) do
+            example.run
+          end
+        end
 
         it "should work on a regular day" do
           time = Time.zone.local(2017, 1, 2, 10, 0) # 2017-01-02 10:00

--- a/spec/models/icon_spec.rb
+++ b/spec/models/icon_spec.rb
@@ -131,12 +131,10 @@ RSpec.describe Icon do
   describe "#use_icon_host" do
     let(:asset_host) { "https://fake.cloudfront.net" }
 
-    before(:each) { @cached_host = ENV['ICON_HOST'] }
-
-    after(:each) { ENV['ICON_HOST'] = @cached_host }
+    before(:each) { allow(ENV).to receive(:[]).and_call_original }
 
     it "does nothing unless asset host is present" do
-      ENV['ICON_HOST'] = nil
+      allow(ENV).to receive(:[]).with('ICON_HOST').and_return(nil)
       icon = build(:icon, user: create(:user))
       url = "https://glowfic-bucket.s3.amazonaws.com/users%2F#{icon.user.id}%2Ficons%2Ffake_test.png"
       icon.s3_key = "users/#{icon.user_id}/icons/fake_test.png"
@@ -146,7 +144,7 @@ RSpec.describe Icon do
     end
 
     it "does nothing unless the icon is uploaded" do
-      ENV['ICON_HOST'] = asset_host
+      allow(ENV).to receive(:[]).with('ICON_HOST').and_return(asset_host)
       icon = build(:icon, user: create(:user))
       url = "https://glowfic-bucket.s3.amazonaws.com/users%2F#{icon.user.id}%2Ficons%2Ffake_test.png"
       icon.s3_key = nil
@@ -156,7 +154,7 @@ RSpec.describe Icon do
     end
 
     it "does nothing unless the icon already has the asset host domain in it" do
-      ENV['ICON_HOST'] = asset_host
+      allow(ENV).to receive(:[]).with('ICON_HOST').and_return(asset_host)
       icon = build(:icon, user: create(:user))
       url = "#{asset_host}/users%2F#{icon.user_id}%2Ficons%2Ffake_test.png"
       icon.s3_key = "users/#{icon.user_id}/icons/fake_test.png"
@@ -166,13 +164,13 @@ RSpec.describe Icon do
     end
 
     it "handles weird URL-less AWS edge case" do
-      ENV['ICON_HOST'] = asset_host
+      allow(ENV).to receive(:[]).with('ICON_HOST').and_return(asset_host)
       icon = build(:uploaded_icon, url: '')
       expect(icon.save).to eq(false)
     end
 
     it "updates the s3 domain to the asset host domain" do
-      ENV['ICON_HOST'] = asset_host
+      allow(ENV).to receive(:[]).with('ICON_HOST').and_return(asset_host)
       icon = build(:icon, user: create(:user))
       icon.url = "https://glowfic-bucket.s3.amazonaws.com/users%2F#{icon.user_id}%2Ficons%2Ffake_test.png"
       icon.s3_key = "users/#{icon.user_id}/icons/fake_test.png"

--- a/spec/script/post_split_spec.rb
+++ b/spec/script/post_split_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "post_split" do # rubocop:disable RSpec/DescribeClass
 
     it "requires valid subject" do
       allow(STDIN).to receive(:gets).and_return('')
+      expect(STDIN).to receive(:gets)
       expect { split_post }.to raise_error(RuntimeError, 'Invalid subject')
     end
 

--- a/spec/script/post_split_spec.rb
+++ b/spec/script/post_split_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "post_split" do # rubocop:disable RSpec/DescribeClass
     let(:reply) { create(:reply) }
 
     it "requires valid subject" do
-      expect(STDIN).to receive(:gets).and_return('')
+      allow(STDIN).to receive(:gets).and_return('')
       expect { split_post }.to raise_error(RuntimeError, 'Invalid subject')
     end
 

--- a/spec/services/post_scraper_spec.rb
+++ b/spec/services/post_scraper_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe PostScraper do
 
     html = "<!DOCTYPE html>\n<html></html>\n"
     stub_with_body = double
-    expect(stub_with_body).to receive(:body).and_return(html)
+    allow(stub_with_body).to receive(:body).and_return(html)
 
     allow(HTTParty).to receive(:get).with(url).once.and_raise(Net::OpenTimeout, 'example failure')
     allow(HTTParty).to receive(:get).with(url).and_return(stub_with_body)

--- a/spec/services/post_scraper_spec.rb
+++ b/spec/services/post_scraper_spec.rb
@@ -306,6 +306,7 @@ RSpec.describe PostScraper do
     html = "<!DOCTYPE html>\n<html></html>\n"
     stub_with_body = double
     allow(stub_with_body).to receive(:body).and_return(html)
+    expect(stub_with_body).to receive(:body)
 
     allow(HTTParty).to receive(:get).with(url).once.and_raise(Net::OpenTimeout, 'example failure')
     allow(HTTParty).to receive(:get).with(url).and_return(stub_with_body)


### PR DESCRIPTION
* Uses Time.use_zone block rather than setting Time.zone
* Replaces instance variables in tests
* Uses numbers for http statuses
* Avoids expect(...).and_return(...) where it's not necessary