### PR TITLE
Fix thread metadata word counts ignoring uncached replies

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -253,12 +253,12 @@ class Post < ApplicationRecord
   end
 
   def total_word_count
-    word_count + replies.sum(:word_count)
+    word_count + reply_word_count_sum(replies)
   end
 
   def word_count_for(user)
     sum = user_id == user.id ? word_count : 0
-    sum + replies.where(user_id: user.id).sum(:word_count)
+    sum + reply_word_count_sum(replies.where(user_id: user.id))
   end
 
   # only returns for authors who have written in the post (it's zero for authors who have not joined)
@@ -300,6 +300,16 @@ class Post < ApplicationRecord
   end
 
   private
+
+  # Sums the word counts of the given replies, falling back to computing the
+  # count on the fly for any replies whose word_count column hasn't been cached
+  # yet (e.g. before the backfill has run). A raw SQL SUM would silently treat
+  # those uncached (NULL) rows as zero.
+  def reply_word_count_sum(scope)
+    cached = scope.where.not(word_count: nil).sum(:word_count)
+    uncached = scope.where(word_count: nil).sum(&:computed_word_count)
+    cached + uncached
+  end
 
   def adjacent_posts_for(user)
     return unless board.ordered?

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -453,6 +453,15 @@ RSpec.describe Post do
       expect(post.total_word_count).to eq(8)
     end
 
+    it "falls back to computing when replies have no cached word_count" do
+      post = create(:post, content: 'one two three four five')
+      one = create(:reply, post: post, content: 'six seven')
+      two = create(:reply, post: post, content: 'eight')
+      Reply.where(id: [one.id, two.id]).update_all(word_count: nil) # rubocop:disable Rails/SkipsModelValidations
+      expect(post.total_word_count).to eq(8)
+      expect(post.word_count_for(one.user)).to eq(2)
+    end
+
     it "guesses correctly without replies" do
       post = create(:post, content: 'one two three four five')
       expect(post.word_count).to eq(5)


### PR DESCRIPTION
The Metadata page's word counts were only reflecting the opening post and any replies whose word_count column had already been backfilled. Post's total_word_count and word_count_for summed replies with a raw SQL SUM on the word_count column, so replies with a NULL (not-yet-cached) word_count were silently treated as zero -- bypassing the Ruby fallback in Writable#word_count that computes the count from content.

Sum the cached reply word counts via SQL as before, but compute on the fly for any replies whose word_count hasn't been cached yet, so the numbers are correct even before the backfill task has run.


Claude-Session: https://claude.ai/code/session_01JDF6XdwJ54xqgUa7Dn56W3