### PR TITLE
Increase colspan to tags > characters header

### DIFF
--- a/app/views/tags/_characters.haml
+++ b/app/views/tags/_characters.haml
@@ -1,6 +1,6 @@
 %table.tag-right-content-box
   %thead
     %tr
-      %th.table-title{colspan: 7} Characters Tagged: #{@tag.name}
+      %th.table-title{colspan: 8} Characters Tagged: #{@tag.name}
   %tbody
     = render 'characters/list_section', name: nil, characters: @characters, hide_buttons: true, show_user: true, show_template: true


### PR DESCRIPTION
Seems to be consistently colspan=8 with the space for the
edit buttons! We're just down by one.

See e.g. https://glowfic.com/tags/322?view=characters

![image](https://user-images.githubusercontent.com/577128/155651226-8c6c938e-96d8-4e10-aeae-6137ff4b0bba.png)