### PR TITLE
Fix/paste bug

### DIFF
--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -287,10 +287,10 @@ function setupTinyMCE() {
     tinyMCE.init({
       selector: selector,
       menubar: false,
-      toolbar: ["bold italic underline strikethrough forecolor | link image | blockquote hr bullist numlist | undo redo"],
+      toolbar: ["bold italic underline strikethrough | link image | blockquote hr bullist numlist | undo redo"],
       branding: false,
       plugins: "wordcount,image,hr,link,autoresize,paste",
-      paste_as_text: false,
+      paste_as_text: true,
       custom_undo_redo_levels: 10,
       content_css: gon.tinymce_css_path,
       statusbar: true,

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -290,7 +290,7 @@ function setupTinyMCE() {
       toolbar: ["bold italic underline strikethrough forecolor | link image | blockquote hr bullist numlist | undo redo"],
       branding: false,
       plugins: "wordcount,image,hr,link,autoresize,paste",
-      paste_as_text: true,
+      paste_as_text: false,
       custom_undo_redo_levels: 10,
       content_css: gon.tinymce_css_path,
       statusbar: true,

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -287,10 +287,9 @@ function setupTinyMCE() {
     tinyMCE.init({
       selector: selector,
       menubar: false,
-      toolbar: ["bold italic underline strikethrough | link image | blockquote hr bullist numlist | undo redo"],
+      toolbar: ["bold italic underline strikethrough forecolor | link image | blockquote hr bullist numlist | undo redo"],
       branding: false,
-      plugins: "wordcount,image,hr,link,autoresize,paste",
-      paste_as_text: true,
+      plugins: "wordcount,image,hr,link,autoresize",
       custom_undo_redo_levels: 10,
       content_css: gon.tinymce_css_path,
       statusbar: true,


### PR DESCRIPTION
We added the paste plugin to TinyMCE in this commit https://github.com/Marri/glowfic/commit/c5cb4bf94e9144de9d0d1a3fd0fff3ef319338e5 as an attempt to try and fix the font size fuckery we'd been seeing as noted here https://github.com/Marri/glowfic/pull/959 but I think we fixed the font size issue here https://github.com/Marri/glowfic/pull/1370 and we're now seeing issues with users using our default layout unable to paste in the RTF error because it causes type errors. Why? WHO KNOWS. But if we don't need the plugin anymore and it's causing issues, might as well :fire: