### PR TITLE
Persist attempted reply to ReplyDraft, not session cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,9 +30,27 @@ class ApplicationController < ActionController::Base
 
   def handle_invalid_token
     flash[:error] = 'Oops, looks like your session expired! Please try another tab or log in again to resume glowficcing.'
-    flash[:error] += ' If you were writing a reply, it has been cached for your next page load.'
-    session[:attempted_reply] = params[:reply] if params[:reply].present?
+    flash[:error] += ' If you were writing a reply, it has been cached for your next page load.' if persist_attempted_reply
     redirect_to root_path
+  end
+
+  # When CSRF rejects a reply submission, stash the in-progress text on the
+  # user's ReplyDraft for the post so build_new_reply_for picks it up on the
+  # next page load. Previously this was crammed into session[:attempted_reply],
+  # but cookie sessions cap at 4KB and long replies overflowed (CookieOverflow
+  # in production). Returns whether anything was persisted, so the flash can
+  # only mention the cache when it actually exists.
+  def persist_attempted_reply
+    return false unless logged_in?
+    reply_params = params[:reply]
+    return false if reply_params.blank?
+    post_id = reply_params[:post_id]
+    return false if post_id.blank?
+
+    permitted = reply_params.permit(:content, :character_id, :icon_id, :character_alias_id, :editor_mode)
+    draft = ReplyDraft.find_or_initialize_by(post_id: post_id, user_id: current_user.id)
+    draft.assign_attributes(permitted)
+    draft.save
   end
 
   def use_javascript(js)

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -123,11 +123,7 @@ class WritableController < ApplicationController
       if @post.taggable_by?(current_user)
         build_template_groups
 
-        session_params = ActionController::Parameters.new(reply: session.fetch(:attempted_reply, {}))
-        reply_hash = permitted_params(session_params)
-        session.delete(:attempted_reply)
-
-        @reply = @post.build_new_reply_for(current_user, reply_hash)
+        @reply = @post.build_new_reply_for(current_user)
         @reply.editor_mode ||= params[:editor_mode] || current_user.default_editor
         @draft = ReplyDraft.draft_for(@post.id, current_user.id)
       end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -559,13 +559,24 @@ RSpec.describe ApplicationController do
       expect(flash[:error]).to include("Oops, looks like your session expired!")
     end
 
-    it "saves reply if present" do
-      reply_param = build(:reply).attributes
-      reply_param.each { |k, v| reply_param[k] = "" if v.nil? }
-      post :create, params: { reply: reply_param }
+    it "saves reply to a draft if present" do
+      user = create(:user)
+      session[:user_id] = user.id
+      target_post = create(:post)
+      content = "in-progress reply content"
+
+      post :create, params: { reply: { post_id: target_post.id, content: content } }
       expect(flash[:error]).to include("Oops, looks like your session expired!")
-      session_save = session[:attempted_reply].permit!
-      expect(session_save.to_h).to eq(reply_param)
+      expect(flash[:error]).to include("cached for your next page load")
+      draft = ReplyDraft.draft_for(target_post.id, user.id)
+      expect(draft).not_to be_nil
+      expect(draft.content).to eq(content)
+    end
+
+    it "does not mention caching when there's no reply to save" do
+      get :index
+      expect(flash[:error]).to include("Oops, looks like your session expired!")
+      expect(flash[:error]).not_to include("cached for your next page load")
     end
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -561,9 +561,9 @@ RSpec.describe ApplicationController do
 
     it "saves reply to a draft if present" do
       user = create(:user)
-      session[:user_id] = user.id
       target_post = create(:post)
       content = "in-progress reply content"
+      login_as(user)
 
       post :create, params: { reply: { post_id: target_post.id, content: content } }
       expect(flash[:error]).to include("Oops, looks like your session expired!")

--- a/spec/controllers/posts/show_spec.rb
+++ b/spec/controllers/posts/show_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe PostsController, 'GET show' do
       allow(Post).to receive(:find_by).with({ id: post.id.to_s }).and_return(post)
 
       allow(post).to receive(:build_new_reply_for).and_call_original
-      expect(post).to receive(:build_new_reply_for).with(user, an_instance_of(ActionController::Parameters).and(be_empty))
+      expect(post).to receive(:build_new_reply_for).with(user)
       expect(controller).to receive(:setup_layout_gon).and_call_original
 
       get :show, params: { id: post.id }
@@ -328,7 +328,7 @@ RSpec.describe PostsController, 'GET show' do
       allow(Post).to receive(:find_by).with({ id: post.id.to_s }).and_return(post)
 
       allow(post).to receive(:build_new_reply_for).and_call_original
-      expect(post).to receive(:build_new_reply_for).with(user, an_instance_of(ActionController::Parameters).and(be_empty)).and_call_original
+      expect(post).to receive(:build_new_reply_for).with(user).and_call_original
 
       get :show, params: { id: post.id }
       expect(response).to have_http_status(200)


### PR DESCRIPTION
## Summary
- `handle_invalid_token` stashes the rejected `params[:reply]` into `session[:attempted_reply]` so the editor can be rehydrated after a CSRF rejection. Cookie sessions cap at 4KB; long replies overflow with `ActionDispatch::Cookies::CookieOverflow`. NR shows 8248-byte payloads on `/posts/2690`.
- `ReplyDraft` already exists for the rehydration use case — `Post#build_new_reply_for` automatically returns a draft if one exists. Write to it on CSRF rejection and drop the session round-trip.
- After this PR the cookie size no longer scales with reply content.

## Trade-offs
- **Audit comment is dropped.** `reply_drafts` has no column for it, so a CSRF-rejected mod edit loses the `audit_comment`. Mod notes are usually short and the worst case is retyping a sentence vs. losing a 4KB reply.
- **Existing draft is overwritten.** If the user already had a `ReplyDraft` for the same post (autosave from earlier) and got CSRF-rejected with new content, the rejected content overwrites the older draft. The old behavior had the *opposite* asymmetry — the draft would win on next page load and the rejected content was silently lost. Either way the with-draft case has only one piece of content surviving; this one preserves what the user most recently typed, which is the better default. A real fix would surface multiple drafts to the user.

## Test plan
- [x] CI rspec suite — added a spec verifying ReplyDraft persistence and updated the build_new_reply_for arg-shape expectation
- [ ] Manual: stale-CSRF a long reply (`curl` POST with invalid token, long `:content`) and verify the next `posts/show` rehydrates the editor with the draft content
- [ ] Manual: confirm no `Set-Cookie` headers > 4KB on the redirect response

🤖 Generated with [Claude Code](https://claude.com/claude-code)