### PR TITLE
Skip COUNT(DISTINCT) when the relation has no joins

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,7 +88,12 @@ class ApplicationController < ActionController::Base
 
   def posts_from_relation(relation, no_tests: true, with_pagination: true, select: '', max: false, with_unread: false, show_blocked: false)
     posts = posts_relation_filter(relation, no_tests: no_tests, show_blocked: show_blocked)
-    posts_count = posts.except(:select, :order, :group).count('DISTINCT posts.id')
+    # DISTINCT only matters when the incoming relation has joins that could
+    # multiply post rows. The bare relation only adds where-clauses, so for
+    # the common case (boards/show, posts/index, owed, hidden) we can skip
+    # the DISTINCT and use a plain COUNT, which PG can answer from the index.
+    count_target = (posts.joins_values + posts.left_outer_joins_values).any? ? 'DISTINCT posts.id' : :all
+    posts_count = posts.except(:select, :order, :group).count(count_target)
     posts = posts_list_relation(posts, select: select, max: max)
     posts = posts.paginate(page: page, total_entries: posts_count) if with_pagination
     calculate_view_status(posts, with_unread: with_unread) if logged_in?


### PR DESCRIPTION
## Summary
- `posts_from_relation` always ran the pagination total as `SELECT COUNT(DISTINCT posts.id)`. DISTINCT is only meaningful when the relation has joins that could multiply post rows.
- For the common case — `boards/show`, `posts/index`, `posts/owed`, `posts/hidden`, `board_sections/show`, `characters/show`, etc. — the incoming relation is a where-only filter and `COUNT(*)` gives the same answer with a cheaper plan.
- Detect joins on the relation (`joins_values + left_outer_joins_values`) and switch to plain count when there are none. Continues to use DISTINCT for callers like `posts/unread` and `tags/show` with `hide_from_all` that DO have post_views/board_views/post_tags joins.

`boards/show` is ~8k req/wk at 223ms avg with ~89ms in the DB; removing the DISTINCT from the count is the cheapest direct improvement.

## Test plan
- [ ] CI rspec suite passes
- [ ] Manual: paginated total on `/boards/<id>` matches the actual number of unsectioned posts
- [ ] Manual: paginated total on `/posts/unread` (joined relation) still correct — should still go through the DISTINCT path
- [ ] Manual: paginated total on `/tags/<id>?view=posts` correct, especially with `hide_from_all` user

## Out of scope
- Caching `boards/show` responses via `fresh_when` — would be a bigger win for pages where the board hasn't changed since the last visit, but needs a sensible etag computation.
- Re-thinking `Post.visible_to` for the access_list branch — the OR-with-IN gets large for users with many `visible_posts` and the planner doesn't always pick well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)