### PR TITLE
Rebase #1562 onto main, fix bugs, and add joinable/default circles

### DIFF
--- a/app/assets/javascripts/access_circles/edit.js
+++ b/app/assets/javascripts/access_circles/edit.js
@@ -1,0 +1,8 @@
+/* global createSelect2 */
+$(document).ready(function() {
+  createSelect2('#access_circle_user_ids', {
+    width: '200px',
+    minimumResultsForSearch: 20,
+    placeholder: 'Choose users(s) for this circle'
+  });
+});

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -35,6 +35,12 @@ function setupMetadataEditor() {
     placeholder: 'Choose user(s) to view this post'
   });
 
+  createSelect2('#post_circle_ids', {
+    width: '200px',
+    minimumResultsForSearch: 20,
+    placeholder: 'Choose circles(s) to view this post'
+  });
+
   createSelect2('#post_unjoined_author_ids', {
     width: '300px',
     minimumResultsForSearch: 20,

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -35,10 +35,10 @@ function setupMetadataEditor() {
     placeholder: 'Choose user(s) to view this post'
   });
 
-  createSelect2('#post_circle_ids', {
+  createSelect2('#post_access_circle_ids', {
     width: '200px',
     minimumResultsForSearch: 20,
-    placeholder: 'Choose circles(s) to view this post'
+    placeholder: 'Choose circle(s) to view this post'
   });
 
   createSelect2('#post_unjoined_author_ids', {

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -14,6 +14,20 @@ $(document).ready(function() {
     allowClear: true,
   });
 
+  createSelect2('#access_circle_id', {
+    ajax: {
+      url: '/api/v1/tags',
+      data: function(params) {
+        const data = queryTransform(params);
+        data.t = 'AccessCircle';
+        return data;
+      },
+      processResults: processTotal(),
+    },
+    placeholder: '— Choose Access Circle —',
+    allowClear: true,
+  });
+
   createSelect2('#character_id', {
     ajax: {
       url: '/api/v1/characters',

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -313,6 +313,8 @@ div.post-subheader { width: 100%; }
     width: 100%;
     height: 100px;
   }
+
+  #access_list label { min-width: 250px; }
 }
 
 .private-note-editor {

--- a/app/concerns/permissible.rb
+++ b/app/concerns/permissible.rb
@@ -18,6 +18,7 @@ module Permissible
     # :delete_tags,
     # :edit_continuities
     :create_news,
+    :view_access_circles,
   ]
 
   def has_permission?(permission)

--- a/app/controllers/access_circles_controller.rb
+++ b/app/controllers/access_circles_controller.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+class AccessCirclesController < ApplicationController
+  before_action :login_required
+  before_action :find_model, only: [:show, :edit, :update, :destroy]
+  before_action :find_user, only: [:index]
+  before_action :require_create_permission, only: [:new, :create]
+  before_action :require_edit_permission, only: [:edit, :update]
+  before_action :require_delete_permission, only: [:destroy]
+  before_action :require_index_permission, only: [:index]
+  before_action :editor_setup, only: [:new, :edit]
+
+  def index
+    @public = params[:user_id].nil?
+
+    @page_title = if @public
+      'Public Access Circles'
+    elsif @user.id == current_user.id
+      "Your Access Circles"
+    else
+      @user.username + "'s Access Circles"
+    end
+
+    @circles = @public ? AccessCircle.visible : AccessCircle.where(user: @user)
+    @circles.ordered_by_name.paginate(page: page)
+  end
+
+  def new
+    @page_title = 'New Access Circle'
+    @circle = AccessCircle.new(user: current_user)
+  end
+
+  def create
+    @circle = AccessCircle.new(user: current_user)
+    @circle.assign_attributes(permitted_params)
+    @circle.users = User.where(id: params[:access_circle].fetch(:user_ids, []))
+
+    unless @circle.save
+      @page_title = 'New Access Circle'
+      flash.now[:error] = {
+        message: "Your access circle could not be saved.",
+        array: @circle.errors.full_messages,
+      }
+      editor_setup
+      render :new and return
+    end
+
+    flash[:success] = "Access circle saved successfully."
+    redirect_to @circle
+  end
+
+  def show
+    @page_title = @circle.name
+    @view = params[:view]
+
+    case @view
+      when 'posts'
+        @posts = posts_from_relation(@circle.posts.ordered)
+      when 'users'
+        @users = @circle.users.paginate(page: page)
+      else
+        @view = 'info'
+    end
+  end
+
+  def edit
+    @page_title = 'Edit Access Circle: ' + @circle.name
+  end
+
+  def update
+    @circle.assign_attributes(permitted_params)
+    @users = User.where(id: params[:access_circle].fetch(:user_ids, []))
+
+    begin
+      AccessCircle.transaction do
+        @circle.users = @users
+        @circle.save!
+      end
+    rescue ActiveRecord::RecordInvalid
+      @page_title = 'Edit Access Circle: ' + @circle.name
+      flash.now[:error] = {
+        message: "Your access circle could not be saved.",
+        array: @circle.errors.full_messages,
+      }
+      editor_setup
+      render :edit
+    else
+      flash[:success] = "Access circle saved successfully."
+      redirect_to @circle
+    end
+  end
+
+  def destroy
+    begin
+      @circle.destroy!
+    rescue ActiveRecord::RecordNotDestroyed
+      flash[:error] = {
+        message: "Access circle could not be deleted.",
+        array: @circle.errors.full_messages,
+      }
+      redirect_to @circle
+    else
+      flash[:success] = "Access circle deleted."
+      redirect_to user_access_circles_path(current_user)
+    end
+  end
+
+  private
+
+  def find_model
+    @circle = AccessCircle.find_by(id: params[:id])
+    unless @circle&.visible_to?(current_user)
+      flash[:error] = "Access circle could not be found."
+      redirect_to user_access_circles_path(current_user)
+    end
+    @tag = @circle
+  end
+
+  def find_user
+    return if params[:user_id].nil?
+    return if (@user = User.active.find_by(id: params[:user_id]))
+    flash[:error] = 'User could not be found.'
+    redirect_to root_path
+  end
+
+  def require_create_permission
+    return unless current_user.read_only?
+    flash[:error] = "You do not have permission to create access circles."
+    redirect_to continuities_path
+  end
+
+  def require_edit_permission
+    return if @circle.editable_by?(current_user)
+    flash[:error] = 'You do not have permission to modify this access circle'
+    redirect_to user_access_circles_path(current_user)
+  end
+
+  def require_delete_permission
+    return if @circle.deletable_by?(current_user)
+    flash[:error] = 'You do not have permission to modify this access circle'
+    redirect_to user_access_circles_path(current_user)
+  end
+
+  def require_index_permission
+    return if params[:user_id].nil? || current_user.id == params[:user_id].to_i || current_user.has_permission?(:view_access_circles)
+    flash[:error] = "You do not have permission to view this page."
+    redirect_to root_path
+  end
+
+  def editor_setup
+    use_javascript('access_circles/edit')
+  end
+
+  def permitted_params
+    permitted = [:name, :description]
+    params.fetch(:access_circle, {}).permit(permitted)
+  end
+end

--- a/app/controllers/access_circles_controller.rb
+++ b/app/controllers/access_circles_controller.rb
@@ -20,8 +20,12 @@ class AccessCirclesController < ApplicationController
       @user.username + "'s Access Circles"
     end
 
-    @circles = @public ? AccessCircle.visible : AccessCircle.where(user: @user)
-    @circles.ordered_by_name.paginate(page: page)
+    circles = @public ? AccessCircle.visible : AccessCircle.where(user: @user)
+    @circles = circles.ordered_by_name.paginate(page: page)
+
+    circle_ids = @circles.map(&:id)
+    @post_counts = PostTag.where(tag_id: circle_ids).group(:tag_id).count
+    @user_counts = Tag::UserTag.where(tag_id: circle_ids).group(:tag_id).count
   end
 
   def new
@@ -151,7 +155,7 @@ class AccessCirclesController < ApplicationController
   end
 
   def permitted_params
-    permitted = [:name, :description]
+    permitted = [:name, :description, :owned]
     params.fetch(:access_circle, {}).permit(permitted)
   end
 end

--- a/app/controllers/access_circles_controller.rb
+++ b/app/controllers/access_circles_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class AccessCirclesController < ApplicationController
   before_action :login_required
-  before_action :find_model, only: [:show, :edit, :update, :destroy]
+  before_action :find_model, only: [:show, :edit, :update, :destroy, :join, :leave]
   before_action :find_user, only: [:index]
   before_action :require_create_permission, only: [:new, :create]
   before_action :require_edit_permission, only: [:edit, :update]
@@ -93,6 +93,28 @@ class AccessCirclesController < ApplicationController
     end
   end
 
+  def join
+    unless @circle.joinable_by?(current_user)
+      flash[:error] = "You can't join this access circle."
+      redirect_to(@circle) and return
+    end
+
+    Tag::UserTag.find_or_create_by!(user: current_user, tag: @circle)
+    flash[:success] = "You joined #{@circle.name}."
+    redirect_to @circle
+  end
+
+  def leave
+    unless @circle.leavable_by?(current_user)
+      flash[:error] = "You aren't a member of this access circle."
+      redirect_to(@circle) and return
+    end
+
+    Tag::UserTag.where(user: current_user, tag: @circle).destroy_all
+    flash[:success] = "You left #{@circle.name}."
+    redirect_to @circle
+  end
+
   def destroy
     begin
       @circle.destroy!
@@ -155,7 +177,7 @@ class AccessCirclesController < ApplicationController
   end
 
   def permitted_params
-    permitted = [:name, :description, :owned]
+    permitted = [:name, :description, :owned, :joinable]
     params.fetch(:access_circle, {}).permit(permitted)
   end
 end

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -26,6 +26,11 @@ class Api::V1::TagsController < Api::ApiController
 
     queryset = queryset.where.not(id: params[:tag_id]) if type == Setting && params[:tag_id].present?
 
+    # only expose access circles the requester can actually see / attach
+    if type == AccessCircle
+      queryset = queryset.where(id: AccessCircle.attachable_by(current_user).select(:id))
+    end
+
     tags = paginate queryset, per_page: 25
     render json: { results: tags }
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -139,6 +139,7 @@ class PostsController < WritableController
     @post.settings = process_tags(Setting, obj_param: :post, id_param: :setting_ids)
     @post.content_warnings = process_tags(ContentWarning, obj_param: :post, id_param: :content_warning_ids)
     @post.labels = process_tags(Label, obj_param: :post, id_param: :label_ids)
+    @post.access_circles = process_tags(AccessCircle, obj_param: :post, id_param: :access_circle_ids)
     process_npc(@post, permitted_character_params)
 
     begin
@@ -223,6 +224,7 @@ class PostsController < WritableController
     settings = process_tags(Setting, obj_param: :post, id_param: :setting_ids)
     warnings = process_tags(ContentWarning, obj_param: :post, id_param: :content_warning_ids)
     labels = process_tags(Label, obj_param: :post, id_param: :label_ids)
+    circles = process_tags(AccessCircle, obj_param: :post, id_param: :access_circle_ids)
 
     is_author = @post.author_ids.include?(current_user.id)
     if current_user.id != @post.user_id && @post.audit_comment.blank? && !is_author
@@ -236,6 +238,7 @@ class PostsController < WritableController
         @post.settings = settings
         @post.content_warnings = warnings
         @post.labels = labels
+        @post.access_circles = circles
         process_npc(@post, permitted_character_params)
         @post.save!
         @post.author_for(current_user).update!(private_note: @post.private_note) if is_author
@@ -367,6 +370,7 @@ class PostsController < WritableController
 
     @author_ids = params.fetch(:post, {}).fetch(:unjoined_author_ids, [])
     @viewer_ids = params.fetch(:post, {}).fetch(:viewer_ids, [])
+    @circle_ids = params.fetch(:post, {}).fetch(:circle_ids, [])
     @settings = process_tags(Setting, obj_param: :post, id_param: :setting_ids)
     @content_warnings = process_tags(ContentWarning, obj_param: :post, id_param: :content_warning_ids)
     @labels = process_tags(Label, obj_param: :post, id_param: :label_ids)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -371,7 +371,7 @@ class PostsController < WritableController
 
     @author_ids = params.fetch(:post, {}).fetch(:unjoined_author_ids, [])
     @viewer_ids = params.fetch(:post, {}).fetch(:viewer_ids, [])
-    @circle_ids = params.fetch(:post, {}).fetch(:circle_ids, [])
+    @circle_ids = params.fetch(:post, {}).fetch(:access_circle_ids, [])
     @settings = process_tags(Setting, obj_param: :post, id_param: :setting_ids)
     @content_warnings = process_tags(ContentWarning, obj_param: :post, id_param: :content_warning_ids)
     @labels = process_tags(Label, obj_param: :post, id_param: :label_ids)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -283,6 +283,7 @@ class PostsController < WritableController
     @setting = Setting.where(id: params[:setting_id]) if params[:setting_id].present?
     @character = Character.where(id: params[:character_id]) if params[:character_id].present?
     @user = User.active.full.where(id: params[:author_id]).ordered if params[:author_id].present?
+    @access_circle = AccessCircle.attachable_by(current_user).where(id: params[:access_circle_id]) if params[:access_circle_id].present?
 
     no_tests = true
     if params[:board_id].present?
@@ -296,6 +297,10 @@ class PostsController < WritableController
     @search_results = Post.ordered
     @search_results = @search_results.where(board_id: params[:board_id]) if params[:board_id].present?
     @search_results = @search_results.where(id: Setting.find(params[:setting_id]).post_tags.pluck(:post_id)) if params[:setting_id].present?
+    if params[:access_circle_id].present?
+      circle = AccessCircle.attachable_by(current_user).find_by(id: params[:access_circle_id])
+      @search_results = circle ? @search_results.where(id: circle.post_tags.pluck(:post_id)) : @search_results.none
+    end
     if params[:subject].present?
       if params[:abbrev].present?
         search = params[:subject].chars.join('% ')

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -122,6 +122,7 @@ class PostsController < WritableController
     @post.board_id = params[:board_id]
     @post.section_id = params[:section_id]
     @post.icon_id = (current_user.active_character ? current_user.active_character.default_icon.try(:id) : current_user.avatar_id)
+    @post.access_circle_ids = current_user.default_access_circle_ids
     @page_title = 'New Post'
 
     @permitted_authors -= [current_user]

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -123,6 +123,7 @@ class PostsController < WritableController
     @post.section_id = params[:section_id]
     @post.icon_id = (current_user.active_character ? current_user.active_character.default_icon.try(:id) : current_user.avatar_id)
     @post.access_circle_ids = current_user.default_access_circle_ids
+    @post.viewer_ids = current_user.default_viewer_ids
     @page_title = 'New Post'
 
     @permitted_authors -= [current_user]

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -141,7 +141,7 @@ class PostsController < WritableController
     @post.settings = process_tags(Setting, obj_param: :post, id_param: :setting_ids)
     @post.content_warnings = process_tags(ContentWarning, obj_param: :post, id_param: :content_warning_ids)
     @post.labels = process_tags(Label, obj_param: :post, id_param: :label_ids)
-    @post.access_circles = process_tags(AccessCircle, obj_param: :post, id_param: :access_circle_ids)
+    @post.access_circles = attachable_access_circles
     process_npc(@post, permitted_character_params)
 
     begin
@@ -226,7 +226,7 @@ class PostsController < WritableController
     settings = process_tags(Setting, obj_param: :post, id_param: :setting_ids)
     warnings = process_tags(ContentWarning, obj_param: :post, id_param: :content_warning_ids)
     labels = process_tags(Label, obj_param: :post, id_param: :label_ids)
-    circles = process_tags(AccessCircle, obj_param: :post, id_param: :access_circle_ids)
+    circles = attachable_access_circles
 
     is_author = @post.author_ids.include?(current_user.id)
     if current_user.id != @post.user_id && @post.audit_comment.blank? && !is_author
@@ -548,5 +548,11 @@ class PostsController < WritableController
       :threaded,
     ]
     params.permit(allowed_params)
+  end
+
+  def attachable_access_circles
+    ids = params.fetch(:post, {}).fetch(:access_circle_ids, []).compact_blank
+    return [] if ids.empty?
+    AccessCircle.attachable_by(current_user).where(id: ids).to_a
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -274,6 +274,7 @@ class UsersController < ApplicationController
       :default_hide_edit_delete_buttons,
       :default_hide_add_bookmark_button,
       default_access_circle_ids: [],
+      default_viewer_ids: [],
     )
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -273,6 +273,7 @@ class UsersController < ApplicationController
       :show_user_in_switcher,
       :default_hide_edit_delete_buttons,
       :default_hide_add_bookmark_button,
+      default_access_circle_ids: [],
     )
   end
 

--- a/app/models/access_circle.rb
+++ b/app/models/access_circle.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class AccessCircle < Tag
+  has_many :user_tags, class_name: 'Tag::UserTag', foreign_key: :tag_id, dependent: :destroy, inverse_of: :tag
+  has_many :users, through: :user_tags, dependent: :destroy
+
+  validates :name, uniqueness: { scope: [:type, :user] }
+
+  scope :visible, -> { where(owned: false) }
+
+  def visible_to?(user)
+    return false if user.nil?
+    return true unless owned?
+    return true if user.admin?
+    user.id == user_id
+  end
+end

--- a/app/models/access_circle.rb
+++ b/app/models/access_circle.rb
@@ -7,6 +7,10 @@ class AccessCircle < Tag
   validates :name, uniqueness: { scope: [:type, :user] }
 
   scope :visible, -> { where(owned: false) }
+  scope :attachable_by, ->(user) {
+    return none unless user
+    where(user: user).or(visible).ordered_by_name
+  }
 
   def visible_to?(user)
     return false if user.nil?

--- a/app/models/access_circle.rb
+++ b/app/models/access_circle.rb
@@ -2,6 +2,7 @@
 class AccessCircle < Tag
   has_many :user_tags, class_name: 'Tag::UserTag', foreign_key: :tag_id, dependent: :destroy, inverse_of: :tag
   has_many :users, through: :user_tags
+  has_many :user_default_access_circles, foreign_key: :tag_id, dependent: :destroy, inverse_of: :access_circle
 
   validates :name, uniqueness: { scope: [:type, :user] }
 

--- a/app/models/access_circle.rb
+++ b/app/models/access_circle.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class AccessCircle < Tag
   has_many :user_tags, class_name: 'Tag::UserTag', foreign_key: :tag_id, dependent: :destroy, inverse_of: :tag
-  has_many :users, through: :user_tags, dependent: :destroy
+  has_many :users, through: :user_tags
 
   validates :name, uniqueness: { scope: [:type, :user] }
 

--- a/app/models/access_circle.rb
+++ b/app/models/access_circle.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class AccessCircle < Tag
   has_many :user_tags, class_name: 'Tag::UserTag', foreign_key: :tag_id, dependent: :destroy, inverse_of: :tag
-  has_many :users, through: :user_tags
+  has_many :users, through: :user_tags, dependent: :destroy
   has_many :user_default_access_circles, foreign_key: :tag_id, dependent: :destroy, inverse_of: :access_circle
 
   validates :name, uniqueness: { scope: [:type, :user] }

--- a/app/models/access_circle.rb
+++ b/app/models/access_circle.rb
@@ -13,4 +13,16 @@ class AccessCircle < Tag
     return true if user.admin?
     user.id == user_id
   end
+
+  def joinable_by?(user)
+    return false unless joinable?
+    return false unless visible_to?(user)
+    user.id != user_id && !user_ids.include?(user.id)
+  end
+
+  def leavable_by?(user)
+    return false unless user
+    return false if user.id == user_id
+    user_ids.include?(user.id)
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -19,6 +19,7 @@ class Post < ApplicationRecord
 
   has_many :post_viewers, inverse_of: :post, dependent: :destroy
   has_many :viewers, through: :post_viewers, source: :user, dependent: :destroy
+
   has_many :favorites, as: :favorite, inverse_of: :favorite, dependent: :destroy
   has_many :views, class_name: 'Post::View', dependent: :destroy
 
@@ -31,6 +32,8 @@ class Post < ApplicationRecord
   has_many :settings, -> { ordered_by_post_tag }, through: :post_tags, source: :setting, dependent: :destroy
   has_many :content_warnings, -> { ordered_by_post_tag }, through: :post_tags, source: :content_warning,
     after_add: :reset_warnings, dependent: :destroy
+  has_many :access_circles, through: :post_tags, source: :access_circle, dependent: :destroy
+  has_many :circle_viewers, through: :access_circles, source: :user, dependent: :destroy
 
   has_many :index_posts, inverse_of: :post, dependent: :destroy
   has_many :indexes, inverse_of: :posts, through: :index_posts, dependent: :destroy

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,8 +32,8 @@ class Post < ApplicationRecord
   has_many :settings, -> { ordered_by_post_tag }, through: :post_tags, source: :setting, dependent: :destroy
   has_many :content_warnings, -> { ordered_by_post_tag }, through: :post_tags, source: :content_warning,
     after_add: :reset_warnings, dependent: :destroy
-  has_many :access_circles, through: :post_tags, source: :access_circle, dependent: :destroy
-  has_many :circle_viewers, through: :access_circles, source: :user, dependent: :destroy
+  has_many :access_circles, through: :post_tags, source: :access_circle
+  has_many :circle_viewers, through: :access_circles, source: :user
 
   has_many :index_posts, inverse_of: :post, dependent: :destroy
   has_many :indexes, inverse_of: :posts, through: :index_posts, dependent: :destroy
@@ -130,7 +130,9 @@ class Post < ApplicationRecord
     return true if privacy_registered? || user.admin?
     return true if privacy_full_accounts? && !user.read_only?
     return user.id == user_id if privacy_private?
-    (post_viewers.pluck(:user_id) + [user_id]).include?(user.id)
+    return true if user.id == user_id
+    return true if post_viewers.where(user_id: user.id).exists?
+    access_circles.joins(:user_tags).where(user_tags: { user_id: user.id }).exists?
   end
 
   def self.posts_fulllocked?(user)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,7 +32,7 @@ class Post < ApplicationRecord
   has_many :settings, -> { ordered_by_post_tag }, through: :post_tags, source: :setting, dependent: :destroy
   has_many :content_warnings, -> { ordered_by_post_tag }, through: :post_tags, source: :content_warning,
     after_add: :reset_warnings, dependent: :destroy
-  has_many :access_circles, through: :post_tags, source: :access_circle
+  has_many :access_circles, through: :post_tags, source: :access_circle, dependent: :destroy
   has_many :circle_viewers, through: :access_circles, source: :user
 
   has_many :index_posts, inverse_of: :post, dependent: :destroy

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -5,6 +5,16 @@ class PostTag < ApplicationRecord
   belongs_to :setting, foreign_key: :tag_id, inverse_of: :post_tags, optional: true
   belongs_to :content_warning, foreign_key: :tag_id, inverse_of: :post_tags, optional: true
   belongs_to :label, foreign_key: :tag_id, inverse_of: :post_tags, optional: true
+  belongs_to :access_circle, foreign_key: :tag_id, inverse_of: :post_tags, optional: true
 
   validates :post, uniqueness: { scope: :tag }
+
+  after_commit :invalidate_caches, on: [:create, :destroy]
+
+  private
+
+  def invalidate_caches
+    return if access_circle.nil?
+    access_circle.user_ids.each { |user_id| Rails.cache.delete(PostViewer.cache_string_for(user_id)) }
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,10 +10,10 @@ class Tag < ApplicationRecord
   has_many :gallery_tags, dependent: :destroy, inverse_of: :tag
   has_many :galleries, through: :gallery_tags, dependent: :destroy
 
-  TYPES = %w(Setting Label ContentWarning GalleryGroup)
+  TYPES = %w(Setting Label ContentWarning GalleryGroup AccessCircle)
 
   validates :name, :type, presence: true
-  validates :name, uniqueness: { scope: :type }
+  validates :name, uniqueness: { scope: :type }, unless: proc { |tag| tag.is_a?(AccessCircle) }
 
   scope :ordered_by_type, -> { order(type: :desc, name: :asc) }
 
@@ -95,7 +95,12 @@ class Tag < ApplicationRecord
       Tag::SettingTag.where(tag_id: self.id, tagged_id: other_tag.id).delete_all
       Tag::SettingTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
       Tag::SettingTag.where(tagged_id: other_tag.id).update_all(tagged_id: self.id)
-      other_tag.destroy
+
+      user_tags = Tag::UserTag.where(tag_id: other_tag.id)
+      user_tags.where(user_id: user_tags.select(:user_id).distinct.pluck(:user_id)).delete_all
+      user_tags.update_all(tag_id: self.id)
+
+      other_tag.destroy!
       # rubocop:enable Rails/SkipsModelValidations
     end
   end

--- a/app/models/tag/user_tag.rb
+++ b/app/models/tag/user_tag.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class Tag::UserTag < ApplicationRecord
+  self.table_name = 'user_tags'
+
+  belongs_to :user, inverse_of: :user_tags, optional: false
+  belongs_to :tag, optional: false
+  belongs_to :access_circle, foreign_key: :tag_id, inverse_of: :user_tags, optional: true
+
+  validates :user, uniqueness: { scope: :tag }
+
+  after_commit :invalidate_cache, on: [:create, :destroy]
+
+  private
+
+  def invalidate_cache
+    Rails.cache.delete(PostViewer.cache_string_for(user_id))
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,7 +108,10 @@ class User < ApplicationRecord
 
   def visible_posts
     Rails.cache.fetch(PostViewer.cache_string_for(self.id), expires_in: 1.month) do
-      PostViewer.where(user: self).pluck(:post_id)
+      viewer_post_ids = PostViewer.where(user: self).pluck(:post_id)
+      circle_ids = user_tags.pluck(:tag_id)
+      circle_post_ids = PostTag.where(tag_id: circle_ids).select(:post_id).distinct.pluck(:post_id)
+      (viewer_post_ids + circle_post_ids).uniq
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,9 @@ class User < ApplicationRecord
   has_many :user_default_access_circles, inverse_of: :user, dependent: :destroy
   has_many :default_access_circles, through: :user_default_access_circles, source: :access_circle
 
+  has_many :user_default_viewers, inverse_of: :user, dependent: :destroy
+  has_many :default_viewers, through: :user_default_viewers, source: :viewer
+
   has_many :bookmarks, inverse_of: :user, dependent: :destroy
   has_many :bookmarked_replies, through: :bookmarks, source: :reply, dependent: :destroy
   has_many :bookmarked_posts, -> { ordered }, through: :bookmarks, source: :post, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,9 @@ class User < ApplicationRecord
   has_many :user_tags, inverse_of: :user, dependent: :destroy
   has_many :content_warnings, -> { ordered_by_user_tag }, through: :user_tags, source: :content_warning, dependent: :destroy
 
+  has_many :user_default_access_circles, inverse_of: :user, dependent: :destroy
+  has_many :default_access_circles, through: :user_default_access_circles, source: :access_circle
+
   has_many :bookmarks, inverse_of: :user, dependent: :destroy
   has_many :bookmarked_replies, through: :bookmarks, source: :reply, dependent: :destroy
   has_many :bookmarked_posts, -> { ordered }, through: :bookmarks, source: :post, dependent: :destroy

--- a/app/models/user_default_access_circle.rb
+++ b/app/models/user_default_access_circle.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class UserDefaultAccessCircle < ApplicationRecord
+  belongs_to :user, inverse_of: :user_default_access_circles, optional: false
+  belongs_to :access_circle, foreign_key: :tag_id, inverse_of: :user_default_access_circles, optional: false
+
+  validates :user_id, uniqueness: { scope: :tag_id }
+end

--- a/app/models/user_default_viewer.rb
+++ b/app/models/user_default_viewer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class UserDefaultViewer < ApplicationRecord
+  belongs_to :user, inverse_of: :user_default_viewers, optional: false
+  belongs_to :viewer, class_name: 'User', inverse_of: false, optional: false
+
+  validates :user_id, uniqueness: { scope: :viewer_id }
+  validate :no_self_default
+
+  private
+
+  def no_self_default
+    errors.add(:viewer_id, "can't be the user themselves") if viewer_id == user_id
+  end
+end

--- a/app/services/tag_searcher.rb
+++ b/app/services/tag_searcher.rb
@@ -11,11 +11,12 @@ class TagSearcher < Object
     @qs = @qs.where(type: tag_type) if tag_type.present?
     @qs = @qs.includes(:user) if tag_type == 'Setting'
     @qs = @qs.where.not(type: 'GalleryGroup') unless tag_type == 'GalleryGroup'
+    @qs = @qs.where.not(type: 'AccessCircle')
     @qs.with_character_counts.paginate(page: page)
   end
 
   def validate_type!(tag_type)
-    return if Tag::TYPES.include?(tag_type)
+    return if (Tag::TYPES - ['AccessCircle']).include?(tag_type)
     raise InvalidTagType.new("Invalid filter")
   end
 end

--- a/app/views/access_circles/_editor.haml
+++ b/app/views/access_circles/_editor.haml
@@ -1,0 +1,27 @@
+-# locals: ( f: )
+
+%tbody
+  %tr
+    %th.sub= f.label :name
+    %td{class: cycle('even', 'odd')}
+      = f.text_field :name, placeholder: "Circle Name", class: 'text'
+  %tr
+    %th.sub= f.label :user, 'Owner'
+    %td{class: cycle('even', 'odd')}
+      = user_link(f.object.user)
+  %tr
+    %th.sub= f.label :owned, 'Public?'
+    %td{class: cycle('even', 'odd')}
+      = f.check_box :owned, class: 'vmid width-15'
+      = f.label :owned, 'Circle is visible to all users'
+  %tr
+    %th.sub= f.label :user_ids, 'Users'
+    %td{class: cycle('even', 'odd')}
+      = f.collection_select(:user_ids, User.where.not(id: current_user.id).ordered,
+        :id, :username, { selected: @user_ids.nil? ? f.object.user_ids : @user_ids }, { multiple: true })
+    %tr
+      %th.sub.vtop= f.label :description
+      %td{class: cycle('even', 'odd')}= f.text_area :description, placeholder: 'Description', cols: 35
+%tfoot
+  %tr
+    %th.form-table-ender{colspan: 2}= submit_tag "Save", class: 'button'

--- a/app/views/access_circles/_editor.haml
+++ b/app/views/access_circles/_editor.haml
@@ -15,6 +15,11 @@
       = f.check_box :owned, class: 'vmid width-15'
       = f.label :owned, 'Only show this circle to me and admins (uncheck to make it browsable by other users)'
   %tr
+    %th.sub= f.label :joinable, 'Joinable?'
+    %td{class: cycle('even', 'odd')}
+      = f.check_box :joinable, class: 'vmid width-15'
+      = f.label :joinable, "Let other users add themselves to this circle (no effect if the circle is private)"
+  %tr
     %th.sub= f.label :user_ids, 'Users'
     %td{class: cycle('even', 'odd')}
       = f.collection_select(:user_ids, User.where.not(id: current_user.id).ordered,

--- a/app/views/access_circles/_editor.haml
+++ b/app/views/access_circles/_editor.haml
@@ -10,10 +10,10 @@
     %td{class: cycle('even', 'odd')}
       = user_link(f.object.user)
   %tr
-    %th.sub= f.label :owned, 'Public?'
+    %th.sub= f.label :owned, 'Private?'
     %td{class: cycle('even', 'odd')}
       = f.check_box :owned, class: 'vmid width-15'
-      = f.label :owned, 'Circle is visible to all users'
+      = f.label :owned, 'Only show this circle to me and admins (uncheck to make it browsable by other users)'
   %tr
     %th.sub= f.label :user_ids, 'Users'
     %td{class: cycle('even', 'odd')}

--- a/app/views/access_circles/_users.haml
+++ b/app/views/access_circles/_users.haml
@@ -1,0 +1,21 @@
+-# locals: ()
+
+%table.tag-right-content-box
+  %thead
+    %tr
+      %th.table-title{colspan: 3} Users in #{@circle.name}
+    %tr
+      %th.sub Name
+      %th.width-70.sub.centered Moiety
+      %th.sub Date Joined
+  %tbody
+    - @users.each do |user|
+      %tr.user-row
+        - klass = cycle('even', 'odd')
+        %td.padding-10.username{class: klass}= link_to user.username, user_path(user)
+        %td.padding-10.user-moiety.centered.width-70{class: klass}= color_block(user)
+        %td.padding-10.user-date{class: klass}= pretty_time(user.created_at)
+  - if @users.total_pages > 1
+    %tfoot
+      %tr
+        %td{colspan: 3}= render 'posts/paginator', paginated: @users

--- a/app/views/access_circles/edit.haml
+++ b/app/views/access_circles/edit.haml
@@ -1,0 +1,13 @@
+- content_for :breadcrumbs do
+  = link_to "Access Circles", user_access_circles_path(current_user)
+  &raquo;
+  = link_to @circle.name, @circle
+  &raquo;
+  %b Edit
+
+= form_for @circle, url: access_circle_path(@circle), method: :put do |f|
+  %table.form-table
+    %thead
+      %tr
+        %th.editor-title{colspan: 2} Edit Access Circle
+      = render 'editor', f: f

--- a/app/views/access_circles/index.haml
+++ b/app/views/access_circles/index.haml
@@ -1,0 +1,43 @@
+- content_for :breadcrumbs do
+  - unless @user.nil? || @user.id == current_user.try(:id)
+    = user_link(@user)
+    &raquo;
+    %b #{@user.username}'s Access Circles
+
+- col_count = 4
+
+%table
+  %thead
+    %tr
+      %th.table-title{colspan: col_count}
+        = @page_title
+        - if !@public && @user.id == current_user&.id
+          = link_to new_access_circle_path do
+            .link-box.action-new + New Circle
+    %tr
+      %th.sub Name
+      %th.sub Posts
+      %th.sub Users
+      %th.sub
+  %tbody
+    - @circles.each do |circle|
+      - klass = cycle('even', 'odd')
+      %tr
+        %td{class: klass}= link_to circle.name, circle
+        %td{class: klass}= @post_counts.fetch(circle.id, 0)
+        %td{class: klass}= @user_counts.fetch(circle.id, 0)
+        %td.width-70.right-align{class: klass}
+          - if circle.editable_by?(current_user)
+            = link_to edit_access_circle_path(circle) do
+              = image_tag "icons/pencil.png", alt: 'Edit'
+          - if circle.deletable_by?(current_user)
+            = link_to delete_path(circle), method: :delete, data: { confirm: "Are you sure you want to delete #{circle.name}?" } do
+              = image_tag "icons/cross.png", alt: 'Delete'
+            &nbsp;
+    - if @circles.empty?
+      %tr
+        %td.centered.padding-10{ class: cycle('even', 'odd'), colspan: col_count } — No matching circles —
+  - if !@circles.empty? && @circles.total_pages > 1
+    %tfoot
+      %tr
+        %td{colspan: 6}= render 'posts/paginator', paginated: @circles

--- a/app/views/access_circles/new.haml
+++ b/app/views/access_circles/new.haml
@@ -1,0 +1,6 @@
+= form_for @circle, url: access_circles_path, method: :post do |f|
+  %table.form-table
+    %thead
+      %tr
+        %th.editor-title{colspan: 2} New Access Circle
+      = render 'editor', f: f

--- a/app/views/access_circles/show.haml
+++ b/app/views/access_circles/show.haml
@@ -1,0 +1,46 @@
+- content_for :breadcrumbs do
+  = link_to "Access Circles", (@circle.owned? ? user_access_circles_path(@circle.user) : access_circles_path)
+  &raquo;
+  %b= @circle.name
+
+%table.left-info-box.tag-info-box
+  %thead
+    %tr
+      %th.info-box-header
+        %span.character-name= @circle.name
+  %tbody
+    %tr
+      %td.centered{class: cycle('even', 'odd')}
+        = link_to access_circle_path(@circle) do
+          = image_tag "icons/chart_bar.png", class: 'vmid', alt: ''
+          Info
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to access_circle_path(@circle, view: 'posts'), rel: 'nofollow' do
+            = image_tag "icons/book_open.png", class: 'vmid', alt: ''
+            Posts
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to access_circle_path(@circle, view: 'users'), rel: 'nofollow' do
+            = image_tag "icons/group.png", class: 'vmid', alt: ''
+            Users
+    - if @circle.editable_by?(current_user)
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to edit_access_circle_path(@circle) do
+            = image_tag "icons/pencil.png", class: 'vmid', alt: ''
+            Edit Access Circle
+    - if @circle.deletable_by?(current_user)
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to access_circle_path(@circle), method: :delete, data: { confirm: 'Are you sure you want to delete this tag?' } do
+            = image_tag "icons/cross.png", class: 'vmid', alt: ''
+            Delete Access Circle
+
+- case @view
+- when 'info'
+  = render 'tags/info'
+- when 'posts'
+  = render 'tags/posts'
+- when 'users'
+  = render 'users'

--- a/app/views/access_circles/show.haml
+++ b/app/views/access_circles/show.haml
@@ -36,6 +36,18 @@
           = link_to access_circle_path(@circle), method: :delete, data: { confirm: 'Are you sure you want to delete this tag?' } do
             = image_tag "icons/cross.png", class: 'vmid', alt: ''
             Delete Access Circle
+    - if @circle.joinable_by?(current_user)
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to join_access_circle_path(@circle), method: :post do
+            = image_tag "icons/add.png", class: 'vmid', alt: ''
+            Join Access Circle
+    - if @circle.leavable_by?(current_user)
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to leave_access_circle_path(@circle), method: :post, data: { confirm: "Leave #{@circle.name}?" } do
+            = image_tag "icons/user_delete.png", class: 'vmid', alt: ''
+            Leave Access Circle
 
 - case @view
 - when 'info'

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -48,7 +48,11 @@
     = f.label :privacy, 'Privacy:'
     = f.select :privacy, options_from_collection_for_select(post_privacy_settings.to_a, :second, :first, post.privacy)
     #access_list
-      = f.label :viewer_ids, '&#8627; Who can view this post? '.html_safe
+      = f.label :circle_ids, '&#8627; Which circles can view this post?'.html_safe
+      = f.collection_select(:access_circle_ids, AccessCircle.where(user: current_user).ordered_by_name,
+        :id, :name, { selected: @circle_ids.nil? ? post.access_circle_ids : @circle_ids }, { multiple: true })
+      %br
+      = f.label :viewer_ids, '&#8627; Which users can view this post?'.html_safe
       = f.collection_select(:viewer_ids, User.active.where.not(id: post.user_id).ordered,
         :id, :username, { selected: @viewer_ids.nil? ? post.viewer_ids : @viewer_ids }, { multiple: true })
 

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -49,8 +49,11 @@
     = f.select :privacy, options_from_collection_for_select(post_privacy_settings.to_a, :second, :first, post.privacy)
     #access_list
       = f.label :circle_ids, '&#8627; Which circles can view this post?'.html_safe
-      = f.collection_select(:access_circle_ids, AccessCircle.where(user: current_user).ordered_by_name,
-        :id, :name, { selected: @circle_ids.nil? ? post.access_circle_ids : @circle_ids }, { multiple: true })
+      - circle_options = AccessCircle.attachable_by(current_user).includes(:user).map do |c|
+        - label = c.user_id == current_user.id ? c.name : "#{c.name} (#{c.user.username})"
+        - [label, c.id]
+      = f.select(:access_circle_ids, options_for_select(circle_options, @circle_ids.nil? ? post.access_circle_ids : @circle_ids),
+        {}, { multiple: true })
       %br
       = f.label :viewer_ids, '&#8627; Which users can view this post?'.html_safe
       = f.collection_select(:viewer_ids, User.active.where.not(id: post.user_id).ordered,

--- a/app/views/posts/search.haml
+++ b/app/views/posts/search.haml
@@ -30,6 +30,10 @@
             %tr
               %td= label_tag :setting_id, 'Setting'
               %td= select_tag :setting_id, options_from_collection_for_select(@setting || [], :id, :name, params[:setting_id]), { prompt: '— Choose Setting —' }
+            - if logged_in?
+              %tr
+                %td= label_tag :access_circle_id, 'Access Circle'
+                %td= select_tag :access_circle_id, options_from_collection_for_select(@access_circle || [], :id, :name, params[:access_circle_id]), { prompt: '— Choose Access Circle —' }
             %tr
               %td= label_tag :subject, 'Subject'
               %td= text_field_tag :subject, params[:subject], style: 'width: 100%; margin: 5px 0px;'

--- a/app/views/posts/show.haml
+++ b/app/views/posts/show.haml
@@ -174,6 +174,10 @@
       -#    Turn on notifications
 - if @post.description.present?
   .post-subheader= sanitize_simple_link_text(@post.description)
+- if @post.privacy_access_list? && @post.user_id == current_user&.id && @post.access_circles.any?
+  .post-subheader
+    Access circles:
+    = safe_join(@post.access_circles.map { |c| link_to(c.name, c) }, ', ')
 - if @prev_post || @next_post
   .post-navheader
     - if @next_post

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -35,8 +35,12 @@
       %td{class: cycle('odd', 'even')}
         = privacy_state(@post.privacy, dark_layout: current_user&.layout_darkmode?)
         - if @post.privacy_access_list?
-          \-
-          = safe_join(@post.post_viewers.map(&:user).map { |u| user_link(u) }, ', ')
+          - viewer_links = @post.post_viewers.map(&:user).map { |u| user_link(u) }
+          - circle_links = @post.access_circles.map { |c| link_to(c.name, c) }
+          - audience_links = viewer_links + circle_links
+          - if audience_links.any?
+            \-
+            = safe_join(audience_links, ', ')
     %tr
       %th.sub.width-150 Authors
       %td{class: cycle('odd', 'even')}

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -98,6 +98,15 @@
           = f.label :default_hide_edit_delete_buttons, 'Hide "Edit" and "Delete" buttons'
         = f.check_box :default_hide_add_bookmark_button
         = f.label :default_hide_add_bookmark_button, 'Hide "Add Bookmark" button'
+    - unless current_user.read_only?
+      %div
+        .sub= f.label :default_access_circle_ids, 'Default access circles'
+        %div{class: cycle('even', 'odd')}
+          .details Circles pre-selected on new access-list posts. You can override the selection per post.
+          = f.collection_select(:default_access_circle_ids,
+            AccessCircle.where(user: current_user).ordered_by_name,
+            :id, :name, { selected: current_user.default_access_circle_ids, include_blank: true },
+            { multiple: true })
     .form-table-ender= submit_tag "Save", class: 'button'
 
 %br

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -107,6 +107,14 @@
             AccessCircle.where(user: current_user).ordered_by_name,
             :id, :name, { selected: current_user.default_access_circle_ids, include_blank: true },
             { multiple: true })
+      %div
+        .sub= f.label :default_viewer_ids, 'Default viewers'
+        %div{class: cycle('even', 'odd')}
+          .details Individual users pre-selected as viewers on new access-list posts. You can override the selection per post.
+          = f.collection_select(:default_viewer_ids,
+            User.active.where.not(id: current_user.id).ordered,
+            :id, :username, { selected: current_user.default_viewer_ids, include_blank: true },
+            { multiple: true })
     .form-table-ender= submit_tag "Save", class: 'button'
 
 %br

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -103,10 +103,11 @@
         .sub= f.label :default_access_circle_ids, 'Default access circles'
         %div{class: cycle('even', 'odd')}
           .details Circles pre-selected on new access-list posts. You can override the selection per post.
-          = f.collection_select(:default_access_circle_ids,
-            AccessCircle.where(user: current_user).ordered_by_name,
-            :id, :name, { selected: current_user.default_access_circle_ids, include_blank: true },
-            { multiple: true })
+          - default_circle_options = AccessCircle.attachable_by(current_user).includes(:user).map do |c|
+            - label = c.user_id == current_user.id ? c.name : "#{c.name} (#{c.user.username})"
+            - [label, c.id]
+          = f.select(:default_access_circle_ids, options_for_select(default_circle_options, current_user.default_access_circle_ids),
+            { include_blank: true }, { multiple: true })
       %div
         .sub= f.label :default_viewer_ids, 'Default viewers'
         %div{class: cycle('even', 'odd')}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     resources :characters, only: :index
     resources :galleries, only: [:index, :show]
     resources :boards, only: :index
+    resources :access_circles, only: :index
     collection do
       get :search
     end
@@ -111,6 +112,7 @@ Rails.application.routes.draw do
     collection { get :search }
   end
   resources :tags, except: [:new, :create]
+  resources :access_circles
 
   # Indexes
   resources :indexes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,7 +112,12 @@ Rails.application.routes.draw do
     collection { get :search }
   end
   resources :tags, except: [:new, :create]
-  resources :access_circles
+  resources :access_circles do
+    member do
+      post :join
+      post :leave
+    end
+  end
 
   # Indexes
   resources :indexes

--- a/db/migrate/20260517220500_add_joinable_to_tags.rb
+++ b/db/migrate/20260517220500_add_joinable_to_tags.rb
@@ -1,0 +1,5 @@
+class AddJoinableToTags < ActiveRecord::Migration[7.2]
+  def change
+    add_column :tags, :joinable, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260517220600_create_user_default_access_circles.rb
+++ b/db/migrate/20260517220600_create_user_default_access_circles.rb
@@ -1,0 +1,11 @@
+class CreateUserDefaultAccessCircles < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_default_access_circles do |t|
+      t.integer :user_id, null: false
+      t.integer :tag_id, null: false
+      t.timestamps null: true
+    end
+    add_index :user_default_access_circles, :user_id
+    add_index :user_default_access_circles, [:user_id, :tag_id], unique: true
+  end
+end

--- a/db/migrate/20260517220700_create_user_default_viewers.rb
+++ b/db/migrate/20260517220700_create_user_default_viewers.rb
@@ -1,0 +1,11 @@
+class CreateUserDefaultViewers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_default_viewers do |t|
+      t.integer :user_id, null: false
+      t.integer :viewer_id, null: false
+      t.timestamps null: true
+    end
+    add_index :user_default_viewers, :user_id
+    add_index :user_default_viewers, [:user_id, :viewer_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_17_220600) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_17_220700) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -463,6 +463,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_17_220600) do
     t.datetime "updated_at"
     t.index ["user_id", "tag_id"], name: "index_user_default_access_circles_on_user_id_and_tag_id", unique: true
     t.index ["user_id"], name: "index_user_default_access_circles_on_user_id"
+  end
+
+  create_table "user_default_viewers", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "viewer_id", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["user_id", "viewer_id"], name: "index_user_default_viewers_on_user_id_and_viewer_id", unique: true
+    t.index ["user_id"], name: "index_user_default_viewers_on_user_id"
   end
 
   create_table "user_tags", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_17_220500) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_17_220600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -454,6 +454,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_17_220500) do
     t.text "description"
     t.boolean "retired", default: false
     t.index ["user_id"], name: "index_templates_on_user_id"
