### PR TITLE
Give search autocomplete API GETs a separate rate-limit bucket

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -16,10 +16,27 @@ ENV.fetch("RACK_ATTACK_BAD_IP", "").split(",").compact_blank.each { |ip| Rack::A
 url = ENV.fetch("HEROKU_REDIS_TEAL_URL", nil)
 Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(url: url, ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }) if url
 
-# Throttle all requests by IP (60rpm)
+# Read-only API GETs power the search forms' autocomplete dropdowns (select2).
+# A single search interaction fans out into many of these requests - one per
+# dropdown opened and one per keystroke - which is fundamentally different from
+# normal page browsing (~1 request per navigation). They get their own, more
+# generous bucket below so a search doesn't exhaust the general per-IP limit.
+def autocomplete_api_request?(req)
+  req.get? && req.path.start_with?('/api/v1/')
+end
+
+# Throttle all requests by IP
 # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+# Autocomplete API GETs are excluded here and counted under 'api/ip' instead.
 Rack::Attack.throttle('req/ip', limit: ENV.fetch("RACK_ATTACK_IP_LIMIT", 25).to_i, period: 5.minutes) do |req|
-  req.ip unless req_logged_in?(req)
+  req.ip if !req_logged_in?(req) && !autocomplete_api_request?(req)
+end
+
+# Throttle the read-only autocomplete API GETs by IP, with a higher limit since
+# a single search legitimately generates many of them.
+# Key: "rack::attack:#{Time.now.to_i/:period}:api/ip:#{req.ip}"
+Rack::Attack.throttle('api/ip', limit: ENV.fetch("RACK_ATTACK_API_LIMIT", 150).to_i, period: 5.minutes) do |req|
+  req.ip if !req_logged_in?(req) && autocomplete_api_request?(req)
 end
 
 # Throttle POST requests to /login by IP address to prevent brute force login attacks


### PR DESCRIPTION
The flat per-IP throttle counted every request, including the /api/v1 autocomplete calls the search forms fire via select2. With no minimum input length, those dropdowns request on open and on each keystroke, so a single search fans out into dozens of requests and blows the 25/5min limit that is otherwise fine for normal browsing (~1 request per page).

Exclude read-only /api/v1 GETs from the general req/ip throttle and count them under a separate, more generous api/ip bucket (default 150/5min, configurable via RACK_ATTACK_API_LIMIT).