### PR TITLE
Don't clobber unread position when opening a reply permalink

### DIFF
--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -563,9 +563,19 @@ div.post-subheader { width: 100%; }
   .permalink-read-notice-message img { margin-right: 5px; }
 
   .permalink-read-notice-actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
     margin-top: 8px;
 
-    .link-box { margin-left: 10px; }
+    .link-box {
+      font-size: $font_size_smallish;
+      height: auto;
+      line-height: 1;
+      margin-left: 0;
+      padding: 6px 12px;
+    }
   }
 }
 

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -556,6 +556,13 @@ div.post-subheader { width: 100%; }
 
 .reply-highlighted { border: 1px $border_color_unread_reply solid; }
 
+/* Reply permalink read-position notice */
+.permalink-read-notice {
+  margin-bottom: 10px;
+
+  .link-box { margin-left: 10px; }
+}
+
 /* History page */
 .history-header { width: 170px; }
 

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -560,7 +560,13 @@ div.post-subheader { width: 100%; }
 .permalink-read-notice {
   margin-bottom: 10px;
 
-  .link-box { margin-left: 10px; }
+  .permalink-read-notice-message img { margin-right: 5px; }
+
+  .permalink-read-notice-actions {
+    margin-top: 8px;
+
+    .link-box { margin-left: 10px; }
+  }
 }
 
 /* History page */

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -563,19 +563,17 @@ div.post-subheader { width: 100%; }
   .permalink-read-notice-message img { margin-right: 5px; }
 
   .permalink-read-notice-actions {
-    align-items: center;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
     margin-top: 8px;
 
+    // font-size matches the .subber .link-box convention in layout.scss for smaller containers
     .link-box {
       font-size: $font_size_smallish;
       height: auto;
       line-height: 1;
-      margin-left: 0;
       padding: 6px 12px;
     }
+
+    > a:first-child .link-box { margin-left: 0; }
   }
 }
 

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -206,7 +206,6 @@ class RepliesController < WritableController
     end
     return unless unread_page < cur_page
 
-    @skip_read_marking = true
     @permalink_jumped_ahead = true
   end
 

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -204,7 +204,8 @@ class RepliesController < WritableController
     else
       unread.post_page(per_page)
     end
-    return if unread_page == cur_page
+    return if unread_page == cur_page # loaded our latest unread page: nothing skipped
+    return if unread_page == cur_page + 1 # loaded the page we just finished reading: not meaningfully "going back"
 
     @skip_read_marking = true
     @permalink_read_direction = unread_page < cur_page ? :earlier : :later

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -84,6 +84,8 @@ class RepliesController < WritableController
     @page_title = @post.subject
     params[:page] ||= @reply.post_page(per_page)
 
+    check_permalink_read_position if logged_in?
+
     show_post(params[:page])
   end
 
@@ -186,6 +188,26 @@ class RepliesController < WritableController
     end
 
     @page_title = @post.subject
+  end
+
+  # Skips auto-advancing the read position when the permalinked page doesn't contain the reader's actual read/unread boundary.
+  def check_permalink_read_position
+    @permalink_reply = @reply
+    cur_page = params[:page].to_i
+    return unless cur_page > 0
+
+    unread = @post.first_unread_for(current_user)
+    unread_page = if unread.nil?
+      @post.replies.paginate(per_page: per_page, page: 1).total_pages
+    elsif unread.is_a?(Post)
+      1
+    else
+      unread.post_page(per_page)
+    end
+    return if unread_page == cur_page
+
+    @skip_read_marking = true
+    @permalink_read_direction = unread_page < cur_page ? :earlier : :later
   end
 
   def require_create_permission

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -190,7 +190,7 @@ class RepliesController < WritableController
     @page_title = @post.subject
   end
 
-  # Skips auto-advancing the read position when the permalinked page doesn't contain the reader's actual read/unread boundary.
+  # Only skips auto-advancing when the permalink jumps ahead of the unread boundary; mark_read's own regression guard already covers the reverse case.
   def check_permalink_read_position
     @permalink_reply = @reply
     cur_page = params[:page].to_i
@@ -204,11 +204,10 @@ class RepliesController < WritableController
     else
       unread.post_page(per_page)
     end