+  end
+
+  create_table "user_default_access_circles", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "tag_id", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["user_id", "tag_id"], name: "index_user_default_access_circles_on_user_id_and_tag_id", unique: true
+    t.index ["user_id"], name: "index_user_default_access_circles_on_user_id"
   end
 
   create_table "user_tags", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_24_202900) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_17_220500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -441,6 +441,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_24_202900) do
     t.string "type"
     t.text "description"
     t.boolean "owned", default: false
+    t.boolean "joinable", default: false, null: false
     t.index ["name"], name: "index_tags_on_name"
     t.index ["type"], name: "index_tags_on_type"
   end

--- a/spec/controllers/access_circles_controller_spec.rb
+++ b/spec/controllers/access_circles_controller_spec.rb
@@ -1,0 +1,472 @@
+RSpec.describe AccessCirclesController do
+  let(:user) { create(:user) }
+  let(:reader) { create(:reader_user) }
+  let(:circle) { create(:circle, user: user) }
+  let(:users) { User.where(id: create_list(:user, 5).map(&:id)) }
+  let(:unrelated) { create(:user) }
+  let(:description) { 'test description' }
+
+  describe "GET index" do
+    it "requires login" do
+      get :index
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to eq("You must be logged in to view that page.")
+    end
+
+    context "with user" do
+      let(:user2) { create(:user) }
+
+      before(:each) { login_as(user) }
+
+      it "requires a valid user" do
+        get :index, params: { user_id: -1 }
+        expect(flash[:error]).to eq('User could not be found.')
+        expect(response).to redirect_to(root_url)
+      end
+
+      it "requires permission" do
+        get :index, params: { user_id: user2.id }
+        expect(flash[:error]).to eq('You do not have permission to view this page.')
+        expect(response).to redirect_to(root_url)
+      end
+
+      it "works" do
+        circles = create_list(:access_circle, 2, user: user)
+        create_list(:access_circle, 3)
+        get :index, params: { user_id: user.id }
+        expect(flash[:error]).not_to be_present
+        expect(response.status).to eq(200)
+        expect(assigns(:user)).to eq(user)
+        expect(assigns(:page_title)).to eq("Your Access Circles")
+        expect(assigns(:circles).ids).to match_array(circles.map(&:id))
+      end
+
+      it "works on other user for admin" do
+        circles = create_list(:access_circle, 2, user: user2)
+        create_list(:access_circle, 2, user: user)
+        create_list(:access_circle, 3)
+        user.update!(role_id: Permissible::ADMIN)
+        get :index, params: { user_id: user2.id }
+        expect(response.status).to eq(200)
+        expect(assigns(:user)).to eq(user2)
+        expect(assigns(:page_title)).to eq("#{user2.username}'s Access Circles")
+        expect(assigns(:circles).ids).to match_array(circles.map(&:id))
+      end
+    end
+
+    context "without user" do
+      it "works" do
+        circles = create_list(:access_circle, 3, owned: false)
+        create_list(:access_circle, 3, owned: true)
+        create(:access_circle, user: user, owned: true)
+        login_as(user)
+        get :index
+        expect(response.status).to eq(200)
+        expect(assigns(:public)).to eq(true)
+        expect(assigns(:page_title)).to eq("Public Access Circles")
+        expect(assigns(:circles).ids).to match_array(circles.map(&:id))
+      end
+    end
+  end
+
+  describe "GET new" do
+    it "requires login" do
+      get :new
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to eq("You must be logged in to view that page.")
+    end
+
+    it 'requires full user' do
+      login_as(reader)
+
+      get :new
+      expect(response).to redirect_to(continuities_path)
+      expect(flash[:error]).to eq("You do not have permission to create access circles.")
+    end
+
+    context "with views" do
+      render_views
+
+      it "works" do
+        login_as(user)
+        get :new
+        expect(response.status).to eq(200)
+        expect(assigns(:circle).user_id).to eq(user.id)
+        expect(assigns(:circle).new_record?).to eq(true)
+      end
+    end
+  end
+
+  describe "POST create" do
+    it "requires login" do
+      post :create
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to eq("You must be logged in to view that page.")
+    end
+
+    it 'requires full user' do
+      login_as(reader)
+
+      post :create
+      expect(response).to redirect_to(continuities_path)
+      expect(flash[:error]).to eq("You do not have permission to create access circles.")
+    end
+
+    it "requires valid parameters" do
+      login_as(user)
+      post :create, params: { access_circle: { name: '' } }
+      expect(response).to render_template(:new)
+      expect(flash[:error][:message]).to eq('Your access circle could not be saved.')
+      expect(flash[:error][:array]).to eq(["Name can't be blank"])
+    end
+
+    context "with views" do
+      render_views
+
+      it "keeps variables on failed save" do
+        login_as(user)
+
+        expect {
+          post :create, params: { access_circle: { name: '', description: description, user_ids: users.ids } }
+        }.not_to change { PostTag.count }
+
+        expect(response).to render_template(:new)
+        expect(flash[:error][:message]).to eq('Your access circle could not be saved.')
+        expect(assigns(:circle).description).to eq(description)
+        expect(assigns(:circle).user_ids).to eq(users.ids)
+      end
+    end
+
+    it "works" do
+      login_as(user)
+      post :create, params: { id: circle.id, access_circle: { name: 'test name', description: description, user_ids: users.ids } }
+      expect(response.status).to redirect_to(assigns(:circle))
+      expect(flash[:success]).to eq('Access circle saved successfully.')
+      expect(assigns(:circle).name).to eq('test name')
+      expect(assigns(:circle).description).to eq(description)
+      expect(assigns(:circle).user_ids).to eq(users.ids)
+    end
+
+    it "ignores invalid user_ids" do
+      login_as(user)
+      post :create, params: { access_circle: { name: 'Test name', user_ids: [-1, '', users[0].id] } }
+      expect(response.status).to redirect_to(assigns(:circle))
+      expect(flash[:success]).to eq('Access circle saved successfully.')
+      expect(assigns(:circle).user_ids).to eq([users[0].id])
+    end
+
+    it "clears relevant caches" do
+      login_as(user)
+      unrelated.visible_posts
+      user.visible_posts
+      users.each(&:visible_posts)
+
+      users.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(true) }
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(unrelated.id))).to be(true)
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(user.id))).to be(true)
+
+      post :create, params: { id: circle.id, access_circle: { name: 'test name', description: description, user_ids: users.ids } }
+      expect(flash[:success]).to eq('Access circle saved successfully.')
+
+      users.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(false) }
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(unrelated.id))).to be(true)
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(user.id))).to be(true)
+    end
+  end
+
+  describe "GET show" do
+    it "requires login" do
+      get :show, params: { id: -1 }
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to eq("You must be logged in to view that page.")
+    end
+
+    it "requires valid circle" do
+      user_id = login
+      get :show, params: { id: -1 }
+      expect(response).to redirect_to(user_access_circles_path(user_id))
+      expect(flash[:error]).to eq("Access circle could not be found.")
+    end
+
+    it "requires permission" do
+      user_id = login
+      get :show, params: { id: circle.id }
+      expect(response).to redirect_to(user_access_circles_path(user_id))
+      expect(flash[:error]).to eq("Access circle could not be found.")
+    end
+
+    context "with views" do
+      render_views
+
+      before(:each) { login_as(user) }
+
+      it "works on info view" do
+        circle.update!(description: 'foobar')
+        get :show, params: { id: circle.id }
+        expect(response.status).to eq(200)
+      end
+
+      it "works on posts view" do
+        posts = create_list(:post, 3, user: user, privacy: :access_list, access_circles: [circle])
+        get :show, params: { id: circle.id, view: 'posts' }
+        expect(response.status).to eq(200)
+        expect(assigns(:posts).ids).to match_array(posts.map(&:id))
+      end
+
+      it "works on users view" do
+        circle.update!(user_ids: users.ids)
+        get :show, params: { id: circle.id, view: 'users' }
+        expect(response.status).to eq(200)
+        expect(assigns(:users).ids).to match_array(users.ids)
+      end
+    end
+
+    it "works for non-owners with public circles" do
+      circle.update!(owned: false)
+      login
+      get :show, params: { id: circle.id }
+      expect(response.status).to eq(200)
+      expect(assigns(:page_title)).to eq(circle.name)
+    end
+
+    it "works for admins" do
+      login_as(create(:admin_user))
+      get :show, params: { id: circle.id }
+      expect(response.status).to eq(200)
+      expect(assigns(:page_title)).to eq(circle.name)
+    end
+  end
+
+  describe "GET edit" do
+    it "requires login" do
+      get :edit, params: { id: -1 }
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to eq("You must be logged in to view that page.")
+    end
+
+    it "requires valid circle" do
+      user_id = login
+      get :edit, params: { id: -1 }
+      expect(response).to redirect_to(user_access_circles_path(user_id))
+      expect(flash[:error]).to eq("Access circle could not be found.")
+    end
+
+    it "requires permission" do
+      user_id = login
+      get :edit, params: { id: circle.id }
+      expect(response).to redirect_to(user_access_circles_path(user_id))
+      expect(flash[:error]).to eq("Access circle could not be found.")
+    end
+
+    it "requires permission for public circles" do
+      circle.update!(owned: false)
+      user_id = login
+      get :edit, params: { id: circle.id }
+      expect(response).to redirect_to(user_access_circles_path(user_id))
+      expect(flash[:error]).to eq('You do not have permission to modify this access circle')
+    end
+
+    context "with views" do
+      render_views
+
+      it "works" do
+        login_as(user)
+        get :edit, params: { id: circle.id }
+        expect(response.status).to eq(200)
+        expect(assigns(:page_title)).to eq("Edit Access Circle: #{circle.name}")
+      end
+    end
+
+    it "works for admins" do
+      login_as(create(:admin_user))
+      get :edit, params: { id: circle.id }
+      expect(response.status).to eq(200)
+      expect(assigns(:page_title)).to eq("Edit Access Circle: #{circle.name}")
+    end
+  end
+
+  describe "PUT update" do
+    it "requires login" do
+      put :update, params: { id: -1 }
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to eq("You must be logged in to view that page.")
+    end
+
+    it "requires valid circle" do
+      user_id = login
+      put :update, params: { id: -1 }
+      expect(response).to redirect_to(user_access_circles_path(user_id))
+      expect(flash[:error]).to eq("Access circle could not be found.")
+    end
+
+    it "requires permission" do
+      user_id = login
+      put :update, params: { id: circle.id }
+      expect(response).to redirect_to(user_access_circles_path(user_id))
+      expect(flash[:error]).to eq("Access circle could not be found.")
+    end
+
+    it "requires permission for public circles" do
+      circle.update!(owned: false)
+      user_id = login
+      put :update, params: { id: circle.id }
+      expect(response).to redirect_to(user_access_circles_path(user_id))
+      expect(flash[:error]).to eq('You do not have permission to modify this access circle')
+    end
+
+    it "requires valid parameters" do
+      login_as(user)
+      put :update, params: { id: circle.id, access_circle: { name: '' } }
+      expect(response).to render_template(:edit)
+      expect(flash[:error][:message]).to eq('Your access circle could not be saved.')
+      expect(flash[:error][:array]).to eq(["Name can't be blank"])
+    end
+
+    context "with views" do
+      render_views
+
+      it "keeps variables on failed save" do
+        login_as(user)
+        circle.update!(description: 'old description', user_ids: [create(:user).id])
+
+        expect {
+          put :update, params: { id: circle.id, access_circle: { name: '', description: description, user_ids: users.ids } }
+        }.not_to change { PostTag.count }
+
+        expect(response).to render_template(:edit)
+        expect(flash[:error][:message]).to eq('Your access circle could not be saved.')
+        expect(assigns(:circle).description).to eq(description)
+        expect(assigns(:circle).user_ids).to eq(users.ids)
+      end
+    end
+
+    it "works" do
+      circle.update!(description: 'old description', user_ids: [create(:user).id])
+      login_as(user)
+      put :update, params: { id: circle.id, access_circle: { name: 'new name', description: description, user_ids: users.ids } }
+      expect(response.status).to redirect_to(circle)
+      expect(flash[:success]).to eq('Access circle saved successfully.')
+
+      circle.reload
+      expect(circle.name).to eq('new name')
+      expect(circle.description).to eq(description)
+      expect(circle.user_ids).to eq(users.ids)
+    end
+
+    it "ignores invalid user_ids" do
+      login_as(user)
+      put :update, params: { id: circle.id, access_circle: { name: 'Test name', user_ids: [-1, '', users[0].id] } }
+      expect(response).to redirect_to(circle)
+      expect(flash[:success]).to eq('Access circle saved successfully.')
+      expect(circle.reload.user_ids).to eq([users[0].id])
+    end
+
+    it "clears relevant caches" do
+      login_as(user)
+
+      old_users = create_list(:user, 2)
+      retained_users = User.where(id: create_list(:user, 2).map(&:id))
+      circle.update!(users: old_users + retained_users)
+
+      unrelated.visible_posts
+      user.visible_posts
+      users.each(&:visible_posts)
+      old_users.each(&:visible_posts)
+      retained_users.each(&:visible_posts)
+
+      users.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(true) }
+      old_users.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(true) }
+      retained_users.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(true) }
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(unrelated.id))).to be(true)
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(user.id))).to be(true)
+
+      put :update, params: {
+        id: circle.id,
+        access_circle: { name: 'test name', description: description, user_ids: (users.ids + retained_users.ids) },
+      }
+      expect(flash[:success]).to eq('Access circle saved successfully.')
+      expect(circle.reload.user_ids).to match_array(users.ids + retained_users.ids)
+
+      users.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(false) }
+      old_users.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(false) }
+      retained_users.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(true) }
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(unrelated.id))).to be(true)
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(user.id))).to be(true)
+    end
+  end
+
+  describe "DELETE destroy" do
+    it "requires login" do
+      delete :destroy, params: { id: -1 }
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to eq("You must be logged in to view that page.")
+    end
+
+    it "requires valid circle" do
+      user_id = login
+      delete :destroy, params: { id: -1 }
+      expect(response).to redirect_to(user_access_circles_path(user_id))
+      expect(flash[:error]).to eq("Access circle could not be found.")
+    end
+
+    it "requires permission" do
+      user_id = login
+      delete :destroy, params: { id: circle.id }
+      expect(response).to redirect_to(user_access_circles_path(user_id))
+      expect(flash[:error]).to eq("Access circle could not be found.")
+    end
+
+    it "requires permission for public circles" do
+      circle.update!(owned: false)
+      user_id = login
+      delete :destroy, params: { id: circle.id }
+      expect(response).to redirect_to(user_access_circles_path(user_id))
+      expect(flash[:error]).to eq('You do not have permission to modify this access circle')
+    end
+
+    it "works" do
+      login_as(user)
+      delete :destroy, params: { id: circle.id }
+      expect(response.status).to redirect_to(user_access_circles_path(user))
+      expect(flash[:success]).to eq("Access circle deleted.")
+    end
+
+    it "works for admins" do
+      admin = create(:admin_user)
+      login_as(admin)
+      delete :destroy, params: { id: circle.id }
+      expect(response.status).to redirect_to(user_access_circles_path(admin))
+      expect(flash[:success]).to eq("Access circle deleted.")
+    end
+
+    it "handles failure" do
+      allow(AccessCircle).to receive(:find_by).with(id: circle.id.to_s).and_return(circle)
+      allow(circle).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
+      login_as(user)
+
+      delete :destroy, params: { id: circle.id }
+      expect(response).to redirect_to(circle)
+      expect(flash[:error][:message]).to eq('Access circle could not be deleted.')
+    end
+
+    it "clears relevant caches" do
+      login_as(user)
+      circle.update!(users: users)
+
+      unrelated.visible_posts
+      user.visible_posts
+      users.each(&:visible_posts)
+
+      users.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(true) }
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(unrelated.id))).to be(true)
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(user.id))).to be(true)
+
+      delete :destroy, params: { id: circle.id }
+      expect(flash[:success]).to eq('Access circle deleted.')
+
+      users.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(false) }
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(unrelated.id))).to be(true)
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(user.id))).to be(true)
+    end
+  end
+end

