### PR TITLE
Update flatposts on more changes

### DIFF
--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -14,7 +14,7 @@ class Reply < ApplicationRecord
 
   after_create :notify_other_authors, :destroy_draft, :update_active_char, :set_last_reply, :update_post, :update_post_authors
   after_update :update_post
-  after_destroy :set_previous_reply_to_last, :remove_post_author
+  after_destroy :set_previous_reply_to_last, :remove_post_author, :update_flat_post
   after_save :update_flat_post
 
   attr_accessor :skip_notify, :skip_post_update, :is_import, :skip_regenerate


### PR DESCRIPTION
Fixes #1645 
Fixes #1460 
Fixes #252

* Regenerates flatpost when reply is destroyed
* Regenerates flatpost when icon or icon keyword is changed
* Regenerates flatpost when character name or screenname is changed
* Regenerates flatpost when username is changed or user is archived