### PR TITLE
Fix Dependabot config error: remove overlapping bundler entry + run on weekends too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,20 +16,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-  - package-ecosystem: "bundler"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    groups:
-      transitive-updates:
-        patterns:
-          - "*"
-        update-types:
-          - patch
-          - minor
-    allow:
-      - dependency-name: "*"
-        dependency-type: "indirect"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,9 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "cron"
+      cronjob: "0 12 * * *"
+      timezone: "America/New_York"
     open-pull-requests-limit: 10
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
Dependabot rejects two update entries with the same package-ecosystem and directory, even with different allow/groups settings, so the monthly indirect-only grouping entry added in #2706 collided with the daily entry. There's no per-entry way to filter by direct vs. indirect dependency type that would let the two coexist, so fold back into a single daily entry for now.

(ugh)

<img width="1164" height="436" alt="image" src="https://github.com/user-attachments/assets/e43ced85-5bfd-4856-920a-e323fdb1b0ab" />

Also updates with a cron to make sure we run on the weekend too.
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cronjob