### PR TITLE
Verify job-summary rake task on a real failure

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -118,8 +118,12 @@ jobs:
         # runtime once the cached log exists; the first run falls back to file
         # size and writes the log for next time. Each worker also writes its own
         # JSON results file (named by its $TEST_ENV_NUMBER) so a failed run can be
-        # summarized in the job summary instead of scrolling interleaved logs.
+        # summarized below instead of scrolling interleaved logs. The whole thing
+        # runs inside a ::group:: fold so the interleaved worker output collapses
+        # out of the way, leaving the failure groups from the next step visible.
         run: |
+          echo "::group::Running $PARALLEL_TEST_PROCESSORS parallel rspec workers"
+          trap 'echo "::endgroup::"' EXIT
           mkdir -p tmp/rspec_output
           bundle exec parallel_rspec spec \
             --runtime-log tmp/parallel_runtime_rspec.log \

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -116,11 +116,17 @@ jobs:
       - name: Run rspec tests in parallel
         # --runtime-log lets parallel_tests balance workers by recorded per-file
         # runtime once the cached log exists; the first run falls back to file
-        # size and writes the log for next time.
+        # size and writes the log for next time. Each worker also writes its own
+        # JSON results file (named by its $TEST_ENV_NUMBER) so a failed run can be
+        # summarized in the job summary instead of scrolling interleaved logs.
         run: |
+          mkdir -p tmp/rspec_output
           bundle exec parallel_rspec spec \
             --runtime-log tmp/parallel_runtime_rspec.log \
-            -o '--format progress --require rspec/github --format RSpec::Github::Formatter'
+            -o '--format progress --require rspec/github --format RSpec::Github::Formatter --format json --out tmp/rspec_output/rspec_$TEST_ENV_NUMBER.json'
+      - name: Summarize rspec failures
+        if: failure()
+        run: bundle exec rake rspec_summary:report
       - name: Merge coverage and enforce threshold
         # only when the suite passed: a failed worker doesn't flush its coverage,
         # which would make the merged total look (misleadingly) too low
@@ -131,6 +137,13 @@ jobs:
         with:
           name: capybara-failure-screenshots
           path: tmp/capybara/
+          if-no-files-found: ignore
+      - name: Upload rspec JSON results
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rspec-json-results
+          path: tmp/rspec_output/
           if-no-files-found: ignore
       - name: Upload MinIO logs
         if: ${{ always() }}

--- a/lib/tasks/rspec_summary.rake
+++ b/lib/tasks/rspec_summary.rake
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+namespace :rspec_summary do
+  desc 'Summarize failed examples from parallel_tests JSON output into a GitHub Actions job summary'
+  task :report do # rubocop:disable Rails/RakeEnvironment -- doesn't need application code
+    require 'json'
+
+    result_files = Dir['tmp/rspec_output/rspec_*.json']
+    if result_files.empty?
+      warn 'No rspec JSON result files found under tmp/rspec_output/ -- skipping failure summary.'
+      next
+    end
+
+    failures = result_files.flat_map do |path|
+      JSON.parse(File.read(path)).fetch('examples', []).select { |example| example['status'] == 'failed' }
+    rescue JSON::ParserError => e
+      warn "Skipping unparseable rspec result file #{path}: #{e.message}"
+      []
+    end
+
+    summary_path = ENV.fetch('GITHUB_STEP_SUMMARY', nil)
+    out = summary_path ? File.open(summary_path, 'a') : $stdout
+    begin
+      if failures.empty?
+        out.puts '## RSpec failures'
+        out.puts
+        out.puts 'No failed examples were recorded in the JSON output (check raw logs for crashes, timeouts, or OOM kills).'
+        next
+      end
+
+      out.puts "## RSpec failures (#{failures.size})"
+      failures.each_with_index do |example, index|
+        message = example.dig('exception', 'message').to_s.strip
+        # limit backtrace shown so the summary doesn't get too long for many failures
+        backtrace = Array(example.dig('exception', 'backtrace')).first(10).join("\n")
+
+        out.puts
+        out.puts "### #{index + 1}. #{example['full_description']}"
+        out.puts "`#{example['file_path']}:#{example['line_number']}`"
+        out.puts
+        out.puts '```'
+        out.puts message
+        out.puts '```'
+        next if backtrace.empty?
+
+        out.puts
+        out.puts '<details><summary>Backtrace</summary>'
+        out.puts
+        out.puts '```'
+        out.puts backtrace
+        out.puts '```'
+        out.puts '</details>'
+      end
+    ensure
+      out.close if summary_path
+    end
+  end
+end

--- a/lib/tasks/rspec_summary.rake
+++ b/lib/tasks/rspec_summary.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 namespace :rspec_summary do
-  desc 'Summarize failed examples from parallel_tests JSON output into a GitHub Actions job summary'
+  desc 'Summarize failed examples from parallel_tests JSON output into the CI log and job summary'
   task :report do # rubocop:disable Rails/RakeEnvironment -- doesn't need application code
     require 'json'
 
@@ -15,6 +15,20 @@ namespace :rspec_summary do
     rescue JSON::ParserError => e
       warn "Skipping unparseable rspec result file #{path}: #{e.message}"
       []
+    end
+
+    # Fold each failure into its own `::group::` in this step's own log. The
+    # $GITHUB_STEP_SUMMARY markdown below only shows up on the run's separate
+    # "Summary" page, not on the job's log page -- groups show up right here,
+    # expanded by default, so failures are visible without leaving the log view.
+    if ENV['GITHUB_ACTIONS']
+      failures.each do |example|
+        puts "::group::FAILED #{example['file_path']}:#{example['line_number']} - #{example['full_description']}"
+        puts example.dig('exception', 'message').to_s.strip
+        puts
+        puts Array(example.dig('exception', 'backtrace')).join("\n")
+        puts '::endgroup::'
+      end
     end
 
     summary_path = ENV.fetch('GITHUB_STEP_SUMMARY', nil)

--- a/spec/ci_intentional_failure_spec.rb
+++ b/spec/ci_intentional_failure_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+# Temporary spec to verify the CI job summary surfaces rspec failures correctly.
+# Remove this file once that's confirmed.
+RSpec.describe "CI intentional failure" do # rubocop:disable RSpec/DescribeClass -- temporary, not testing a class
+  it "fails on purpose" do
+    expect(1).to eq(2) # rubocop:disable RSpec/ExpectActual -- temporary, intentional failure
+  end
+end


### PR DESCRIPTION
Stacked on #2827. Adds a deliberately failing spec so that PR's CI run actually fails, letting us confirm the job summary renders correctly against a real parallel_rspec run rather than hand-built JSON fixtures.

Not for merging — close once the summary is confirmed and #2827 is settled.