### PR TITLE
Add stop word pruning info and exact string match to post search

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -585,6 +585,14 @@ tr.gallery-tags .tag-item { color: $font_color_tag_item_gallery; }
   color: $font_color_search_box;
 }
 
+.search-notice {
+  padding: 8px 12px;
+  margin-bottom: 10px;
+  font-size: 0.9em;
+  font-style: italic;
+  color: #665;
+}
+
 .search-icon-preview { vertical-align: middle; }
 .search-icon-keyword { padding-left: 5px; }
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -295,8 +295,18 @@ class PostsController < WritableController
       if params[:abbrev].present?
         search = params[:subject].chars.join('% ')
         @search_results = @search_results.where('subject ILIKE ?', "%#{search}%")
+      elsif params[:exact].present?
+        @search_results = @search_results.where('subject ILIKE ?', "%#{params[:subject]}%")
       else
-        @search_results = @search_results.search(params[:subject]).where('subject ILIKE ?', "%#{params[:subject]}%")
+        pruned = detect_pruned_words(params[:subject])
+        if pruned[:all_pruned]
+          @search_results = @search_results.where('subject ILIKE ?', "%#{params[:subject]}%")
+          @pruned_words = pruned[:pruned_words]
+          @all_pruned = true
+        else
+          @search_results = @search_results.search(params[:subject]).where('subject ILIKE ?', "%#{params[:subject]}%")
+          @pruned_words = pruned[:pruned_words] if pruned[:pruned_words].any?
+        end
       end
     end
     @search_results = @search_results.complete if params[:completed].present?
@@ -357,6 +367,28 @@ class PostsController < WritableController
   end
 
   private
+
+  # Postgres's built-in english tsearch dictionary (tsearch_data/english.stop).
+  # Comparing against this static list avoids round-tripping to the DB once
+  # per input word — a long search string would otherwise trigger N queries
+  # in series (per code review feedback).
+  POSTGRES_ENGLISH_STOP_WORDS = Set.new(%w[
+    i me my myself we our ours ourselves you your yours yourself yourselves
+    he him his himself she her hers herself it its itself they them their
+    theirs themselves what which who whom this that these those am is are
+    was were be been being have has had having do does did doing a an the
+    and but if or because as until while of at by for with about against
+    between into through during before after above below to from up down in
+    out on off over under again further then once here there when where why
+    how all any both each few more most other some such no nor not only own
+    same so than too very s t can will just don should now
+  ]).freeze
+
+  def detect_pruned_words(query)
+    words = query.split(/\s+/).reject(&:blank?)
+    pruned_words = words.select { |word| POSTGRES_ENGLISH_STOP_WORDS.include?(word.downcase) }
+    { pruned_words: pruned_words, all_pruned: pruned_words.length == words.length && words.any? }
+  end
 
   def preview
     @post ||= Post.new(user: current_user)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -366,12 +366,7 @@ class PostsController < WritableController
     redirect_to post_path(@post)
   end
 
-  private
-
   # Postgres's built-in english tsearch dictionary (tsearch_data/english.stop).
-  # Comparing against this static list avoids round-tripping to the DB once
-  # per input word — a long search string would otherwise trigger N queries
-  # in series (per code review feedback).
   POSTGRES_ENGLISH_STOP_WORDS = Set.new(%w[
     i me my myself we our ours ourselves you your yours yourself yourselves
     he him his himself she her hers herself it its itself they them their
@@ -384,8 +379,10 @@ class PostsController < WritableController
     same so than too very s t can will just don should now
   ]).freeze
 
+  private
+
   def detect_pruned_words(query)
-    words = query.split(/\s+/).reject(&:blank?)
+    words = query.split(/\s+/).compact_blank
     pruned_words = words.select { |word| POSTGRES_ENGLISH_STOP_WORDS.include?(word.downcase) }
     { pruned_words: pruned_words, all_pruned: pruned_words.length == words.length && words.any? }
   end

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -39,6 +39,11 @@
                 = check_box_tag :abbrev, true, params[:abbrev].present?, { class: 'vmid no-margin', style: 'margin-bottom: 3px;' }
                 = label_tag :abbrev, 'Search for acronym'
             %tr
+              %td Exact
+              %td.padding-5
+                = check_box_tag :exact, true, params[:exact].present?, { class: 'vmid no-margin', style: 'margin-bottom: 3px;' }
+                = label_tag :exact, 'Exact string match'
+            %tr
               %td Completed
               %td.padding-5
                 = check_box_tag :completed, true, params[:completed].present?, { class: 'vmid no-margin', style: 'margin-bottom: 3px;' }
@@ -52,6 +57,16 @@
             %tr
               %td.centered{colspan: 2}= submit_tag "Search", class: 'button'
       %td.vtop#search_results
+        - if @pruned_words.present?
+          %p.search-notice
+            - if @all_pruned
+              All search terms were too common for full-text search
+              = "(#{@pruned_words.map { |w| "\"#{w}\"" }.join(', ')})."
+              Falling back to exact string matching.
+            - else
+              Some search terms were too common for full-text search and were ignored:
+              = "#{@pruned_words.map { |w| "\"#{w}\"" }.join(', ')}."
+              Use "Exact string match" to search for the full phrase.
         - if @search_results.present?
           %table
             %thead


### PR DESCRIPTION
When PostgreSQL's full-text search prunes common words (stop words) from a search query, display a notice explaining which words were ignored. When all words are pruned, automatically fall back to ILIKE matching.

Add an "Exact string match" checkbox that bypasses full-text search entirely and uses ILIKE for the subject field, which handles queries with short/common words that PostgreSQL's English dictionary removes.

https://claude.ai/code/session_01AUdgfaFCydFiBRpbWiHerJ