### PR TITLE
Apply Rails/SaveBang to silent-failure callers

### DIFF
--- a/app/concerns/owable.rb
+++ b/app/concerns/owable.rb
@@ -26,13 +26,13 @@ module Owable
     def opt_out_of_owed(user)
       return unless (author = author_for(user))
       author.destroy and return true unless author.joined?
-      author.update(can_owe: false)
+      author.update!(can_owe: false)
     end
 
     def opt_in_to_owed(user)
       return unless (author = author_for(user))
       return if author.can_owe?
-      author.update(can_owe: true)
+      author.update!(can_owe: true)
     end
 
     def author_for(user)
@@ -43,9 +43,9 @@ module Owable
 
     def add_creator_to_authors
       if author_ids.include?(user_id)
-        author_for(user).update(joined: true, joined_at: created_at, private_note: private_note)
+        author_for(user).update!(joined: true, joined_at: created_at, private_note: private_note)
       else
-        post_authors.create(user: user, joined: true, joined_at: created_at, private_note: private_note)
+        post_authors.create!(user: user, joined: true, joined_at: created_at, private_note: private_note)
       end
     end
 

--- a/app/concerns/viewable.rb
+++ b/app/concerns/viewable.rb
@@ -13,7 +13,7 @@ module Viewable
 
       return view.update(read_at: Time.now.in_time_zone) unless at_time.present?
       return true if view.read_at && at_time <= view.read_at && !force
-      view.update(read_at: at_time)
+      view.update!(read_at: at_time)
     end
 
     def ignore(user)

--- a/app/controllers/api/v1/index_posts_controller.rb
+++ b/app/controllers/api/v1/index_posts_controller.rb
@@ -44,14 +44,14 @@ class Api::V1::IndexPostsController < Api::ApiController
       posts = posts.sort_by { |post| post_ids.index(post.id) }
       posts.each_with_index do |post, i|
         next if post.section_order == i
-        post.update(section_order: i)
+        post.update!(section_order: i)
       end
 
       other_posts = IndexPost.where(index_id: index.id, index_section_id: section_id).where.not(id: post_ids).ordered_in_section
       other_posts.each_with_index do |post, i|
         pos = i + posts_count
         next if post.section_order == pos
-        post.update(section_order: pos)
+        post.update!(section_order: pos)
       end
     end
 

--- a/app/controllers/api/v1/index_sections_controller.rb
+++ b/app/controllers/api/v1/index_sections_controller.rb
@@ -36,14 +36,14 @@ class Api::V1::IndexSectionsController < Api::ApiController
       sections = sections.sort_by { |section| section_ids.index(section.id) }
       sections.each_with_index do |section, i|
         next if section.section_order == i
-        section.update(section_order: i)
+        section.update!(section_order: i)
       end
 
       other_sections = IndexSection.where(index_id: index.id).where.not(id: section_ids).ordered
       other_sections.each_with_index do |section, j|
         order = j + sections_count
         next if section.section_order == order
-        section.update(section_order: order)
+        section.update!(section_order: order)
       end
     end
 

--- a/app/controllers/api/v1/subcontinuities_controller.rb
+++ b/app/controllers/api/v1/subcontinuities_controller.rb
@@ -48,14 +48,14 @@ class Api::V1::SubcontinuitiesController < Api::ApiController
       sections = sections.sort_by { |section| section_ids.index(section.id) }
       sections.each_with_index do |section, index|
         next if section.section_order == index
-        section.update(section_order: index)
+        section.update!(section_order: index)
       end
 
       other_sections = BoardSection.where(board_id: board.id).where.not(id: section_ids).ordered
       other_sections.each_with_index do |section, i|
         index = i + sections_count
         next if section.section_order == index
-        section.update(section_order: index)
+        section.update!(section_order: index)
       end
     end
 

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -60,7 +60,7 @@ class Block < ApplicationRecord
   def mark_messages_read
     Message.where(unread: true, sender_id: blocked_user_id, recipient_id: blocking_user_id).find_each do |message|
       message.unread = false
-      message.save
+      message.save!
     end
   end
 

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -91,7 +91,7 @@ class Character < ApplicationRecord
     galleries.each_with_index do |other, index|
       next if other.section_order == index
       other.section_order = index
-      other.save
+      other.save!
     end
   end
 
@@ -124,7 +124,7 @@ class Character < ApplicationRecord
           group_gallery_ids.delete(gallery_id)
         else
           # destroy joins that are not in the new set of IDs
