### PR TITLE
Fix IDOR vulnerability in user icon modification a gallery

### DIFF
--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -253,7 +253,7 @@ class GalleriesController < UploadingController
   end
 
   def permitted_params
-    params.fetch(:gallery, {}).permit(
+    permitted = params.fetch(:gallery, {}).permit(
       :name,
       galleries_icons_attributes: [
         :id,
@@ -262,6 +262,10 @@ class GalleriesController < UploadingController
       ],
       icon_ids: [],
     )
+    if permitted[:icon_ids].present?
+      permitted[:icon_ids] = Icon.where(id: permitted[:icon_ids], user_id: current_user.id).pluck(:id)
+    end
+    permitted
   end
 
   def icon_params(paramset)

--- a/app/models/galleries_icon.rb
+++ b/app/models/galleries_icon.rb
@@ -7,6 +7,15 @@ class GalleriesIcon < ApplicationRecord
   after_create :set_has_gallery
   after_destroy :unset_has_gallery
   validates :gallery, uniqueness: { scope: :icon }
+  validate :icon_belongs_to_gallery_user
+
+  private
+
+  def icon_belongs_to_gallery_user
+    return unless icon && gallery
+    return if icon.user_id == gallery.user_id
+    errors.add(:icon, "must belong to the gallery owner")
+  end
 
   def unset_has_gallery
     return if icon.galleries.present?

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -152,6 +152,15 @@ RSpec.describe GalleriesController do
       expect(gallery.gallery_groups).to match_array([group])
     end
 
+    it "does not associate icons belonging to other users" do
+      user = create(:user)
+      other_user = create(:user)
+      other_icon = create(:icon, user: other_user)
+      login_as(user)
+      post :create, params: { gallery: { name: 'Test Gallery', icon_ids: [other_icon.id] } }
+      expect(Gallery.last.icons).to be_empty
+    end
+
     it "creates new gallery groups" do
       existing_name = create(:gallery_group)
       existing_case = create(:gallery_group)
@@ -285,7 +294,7 @@ RSpec.describe GalleriesController do
       it "calculates OpenGraph meta" do
         user = create(:user, username: 'user')
         gallery = create(:gallery, name: 'gallery', user: user)
-        create_list(:icon, 16, gallery_ids: [gallery.id])
+        create_list(:icon, 16, user: user, gallery_ids: [gallery.id])
         get :show, params: { id: gallery.id }
 
         meta_og = assigns(:meta_og)
@@ -302,7 +311,7 @@ RSpec.describe GalleriesController do
           user: user,
           gallery_groups: [create(:gallery_group, name: "Tag 1"), create(:gallery_group, name: "Tag 2")],
         )
-        create_list(:icon, 16, gallery_ids: [gallery.id])
+        create_list(:icon, 16, user: user, gallery_ids: [gallery.id])
         get :show, params: { id: gallery.id }
 
         meta_og = assigns(:meta_og)
@@ -550,6 +559,34 @@ RSpec.describe GalleriesController do
       expect(flash[:success]).to eq('Gallery updated.')
       expect(gallery.reload.icons).to be_empty
       expect(Icon.find_by(id: icon.id)).to be_nil
+    end
+
+    it "does not associate icons belonging to other users via icon_ids" do
+      user = create(:user)
+      gallery = create(:gallery, user: user)
+      other_user = create(:user)
+      other_icon = create(:icon, user: other_user)
+      login_as(user)
+
+      put :update, params: { id: gallery.id, gallery: { icon_ids: [other_icon.id] } }
+      expect(gallery.reload.icons).to be_empty
+    end
+
+    it "does not allow modifying icons belonging to other users via nested attributes" do
+      user = create(:user)
+      gallery = create(:gallery, user: user)
+      other_user = create(:user)
+      other_icon = create(:icon, user: other_user)
+      original_url = other_icon.url
+      login_as(user)
+
+      # Attempt to associate and modify in one request
+      put :update, params: {
+        id: gallery.id,
+        gallery: { icon_ids: [other_icon.id] },
+      }
+      expect(gallery.reload.icons).not_to include(other_icon)
+      expect(other_icon.reload.url).to eq(original_url)
     end
 
     it "creates new gallery groups" do

--- a/spec/controllers/icons_controller_spec.rb
+++ b/spec/controllers/icons_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe IconsController do
       it "skips other people's icons" do
         icon = create(:icon)
         gallery = create(:gallery, user: user)
-        gallery.icons << icon
+        GalleriesIcon.new(gallery: gallery, icon: icon).save(validate: false)
         icon.reload
         expect(icon.galleries.count).to eq(1)
         delete :delete_multiple, params: { marked_ids: [icon.id], gallery_id: gallery.id, gallery_delete: true }

--- a/spec/helpers/icon_helper_spec.rb
+++ b/spec/helpers/icon_helper_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe IconHelper do
 
     it "returns icons if character has icons" do
       icons = ['icon 1', 'icon 2', 'icon 3'].map { |k| create(:icon, keyword: k, user: user) }
-      character.galleries << create(:gallery, icons: icons)
+      character.galleries << create(:gallery, user: user, icons: icons)
       post.character = character
       post.icon = icons[0]
       icons = Icon.where(id: icons.map(&:id)).ordered


### PR DESCRIPTION
Add ownership validation to GalleriesIcon ensuring icons can only be associated with galleries owned by the same user. Filter icon_ids in the controller's permitted_params for defense-in-depth, consistent with the existing check in the icon action. Fix tests that relied on cross-user icon associations.

https://claude.ai/code/session_01P6bBgH1QjGbQGzV3yBMDHe