-    return if unread_page == cur_page # loaded our latest unread page: nothing skipped
-    return if unread_page == cur_page + 1 # loaded the page we just finished reading: not meaningfully "going back"
+    return unless unread_page < cur_page
 
     @skip_read_marking = true
-    @permalink_read_direction = unread_page < cur_page ? :earlier : :later
+    @permalink_jumped_ahead = true
   end
 
   def require_create_permission

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -132,7 +132,7 @@ class WritableController < ApplicationController
         @draft = ReplyDraft.draft_for(@post.id, current_user.id)
       end
 
-      @post.mark_read(current_user, at_time: @post.read_time_for(@replies)) unless @skip_read_marking
+      @post.mark_read(current_user, at_time: @post.read_time_for(@replies)) unless @permalink_jumped_ahead
     end
 
     if display_warnings?

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -132,7 +132,7 @@ class WritableController < ApplicationController
         @draft = ReplyDraft.draft_for(@post.id, current_user.id)
       end
 
-      @post.mark_read(current_user, at_time: @post.read_time_for(@replies))
+      @post.mark_read(current_user, at_time: @post.read_time_for(@replies)) unless @skip_read_marking
     end
 
     if display_warnings?

--- a/app/views/replies/_permalink_read_notice.haml
+++ b/app/views/replies/_permalink_read_notice.haml
@@ -1,13 +1,16 @@
 -# locals: ( reply:, post:, direction: )
 
-.permalink-read-notice.flash.error
+.permalink-read-notice.flash.success
   = link_to '#' do
     = image_tag 'icons/cross.png'.freeze, class: 'float-right flash-dismiss'.freeze, alt: 'Dismiss'
-  - if direction == :earlier
-    Your reading position on this thread is earlier than this page, so it has not been updated.
+  .permalink-read-notice-message
+    = image_tag 'icons/eye.png'.freeze, class: 'vmid'.freeze, alt: ''
+    - if direction == :earlier
+      Your reading position on this thread is earlier than this page, so it has not been updated.
+    - else
+      You have already read further in this thread than this page.
+  .permalink-read-notice-actions
     = link_to '(Go to your reading position)', unread_path(post)
-    = link_to post_path(post, unread: true, at_id: reply.id), method: :put do
-      .link-box.action-edit Mark as read up to here
-  - else
-    You have already read further in this thread than this page.
-    = link_to '(Go to your reading position)', unread_path(post)
+    - if direction == :earlier
+      = link_to post_path(post, unread: true, at_id: reply.id), method: :put do
+        .link-box.action-edit Mark as read up to here

--- a/app/views/replies/_permalink_read_notice.haml
+++ b/app/views/replies/_permalink_read_notice.haml
@@ -1,0 +1,13 @@
+-# locals: ( reply:, post:, direction: )
+
+.permalink-read-notice.flash.error
+  = link_to '#' do
+    = image_tag 'icons/cross.png'.freeze, class: 'float-right flash-dismiss'.freeze, alt: 'Dismiss'
+  - if direction == :earlier
+    Your reading position on this thread is earlier than this page, so it has not been updated.
+    = link_to '(Go to your reading position)', unread_path(post)
+    = link_to post_path(post, unread: true, at_id: reply.id), method: :put do
+      .link-box.action-edit Mark as read up to here
+  - else
+    You have already read further in this thread than this page.
+    = link_to '(Go to your reading position)', unread_path(post)

--- a/app/views/replies/_permalink_read_notice.haml
+++ b/app/views/replies/_permalink_read_notice.haml
@@ -1,17 +1,13 @@
--# locals: ( reply:, post:, direction: )
+-# locals: ( reply:, post: )
 
 .permalink-read-notice.flash.success
   = link_to '#' do
     = image_tag 'icons/cross.png'.freeze, class: 'float-right flash-dismiss'.freeze, alt: 'Dismiss'
   .permalink-read-notice-message
     = image_tag 'icons/eye.png'.freeze, class: 'vmid'.freeze, alt: ''
-    - if direction == :earlier
-      Your reading position on this thread is earlier than this page, so it has not been updated.
-    - else
-      You have already read further in this thread than this page.
+    Your reading position on this thread is earlier than this page, so it has not been updated.
   .permalink-read-notice-actions
     = link_to unread_path(post) do
       .link-box.action-edit Go to previous position
