### PR TITLE
Fix flaky icon-picker system spec

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,7 +111,7 @@ FactoryBot.define do
 
   factory :icon do
     user
-    url { "http://www.fakeicon.com" }
+    url { "https://example.com/fake-icon.png" }
     sequence :keyword, ordered_numbers do |n|
       "totally fake #{n}"
     end

--- a/spec/system/replies/new_spec.rb
+++ b/spec/system/replies/new_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Creating replies" do
 
         find_by_id('current-icon-holder').click
         expect(page).to have_text("icons of the <strong>")
-        find(:xpath, "//*[contains(@class,'gallery-icon')][contains(text(),'<strong> icon')]//img").click
+        within('.gallery-icon', text: "<strong> icon") { find('img').click }
 
         click_button "HTML"
 


### PR DESCRIPTION
## Summary
- The icon-picker click in "User interacts with javascript" targets an `<img>` with no fixed width/height, so until the browser resolves its `src` it renders at effectively zero size and Capybara can't see it as visible.
- Current hypothesis: The default `:icon` factory URL pointed at an arbitrary external host (`fakeicon.com`) whose DNS/connection timing is unpredictable, occasionally outlasting Capybara's wait window in CI (confirmed via a CI failure screenshot showing the icon blank while a same-page locally-served image rendered fine).
- Switched the default factory URL to `example.com`, matching the reliable-domain convention already used by other JS system specs for fake icon URLs (e.g. `characters/show_spec.rb`, `templates/show_spec.rb`).
- Also replaced the single compound XPath with a scoped `within`/`find`, so a future failure here points at exactly which part didn't match.

## Test plan
- [x] `bin/with-bundle rspec spec/system/replies/new_spec.rb spec/models/icon_spec.rb` — 41 examples, 0 failures