### PR TITLE
Update bundler, nodejs and eslint for equality between envs

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,8 @@
+extends:
+  - eslint:recommended
+
+root: true
+
 parserOptions:
   ecmaVersion: 5
 
@@ -8,33 +13,10 @@ env:
 # http://eslint.org/docs/rules/
 rules:
   # Possible Errors
-  no-cond-assign: 2
   no-console: 0
-  no-constant-condition: 2
-  no-control-regex: 2
-  no-debugger: 2
-  no-dupe-args: 2
-  no-dupe-keys: 2
-  no-duplicate-case: 2
-  no-empty: 2
-  no-empty-character-class: 2
-  no-ex-assign: 2
-  no-extra-boolean-cast: 2
   no-extra-parens: 0
-  no-extra-semi: 2
-  no-func-assign: 2
-  no-inner-declarations: [2, functions]
-  no-invalid-regexp: 2
-  no-irregular-whitespace: 2
   no-negated-in-lhs: 2
-  no-obj-calls: 2
-  no-regex-spaces: 2
-  no-sparse-arrays: 2
-  no-unexpected-multiline: 2
-  no-unreachable: 2
-  use-isnan: 2
   valid-jsdoc: 0
-  valid-typeof: 2
 
   # Best Practices
   accessor-pairs: 2
@@ -49,19 +31,15 @@ rules:
   guard-for-in: 2
   no-alert: 0
   no-caller: 1
-  no-case-declarations: 2
   no-div-regex: 2
   no-else-return: 2
   no-empty-function: 2
-  no-empty-pattern: 2
   no-eq-null: 2
   no-eval: 2
   no-extend-native: 2
   no-extra-bind: 2
   no-extra-label: 2
-  no-fallthrough: 2
   no-floating-decimal: 2
-  no-global-assign: 2
   no-implicit-coercion: 2
   no-implicit-globals: 0
   no-implied-eval: 2
@@ -76,29 +54,23 @@ rules:
   no-new: 2
   no-new-func: 2
   no-new-wrappers: 2
-  no-octal: 2
   no-octal-escape: 2
   no-param-reassign: 0
   no-proto: 2
-  no-redeclare: 2
   no-restricted-properties: 2
   no-return-assign: 2
   no-return-await: 2
   no-script-url: 2
-  no-self-assign: 2
   no-self-compare: 2
   no-sequences: 2
   no-throw-literal: 2
   no-unmodified-loop-condition: 2
   no-unused-expressions: 2
-  no-unused-labels: 2
   no-useless-call: 2
   no-useless-concat: 2
-  no-useless-escape: 2
   no-useless-return: 2
   no-void: 2
   no-warning-comments: 1
-  no-with: 2
   prefer-promise-reject-errors: 2
   radix: 0
   require-await: 1
@@ -112,12 +84,9 @@ rules:
   # Variables
   init-declarations: 0
   no-catch-shadow: 2
-  no-delete-var: 2
   no-label-var: 2
   no-restricted-globals: 2
   no-shadow: 2
-  no-shadow-restricted-names: 2
-  no-undef: 1
   no-undef-init: 2
   no-undefined: 2
   no-unused-vars:
@@ -191,7 +160,6 @@ rules:
   no-inline-comments: 0
   no-lonely-if: 1
   no-mixed-operators: 2
-  no-mixed-spaces-and-tabs: 2
   no-multi-assign: 1
   no-multiple-empty-lines: 0
   no-negated-condition: 1
@@ -245,13 +213,8 @@ rules:
   arrow-body-style: 0
   arrow-parens: 0
   arrow-spacing: 0
-  constructor-super: 0
   generator-star-spacing: 0
   no-arrow-condition: 0
-  no-class-assign: 0
-  no-const-assign: 0
-  no-dupe-class-members: 0
-  no-this-before-super: 0
   no-var: 0
   object-shorthand: 0
   prefer-arrow-callback: 0
@@ -259,4 +222,3 @@ rules:
   prefer-reflect: 0
   prefer-spread: 0
   prefer-template: 0
-  require-yield: 0

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v2
-      - run: npm install eslint@7
+      - run: npm install eslint@8
       - run: npx eslint -v
       - uses: reviewdog/action-eslint@v1
         with:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v2
-      - run: npm install eslint@~6.0.0
+      - run: npm install eslint@7
       - run: npx eslint -v
       - uses: reviewdog/action-eslint@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ RUN gem install bundler -v $bundler_version
 
 ADD Gemfile* /code/
 RUN bundler _${bundler_version}_ install --jobs $(nproc)
-RUN npm i -g eslint@7
+RUN npm i -g eslint@8
 RUN npm i -g stylelint stylelint-config-standard stylelint-declaration-strict-value stylelint-order stylelint-scss

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /code
 
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
 RUN apt-get update && apt-get install -y \
     curl \
     nodejs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
     chromium \
   && apt-get clean
 
-ARG bundler_version=2.2.16
+ARG bundler_version=2.3.10
 
 RUN gem install bundler -v $bundler_version
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,4 +512,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.2.16
+   2.3.10


### PR DESCRIPTION
Heroku uses fixed versions of bundler (2.3.10) and nodejs (16.x), which we were outdated on. Our GitHub Actions check uses a different version of eslint from the one installed in our Dockerfile, so I've also bumped that!