### PR TITLE
Reply layout options: alternating icons + Pesterchum

### DIFF
--- a/app/assets/javascripts/posts/alternating_icons.js
+++ b/app/assets/javascripts/posts/alternating_icons.js
@@ -1,0 +1,52 @@
+/* Dynamic icon sizing for the alternating-icons reply layout.
+ *
+ * Inspired by jbeshir/glowficlog's compact reader: instead of a fixed icon on
+ * every reply, scale each reply's icon to roughly match the height of its own
+ * post body (clamped between MIN and CAP). Short, rapid-fire replies get a
+ * small icon so the exchange stays dense; long replies keep a full-size icon.
+ *
+ * We size to the post's own content height rather than the distance to the next
+ * same-side reply (jbeshir's gutter approach): the icon here lives in a floated
+ * info chip, so an icon taller than its body would inflate the post and feed
+ * back into the layout. Capping at the body height keeps it stable.
+ */
+$(document).ready(function() {
+  if (!document.body.classList.contains('alternating-icons')) return;
+
+  const MIN = 28; // never shrink an icon below this (stays recognizable)
+  const CAP = 96; // never grow past this (matches the non-alternating icon size)
+
+  const clamp = function(min, value, max) {
+    return Math.min(max, Math.max(min, value));
+  };
+
+  const sizeIcons = function() {
+    const posts = document.querySelectorAll('#content .post-container');
+    Array.from(posts).forEach(function(post) {
+      const icon = post.querySelector('.post-icon img, .post-icon div');
+      const content = post.querySelector('.post-content');
+      if (!icon || !content) return;
+
+      // Square box, sized to the body height. Non-square icons are not
+      // distorted: replies.scss sets object-fit: contain on these icons, so a
+      // non-square image is letterboxed inside the square box — the same way
+      // glowfic presents icons everywhere else.
+      const size = clamp(MIN, content.offsetHeight, CAP);
+      icon.style.width = size + 'px';
+      icon.style.height = size + 'px';
+    });
+  };
+
+  const debounce = function(fn, wait) {
+    let timer = null;
+    return function() {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(fn, wait);
+    };
+  };
+
+  sizeIcons();
+  // Webfonts/images can land after ready and change body heights; recompute.
+  $(window).on('load', sizeIcons);
+  $(window).on('resize', debounce(sizeIcons, 150));
+});

