### PR TITLE
Add sort-by-unread for Unread, Favorites, and Daily Report

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -281,6 +281,10 @@ td, .table-list li { font-size: $font_size_small; }
   .link-box { font-size: $font_size_smallish; }
 }
 
+th.sub a.current-sort {
+  font-weight: bold;
+}
+
 .check-all-box {
   /* The .sub or .subber that has the "check all" checkbox */
   width: 30px;

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -18,7 +18,16 @@ class FavoritesController < ApplicationController
 
     @posts = Post.where(id: author_posts).or(Post.where(id: post_favorites)).or(Post.where(board_id: board_favorites))
     @posts = @posts.not_ignored_by(current_user) if current_user&.hide_from_all
-    @posts = posts_from_relation(@posts.ordered, with_unread: true)
+
+    @sort = params[:sort] if params[:sort] == 'unread'
+    if @sort == 'unread'
+      ordered = @posts.with_unread_count(current_user).order(Arel.sql('unread_count DESC'), tagged_at: :desc)
+    else
+      ordered = @posts.ordered
+    end
+    @posts = posts_from_relation(ordered, with_unread: true)
+    @paginate_params = { sort: @sort }.compact if @sort
+
     @hide_quicklinks = true
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,6 +22,11 @@ class ReportsController < ApplicationController
       @new_today = params[:new_today].present?
       @posts = DailyReport.new(@day).posts(sort, @new_today)
       @posts = @posts.not_ignored_by(current_user) if current_user&.hide_from_all
+      if params[:sort] == 'unread' && logged_in?
+        @posts = @posts.with_unread_count(current_user)
+          .reorder(Arel.sql('unread_count DESC'), Arel.sql('first_updated_at DESC'))
+        @paginate_params = { id: @report_type, day: params[:day], sort: 'unread', new_today: params[:new_today] }.compact
+      end
       @posts = posts_from_relation(@posts, max: !@new_today)
     else
       @posts = Post.where(tagged_at: 1.month.ago.all_month)

--- a/app/views/favorites/index.haml
+++ b/app/views/favorites/index.haml
@@ -33,4 +33,6 @@
           %td.centered.no-posts.odd{colspan: 2} — No favorites yet —
 
 - else
-  = render 'posts/list', posts: @posts, show_unread_count: true
+  = render 'posts/list', posts: @posts, show_unread_count: true,
+    sort_url: ->(s) { favorites_path(sort: s) },
+    current_sort: @sort

--- a/app/views/posts/_list.haml
+++ b/app/views/posts/_list.haml
@@ -1,10 +1,10 @@
--# locals: ( posts:, table_class: '', hide_continuity: false, show_unread_count: false, check_box_name: nil )
+-# locals: ( posts:, table_class: '', hide_continuity: false, show_unread_count: false, check_box_name: nil, sort_url: nil, current_sort: nil )
 
 - col_count = 5
 - col_count += 1 unless hide_continuity # Include continuity name
 - col_count += 1 if show_unread_count # Include # Unread
 - col_count += 1 if check_box_name # Include form check box tags
-- post_args = local_assigns.except(:posts, :list, :table_class)
+- post_args = local_assigns.except(:posts, :list, :table_class, :sort_url, :current_sort)
 
 %span.time-loaded= pretty_time(DateTime.now.in_time_zone)
 
@@ -25,8 +25,16 @@
       %th.sub Authors
       %th.sub Replies
       - if show_unread_count
-        %th.sub Unread
-      %th.sub Last Updated
+        %th.sub
+          - if sort_url
+            = link_to 'Unread', sort_url.call('unread'), class: ('current-sort' if current_sort == 'unread')
+          - else
+            Unread
+      %th.sub
+        - if sort_url
+          = link_to 'Last Updated', sort_url.call(nil), class: ('current-sort' unless current_sort.present?)
+        - else
+          Last Updated
       - if check_box_name
         %th.sub.check-all-box
           - unless posts.empty?

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -51,7 +51,10 @@
   %td.width-70.post-replies.vtop{class: klass}= link_to replies_count, stats_post_path(post)
   - if logged_in? && show_unread_count
     %td.width-70.vtop{class: klass}
-      - if @opened_ids.include?(post.id) && unread_ids.include?(post.id)
+      - if post.has_attribute?(:unread_count)
+        - count = post.unread_count
+        = count > 0 ? count : '-'
+      - elsif @opened_ids.include?(post.id) && unread_ids.include?(post.id)
         = @unread_counts.fetch(post.id, 0)
       - else
         \-

--- a/app/views/posts/unread.haml
+++ b/app/views/posts/unread.haml
@@ -14,7 +14,9 @@
         Opened Threads &raquo;
 
 = form_tag mark_posts_path, method: :post do
-  = render 'posts/list', posts: @posts, show_unread_count: true, check_box_name: 'marked_ids[]'
+  = render 'posts/list', posts: @posts, show_unread_count: true, check_box_name: 'marked_ids[]',
+    sort_url: ->(s) { unread_posts_path(sort: s, started: @started || nil) },
+    current_sort: @sort
   - unless @posts.empty?
     %table
       %tr

--- a/app/views/reports/_daily.haml
+++ b/app/views/reports/_daily.haml
@@ -35,7 +35,11 @@
         %th.subber Authors
         %th.subber.width-70 Replies
         %th.subber.width-70 Today
-        %th.subber.width-70= link_to 'Updated', url_for(day: params[:day], sort: 'updated')
+        %th.subber.width-70
+          = link_to 'Updated', url_for(day: params[:day], sort: 'updated')
+          - if logged_in?
+            |
+            = link_to 'Unread', url_for(day: params[:day], sort: 'unread')
   - if @posts.present?
     %tbody
       - @posts.each do |post|


### PR DESCRIPTION
## Summary
- Adds a `?sort=unread` query parameter to sort posts by most-unread-first in the Unread Posts, Favorites, and Daily Report views
- Implements a `with_unread_count` scope on Post that computes unread reply counts via a correlated SQL subquery, enabling ORDER BY before pagination
- Makes "Unread" and "Last Updated" column headers into clickable sort links that preserve view-specific params (e.g. `started`, pagination) across pages
- Uses the SQL-computed `unread_count` attribute on each post when available, falling back to existing `@unread_counts` display logic for the default sort

## Test plan
- [x] Visit `/posts/unread?sort=unread` — posts should sort by most unread replies first
- [x] Visit `/posts/unread?started=true&sort=unread` — opened posts sort by unread, `started` param preserved across pagination
- [x] Visit `/favorites?sort=unread` — favorite posts sort by unread count
- [x] Visit `/reports/daily?sort=unread` — daily report sorts by unread count
- [x] Click "Last Updated" header to return to default sort
- [x] Verify pagination preserves sort parameter on all views
- [x] Verify default sort (no `?sort` param) behaves identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)