### PR TITLE
Paginate icon editor on galleries/edit

### DIFF
--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -106,7 +106,7 @@ class GalleriesController < UploadingController
       render :edit
     else
       flash[:success] = "Gallery updated."
-      redirect_to edit_gallery_path(@gallery)
+      redirect_to edit_gallery_path(@gallery, page: params[:page])
     end
   end
 

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -76,6 +76,15 @@ class GalleriesController < UploadingController
     @page_title = 'Edit Gallery: ' + @gallery.name
     use_javascript('galleries/uploader')
     use_javascript('galleries/edit')
+    # Default per_page is 25 site-wide. Most galleries are small enough to
+    # fit comfortably and the form is more useful when whole; pick a higher
+    # threshold (100) so only the truly big galleries get paginated. The
+    # bimodal 6.3s p99 we were seeing on this action came from galleries
+    # with 200-500 icons.
+    @editable_galleries_icons = @gallery.galleries_icons
+      .joins(:icon)
+      .order(Arel.sql('LOWER(keyword)'))
+      .paginate(page: page, per_page: 100)
   end
 
   def update

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -76,15 +76,7 @@ class GalleriesController < UploadingController
     @page_title = 'Edit Gallery: ' + @gallery.name
     use_javascript('galleries/uploader')
     use_javascript('galleries/edit')
-    # Default per_page is 25 site-wide. Most galleries are small enough to
-    # fit comfortably and the form is more useful when whole; pick a higher
-    # threshold (100) so only the truly big galleries get paginated. The
-    # bimodal 6.3s p99 we were seeing on this action came from galleries
-    # with 200-500 icons.
-    @editable_galleries_icons = @gallery.galleries_icons
-      .joins(:icon)
-      .order(Arel.sql('LOWER(keyword)'))
-      .paginate(page: page, per_page: 100)
+    load_editable_galleries_icons
   end
 
   def update
@@ -103,6 +95,7 @@ class GalleriesController < UploadingController
       use_javascript('galleries/edit')
       editor_setup
       set_s3_url
+      load_editable_galleries_icons
       render :edit
     else
       flash[:success] = "Gallery updated."
@@ -244,6 +237,18 @@ class GalleriesController < UploadingController
   def editor_setup
     use_javascript('galleries/editor')
     gon.user_id = current_user.id
+  end
+
+  # Default per_page is 25 site-wide. Most galleries are small enough to fit
+  # comfortably and the form is more useful when whole; pick a higher
+  # threshold (100) so only the truly big galleries get paginated. The
+  # bimodal 6.3s p99 we were seeing on this action came from galleries with
+  # 200-500 icons.
+  def load_editable_galleries_icons
+    @editable_galleries_icons = @gallery.galleries_icons
+      .joins(:icon)
+      .order(Arel.sql('LOWER(keyword)'))
+      .paginate(page: page, per_page: 100)
   end
 
   def og_data

--- a/app/views/galleries/edit.haml
+++ b/app/views/galleries/edit.haml
@@ -13,10 +13,14 @@
     .editor-title Edit Gallery
     = render 'editor', f: f, gallery: @gallery
     .subber Edit Icons
+  - if @editable_galleries_icons.total_pages > 1
+    = render 'posts/paginator', paginated: @editable_galleries_icons
   .gallery-icons-edit
-    = f.fields_for :galleries_icons, @gallery.galleries_icons.joins(:icon).order(Arel.sql('LOWER(keyword)')) do |gif|
+    = f.fields_for :galleries_icons, @editable_galleries_icons do |gif|
       .gallery-icon-editor
         = gif.fields_for :icon do |i|
           = render 'icons/editor', f: i, gif: gif
+  - if @editable_galleries_icons.total_pages > 1
+    = render 'posts/paginator', paginated: @editable_galleries_icons
   .submit-button
     = submit_tag "Save", class: 'button'


### PR DESCRIPTION
## Summary
- `galleries/edit` renders one nested form per `gallery_icon`. Galleries with hundreds of icons mean hundreds of form sections. NR shows p99 = 6.3s on this action, bimodal — small galleries fast, large galleries painful.
- Paginate the icon list to 100/page. Small galleries (the bulk) still render on a single page so day-to-day UX is unchanged; only galleries with >100 icons get split.
- `accepts_nested_attributes_for :galleries_icons` only updates the icons present in submitted params, so saving from any one page doesn't disturb icons on other pages.

## Test plan
- [ ] CI rspec suite passes
- [ ] Manual: edit a small gallery (10 icons), all icons visible, save works as before
- [ ] Manual: edit a large gallery (>100 icons), see paginator above/below the icon grid, save on a non-first page persists only that page's changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)