--- a/spec/controllers/access_circles_controller_spec.rb
+++ b/spec/controllers/access_circles_controller_spec.rb
@@ -469,4 +469,58 @@ RSpec.describe AccessCirclesController do
       expect(Rails.cache.exist?(PostViewer.cache_string_for(user.id))).to be(true)
     end
   end
+
+  describe "POST join" do
+    let(:joinable) { create(:access_circle, user: user, owned: false, joinable: true) }
+
+    it "requires login" do
+      post :join, params: { id: joinable.id }
+      expect(response).to redirect_to(root_url)
+    end
+
+    it "rejects circles that aren't joinable" do
+      private_circle = create(:access_circle, user: user, owned: true, joinable: false)
+      login_as(unrelated)
+      post :join, params: { id: private_circle.id }
+      expect(flash[:error]).to eq("Access circle could not be found.")
+    end
+
+    it "rejects when joinable flag is false" do
+      joinable.update!(joinable: false)
+      login_as(unrelated)
+      post :join, params: { id: joinable.id }
+      expect(flash[:error]).to eq("You can't join this access circle.")
+    end
+
+    it "adds the user" do
+      login_as(unrelated)
+      expect { post :join, params: { id: joinable.id } }.to change { Tag::UserTag.count }.by(1)
+      expect(flash[:success]).to eq("You joined #{joinable.name}.")
+      expect(joinable.reload.users).to include(unrelated)
+    end
+
+    it "is idempotent" do
+      Tag::UserTag.create!(user: unrelated, tag: joinable)
+      login_as(unrelated)
+      post :join, params: { id: joinable.id }
+      expect(flash[:error]).to eq("You can't join this access circle.")
+    end
+  end
+
+  describe "POST leave" do
+    let(:joinable) { create(:access_circle, user: user, owned: false, joinable: true) }
+
+    it "rejects non-members" do
+      login_as(unrelated)
+      post :leave, params: { id: joinable.id }
+      expect(flash[:error]).to eq("You aren't a member of this access circle.")
+    end
+
+    it "removes the user" do
+      Tag::UserTag.create!(user: unrelated, tag: joinable)
+      login_as(unrelated)
+      expect { post :leave, params: { id: joinable.id } }.to change { Tag::UserTag.count }.by(-1)
+      expect(flash[:success]).to eq("You left #{joinable.name}.")
+    end
+  end
 end