-    - if direction == :earlier
-      = link_to post_path(post, unread: true, at_id: reply.id), method: :put do
-        .link-box.action-new Mark read here
+    = link_to post_path(post, unread: true, at_id: reply.id), method: :put do
+      .link-box.action-new Mark read here

--- a/app/views/replies/_permalink_read_notice.haml
+++ b/app/views/replies/_permalink_read_notice.haml
@@ -10,7 +10,8 @@
     - else
       You have already read further in this thread than this page.
   .permalink-read-notice-actions
-    = link_to '(Go to your reading position)', unread_path(post)
+    = link_to unread_path(post) do
+      .link-box.action-edit Go to previous position
     - if direction == :earlier
       = link_to post_path(post, unread: true, at_id: reply.id), method: :put do
-        .link-box.action-edit Mark as read up to here
+        .link-box.action-new Mark read here

--- a/app/views/replies/_permalink_read_notice.haml
+++ b/app/views/replies/_permalink_read_notice.haml
@@ -9,5 +9,5 @@
   .permalink-read-notice-actions
     = link_to unread_path(post) do
       .link-box.action-edit Go to previous position
-    = link_to post_path(post, unread: true, at_id: reply.id), method: :put do
+    = link_to post_path(post, unread: true, at_id: reply.id), method: :put, data: { confirm: 'Are you sure you want to mark your reading position here?' } do
       .link-box.action-new Mark read here

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -9,7 +9,7 @@
 .post-container{class: [write, (reply == @unread && current_user.try(:visible_unread?)) ? 'reply-highlighted' : '']}
   - if reply.is_a?(Reply) && reply.id.present?
     %a.noheight{id: "reply-#{reply.id}"}= " "
-  - if reply == @permalink_reply && @permalink_jumped_ahead
+  - if @permalink_jumped_ahead && reply == @permalink_reply
     = render 'replies/permalink_read_notice', reply: reply, post: @post
   - if reply == @unread
     .unread-marker-container

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -9,8 +9,8 @@
 .post-container{class: [write, (reply == @unread && current_user.try(:visible_unread?)) ? 'reply-highlighted' : '']}
   - if reply.is_a?(Reply) && reply.id.present?
     %a.noheight{id: "reply-#{reply.id}"}= " "
-  - if reply == @permalink_reply && @permalink_read_direction.present?
-    = render 'replies/permalink_read_notice', reply: reply, post: @post, direction: @permalink_read_direction
+  - if reply == @permalink_reply && @permalink_jumped_ahead
+    = render 'replies/permalink_read_notice', reply: reply, post: @post
   - if reply == @unread
     .unread-marker-container
       %a#unread.unread-marker First unread marker

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -9,6 +9,8 @@
 .post-container{class: [write, (reply == @unread && current_user.try(:visible_unread?)) ? 'reply-highlighted' : '']}
   - if reply.is_a?(Reply) && reply.id.present?
     %a.noheight{id: "reply-#{reply.id}"}= " "
+  - if reply == @permalink_reply && @permalink_read_direction.present?
+    = render 'replies/permalink_read_notice', reply: reply, post: @post, direction: @permalink_read_direction
   - if reply == @unread
     .unread-marker-container
       %a#unread.unread-marker First unread marker

--- a/spec/controllers/replies/show_spec.rb
+++ b/spec/controllers/replies/show_spec.rb
@@ -72,35 +72,37 @@ RSpec.describe RepliesController, 'GET show' do
 
     before(:each) { login_as(user) }
 
-    it "leaves read position untouched and flags 'earlier' when the thread has never been read" do
+    it "leaves read position untouched when the thread has never been read" do
       target = replies[10] # page 3 of 3 with per_page: 5
 
       get :show, params: { id: target.id, per_page: 5 }
 
       expect(response).to have_http_status(200)
       expect(assigns(:permalink_reply)).to eq(target)
-      expect(assigns(:permalink_read_direction)).to eq(:earlier)
+      expect(assigns(:permalink_jumped_ahead)).to eq(true)
       expect(Post::View.where(post: post, user: user)).not_to exist
     end
 
