### PR TITLE
Avoid breaking tags across pages when printing

### DIFF
--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -183,6 +183,7 @@ div.post-subheader { width: 100%; }
 #content > .post-container, .flat-post-replies .post-container {
   padding: 0;
   overflow: auto;
+  break-inside: avoid;
 }
 
 .post-edit-box {


### PR DESCRIPTION
Before:
<img width="746" height="343" alt="image" src="https://github.com/user-attachments/assets/f1302e91-3080-4cdd-a4a7-5a0684f08888" />
<img width="735" height="320" alt="image" src="https://github.com/user-attachments/assets/a47e4a20-0334-46df-bef4-dc41d098b8ad" />
<img width="774" height="535" alt="image" src="https://github.com/user-attachments/assets/9a67c917-2501-41a2-b2e5-359bdbd83bc9" />

After:
<img width="766" height="984" alt="image" src="https://github.com/user-attachments/assets/0a6064b1-e861-4b0d-bd03-88a11f2c5644" />
<img width="737" height="702" alt="image" src="https://github.com/user-attachments/assets/834e05e3-eb41-4bce-9bf9-390b07e18c92" />
<img width="774" height="758" alt="image" src="https://github.com/user-attachments/assets/1b19a69d-1809-43ba-9aaa-2990adece164" />
