### PR TITLE
Use subquery for board_id filter in Reply::Searcher

### DIFF
--- a/app/services/reply/searcher.rb
+++ b/app/services/reply/searcher.rb
@@ -65,8 +65,10 @@ class Reply::Searcher < Generic::Searcher
     if @post
       @search_results = @search_results.where(post_id: @post.id)
     elsif board_id.present?
-      post_ids = Post.where(board_id: board_id).pluck(:id)
-      @search_results = @search_results.where(post_id: post_ids)
+      # Subquery instead of pluck+IN so PG can use a hash/index join on
+      # board_id rather than serializing a thousands-long id list and
+      # falling off the index. Has caused statement_timeout in production.
+      @search_results = @search_results.where(post_id: Post.where(board_id: board_id).select(:id))
     end
   end
 


### PR DESCRIPTION
## Summary
- `Reply::Searcher#filter_parents` was loading every post id in the requested board into Ruby (`Post.where(board_id:).pluck(:id)`) and then passing that list as `WHERE post_id IN (...)`. For popular boards (thousands of posts) PG flips the plan and the query starts hitting the 20s statement_timeout.
- Replace with a subquery (`Post.where(board_id:).select(:id)`) so PG can choose the join strategy with full cardinality info on both sides.

NR shows 9 `ActionView::Template::Error`/`PG::QueryCanceled` on `/replies/search` in the last 7 days, all from statement_timeout.

## Out of scope (follow-up)
- The secondary `replies.content ILIKE '%phrase%'` filter in `search_content` (added to enforce exact-phrase containment after the tsquery match) can't use the gin index — leading wildcard ILIKE is always a seq scan. Worth converting to a `phraseto_tsquery` / `<->` proximity operator in a separate PR; semantics change so it needs more care.

## Test plan
- [ ] CI rspec suite passes
- [ ] Manual: `/replies/search?board_id=<large board>&subj_content=foo` returns in well under 20s
- [ ] Manual: same query with no board filter still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)