-    it "leaves read position untouched and flags 'earlier' when partially read" do
-      Timecop.freeze(replies[2].created_at + 30.seconds) { post.mark_read(user) }
+    it "leaves read position untouched when partially read and permalink is ahead" do
+      read_time = replies[2].created_at + 30.seconds
+      Timecop.freeze(read_time) { post.mark_read(user) }
       target = replies[10] # page 3, ahead of the unread boundary on page 1
 
       get :show, params: { id: target.id, per_page: 5 }
 
-      expect(assigns(:permalink_read_direction)).to eq(:earlier)
-      expect(post.reload.last_read(user)).to be_the_same_time_as(replies[2].created_at + 30.seconds)
+      expect(assigns(:permalink_jumped_ahead)).to eq(true)
+      expect(post.reload.last_read(user)).to be_the_same_time_as(read_time)
     end
 
-    it "leaves read position untouched and flags 'later' when fully read" do
-      Timecop.freeze(replies.last.created_at + 30.seconds) { post.mark_read(user) }
+    it "shows no warning and updates read position normally when the permalink is behind the fully-read boundary" do
+      read_time = replies.last.created_at + 30.seconds
+      Timecop.freeze(read_time) { post.mark_read(user) }
       target = replies[1] # page 1, behind the fully-read boundary on page 3
 
       get :show, params: { id: target.id, per_page: 5 }
 
-      expect(assigns(:permalink_read_direction)).to eq(:later)
-      expect(post.reload.last_read(user)).to be_the_same_time_as(replies.last.created_at + 30.seconds)
+      expect(assigns(:permalink_jumped_ahead)).to be_nil
+      expect(post.reload.last_read(user)).to be_the_same_time_as(read_time)
     end
 
     it "updates read position normally when the permalink matches the unread position" do
@@ -108,7 +110,7 @@ RSpec.describe RepliesController, 'GET show' do
 
       get :show, params: { id: target.id, per_page: 5 }
 
-      expect(assigns(:permalink_read_direction)).to be_nil
+      expect(assigns(:permalink_jumped_ahead)).to be_nil
       expect(post.reload.last_read(user)).not_to be_nil
     end
 
@@ -118,7 +120,7 @@ RSpec.describe RepliesController, 'GET show' do
 
       get :show, params: { id: target.id, per_page: 5 }
 
-      expect(assigns(:permalink_read_direction)).to be_nil
+      expect(assigns(:permalink_jumped_ahead)).to be_nil
       expect(post.reload.last_read(user)).to be_the_same_time_as(replies[9].created_at)
     end
 
@@ -128,7 +130,7 @@ RSpec.describe RepliesController, 'GET show' do
 
       get :show, params: { id: target.id, per_page: 5 }
 
-      expect(assigns(:permalink_read_direction)).to be_nil
+      expect(assigns(:permalink_jumped_ahead)).to be_nil
     end
   end
 end

--- a/spec/controllers/replies/show_spec.rb
+++ b/spec/controllers/replies/show_spec.rb
@@ -111,5 +111,24 @@ RSpec.describe RepliesController, 'GET show' do
       expect(assigns(:permalink_read_direction)).to be_nil
       expect(post.reload.last_read(user)).not_to be_nil
     end
+
+    it "shows no warning for a permalink on the page the reader just finished reading" do
+      Timecop.freeze(replies[9].created_at) { post.mark_read(user) }
+      target = replies[7] # page 2, the page that was just fully read
+
+      get :show, params: { id: target.id, per_page: 5 }
+
+      expect(assigns(:permalink_read_direction)).to be_nil
+      expect(post.reload.last_read(user)).to be_the_same_time_as(replies[9].created_at)
+    end
+
+    it "shows no warning for a permalink on the page right after the one the reader just finished" do
+      Timecop.freeze(replies[9].created_at) { post.mark_read(user) }
+      target = replies[10] # page 3, the very next (first unread) page
+
+      get :show, params: { id: target.id, per_page: 5 }
+
+      expect(assigns(:permalink_read_direction)).to be_nil
+    end
   end
 end

--- a/spec/controllers/replies/show_spec.rb
+++ b/spec/controllers/replies/show_spec.rb
@@ -62,4 +62,54 @@ RSpec.describe RepliesController, 'GET show' do
   it "has more tests" do
     skip
   end
