### PR TITLE
Upgrade nodejs to 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /etc/apt/keyrings/postgresql.asc && \
   echo "deb [signed-by=/etc/apt/keyrings/postgresql.asc] https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >> /etc/apt/sources.list.d/nodesource.list
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" >> /etc/apt/sources.list.d/nodesource.list
 RUN echo "Package: nodejs\nPin: origin deb.nodesource.com\nPin-Priority: 600\n\nPackage: nodejs\nPin: origin deb.debian.org\nPin-Priority: -10" > /etc/apt/preferences.d/nodejs
 RUN echo "Package: postgresql* libpq-dev\nPin: origin apt.postgresql.org\nPin-Priority: 600\n\nPackage: postgresql* libpq-dev\nPin: origin deb.debian.org\nPin-Priority: -10" > /etc/apt/preferences.d/postgresql
 RUN apt-get update \

--- a/shell.nix
+++ b/shell.nix
@@ -28,7 +28,7 @@ pkgs.mkShell {
     ruby
 
     # Node.js for asset pipeline and linting
-    pkgs.nodejs_22
+    pkgs.nodejs_24
 
     # PostgreSQL client and server for local dev
     pkgs.postgresql_16


### PR DESCRIPTION
Matches the version Heroku defaults to now (more or less - 24.13.0)

Guessing at how to update the .nix file, looks like nix-shell runs for me locally so I think it's a safe update (which node now points to /nix/store/cikdc61gfwvdma6y0p9b5d5d448aqcv6-nodejs-24.12.0/bin/node)

I don't see us setting up a node in the GitHub Actions...? I think we're OK there, I guess? Probably using the default version in the environment. Last upgrade in https://github.com/glowfic-constellation/glowfic/pull/2618 didn't seem to upgrade Actions.