### PR TITLE
Remove Docker chromium version constraint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     nodejs \
     postgresql-client-11 \
-    chromium=90.* \
+    chromium \
   && apt-get clean
 
 ARG bundler_version=2.2.16


### PR DESCRIPTION
Ended up just being way more annoying to deal
with than it was helpful - removing it to reduce
churn.