-          char_gal.destroy
+          char_gal.destroy!
         end
       end
       new_ids.each do |gallery_id|
@@ -134,7 +134,7 @@ class Character < ApplicationRecord
       # leftover galleries from gallery groups will be added by that model
       self.characters_galleries = new_chargals
       if persisted?
-        self.update(characters_galleries: new_chargals)
+        self.update!(characters_galleries: new_chargals)
       else
         self.assign_attributes(characters_galleries: new_chargals)
       end

--- a/app/models/galleries_icon.rb
+++ b/app/models/galleries_icon.rb
@@ -19,11 +19,11 @@ class GalleriesIcon < ApplicationRecord
 
   def unset_has_gallery
     return if icon.galleries.present?
-    icon.update(has_gallery: false)
+    icon.update!(has_gallery: false)
   end
 
   def set_has_gallery
     return if icon.has_gallery?
-    icon.update(has_gallery: true)
+    icon.update!(has_gallery: true)
   end
 end

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -27,7 +27,7 @@ class News < ApplicationRecord
     end
 
     return true if view.news_id > self.id
-    view.update(news: self)
+    view.update!(news: self)
   end
 
   def self.num_unread_for(user)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -95,7 +95,7 @@ class Tag < ApplicationRecord
       Tag::SettingTag.where(tag_id: self.id, tagged_id: other_tag.id).delete_all
       Tag::SettingTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
       Tag::SettingTag.where(tagged_id: other_tag.id).update_all(tagged_id: self.id)
-      other_tag.destroy
+      other_tag.destroy!
       # rubocop:enable Rails/SkipsModelValidations
     end
   end

--- a/app/services/report.rb
+++ b/app/services/report.rb
@@ -17,7 +17,7 @@ class Report < Object
 
     return true if at_time <= view.read_at.to_date
     view.read_at = at_time
-    view.save
+    view.save!
   end
 
   def self.last_read(user)


### PR DESCRIPTION
Split from PR #2730 per @Marri's review. The bang conversions are semantically different from the rest of that PR's style sweep — they change error-handling behavior for callers that previously relied on silent failure (returning `false` rather than raising). Deserves its own review thread.

## Each call site and why bang is likely correct

| Call site | Reason raise > silent failure |
|---|---|
| `Owable#opt_in_to_owed` / `opt_out_of_owed` / `add_creator_to_authors` | Internal helpers in Post create flow. Silent `Post::Author` save failure leaves a Post with inconsistent author state. |
| `Viewable#mark_read` | The new_record branch already raises via `save`; the existing-record branch silent-failing was an asymmetry. |
| `Api::V1::IndexPostsController#reorder` / `IndexSectionsController#reorder` / `SubcontinuitiesController#reorder` | Loops inside a `transaction` block; any silent failure leaves ordering half-applied rather than rolling back. |
| `Block#mark_messages_read` (`Message.save!`) | `after_create` callback on Block; silent failure makes the block half-effective. |
| `Character#reorder_galleries` (`CharactersGallery.save!`) | Loop in a transaction; silent failure leaves galleries out of order. |
| `Character#ungrouped_gallery_ids=` (`CharactersGallery.destroy!`, `Character.update!`) | Source has an explicit `WARNING: this method *will make changes*` comment; silent failure is worse than raise. |
| `GalleriesIcon#set_has_gallery` / `unset_has_gallery` (`Icon.update!`) | `after_create` / `after_destroy` callbacks on the join; silent failure desynchronizes `Icon.has_gallery` from reality. |
| `News#mark_read` (`NewsView.update!`) | Same shape as Viewable — symmetry with the `save` branch. |
| `Tag#merge_with` (`Tag.destroy!`) | Inside transaction following `delete_all`/`update_all`; raise on failure keeps the whole merge atomic. |
| `Report.mark_read` (`ReportView.save!`) | Same shape as Viewable. |

## Out of scope (intentionally left non-bang)

Anything outside controllers/models/services that's part of a callback chain where the existing return value is used or where I couldn't easily verify the contract. The rest of #2730 (formatting, hash syntax, $stdout, `instance_of?`, rubocop_todo entries) is the no-behavior-change part and remains there.

## If wrong

If any of these turn out to be load-bearing (something rescues the silent `false`), please flag the specific call site — happy to switch it back. The transaction-wrapped ones in particular are the most defensible; the after_callback ones (GalleriesIcon, Block) are where I'd want a second look.

## Test plan
- [ ] CI rspec suite passes
- [ ] Manual: trigger each path in a sandbox and confirm the new exception flow doesn't bubble where it shouldn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)