+
+  context "permalink read position" do
+    let(:user) { create(:user) }
+    let(:post) { create(:post) }
+    let!(:replies) do
+      (1..12).map { |i| Timecop.freeze(post.created_at + i.minutes) { create(:reply, post: post) } }
+    end
+
+    before(:each) { login_as(user) }
+
+    it "leaves read position untouched and flags 'earlier' when the thread has never been read" do
+      target = replies[10] # page 3 of 3 with per_page: 5
+
+      get :show, params: { id: target.id, per_page: 5 }
+
+      expect(response).to have_http_status(200)
+      expect(assigns(:permalink_reply)).to eq(target)
+      expect(assigns(:permalink_read_direction)).to eq(:earlier)
+      expect(Post::View.where(post: post, user: user)).not_to exist
+    end
+
+    it "leaves read position untouched and flags 'earlier' when partially read" do
+      Timecop.freeze(replies[2].created_at + 30.seconds) { post.mark_read(user) }
+      target = replies[10] # page 3, ahead of the unread boundary on page 1
+
+      get :show, params: { id: target.id, per_page: 5 }
+
+      expect(assigns(:permalink_read_direction)).to eq(:earlier)
+      expect(post.reload.last_read(user)).to be_the_same_time_as(replies[2].created_at + 30.seconds)
+    end
+
+    it "leaves read position untouched and flags 'later' when fully read" do
+      Timecop.freeze(replies.last.created_at + 30.seconds) { post.mark_read(user) }
+      target = replies[1] # page 1, behind the fully-read boundary on page 3
+
+      get :show, params: { id: target.id, per_page: 5 }
+
+      expect(assigns(:permalink_read_direction)).to eq(:later)
+      expect(post.reload.last_read(user)).to be_the_same_time_as(replies.last.created_at + 30.seconds)
+    end
+
+    it "updates read position normally when the permalink matches the unread position" do
+      target = replies[0] # page 1, matching the never-read boundary
+
+      get :show, params: { id: target.id, per_page: 5 }
+
+      expect(assigns(:permalink_read_direction)).to be_nil
+      expect(post.reload.last_read(user)).not_to be_nil
+    end
+  end
 end

--- a/spec/system/replies/show_spec.rb
+++ b/spec/system/replies/show_spec.rb
@@ -25,9 +25,21 @@ RSpec.describe "Reply permalinks" do
 
     visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
     click_link 'Mark read here'
+    page.accept_confirm
 
     expect(page).to have_selector('.table-title', text: 'Unread Posts')
     expect(post.reload.first_unread_for(user)).to eq(target)
+  end
+
+  scenario "Dismissing the 'Mark read here' confirm leaves the reading position unchanged", :js do
+    target = replies[10]
+
+    visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
+    click_link 'Mark read here'
+    page.dismiss_confirm
+
+    expect(page).to have_selector('.permalink-read-notice')
+    expect(post.reload.first_unread_for(user)).to eq(post) # still fully unread, untouched
   end
 
   scenario "Permalink to a reply the reader has already read past shows no notice" do

--- a/spec/system/replies/show_spec.rb
+++ b/spec/system/replies/show_spec.rb
@@ -14,17 +14,17 @@ RSpec.describe "Reply permalinks" do
 
     within(".post-container:has(#reply-#{target.id})") do
       expect(page).to have_selector('.permalink-read-notice', text: 'Your reading position on this thread is earlier than this page')
-      expect(page).to have_link('(Go to your reading position)')
-      expect(page).to have_link('Mark as read up to here')
+      expect(page).to have_link('Go to previous position')
+      expect(page).to have_link('Mark read here')
     end
     expect(post.reload.first_unread_for(user)).to eq(post) # still fully unread, untouched
   end
 
-  scenario "Clicking 'Mark as read up to here' updates the reading position", :js do
+  scenario "Clicking 'Mark read here' updates the reading position", :js do
     target = replies[10]
 
     visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
-    click_link 'Mark as read up to here'
+    click_link 'Mark read here'
 
     expect(page).to have_selector('.table-title', text: 'Unread Posts')
     expect(post.reload.first_unread_for(user)).to eq(target)
@@ -38,8 +38,8 @@ RSpec.describe "Reply permalinks" do
 
     within(".post-container:has(#reply-#{target.id})") do
       expect(page).to have_selector('.permalink-read-notice', text: 'You have already read further in this thread than this page')
