### PR TITLE
Add unread filter to post search

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -287,6 +287,8 @@ class PostsController < WritableController
 
     return unless params[:commit].present?
 
+    @show_unread = params[:unread].present? && logged_in?
+
     response.headers['X-Robots-Tag'] = 'noindex'
     @search_results = Post.ordered
     @search_results = @search_results.where(board_id: params[:board_id]) if params[:board_id].present?
@@ -311,8 +313,26 @@ class PostsController < WritableController
       post_ids = Reply.where(character_id: params[:character_id]).select(:post_id).distinct.pluck(:post_id)
       @search_results = @search_results.where(character_id: params[:character_id]).or(@search_results.where(id: post_ids))
     end
-    @search_results = @search_results.not_ignored_by(current_user) if current_user&.hide_from_all && params[:hide_ignored].present?
-    @search_results = posts_from_relation(@search_results, show_blocked: !!params[:show_blocked], no_tests: no_tests)
+    if @show_unread
+      @search_results = @search_results.not_ignored_by(current_user)
+
+      # post view does not exist and (board view does not exist or post has updated since board view read_at)
+      no_post_view = @search_results.where(post_views: { id: nil })
+      updated_since_board_read = no_post_view.where(board_views: { read_at: nil })
+        .or(no_post_view.where("date_trunc('second', board_views.read_at) < date_trunc('second', posts.tagged_at)"))
+      no_post_view = no_post_view.where(board_views: { user_id: nil }).or(updated_since_board_read)
+
+      # post view exists and post has updated since post view read_at
+      with_post_view = @search_results.where.not(post_views: { id: nil })
+      with_post_view = with_post_view.where(post_views: { read_at: nil })
+        .or(with_post_view.where("date_trunc('second', post_views.read_at) < date_trunc('second', posts.tagged_at)"))
+
+      @search_results = with_post_view.or(no_post_view)
+    elsif current_user&.hide_from_all && params[:hide_ignored].present?
+      @search_results = @search_results.not_ignored_by(current_user)
+    end
+
+    @search_results = posts_from_relation(@search_results, show_blocked: !!params[:show_blocked], no_tests: no_tests, with_unread: @show_unread)
   end
 
   def warnings

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -43,6 +43,12 @@
               %td.padding-5
                 = check_box_tag :completed, true, params[:completed].present?, { class: 'vmid no-margin', style: 'margin-bottom: 3px;' }
                 = label_tag :completed, "Completed Only"
+            - if logged_in?
+              %tr
+                %td Unread
+                %td.padding-5
+                  = check_box_tag :unread, true, params[:unread].present?, { class: 'vmid no-margin', style: 'margin-bottom: 3px;' }
+                  = label_tag :unread, "Unread Only"
             - if current_user&.hide_from_all
               %tr
                 %td Ignored
@@ -61,9 +67,11 @@
                 %th.sub Continuity
                 %th.sub Authors
                 %th.sub Replies
+                - if @show_unread
+                  %th.sub Unread
                 %th.sub Last Updated
             %tbody
-              = render partial: 'posts/list_item', collection: @search_results, as: :post
+              = render partial: 'posts/list_item', collection: @search_results, as: :post, locals: { show_unread_count: !!@show_unread }
 
   - if @search_results && @search_results.total_pages > 1
     %tfoot

--- a/spec/controllers/posts/search_spec.rb
+++ b/spec/controllers/posts/search_spec.rb
@@ -158,13 +158,16 @@ RSpec.describe PostsController, 'GET search' do
       it "includes posts with new replies since last read" do
         user = create(:user)
         login_as(user)
+        now = Time.zone.now
 
-        post_with_new = create(:post)
-        post_with_new.mark_read(user, at_time: post_with_new.tagged_at)
-        create(:reply, post: post_with_new) # creates new activity after mark_read
+        # Use Timecop so the SQL's date_trunc('second', read_at) < date_trunc('second', tagged_at)
+        # actually sees distinct seconds — otherwise post and reply land in the same second.
+        post_with_new = Timecop.freeze(now) { create(:post) }
+        Timecop.freeze(now + 1.second) { post_with_new.mark_read(user, at_time: post_with_new.tagged_at) }
+        Timecop.freeze(now + 3.seconds) { create(:reply, post: post_with_new) }
 
-        fully_read = create(:post)
-        fully_read.mark_read(user, at_time: fully_read.tagged_at)
+        fully_read = Timecop.freeze(now) { create(:post) }
+        Timecop.freeze(now + 1.second) { fully_read.mark_read(user, at_time: fully_read.tagged_at) }
 
         get :search, params: { commit: true, unread: true }
         expect(assigns(:search_results)).to match_array([post_with_new])

--- a/spec/controllers/posts/search_spec.rb
+++ b/spec/controllers/posts/search_spec.rb
@@ -134,6 +134,69 @@ RSpec.describe PostsController, 'GET search' do
       expect(assigns(:search_results)).to eq([posts[1], posts[2], posts[3], posts[0]])
     end
 
+    context "filters by unread" do
+      it "ignores unread param when logged out" do
+        create_list(:post, 2)
+        get :search, params: { commit: true, unread: true }
+        expect(assigns(:search_results)).to match_array(Post.all)
+        expect(assigns(:show_unread)).not_to be_truthy
+      end
+
+      it "returns only unread posts when logged in" do
+        user = create(:user)
+        login_as(user)
+
+        unread_post = create(:post) # never viewed
+        read_post = create(:post)
+        read_post.mark_read(user, at_time: read_post.tagged_at)
+
+        get :search, params: { commit: true, unread: true }
+        expect(assigns(:search_results)).to match_array([unread_post])
+        expect(assigns(:show_unread)).to eq(true)
+      end
+
+      it "includes posts with new replies since last read" do
+        user = create(:user)
+        login_as(user)
+
+        post_with_new = create(:post)
+        post_with_new.mark_read(user, at_time: post_with_new.tagged_at)
+        create(:reply, post: post_with_new) # creates new activity after mark_read
+
+        fully_read = create(:post)
+        fully_read.mark_read(user, at_time: fully_read.tagged_at)
+
+        get :search, params: { commit: true, unread: true }
+        expect(assigns(:search_results)).to match_array([post_with_new])
+      end
+
+      it "excludes ignored posts" do
+        user = create(:user)
+        login_as(user)
+
+        ignored_post = create(:post)
+        ignored_post.ignore(user)
+
+        unread_post = create(:post)
+
+        get :search, params: { commit: true, unread: true }
+        expect(assigns(:search_results)).to match_array([unread_post])
+      end
+
+      it "combines with other search filters" do
+        user = create(:user)
+        login_as(user)
+        board = create(:board)
+
+        unread_in_board = create(:post, board: board)
+        create(:post, board: board).tap { |p| p.mark_read(user, at_time: p.tagged_at) } # read in board
+        create(:post) # unread but different board
+
+        get :search, params: { commit: true, unread: true, board_id: board.id }
+        expect(assigns(:search_results)).to match_array([unread_in_board])
+      end
+    end
+
     context "when logged out" do
       it_behaves_like "logged out post list"
     end


### PR DESCRIPTION
Allow logged-in users to filter search results to only show unread posts. Adds an "Unread Only" checkbox to the search form, applies the same unread logic used by the Unread Threads page, and shows unread count and indicators in search results when enabled.

https://claude.ai/code/session_01JAgDGZtoPXkgfJ2JqRf3Nd