### PR TITLE
Preload the Rails app in Puma so workers share memory via CoW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ backstop/reports/*
 /.gems
 /.envrc
 dump.rdb
+node_modules/

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -48,13 +48,35 @@ workers ENV.fetch("WEB_CONCURRENCY", 2)
 # into R14 at WEB_CONCURRENCY=2.
 preload_app!
 
-# Drop any connections the master may have opened (Redis namespace,
-# ActiveRecord pool) before workers fork. Sharing a live socket between
-# forked processes corrupts both ends; closing here forces each worker to
-# reconnect lazily on first use.
+# Drop any connections the master may have opened before workers fork.
+# Sharing a live socket between forked processes corrupts both ends;
+# closing here forces each worker to reconnect lazily on first use.
+#
+# Three Redis clients reach into prod:
+#   1. $redis (config/initializers/redis.rb) wraps REDIS_URL via
+#      Redis::Namespace and is handed to Resque.redis=. Eagerly built at
+#      app boot, so always live in the master.
+#   2. Rails.cache (config/environments/production.rb) is a
+#      RedisCacheStore pointed at REDIS_CACHE_URL.
+#   3. Rack::Attack.cache.store (config/initializers/rack_attack.rb) is
+#      another RedisCacheStore pointed at HEROKU_REDIS_TEAL_URL.
+#
+# (2) and (3) hold ConnectionPools whose connections only open on first
+# read/write. With preload_app! the master itself never serves a request
+# so those pools should be empty — but defensively drain them in case
+# any initializer pokes at the cache during boot.
 before_fork do
   ActiveRecord::Base.connection_handler.clear_active_connections! if defined?(ActiveRecord::Base)
   $redis&.close
+  [Rails.cache, (defined?(Rack::Attack) ? Rack::Attack.cache.store : nil)].compact.each do |store|
+    next unless store.respond_to?(:redis)
+    pool_or_client = store.redis
+    if pool_or_client.respond_to?(:shutdown)
+      pool_or_client.shutdown(&:close)
+    elsif pool_or_client.respond_to?(:close)
+      pool_or_client.close
+    end
+  end
 end
 
 # Per-worker setup. Barnes reports GC / process stats from a background

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -39,9 +39,30 @@ environment ENV.fetch("RAILS_ENV", "development")
 # We default to 2 to guarantee our fork hooks run.
 workers ENV.fetch("WEB_CONCURRENCY", 2)
 
-# Report statsd metrics for Heroku monitoring.
-require 'barnes'
+# Boot the Rails app once in the master process so worker forks share its
+# memory pages via copy-on-write. The Linux kernel keeps unmodified pages
+# shared between parent and child, so the full Rails framework footprint
+# (gem code, parsed class trees, etc.) is paid for once per dyno instead
+# of once per worker. Without this, each Puma worker independently loads
+# Rails and runs ~270 MB resident, which is what pushes Standard-1X dynos
+# into R14 at WEB_CONCURRENCY=2.
+preload_app!
+
+# Drop any connections the master may have opened (Redis namespace,
+# ActiveRecord pool) before workers fork. Sharing a live socket between
+# forked processes corrupts both ends; closing here forces each worker to
+# reconnect lazily on first use.
 before_fork do
+  ActiveRecord::Base.connection_handler.clear_active_connections! if defined?(ActiveRecord::Base)
+  $redis&.close
+end
+
+# Per-worker setup. Barnes reports GC / process stats from a background
+# thread, which doesn't survive `fork`, so it has to start in each worker
+# rather than in the master. Active Record reconnects automatically on
+# first query in Rails 7+, so no explicit `establish_connection` is needed.
+require 'barnes'
+on_worker_boot do
   Barnes.start
 end
 


### PR DESCRIPTION
## Why

Without \`preload_app!\`, every Puma worker independently boots its own copy of the Rails app — no copy-on-write sharing between master and children. With \`WEB_CONCURRENCY=2\` each worker is ~270 MB resident, putting the dyno at ~540 MB before any request runs. Standard-1X's ceiling is 512 MB, which is exactly why R14 events are constant in the logs.

With \`preload_app!\`, the master boots Rails once and forks workers from it. The Linux kernel keeps unmodified pages shared between parent and child, so the bulk of the loaded framework — gem code, parsed class trees, the audited/pg_search/aws-sdk-s3 class graphs — is paid for once per dyno instead of once per worker. Expected drop: roughly 100–150 MB of resident RSS per web dyno at WEB_CONCURRENCY=2, which is enough to clear R14 on Standard-1X.

## What

- \`preload_app!\` in \`config/puma.rb\`.
- \`before_fork\` closes the master's \`\$redis\` connection (from \`config/initializers/redis.rb\`, which opens it eagerly) and clears the AR pool. Sharing a live TCP socket between forked processes corrupts both ends; closing before fork forces each worker to reconnect lazily on first use.
- \`Barnes.start\` moves from \`before_fork\` to \`on_worker_boot\`. Barnes runs a background thread that reports GC/process stats via statsd, and threads don't survive \`fork(2)\` — calling it in the master with preloading on means only the master gets monitored. Per-worker boot is where it belongs.

NewRelic and Scout auto-detect Puma preload and restart their own threads on worker boot, so no explicit hook is needed for either.

## Caveats / what to watch after deploy

- Verify with \`heroku ps -a vast-journey-9935\` that web dyno total RSS drops by ~100–150 MB and the R14 rate falls.
- Check that both APM dashboards (Scout + NewRelic) keep reporting per-worker after the deploy — if one goes quiet, that gem version probably doesn't auto-handle preload and needs an explicit \`on_worker_boot\` hook.
- The Resque worker dyno is unaffected (Procfile runs \`rake resque:work\` directly, not Puma). Its baseline stays the same.
- Couldn't validate locally; this is a real prod-behavior change, so worth watching dyno memory metrics for the first hour after merge.