-      expect(page).to have_link('(Go to your reading position)')
-      expect(page).to have_no_link('Mark as read up to here')
+      expect(page).to have_link('Go to previous position')
+      expect(page).to have_no_link('Mark read here')
     end
     expect(post.reload.last_read(user)).to be_the_same_time_as(replies.last.created_at + 30.seconds)
   end

--- a/spec/system/replies/show_spec.rb
+++ b/spec/system/replies/show_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe "Reply permalinks" do
+  let(:user) { create(:user) }
+  let(:post) { create(:post) }
+  let!(:replies) do
+    (1..12).map { |i| Timecop.freeze(post.created_at + i.minutes) { create(:reply, post: post) } }
+  end
+
+  before(:each) { login(user) }
+
+  scenario "Permalink to a reply ahead of the reader's position" do
+    target = replies[10]
+
+    visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
+
+    within(".post-container:has(#reply-#{target.id})") do
+      expect(page).to have_selector('.permalink-read-notice', text: 'Your reading position on this thread is earlier than this page')
+      expect(page).to have_link('(Go to your reading position)')
+      expect(page).to have_link('Mark as read up to here')
+    end
+    expect(post.reload.first_unread_for(user)).to eq(post) # still fully unread, untouched
+  end
+
+  scenario "Clicking 'Mark as read up to here' updates the reading position", :js do
+    target = replies[10]
+
+    visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
+    click_link 'Mark as read up to here'
+
+    expect(page).to have_selector('.table-title', text: 'Unread Posts')
+    expect(post.reload.first_unread_for(user)).to eq(target)
+  end
+
+  scenario "Permalink to a reply the reader has already read past" do
+    Timecop.freeze(replies.last.created_at + 30.seconds) { post.mark_read(user) }
+    target = replies[1]
+
+    visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
+
+    within(".post-container:has(#reply-#{target.id})") do
+      expect(page).to have_selector('.permalink-read-notice', text: 'You have already read further in this thread than this page')
+      expect(page).to have_link('(Go to your reading position)')
+      expect(page).to have_no_link('Mark as read up to here')
+    end
+    expect(post.reload.last_read(user)).to be_the_same_time_as(replies.last.created_at + 30.seconds)
+  end
+
+  scenario "Permalink matching the reader's position shows no notice" do
+    target = replies[0]
+
+    visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
+
+    expect(page).to have_selector('.content-header', text: post.subject)
+    expect(page).to have_no_selector('.permalink-read-notice')
+    expect(post.reload.last_read(user)).not_to be_nil
+  end
+
+  scenario "Notice can be dismissed", :js do
+    target = replies[10]
+
+    visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
+    expect(page).to have_selector('.permalink-read-notice')
+
+    within('.permalink-read-notice') { find('.flash-dismiss').click }
+
+    expect(page).to have_no_selector('.permalink-read-notice', wait: 2)
+  end
+end

--- a/spec/system/replies/show_spec.rb
+++ b/spec/system/replies/show_spec.rb
@@ -30,18 +30,16 @@ RSpec.describe "Reply permalinks" do
     expect(post.reload.first_unread_for(user)).to eq(target)
   end
 
-  scenario "Permalink to a reply the reader has already read past" do
-    Timecop.freeze(replies.last.created_at + 30.seconds) { post.mark_read(user) }
+  scenario "Permalink to a reply the reader has already read past shows no notice" do
+    read_time = replies.last.created_at + 30.seconds
+    Timecop.freeze(read_time) { post.mark_read(user) }
     target = replies[1]
 
     visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
 
-    within(".post-container:has(#reply-#{target.id})") do
-      expect(page).to have_selector('.permalink-read-notice', text: 'You have already read further in this thread than this page')
-      expect(page).to have_link('Go to previous position')
-      expect(page).to have_no_link('Mark read here')
-    end
-    expect(post.reload.last_read(user)).to be_the_same_time_as(replies.last.created_at + 30.seconds)
+    expect(page).to have_selector('.content-header', text: post.subject)
+    expect(page).to have_no_selector('.permalink-read-notice')
+    expect(post.reload.last_read(user)).to be_the_same_time_as(read_time)
   end
 
   scenario "Permalink matching the reader's position shows no notice" do