--- a/spec/controllers/posts/create_spec.rb
+++ b/spec/controllers/posts/create_spec.rb
@@ -558,7 +558,7 @@ RSpec.describe PostsController, 'POST create' do
     circle_viewers = User.where(id: create_list(:user, 3).map(&:id))
     unrelated = create(:user)
     all = User.where(id: [user.id, coauthor.id, viewer.id, circle_viewers.ids, unrelated.id].flatten)
-    circle = create(:access_circle, users: circle_viewers)
+    circle = create(:access_circle, user: user, users: circle_viewers)
 
     all.each(&:visible_posts)
     all.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to eq(true) }

--- a/spec/controllers/posts/update_spec.rb
+++ b/spec/controllers/posts/update_spec.rb
@@ -919,6 +919,73 @@ RSpec.describe PostsController, 'PUT update' do
       expect(response).to redirect_to(post_url(post))
       expect(flash[:error]).to eq("You do not have permission to modify this post.")
     end
+
+    it "regenerates visible_posts" do
+      old_viewer = create(:user)
+      new_viewer = create(:user)
+      still_viewer = create(:user)
+      old_circle_viewers = User.where(id: create_list(:user, 3).map(&:id))
+      new_circle_viewers = User.where(id: create_list(:user, 3).map(&:id))
+      shared_circle_viewers = User.where(id: create_list(:user, 2).map(&:id))
+      retained_circle_viewers = User.where(id: create_list(:user, 3).map(&:id))
+      unrelated = create(:user)
+
+      all = [
+        user.id,
+        coauthor.id,
+        old_viewer.id,
+        new_viewer.id,
+        still_viewer.id,
+        old_circle_viewers.ids,
+        new_circle_viewers.ids,
+        shared_circle_viewers.ids,
+        retained_circle_viewers.ids,
+        unrelated.id,
+      ].flatten
+
+      all = User.where(id: all)
+      circle1 = create(:access_circle, users: old_circle_viewers + shared_circle_viewers)
+      circle2 = create(:access_circle, users: new_circle_viewers + shared_circle_viewers)
+      circle3 = create(:access_circle, users: retained_circle_viewers)
+      post = create(:post,
+        user: user,
+        authors: [coauthor],
+        authors_locked: true,
+        privacy: :access_list,
+        viewers: [coauthor, old_viewer, still_viewer],
+        access_circles: [circle1, circle3],
+      )
+      create(:reply, post: post, user: coauthor)
+
+      all.each(&:visible_posts)
+      all.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to eq(true) }
+
+      login_as(user)
+
+      put :update, params: {
+        id: post.id,
+        post: {
+          viewer_ids: [coauthor.id, new_viewer.id, still_viewer.id],
+          access_circle_ids: [circle2.id, circle3.id],
+        },
+      }
+
+      expect(flash[:success]).to eq('Post updated.')
+      post.reload
+      expect(post.viewers).to match_array([new_viewer, still_viewer, coauthor])
+      expect(post.access_circles).to match_array([circle2, circle3])
+
+      old_circle_viewers.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(false) }
+      new_circle_viewers.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(false) }
+      shared_circle_viewers.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(false) }
+      retained_circle_viewers.each { |u| expect(Rails.cache.exist?(PostViewer.cache_string_for(u.id))).to be(true) }
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(coauthor.id))).to be(true)
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(old_viewer.id))).to be(false)
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(new_viewer.id))).to be(false)
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(still_viewer.id))).to be(true)
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(unrelated.id))).to be(true)
+      expect(Rails.cache.exist?(PostViewer.cache_string_for(user.id))).to be(true)
+    end
   end
 
   context "metadata" do

