### PR TITLE
Disable keepalive per Heroku recommendation

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -54,3 +54,6 @@ plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
+
+# https://www.heroku.com/blog/pumas-routers-keepalives-ohmy/#the-solution
+enable_keep_alives false


### PR DESCRIPTION
See https://www.heroku.com/blog/pumas-routers-keepalives-ohmy/#the-solution for more information.

~~Cannot be released until we are on a version of Puma that supports this option, currently predicted to be 6.5.0~~ we're on 6.6.0, onwards