### PR TITLE
Re-enable Active Record cache versioning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -81,10 +81,6 @@ module Glowfic
     config.middleware.use Rack::Pratchett
     config.middleware.use Rack::Deflater
 
-    # redis-rails does not support cache versioning
-    config.active_record.cache_versioning = false
-    config.active_record.collection_cache_versioning = false
-
     # Setting enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. We are
     # deploying to a memory constrained environment so we set this to `false`.
     config.yjit = false


### PR DESCRIPTION
## Why

These overrides were added with the comment \`redis-rails does not support cache versioning\`. \`redis-rails\` is no longer in the Gemfile — we're on plain \`redis 5.4.1\` plus the Rails-built-in \`:redis_cache_store\`, which supports recyclable cache keys and the \`cache_version\` parameter fully.

## What

Removes the explicit \`config.active_record.cache_versioning = false\` and \`config.active_record.collection_cache_versioning = false\` lines, falling back to the Rails 7.2 defaults (both \`true\`).

With versioning on:

- \`Model#cache_key\` returns a stable key that doesn't change on update.
- \`updated_at\` moves to a separate \`cache_version\` argument the cache backend uses for staleness checks.
- The same Redis key is reused across updates instead of writing a new one and abandoning the old (eventually-expiring) entry. Meaningful on \`heroku-redis:mini\` (25 MB cap).
- Collection caches (\`cache @posts do ... end\`) re-use the same key when individual members change, dropping cache write amplification.

## Rollout

Existing cached entries written with the old key shape will recompute once on first access after deploy. No data migration needed; the cache is allowed to churn. Effectively a one-shot cache miss across the running set of pages.