### PR TITLE
Add DB connection resilience for maintenance/failover events

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,5 +20,12 @@ production:
   <<: *default
   database: db/production.sqlite3
   pool: <%= ENV["DB_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  # Prune dead connections from the pool so a DB maintenance/failover event
+  # doesn't leave stale sockets to be handed out until they're next used.
+  reaping_frequency: <%= ENV["DB_REAPING_FREQUENCY"] || 10 %>
+  # Fail fast against a dead/changed endpoint instead of hanging on connect
+  # or waiting the full default for a pool checkout.
+  connect_timeout: <%= ENV["DB_CONNECT_TIMEOUT"] || 5 %>
+  checkout_timeout: <%= ENV["DB_CHECKOUT_TIMEOUT"] || 5 %>
   variables:
     statement_timeout: <%= ENV["STATEMENT_TIMEOUT"] %>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -45,6 +45,14 @@ before_fork do
   Barnes.start
 end
 
+# Each clustered worker is forked from the master, so re-establish its own
+# Active Record connections on boot rather than inheriting the master's.
+# Belt-and-suspenders against stale connections after a DB maintenance event
+# (mirrors what config/initializers/resque.rb does on fork).
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord::Base)
+end
+
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 


### PR DESCRIPTION
## Why

After a Postgres maintenance/failover, the long-lived connections held in each Puma worker's pool die server-side but aren't proactively recycled. With no reaping/timeout config, dead sockets linger in the pool and get handed to requests (erroring until the pool cycles), so a **manual app restart** has been needed to pick up fresh connections — especially when a failover changes the endpoint IP behind the hostname (a restart forces fresh DNS resolution).

## What

- **`config/database.yml`** (production):
  - `reaping_frequency` — reaper thread prunes dead pooled connections instead of waiting until they're next checked out
  - `connect_timeout` / `checkout_timeout` — fail fast against a dead/changed endpoint rather than hanging
  - All three env-tunable (`DB_REAPING_FREQUENCY`, `DB_CONNECT_TIMEOUT`, `DB_CHECKOUT_TIMEOUT`), defaulting to 10s / 5s / 5s
- **`config/puma.rb`**: `on_worker_boot` re-establishes Active Record connections per forked worker, mirroring the existing Resque fork hooks in `config/initializers/resque.rb`

## Notes

Config-only; no behavior change in normal operation. Intent is to let the app recover from DB maintenance without a manual restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)