### PR TITLE
Enhance Indexes (perms, discoverability, pagination, flat view)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ backstop/reports/*
 /.gems
 /.envrc
 dump.rdb
+node_modules/

--- a/app/concerns/permissible.rb
+++ b/app/concerns/permissible.rb
@@ -14,6 +14,7 @@ module Permissible
     :split_posts,
     :regenerate_flat_posts,
     :relocate_characters,
+    :edit_indexes,
     # :edit_tags,
     # :delete_tags,
     # :edit_continuities

--- a/app/controllers/indexes_controller.rb
+++ b/app/controllers/indexes_controller.rb
@@ -40,9 +40,16 @@ class IndexesController < ApplicationController
     end
 
     @page_title = @index.name.to_s
-    @sectionless = @index.posts.where(index_posts: { index_section_id: nil })
-    @sectionless = @sectionless.ordered_by_index
     dbselect = ', index_posts.description as index_description, index_posts.id as index_post_id'
+    @sectionless = @index.posts.where(index_posts: { index_section_id: nil }).ordered_by_index
+
+    if params[:view] == 'flat'
+      response.headers['X-Robots-Tag'] = 'noindex'
+      @sectionless = posts_from_relation(@sectionless, with_pagination: false, select: dbselect)
+      render :flat, layout: false
+      return
+    end
+
     @sectionless = posts_from_relation(@sectionless, select: dbselect)
   end
 

--- a/app/controllers/indexes_controller.rb
+++ b/app/controllers/indexes_controller.rb
@@ -43,7 +43,7 @@ class IndexesController < ApplicationController
     @sectionless = @index.posts.where(index_posts: { index_section_id: nil })
     @sectionless = @sectionless.ordered_by_index
     dbselect = ', index_posts.description as index_description, index_posts.id as index_post_id'
-    @sectionless = posts_from_relation(@sectionless, with_pagination: false, select: dbselect)
+    @sectionless = posts_from_relation(@sectionless, select: dbselect)
   end
 
   def edit

--- a/app/models/index.rb
+++ b/app/models/index.rb
@@ -3,7 +3,7 @@ class Index < ApplicationRecord
   include Concealable
 
   has_many :index_posts, inverse_of: :index, dependent: :destroy
-  has_many :posts, through: :index_posts, dependent: :destroy
+  has_many :posts, through: :index_posts
   has_many :index_sections, inverse_of: :index, dependent: :destroy
   belongs_to :user, inverse_of: :indexes, optional: false
 

--- a/app/views/indexes/flat.haml
+++ b/app/views/indexes/flat.haml
@@ -1,0 +1,49 @@
+!!!
+%html
+  %head
+    %title #{@index.name} | Glowfic Constellation
+    %meta{ charset: "utf-8" }
+    %meta{ name: "viewport", content: "width=device-width" }
+    = stylesheet_link_tag 'application'
+    - if current_user.try(:layout).present?
+      = stylesheet_link_tag "layouts/#{current_user.layout}"
+    = favicon_link_tag 'favicons/favicon-32x32.png', type: 'image/png', rel: 'icon', sizes: '32x32'
+    = favicon_link_tag 'favicons/favicon-16x16.png', type: 'image/png', rel: 'icon', sizes: '16x16'
+  %body
+    #content
+      = link_to @index do
+        &laquo; Back
+      %br
+      .details.float-right
+        Generated: #{pretty_time(DateTime.now.in_time_zone)}
+      .content-header
+        %span#post-title= @index.name
+      - if @index.description.present?
+        .post-subheader= sanitize_written_content(@index.description)
+
+      %table
+        - @index.index_sections.ordered.each do |section|
+          %tr
+            %th.table-title{colspan: 2}= section.name
+          - if section.description.present?
+            %tr
+              %td.subber.index-description{colspan: 2}= sanitize_written_content(section.description)
+          - section.posts.ordered_by_index.includes(:user).each do |post|
+            %tr
+              %td.padding-10= link_to post.subject, post_url(post)
+              %td.padding-10.right-align
+                - if post.user.deleted?
+                  %em (deleted user)
+                - else
+                  = post.user.username
+        - if @sectionless.present?
+          %tr
+            %th.table-title{colspan: 2} (no section)
+          - @sectionless.each do |post|
+            %tr
+              %td.padding-10= link_to post.subject, post_url(post)
+              %td.padding-10.right-align
+                - if post.user.deleted?
+                  %em (deleted user)
+                - else
+                  = post.user.username

--- a/app/views/indexes/index.haml
+++ b/app/views/indexes/index.haml
@@ -3,7 +3,7 @@
     %tr
       %th.table-title{colspan: 3}
         Indexes
-        - if logged_in? && current_user.admin?
+        - if logged_in? && !current_user.read_only?
           = link_to new_index_path do
             .link-box.action-new + New Index
     %tr

--- a/app/views/indexes/show.haml
+++ b/app/views/indexes/show.haml
@@ -5,6 +5,8 @@
 
 - content_for :posts_title do
   = @index.name
+  = link_to index_path(@index, view: 'flat'), rel: 'nofollow noindex' do
+    .link-box View Flat HTML
   - if @index.editable_by?(current_user)
     = link_to new_index_post_path params: { index_id: @index.id } do
       .link-box.action-new + Add Post to Index

--- a/app/views/indexes/show.haml
+++ b/app/views/indexes/show.haml
@@ -30,3 +30,7 @@
       %tr
         %td.continuity-spacer{colspan: 7}
       = render partial: 'posts/list_item', collection: @sectionless, as: :post, locals: { index: @index }
+  - if @sectionless.respond_to?(:total_pages) && @sectionless.total_pages > 1
+    %tfoot
+      %tr
+        %td{colspan: 7}= render 'posts/paginator', paginated: @sectionless


### PR DESCRIPTION
Five small enhancements to the Indexes feature, surfaced from a quick audit. One commit per change so each can be reviewed (or reverted) independently.

## Commits

1. **Register `:edit_indexes` in `MOD_PERMS`** — `Index#editable_by?` calls `has_permission?(:edit_indexes)` for users editing someone else's `authors_locked: true` index, but the permission wasn't in `MOD_PERMS`. Mods couldn't moderate locked indexes (admins still passed via the early return). One-line fix.

2. **Show "+ New Index" to all full users** — the controller permits any non-read-only user to POST `/indexes`, but the index list view only rendered the create link for admins. Match the view to the controller. If the policy is meant to be admin-only the controller should enforce it; the inconsistency was just hiding a working feature.

3. **Drop redundant `dependent: :destroy` on `Index#posts`** — `has_many :posts, through: :index_posts, dependent: :destroy` is redundant with the direct `has_many :index_posts, dependent: :destroy` on the same model. Drop the through-target one; it invites the misreading that destroying an Index also destroys its Posts.

4. **Paginate sectionless posts on `indexes#show`** — `show` was passing `with_pagination: false` to `posts_from_relation`. For long-running indexes with hundreds of sectionless entries the page is a wall. Flip it on (default behavior) and render the standard paginator when `total_pages > 1`. Sections themselves are still rendered one-at-a-time without inter-section pagination since they're already curator-grouped.

5. **Add flat view for indexes** — `/indexes/:id?view=flat` renders a layout-stripped table of contents: index name + description, each section's name + description, each post (linked, with author shown). Mirrors the existing `posts/show` flat view; useful for saving/printing a curated reading list. Doesn't expand post bodies inline — linking to each post keeps the page tractable for large indexes.

## Audit results not in this PR

Two items I expected to find turned out to already be done:
- IndexSection already has a `description` column, form, and show rendering.
- Sectionless and sectioned posts are already privacy-filtered via `posts_from_relation` → `posts.visible_to(current_user)`.

Bigger features I scoped out:
- Bulk import (add all posts from a board/section/tag to an index) — feature ask, separate PR.
- Within-section pagination — felt wrong to paginate something the curator deliberately ordered.

## Test plan
- [ ] CI rspec suite passes
- [ ] Manual: as a mod (non-admin), edit a `authors_locked: true` index owned by another user — should work
- [ ] Manual: as a full non-admin user on `/indexes`, see "+ New Index" link
- [ ] Manual: create an index with >25 sectionless posts, see paginator on `show`
- [ ] Manual: `/indexes/:id?view=flat` renders a clean table-of-contents page

🤖 Generated with [Claude Code](https://claude.com/claude-code)