--- a/app/assets/stylesheets/layouts/_pesterchum_selectors.scss
+++ b/app/assets/stylesheets/layouts/_pesterchum_selectors.scss
@@ -1,0 +1,151 @@
+/* Pesterchum-style hypercompact chat view (shared rules)
+ *
+ * Renders each reply as a tight chat line -- a small handle (the character,
+ * with screenname/author dimmed beside it) followed by the message body -- in a
+ * monospace font with the icon shrunk to a chat avatar. The point is to make
+ * fast 1-2 sentence back-and-forth scan like a chat log instead of a stack of
+ * tall icon blocks, without throwing the icons away entirely.
+ *
+ * These rules are theme-agnostic; a layout pairs them with a colour theme (the
+ * bundled Pesterchum views pair them with the dark theme). Everything is scoped
+ * under .post-container / #content so it beats the base reply rules on
+ * specificity without needing !important. */
+
+$pesterchum_font: 'Courier New', courier, monospace;
+$pesterchum_handle_width: 12em;
+
+#content > .post-container,
+.flat-post-replies .post-container {
+  position: relative;
+  overflow: visible;
+  break-inside: avoid;
+}
+
+.post-container .padding-10 {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  padding: 2px 8px;
+  font-family: $pesterchum_font;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+/* Handle column: icon + character + author, all kept on one line. */
+.post-container .post-info-box {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  float: none;
+  width: auto;
+  max-width: $pesterchum_handle_width;
+  margin: 0 6px 0 0;
+  overflow: hidden;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.post-container .post-icon {
+  height: auto;
+  background: none;
+
+  img, div {
+    width: 18px;
+    height: 18px;
+    margin: 0 4px 0 0;
+    object-fit: contain;
+    vertical-align: middle;
+  }
+}
+
+.post-container .post-info-text {
+  display: inline;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.post-container .post-character,
+.post-container .post-screenname,
+.post-container .post-author {
+  display: inline;
+  padding: 0;
+  background: none;
+  white-space: nowrap;
+}
+
+.post-container .post-character {
+  font-weight: bold;
+
+  a { text-decoration: none; }
+
+  &::after { content: ':'; }
+}
+
+/* Screenname/author trail the character handle, dimmed. */
+.post-container .post-screenname,
+.post-container .post-author {
+  margin-left: 4px;
+  font-size: 0.8em;
+  opacity: 0.6;
+}
+
+.post-container .spacer-alt {
+  display: none;
+}
+
+/* Message body fills the rest of the row; long messages hang-indent. */
+.post-container .post-content {
+  flex: 1 1 60%;
+  min-width: 12em;
+  margin: 0;
+
+  p { margin: 0 0 2px; }
+
+  blockquote {
+    margin-left: 1.5em;
+    margin-right: 0;
+  }
+}
+
+/* Action buttons collapse into a faint trailing cluster that wakes up on hover. */
+.post-container .post-edit-box {
+  order: 5;
+  float: none;
+  margin: 0 0 0 6px;
+  padding: 0;
+  opacity: 0.2;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  img {
+    width: 12px;
+    height: 12px;
+  }
+}
+
+/* Timestamp footer is pulled out of the flow so it costs no height; it fades in
+ * at the top-right of a row on hover. */
+.post-container .post-footer {
+  position: absolute;
+  top: 2px;
+  right: 8px;
+  margin: 0;
+  padding: 0;
+  opacity: 0;
+  pointer-events: none;
+
+  .right-align {
+    width: auto;
+    font-size: 0.7rem;
+  }
+
+  .padding-5 {
+    padding: 0;
+  }
+}
+
+.post-container:hover .post-footer {
+  opacity: 0.55;
+}

--- a/app/assets/stylesheets/layouts/pesterchum.scss
+++ b/app/assets/stylesheets/layouts/pesterchum.scss
@@ -1,0 +1,5 @@
+/* Pesterchum: a dark, hypercompact chat-log view that keeps a small icon.
+ * Reuses the bundled dark colour theme, then layers the chat-style reply rules
+ * on top. */
+@import 'dark';
+@import 'pesterchum_selectors';

--- a/app/assets/stylesheets/layouts/pesterchummemo.scss
+++ b/app/assets/stylesheets/layouts/pesterchummemo.scss
@@ -1,0 +1,23 @@
+/* Pesterchum Memo: the most compact chat view -- iconless, with a fixed-width
+ * handle column so messages line up like a Pesterchum memo (group chat). */
+@import 'dark';
+@import 'pesterchum_selectors';
+
+.post-container .padding-10 {
+  padding: 0 8px;
+  font-size: 0.8rem;
+  line-height: 1.3;
+}
+
+/* Drop the icon entirely and align every handle to the same column. */
+.post-container .post-icon {
+  display: none;
+}
+
+.post-container .post-info-box {
+  flex: 0 0 $pesterchum_handle_width;
+  width: $pesterchum_handle_width;
+  justify-content: flex-end;
+  margin-right: 8px;
+  text-align: right;
+}

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -575,3 +575,86 @@ div.post-subheader { width: 100%; }
 @media (max-width: 850px) {
   .bookmark-editor-fields, .bookmark-editor-buttons { display: block; margin-right: 0; }
 }
+
+/* ---------------------------------------------------------------------------
+ * Alternating icon layout (opt-in via the "Alternating icons" account setting)
+ *
+ * Goal: make fast-paced 1-2 sentence dialogue much less scroll-y without
+ * removing the icons. The icon + character/author info becomes a small floated
+ * block that the reply text flows around in an "L" shape (beside the icon, then
+ * wrapping underneath it for longer replies). Consecutive replies alternate the
+ * icon between the left and right edges (.icon-left / .icon-right) so it's easy
+ * to track who is speaking in a rapid back-and-forth.
+ * ------------------------------------------------------------------------- */
+.alternating-icons {
+  // Tighten the breathing room around each reply.
+  #content > .post-container .padding-10 { padding: 4px 8px; }
+
+  // The info "chip": a small icon sitting *next to* a compact name/author
+  // column (not stacked beneath it), so the whole floated block is only about
+  // as tall as the icon. A one-line reply then collapses to roughly icon
+  // height instead of icon + three stacked label bars + footer.
+  .post-info-box {
+    float: left;
+    width: auto;
+    max-width: 45%;
+    margin: 0 8px 2px 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    text-align: left;
+    font-size: $font_size_smaller;
+  }
+
+  .post-icon {
+    height: auto;
+    background: none;
+    flex: 0 0 auto;
+
+    img, div {
+      width: 44px;
+      height: 44px;
+      margin: 0;
+      object-fit: contain;
+    }
+  }
+
+  .post-info-text { min-width: 0; }
+
+  .post-character, .post-screenname, .post-author {
+    padding: 1px 4px;
+    line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  // The icon block is much narrower now, so quotes/lists don't need the big
+  // indent that was there to clear the old 150px sidebar.
+  .post-content {
+    blockquote { margin-left: 1em; margin-right: 1em; }
+    ul, ol { padding-left: 20px; }
+
+    p:first-child { margin-top: 0; }
+  }
+
+  // Keep the timestamp but make it tiny so it barely adds height.
+  .post-footer {
+    .right-align { font-size: $font_size_smaller; }
+    .padding-5 { padding: 1px 4px; }
+  }
+
+  // Mirror everything for replies whose icon sits on the right edge.
+  .icon-right {
+    .post-info-box {
+      float: right;
+      flex-direction: row-reverse;
+      margin: 0 0 2px 8px;
+    }
+
+    .post-edit-box {
+      float: left;
+      margin: 0 8px 0 0;
+    }
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -273,6 +273,7 @@ class UsersController < ApplicationController
       :show_user_in_switcher,
       :default_hide_edit_delete_buttons,
       :default_hide_add_bookmark_button,
+      :alternating_icons,
     )
   end
 

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -116,6 +116,7 @@ class WritableController < ApplicationController
     @meta_og[:url] = @meta_canonical
 
     use_javascript('posts/show')
+    use_javascript('posts/alternating_icons') if current_user.try(:alternating_icons)
     if logged_in?
       use_javascript('posts/editor')
       setup_layout_gon

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,6 +74,8 @@ module ApplicationHelper
       'Starry Light' => 'starrylight',
       Monochrome: 'monochrome',
       'Milky River' => 'river',
+      Pesterchum: 'pesterchum',
+      'Pesterchum Memo' => 'pesterchummemo',
     }
     options_for_select(layouts, default)
   end

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -53,7 +53,7 @@
 
     = include_gon
     = javascript_include_tag 'application_deferred'.freeze, defer: :defer
-  %body
+  %body{class: current_user.try(:alternating_icons) ? 'alternating-icons' : nil}
     #holder
       #header
         - if logged_in?

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -1,4 +1,4 @@
--# locals: ( reply:, hide_footer: false, hide_post_edit_box: false, split_ui: false )
+-# locals: ( reply:, hide_footer: false, hide_post_edit_box: false, split_ui: false, reply_counter: 0 )
 
 - if reply.is_a?(Post)
   - write = 'post-post'.freeze
@@ -6,7 +6,12 @@
   - write = 'post-reply'.freeze
 - else
   - write = ''.freeze
-.post-container{class: [write, (reply == @unread && current_user.try(:visible_unread?)) ? 'reply-highlighted' : '']}
+-# For the opt-in "alternating icons" layout: alternate which side the icon
+-# sits on so rapid back-and-forth dialogue is easier to follow. reply_counter is
+-# supplied automatically when rendered as a collection; it defaults to 0 for the
+-# opening post and other one-off renders, which keeps their icon on the left.
+- icon_side = reply_counter.odd? ? 'icon-right'.freeze : 'icon-left'.freeze
+.post-container{class: [write, icon_side, (reply == @unread && current_user.try(:visible_unread?)) ? 'reply-highlighted' : '']}
   - if reply.is_a?(Reply) && reply.id.present?
     %a.noheight{id: "reply-#{reply.id}"}= " "
   - if reply == @unread

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -98,6 +98,11 @@
           = f.label :default_hide_edit_delete_buttons, 'Hide "Edit" and "Delete" buttons'
         = f.check_box :default_hide_add_bookmark_button
         = f.label :default_hide_add_bookmark_button, 'Hide "Add Bookmark" button'
+    %div
+      .sub Reply layout
+      .checkbox-field{class: cycle('even', 'odd')}
+        = f.check_box :alternating_icons
+        = f.label :alternating_icons, "Alternating icons (compact, icons alternate left/right)"
     .form-table-ender= submit_tag "Save", class: 'button'
 
 %br

--- a/db/migrate/20260621000000_add_alternating_icons_to_users.rb
+++ b/db/migrate/20260621000000_add_alternating_icons_to_users.rb
@@ -1,0 +1,5 @@
+class AddAlternatingIconsToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :alternating_icons, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_04_215359) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_21_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -502,6 +502,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_04_215359) do
     t.boolean "public_bookmarks", default: false
     t.boolean "default_hide_edit_delete_buttons", default: false
     t.boolean "default_hide_add_bookmark_button", default: false
+    t.boolean "alternating_icons", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/spec/controllers/posts/show_spec.rb
+++ b/spec/controllers/posts/show_spec.rb
@@ -184,6 +184,26 @@ RSpec.describe PostsController, 'GET show' do
       get :show, params: { id: post.id }
       expect(response.status).to eq(200)
     end
+
+    it "alternates reply icon sides and only opts in via the user setting" do
+      create(:reply, post: post, with_icon: true, with_character: true)
+
+      get :show, params: { id: post.id }
+      expect(response.status).to eq(200)
+      # parity classes are always emitted (deterministic, so they stay cache-safe)
+      expect(response.body).to include('icon-left')
+      expect(response.body).to include('icon-right')
+
+      login_as(create(:user, alternating_icons: false))
+      get :show, params: { id: post.id }
+      expect(response.body).not_to include('class="alternating-icons"')
+      expect(assigns(:javascripts)).not_to include('posts/alternating_icons')
+
+      login_as(create(:user, alternating_icons: true))
+      get :show, params: { id: post.id }
+      expect(response.body).to include('alternating-icons')
+      expect(assigns(:javascripts)).to include('posts/alternating_icons')
+    end
   end
 
   context "with at_id" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -403,6 +403,7 @@ RSpec.describe UsersController do
         favorite_notifications: false,
         show_user_in_switcher: false,
         default_character_split: 'none',
+        alternating_icons: true,
       }
 
       # ensure new values are different, so test tests correct things

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -265,4 +265,17 @@ RSpec.describe ApplicationHelper do
       expect(helper.loading_tag(id: 'loading-5')).to eq(expected)
     end
   end
+
+  describe "#layout_options" do
+    it "offers the Pesterchum hypercompact layouts" do
+      html = helper.layout_options
+      expect(html).to include('value="pesterchum"')
+      expect(html).to include('value="pesterchummemo"')
+    end
+
+    it "marks the user's chosen layout as selected" do
+      html = helper.layout_options('pesterchummemo')
+      expect(html).to include('<option selected="selected" value="pesterchummemo">')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Reply-layout options, split out of the custom-CSS-skins PR (#2793) per review (@teceler — "too many things for one PR"). This PR carries **only** the reply-layout work; the two features are independent and can merge in either order.

## Reply layout options

- **Alternating icons** (Account Settings → *Reply layout*): a compact layout where reply icons alternate left/right so rapid back-and-forth dialogue is easier to follow. Implemented as an `alternating-icons` body class (gated on the user setting); `replies/_single.haml` alternates an `icon-left`/`icon-right` class per reply via `reply_counter`.
  - **Dynamic icon sizing** (`posts/alternating_icons.js`, loaded only when the layout is active): each reply's icon is scaled to its own body height, clamped 28–96px. One-line interjections collapse to a small icon so dense exchanges stay tight, while long replies keep a full-size icon. Inspired by [jbeshir/glowficlog](https://github.com/jbeshir/glowficlog)'s compact reader, but sized to each post's own content height (the icon lives in a floated info chip, so capping at the body height stops it inflating the post). Pure progressive enhancement — re-runs on load/resize; the layout is fully usable with JS off, and non-square icons are letterboxed via `object-fit: contain`.
- **Pesterchum / Pesterchum Memo** layouts: selectable from the existing layout dropdown like any other site layout. New stylesheets under `app/assets/stylesheets/layouts/`.

### Migration

- `add_alternating_icons_to_users` (`users.alternating_icons`, default false).

## Tests

Reply-icon-side parity + the opt-in setting (posts/show), the Pesterchum `layout_options`, and the `alternating_icons` user setting.

## Screenshots

Alternating icons (icons alternate left/right per reply; short replies get small icons, long ones full-size):

![Alternating icons layout](https://raw.githubusercontent.com/l1n/glowfic/c56a6277f638574b10de9e3836c8c1b5912dc0a5/docs/screenshots/06-alternating-icons.png)

| Pesterchum | Pesterchum Memo |
| --- | --- |
| ![Pesterchum layout](https://raw.githubusercontent.com/l1n/glowfic/c56a6277f638574b10de9e3836c8c1b5912dc0a5/docs/screenshots/07-pesterchum-layout.png) | ![Pesterchum Memo layout](https://raw.githubusercontent.com/l1n/glowfic/c56a6277f638574b10de9e3836c8c1b5912dc0a5/docs/screenshots/08-pesterchum-memo-layout.png) |

<sub>Screenshots are hosted on the `pr2793-screenshots` branch.</sub>
