### PR TITLE
Add the text color toolbar button to RTF editor

### DIFF
--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -287,7 +287,7 @@ function setupTinyMCE() {
     tinyMCE.init({
       selector: selector,
       menubar: false,
-      toolbar: ["bold italic underline strikethrough | link image | blockquote hr bullist numlist | undo redo"],
+      toolbar: ["bold italic underline strikethrough forecolor | link image | blockquote hr bullist numlist | undo redo"],
       branding: false,
       plugins: "wordcount,image,hr,link,autoresize,paste",
       paste_as_text: true,


### PR DESCRIPTION
Per https://discord.com/channels/294167563447828481/946858150340993034/946962831260143668. A better solution would be to allow setting toolbar from some kind of user-level property, but this was easier.