### PR TITLE
Fix Rubocop lints

### DIFF
--- a/app/concerns/taggable.rb
+++ b/app/concerns/taggable.rb
@@ -4,7 +4,7 @@ module Taggable
   def process_tags(klass, obj_param:, id_param:)
     # fetch and clean tag ids
     ids = params.fetch(obj_param, {}).fetch(id_param, [])
-    ids = ids.reject(&:blank?).map(&:to_s)
+    ids = ids.compact_blank.map(&:to_s)
     return [] unless ids.present?
 
     # store formatted for creation-order sorting later

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -364,7 +364,7 @@ class CharactersController < ApplicationController
     linked << ("Nickname".pluralize(nicknames.count) + ": " + nicknames.join(', ')) if nicknames.present?
     settings = @character.settings.pluck(:name)
     linked << ("Setting".pluralize(settings.count) + ": " + settings.join(', ')) if settings.present?
-    desc = [linked.join('. ')].reject(&:blank?)
+    desc = [linked.join('. ')].compact_blank
     desc << generate_short(@character.description) if @character.description.present?
     reply_posts = Reply.where(character_id: @character.id).select(:post_id).distinct.pluck(:post_id)
     posts_count = Post.where(character_id: @character.id).or(Post.where(id: reply_posts)).privacy_public.uniq.count

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -410,7 +410,7 @@ class PostsController < WritableController
   def editor_setup
     super
     @permitted_authors = User.active.ordered - (@post.try(:joined_authors) || [])
-    @author_ids = permitted_params[:unjoined_author_ids].reject(&:blank?).map(&:to_i) if permitted_params.key?(:unjoined_author_ids)
+    @author_ids = permitted_params[:unjoined_author_ids].compact_blank.map(&:to_i) if permitted_params.key?(:unjoined_author_ids)
     @author_ids ||= @post.try(:unjoined_author_ids) || []
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
-class AsyncMailer < ActionMailer::Base
+class ApplicationMailer < ActionMailer::Base
   include Resque::Mailer
 
   default from: "Glowfic Constellation <#{ENV.fetch('GMAIL_USERNAME', nil)}>"

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,4 +1,4 @@
-class UserMailer < AsyncMailer
+class UserMailer < ApplicationMailer
   helper WritableHelper
   helper IconHelper
 

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -70,7 +70,7 @@ class Character < ApplicationRecord
   def selector_name(include_settings: false)
     parts = [name, nickname, screenname]
     parts << settings.pluck(:name).join(' & ') if include_settings
-    parts.reject(&:blank?).join(' | ')
+    parts.compact_blank.join(' | ')
   end
 
   def reorder_galleries(_gallery=nil)

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -10,11 +10,8 @@ end
 
 Resque::Mailer.error_handler = lambda { |mailer, _message, error, action, args|
   # Necessary to re-enqueue jobs that receieve the SIGTERM signal
-  if error.is_a?(Resque::TermException)
-    Resque.enqueue(mailer, action, *args)
-  else
-    raise error
-  end
+  raise error unless error.is_a?(Resque::TermException)
+  Resque.enqueue(mailer, action, *args)
 }
 Resque::Mailer.excluded_environments = [] # I explicitly want this to run in tests; don't exclude them.
 


### PR DESCRIPTION
Fixes some cops that were apparently introduced in the Rails 6.1 upgrade! Supersedes #1713, since it doesn't actually rely on the Ruby upgrade at all.