### PR TITLE
Fix XSS vulnerabilities in search highlight rendering and post link titles

### DIFF
--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -22,9 +22,9 @@
         = link_to unread_path(post) do
           = image_tag lastlink_img, class: 'vmid mobile-target', title: 'First Unread', alt: 'Jump To End'
     - if logged_in? && @opened_ids.present? && @opened_ids.exclude?(post.id)
-      %b= link_to post.subject, post_path(post), title: strip_tags(post.description)&.html_safe
+      %b= link_to post.subject, post_path(post), title: strip_tags(post.description)
     - else
-      = link_to post.subject, post_path(post), title: strip_tags(post.description)&.html_safe
+      = link_to post.subject, post_path(post), title: strip_tags(post.description)
     - if !@hide_quicklinks && (!logged_in? || per_page > 0)
       - total_pages = (replies_count.to_f / per_page).ceil
       - if total_pages > 1

--- a/app/views/replies/search.haml
+++ b/app/views/replies/search.haml
@@ -86,10 +86,10 @@
                         = image_tag "icons/link.png".freeze, title: 'Permalink'.freeze, alt: 'Permalink'.freeze
                       = link_to stats_post_path(reply.post) do
                         = image_tag "icons/chart_bar.png".freeze, title: 'View Metadata'.freeze, alt: 'View Metadata'.freeze
-                    %b= link_to reply.post.subject, reply_path(reply, anchor: "reply-#{reply.id}"), title: strip_tags(reply.post.description)&.html_safe
+                    %b= link_to reply.post.subject, reply_path(reply, anchor: "reply-#{reply.id}"), title: strip_tags(reply.post.description)
                     .post-content
                       - if params[:subj_content].present?
-                        = reply.pg_search_highlight.html_safe
+                        = Glowfic::Sanitizers.written(reply.pg_search_highlight)
                       - else
                         = sanitize_written_content(reply.content, reply.editor_mode)
                     .post-footer


### PR DESCRIPTION
Sanitize pg_search_highlight output through Glowfic::Sanitizers.written before rendering, preventing stored XSS via malicious reply content. Remove .html_safe from strip_tags output on post description title attributes, preventing attribute injection via unescaped quotes.

https://claude.ai/code/session_01981D12QgcXAhSQjMzqXMDb