### PR TITLE
Disable Rails/SaveBang cop on app/ and config/

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -393,6 +393,9 @@ Rails/RenderPlainText:
 
 Rails/SaveBang:
   Enabled: true
+  Exclude:
+    - 'app/**/*'
+    - 'config/**/*'
 
 Rails/ShortI18n:
   Enabled: true


### PR DESCRIPTION
Since we seem to be ignoring the warnings anyway.

Leaving it on on spec which we want to fail noisily.

I'm open to instead putting this in a rubocop-todo file if we want to actually check return values of stuff, but.