### PR DESCRIPTION
## Summary
- Opening a permalink to a reply used to silently auto-advance the reader's unread/read position to whatever page the reply landed on, even skipping over content they hadn't actually read. There was no way to undo this.
- `RepliesController#show` now checks whether the permalinked page advances beyond the reader's real unread boundary (`Post#first_unread_for`). If it does, the read position is left untouched for that view, and a dismissible inline notice is shown at the permalinked reply explaining why, with a link to their actual reading position.
- The notice also offers a "Mark as read up to here" button (reusing the existing "mark unread at reply" endpoint) to explicitly opt in to advancing.

## Screenshots

<img width="1366" height="625" alt="default_earlier_desktop" src="https://github.com/user-attachments/assets/163104a1-7aa6-4435-aa63-d13bca4f77dc" />

(we don't show a warning if you're on the expected page or if you're "in the past" - users won't want the noise while re-reading where they often don't adjust their unread position)

mobile view:
<img width="390" height="844" alt="default_earlier_mobile" src="https://github.com/user-attachments/assets/3c257585-3da1-46aa-bb4d-e3c91a83f854" />

starrylight view:
<img width="390" height="844" alt="starrylight_earlier_mobile" src="https://github.com/user-attachments/assets/1645c6ee-26b2-4f6f-9e88-1dd8b4ff3308" />

## Test plan
- [x] `bin/with-bundle rspec spec/controllers/replies/show_spec.rb` — new permalink read-position cases (never read / partially read / fully read / matching)
- [x] `bin/with-bundle rspec spec/system/replies/show_spec.rb` — new system spec, the "mark as read" button, and dismiss
- [x] `bin/with-bundle rspec spec/controllers/replies spec/controllers/posts` — no regressions (427 examples, 0 failures)
- [x] `bin/with-bundle rubocop` / `bin/with-bundle haml-lint` on touched files

## Screenshot script

<details><summary>spec/system/replies/_tmp_screenshot_spec.rb</summary>

```
rm -f /tmp/screenshots/*.png
bin/with-bundle rspec spec/system/replies/_tmp_screenshot_spec.rb 2>&1
```

```rb
RSpec.describe "Reply permalink screenshots", :js do
  def make_scenario(layout)
    user = create(:user, layout: (layout == 'default' ? nil : layout))
    post = create(:post, subject: 'Sample post about wandering the archives')
    replies = (1..12).map { |i| Timecop.freeze(post.created_at + i.minutes) { create(:reply, post: post) } }
    login(user)
    [user, post, replies]
  end

  def enable_mobile_viewport!
    page.driver.browser.manage.window.resize_to(390, 844)
    page.driver.browser.execute_cdp(
      'Emulation.setDeviceMetricsOverride',
      width: 390, height: 844, deviceScaleFactor: 3, mobile: true,
    )
  end

  def reset_viewport!
    page.driver.browser.execute_cdp('Emulation.clearDeviceMetricsOverride')
    page.driver.browser.manage.window.resize_to(1366, 768)
  end

  %w[default starrylight].each do |layout|
    context "#{layout} layout" do
      scenario "earlier notice - desktop" do
        _user, post, replies = make_scenario(layout)
        target = replies[10]
        visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
        page.save_screenshot("/tmp/screenshots/#{layout}_earlier_desktop.png")
      end

      # (irrelevant in latest code)
      scenario "later notice - desktop" do
        user, post, replies = make_scenario(layout)
        Timecop.freeze(replies.last.created_at + 30.seconds) { post.mark_read(user) }
        target = replies[1]
        visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
        page.save_screenshot("/tmp/screenshots/#{layout}_later_desktop.png")
      end

      scenario "earlier notice - mobile" do
        _user, post, replies = make_scenario(layout)
        enable_mobile_viewport!
        target = replies[10]
        visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
        page.save_screenshot("/tmp/screenshots/#{layout}_earlier_mobile.png")
        reset_viewport!
      end

      # (irrelevant in latest code)
      scenario "later notice - mobile" do
        user, post, replies = make_scenario(layout)
        Timecop.freeze(replies.last.created_at + 30.seconds) { post.mark_read(user) }
        enable_mobile_viewport!
        target = replies[1]
        visit reply_path(target, anchor: "reply-#{target.id}", per_page: 5)
        page.save_screenshot("/tmp/screenshots/#{layout}_later_mobile.png")
        reset_viewport!
      end
    end
  end
end
```


</details>