--- a/spec/controllers/posts/update_spec.rb
+++ b/spec/controllers/posts/update_spec.rb
@@ -944,9 +944,9 @@ RSpec.describe PostsController, 'PUT update' do
       ].flatten
 
       all = User.where(id: all)
-      circle1 = create(:access_circle, users: old_circle_viewers + shared_circle_viewers)
-      circle2 = create(:access_circle, users: new_circle_viewers + shared_circle_viewers)
-      circle3 = create(:access_circle, users: retained_circle_viewers)
+      circle1 = create(:access_circle, user: user, users: old_circle_viewers + shared_circle_viewers)
+      circle2 = create(:access_circle, user: user, users: new_circle_viewers + shared_circle_viewers)
+      circle3 = create(:access_circle, user: user, users: retained_circle_viewers)
       post = create(:post,
         user: user,
         authors: [coauthor],

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -232,6 +232,11 @@ FactoryBot.define do
     factory :gallery_group, class: :gallery_group do
       type { 'GalleryGroup' }
     end
+
+    factory :access_circle, class: :access_circle, aliases: [:circle] do
+      type { 'AccessCircle' }
+      owned { true }
+    end
   end
 
   factory :message do

--- a/spec/models/access_circle_spec.rb
+++ b/spec/models/access_circle_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe AccessCircle do
+  describe "validations" do
+    let(:user) { create(:user) }
+
+    it "requires a user" do
+      circle = build(:access_circle, user_id: nil)
+      expect(circle).not_to be_valid
+    end
+
+    it "requires a name" do
+      circle = build(:access_circle, name: nil)
+      expect(circle).not_to be_valid
+    end
+
+    it "requires a unique name per user" do
+      circle1 = create(:access_circle, user: user)
+      circle2 = build(:access_circle, user: user, name: circle1.name)
+      expect(circle2).not_to be_valid
+    end
+
+    it "can have the same name as another user's circle" do
+      circle1 = create(:access_circle)
+      circle2 = build(:access_circle, name: circle1.name)
+      expect(circle1.user_id).not_to eq(circle2.user_id)
+      expect(circle2).to be_valid
+    end
+
+    it "can have the same name as a setting" do
+      setting = create(:setting, user: user, owned: true)
+      circle = build(:access_circle, user: user, name: setting.name)
+      expect(circle).to be_valid
+    end
+  end
+
+  describe 'visible_to?' do
+    let(:user) { create(:user) }
+    let(:circle) { create(:access_circle, user: user) }
+    let(:reader) { create(:reader_user) }
+    let(:other) { create(:user) }
+
+    it 'does not allow logged out users' do
+      expect(circle.visible_to?(nil)).to eq(false)
+    end
+
+    it 'does not allow logged out users for public circles' do
+      circle.update!(owned: false)
+      expect(circle.visible_to?(nil)).to eq(false)
+    end
+
+    it 'returns true if the circle is public' do
+      circle.update!(owned: false)
+
+      aggregate_failures do
+        expect(circle.visible_to?(reader)).to eq(true)
+        expect(circle.visible_to?(other)).to eq(true)
+      end
+    end
+
+    it 'returns true for admins' do
+      expect(circle.visible_to?(create(:admin_user))).to eq(true)
+    end
+
+    it 'returns true for own circles' do
+      expect(circle.visible_to?(user)).to eq(true)
+    end
+
+    it 'returns false for other circles' do
+      aggregate_failures do
+        expect(circle.visible_to?(reader)).to eq(false)
+        expect(circle.visible_to?(other)).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/models/access_circle_spec.rb
+++ b/spec/models/access_circle_spec.rb
@@ -71,4 +71,52 @@ RSpec.describe AccessCircle do
       end
     end
   end
+
+  describe 'joinable_by?' do
+    let(:owner) { create(:user) }
+    let(:other) { create(:user) }
+    let(:circle) { create(:access_circle, user: owner, owned: false, joinable: true) }
+
+    it 'is false when not joinable' do
+      circle.update!(joinable: false)
+      expect(circle.joinable_by?(other)).to eq(false)
+    end
+
+    it 'is false for the owner' do
+      expect(circle.joinable_by?(owner)).to eq(false)
+    end
+
+    it 'is false when the circle is private' do
+      circle.update!(owned: true)
+      expect(circle.joinable_by?(other)).to eq(false)
+    end
+
+    it 'is false for users that are already members' do
+      Tag::UserTag.create!(user: other, tag: circle)
+      expect(circle.joinable_by?(other.reload)).to eq(false)
+    end
+
+    it 'is true for an outsider on a joinable public circle' do
+      expect(circle.joinable_by?(other)).to eq(true)
+    end
+  end
+
+  describe 'leavable_by?' do
+    let(:owner) { create(:user) }
+    let(:member) { create(:user) }
+    let(:circle) { create(:access_circle, user: owner, owned: false, joinable: true) }
+
+    it 'is false for non-members' do
+      expect(circle.leavable_by?(member)).to eq(false)
+    end
+
+    it 'is false for the owner' do
+      expect(circle.leavable_by?(owner)).to eq(false)
+    end
+
+    it 'is true for a member' do
+      Tag::UserTag.create!(user: member, tag: circle)
+      expect(circle.leavable_by?(member.reload)).to eq(true)
+    end
+  end
 end

--- a/spec/models/access_circle_spec.rb
+++ b/spec/models/access_circle_spec.rb
@@ -101,6 +101,24 @@ RSpec.describe AccessCircle do
     end
   end
 
+  describe '.attachable_by' do
+    let(:user) { create(:user) }
+    let(:other) { create(:user) }
+
+    it 'returns nothing for a nil user' do
+      create(:access_circle, user: other, owned: false)
+      expect(AccessCircle.attachable_by(nil)).to be_empty
+    end
+
+    it 'includes the user own circles' do
+      mine_private = create(:access_circle, user: user, owned: true)
+      mine_public = create(:access_circle, user: user, owned: false)
+      _theirs_private = create(:access_circle, user: other, owned: true)
+      theirs_public = create(:access_circle, user: other, owned: false)
+      expect(AccessCircle.attachable_by(user)).to contain_exactly(mine_private, mine_public, theirs_public)
+    end
+  end
+
   describe 'leavable_by?' do
     let(:owner) { create(:user) }
     let(:member) { create(:user) }

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -570,6 +570,23 @@ RSpec.describe Post do
         expect(post.reload).to be_visible_to(user)
       end
 
+      it "is visible to member of an access circle on the post" do
+        user = create(:user)
+        circle = create(:access_circle, user: post.user)
+        Tag::UserTag.create!(user: user, tag: circle)
+        post.access_circles << circle
+        expect(post.reload).to be_visible_to(user)
+      end
+
+      it "is not visible to member of a different circle" do
+        user = create(:user)
+        member_circle = create(:access_circle, user: post.user)
+        attached_circle = create(:access_circle, user: post.user)
+        Tag::UserTag.create!(user: user, tag: member_circle)
+        post.access_circles << attached_circle
+        expect(post.reload).not_to be_visible_to(user)
+      end
+
       it "is not visible to author" do # TODO seems wrong
         reply = create(:reply, post: post)
         expect(post).not_to be_visible_to(reply.user)


### PR DESCRIPTION
Rebases @teceler's #1562 onto current `main` and continues the work. The original PR has been open since 2021-07-18 and now applies cleanly on top of the December 2024 user_tags migration that's already on main.

Marked as draft for review of the additions on top of the original — would like a second pair of eyes on the visibility wiring and the joinable/default-circle UX before un-drafting.

## What's here

**Rebased PR #1562 (squashed into one commit, original author attributed)**
- `AccessCircle < Tag` with `Tag::UserTag` join model
- `AccessCirclesController` + views, post editor integration, cache invalidation

**Bug fixes on top of #1562**
- `Post#visible_to?` now honors circle membership the way the `visible_to` scope does. The scope already used `user.visible_posts` (which includes circle posts); the instance method was still checking `post_viewers` only, so per-post permission checks returned false for circle members.
- `AccessCirclesController#index` assigns the paginated relation back to `@circles` and precomputes `@post_counts` / `@user_counts` the view references. Previously the page would NoMethodError on render.
- Allows `:owned` through `permitted_params`. The form field was being stripped silently, so every new circle was created public.
- Drops `dependent: :destroy` from `Post#access_circles`, `Post#circle_viewers`, and `AccessCircle#users` `has_many through` associations — Rails would cascade through to the target table (destroying `User` rows on circle destroy, etc.). The intermediate join records still cascade via the direct `post_tags` / `user_tags` association.
- Relabels the "Public?" / "is visible to all users" checkbox to "Private?", since checking it actually makes the circle private.
- Adds `:view_access_circles` to `MOD_PERMS`. The controller's permission check was referencing it but it didn't exist anywhere.
- `posts/editor.js` was calling `createSelect2('#post_circle_ids')` but the field id is `#post_access_circle_ids`, so the select2 widget was never attached.
- `PostsController#preview` was reading `params[:post][:circle_ids]` but the field is `:access_circle_ids`, so previewing wiped the selected circles.

**Joinable circles (#415)**
Owners can mark a non-private circle as joinable. Any logged-in user who can see a joinable circle can add or remove themselves via Join / Leave links on the circle's show page — no more "people asking one by one to be added" for the use case the issue describes.

**Default access lists per user (#47)**
Lets a user pre-select circles AND individual viewers on every new post.
- `user_default_access_circles` and `user_default_viewers` join tables
- Multi-selects on the user edit page (`/users/:id/edit`)
- `PostsController#new` pre-fills both `@post.access_circle_ids` and `@post.viewer_ids`

**Cross-user circle attachment**
- `AccessCircle.attachable_by(user)` scope: user's own circles (private or public) plus other people's public circles.
- Post editor and default-circles dropdown list attachable circles, with the owner's username appended for non-self-owned entries.
- `PostsController#create` / `#update` build the access_circles list through the same scope so a malicious client can't attach a private circle by submitting its id directly.

**Post search by circle**
- `/posts/search` has an Access Circle filter alongside the existing Setting / Author / Character filters.
- `Api::V1::TagsController#index` filters `AccessCircle` results through `attachable_by(current_user)`, so the autocomplete doesn't expose private circles owned by others.

**Display**
- The post show page lists the attached circles below the description for the author.
- The post stats page includes circle links in the Audience row.

## Test plan

- [ ] CI rspec suite passes (I couldn't run it locally — Ruby 3.4.8 not installed in my env, but `ruby -c` syntax checks pass on every modified file)
- [ ] Manually verify the access circle index page renders with `@post_counts` / `@user_counts` populated
- [ ] Manually verify Join / Leave round trip on a joinable public circle
- [ ] Manually verify default circles and default viewers set on a user pre-fill on new post form
- [ ] Manually verify a post with `access_list` privacy + a circle is visible to circle members and invisible to non-members (both the listing scope and per-post permission)
- [ ] Manually verify a post can be filtered by access circle in search
- [ ] Manually verify attaching another user's public circle to your own post works, and trying to attach a private circle owned by someone else does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)