### PR TITLE
Add background-color back to login warning

### DIFF
--- a/app/assets/javascripts/global.js
+++ b/app/assets/javascripts/global.js
@@ -39,7 +39,7 @@ $(document).ready(function() {
     // find or create the warning box
     var warningBox = $('#login_status_warning');
     if (warningBox.length === 0) {
-      warningBox = $('<div class="flash inbox pointer" id="login_status_warning">');
+      warningBox = $('<div class="flash breadcrumbs pointer" id="login_status_warning">');
       warningBox.click(function() { $(this).remove(); });
       $('#header').after(warningBox);
     }

--- a/app/assets/javascripts/global.js
+++ b/app/assets/javascripts/global.js
@@ -39,7 +39,7 @@ $(document).ready(function() {
     // find or create the warning box
     var warningBox = $('#login_status_warning');
     if (warningBox.length === 0) {
-      warningBox = $('<div class="flash breadcrumbs pointer" id="login_status_warning">');
+      warningBox = $('<div class="flash error pointer" id="login_status_warning">');
       warningBox.click(function() { $(this).remove(); });
       $('#header').after(warningBox);
     }


### PR DESCRIPTION
When we removed the inbox flash, we also incidentally
removed the background from the login warning, where you
log in/out in another tab!

This adds it back, piggybacking off the breadcrumbs color.
We could instead use `success`, or `error`, or create a new
separate category for this - I went with a small change
here that hopefully wouldn't use a confusing color, but am
open to thoughts!

Here's how it looks on starrylight before the change:

![image](https://user-images.githubusercontent.com/577128/155650847-f3e7c23e-b1e6-48b9-93af-248eb7012e28.png)

And here's how it looks afterwards:

![image](https://user-images.githubusercontent.com/577128/155651340-5dc86a20-8c7e-4aa0-b2c2-d647025897f3.png)
