### PR TITLE
Safe-navigate author_for in posts#update

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -238,7 +238,7 @@ class PostsController < WritableController
         @post.labels = labels
         process_npc(@post, permitted_character_params)
         @post.save!
-        @post.author_for(current_user).update!(private_note: @post.private_note) if is_author
+        @post.author_for(current_user)&.update!(private_note: @post.private_note) if is_author
       end
     rescue ActiveRecord::RecordInvalid => e
       render_errors(@post, action: 'updated', now: true, err: e)


### PR DESCRIPTION
## Summary
- `PostsController#update` line 241: `@post.author_for(current_user).update!(...)` 500s with `NoMethodError: undefined method 'update!' for nil`.
- Add `&.` to short-circuit cleanly when `author_for` returns nil.

Found via New Relic: 1 occurrence under `POST /posts/58816`, referrer `/posts/58816/edit` (real user).

## Root cause
Stale association cache + a setter that mutates the DB before the cache is invalidated:

1. `find_model` → `@post.visible_to?` reads `author_ids` (via `author_blocking?`), **caching** the `authors` collection on the instance.
2. `@post.assign_attributes(permitted_params)` includes `unjoined_author_ids: [...]`. Rails' `unjoined_authors=` setter **immediately destroys** the user's `post_authors` row in the DB if their id isn't in the new list (the row has `joined: false`).
3. `is_author = @post.author_ids.include?(current_user.id)` at line 231 reads the **cached** collection — still says true even though the DB row is now gone.
4. The transaction runs, `@post.save!` succeeds.
5. `@post.author_for(current_user)` (line 241) does a fresh `find_by`, returns **nil**, and `.update!` blows up.

The user path that hits this: an invited but unjoined co-author edits the post and removes themselves from the "Invite coauthors" multi-select. The OP can't trigger it — their post_author row has `joined: true`, which `unjoined_authors=` ignores.

The `&.` is the correct fix as a no-crash: if the user just removed their own authorship, there's nothing to write a `private_note` to, and silently skipping is semantically right. Audit-comment-bypass is also correct here (user opting out of their own coauthor invite isn't a moderator action).

A "proper" fix would compute `is_author` AFTER `assign_attributes`, but that's a behavioral change with edge cases (e.g., should the audit_comment requirement kick in once they're no longer an author?). Leaving that to a follow-up — 1 occurrence in 30 days doesn't warrant the complexity right now.

## Test plan
- [ ] CI rspec suite passes
- [ ] Manual: update a post as an author and verify the `private_note` still saves
- [ ] Manual: as an invited unjoined coauthor, edit a post, remove yourself from "Invite coauthors", save — should succeed (used to 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)