### PR TITLE
Secondary continuities

### DIFF
--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -66,7 +66,7 @@ function setupMetadataEditor() {
   if ($("#post_section_id").val() === '') setSections();
   $("#post_board_id").change(function() { setSections(); });
 
-  setupSecondaryBoards();
+  setupSecondaryContinuities();
 
   $("#post_privacy").change(function() {
     if ($(this).val() === 'access_list') {
@@ -511,7 +511,7 @@ function setSections() {
   }, 'json');
 }
 
-function setupSecondaryBoards() {
+function setupSecondaryContinuities() {
   const select = $('#post_secondary_board_ids');
   if (select.length === 0) return;
 

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -66,6 +66,8 @@ function setupMetadataEditor() {
   if ($("#post_section_id").val() === '') setSections();
   $("#post_board_id").change(function() { setSections(); });
 
+  setupSecondaryBoards();
+
   $("#post_privacy").change(function() {
     if ($(this).val() === 'access_list') {
       $("#access_list").show();
@@ -506,6 +508,60 @@ function setSections() {
       $("#post_section_id").val("").trigger("change.select2");
       $("#section").hide();
     }
+  }, 'json');
+}
+
+function setupSecondaryBoards() {
+  const select = $('#post_secondary_board_ids');
+  if (select.length === 0) return;
+
+  createSelect2('#post_secondary_board_ids', {
+    width: '300px',
+    minimumResultsForSearch: 20,
+    placeholder: 'Choose other continuities for this post'
+  });
+
+  select.change(function() {
+    const selected = ($(this).val() || []).map(Number);
+    const container = $('#secondary-sections');
+
+    // Remove rows for boards no longer selected
+    container.find('.secondary-membership-row').each(function() {
+      const boardId = parseInt($(this).data('board-id'));
+      if (!selected.includes(boardId)) $(this).remove();
+    });
+
+    // Add rows for newly selected boards
+    selected.forEach(function(boardId) {
+      if (container.find('.secondary-membership-row[data-board-id="' + boardId + '"]').length > 0) return;
+      addSecondaryMembershipRow(boardId, container);
+    });
+  });
+}
+
+function addSecondaryMembershipRow(boardId, container) {
+  $.authenticatedGet('/api/v1/boards/' + boardId, {}, function(resp) {
+    const row = $('<div class="secondary-membership-row">').attr('data-board-id', boardId);
+    row.append($('<b>').text(resp.name));
+    row.append($('<input type="hidden">').attr({
+      name: 'post[secondary_memberships][][board_id]',
+      value: boardId
+    }));
+    if (resp.board_sections && resp.board_sections.length > 0) {
+      row.append(' section: ');
+      const sectionSelect = $('<select>').attr('name', 'post[secondary_memberships][][section_id]');
+      sectionSelect.append('<option value="">— Choose Section —</option>');
+      resp.board_sections.forEach(function(section) {
+        sectionSelect.append($('<option>').attr('value', section.id).text(section.name));
+      });
+      row.append(sectionSelect);
+    } else {
+      row.append($('<input type="hidden">').attr({
+        name: 'post[secondary_memberships][][section_id]',
+        value: ''
+      }));
+    }
+    container.append(row);
   }, 'json');
 }
 

--- a/app/assets/javascripts/reorder.js
+++ b/app/assets/javascripts/reorder.js
@@ -134,6 +134,8 @@ function syncRowOrders(orderBox, path, param) {
   json['ordered_' + param] = orderedIds;
   // and restrict to relevant section_id if given
   if (window.gon && window.gon.section_id) json.section_id = window.gon.section_id;
+  // and the continuity being reordered, since posts may be in it secondarily
+  if (window.gon && window.gon.board_id) json.board_id = window.gon.board_id;
 
   $.authenticatedPost(path, json, function(resp) {
     // Check the list doesn't have new elements, warn but don't block if it does

--- a/app/concerns/owable.rb
+++ b/app/concerns/owable.rb
@@ -50,7 +50,7 @@ module Owable
     end
 
     def update_board_cameos
-      boards.uniq.each { |b| cameo_authors_into(b) }
+      boards.each { |b| cameo_authors_into(b) }
     end
 
     def cameo_authors_into(board)

--- a/app/concerns/owable.rb
+++ b/app/concerns/owable.rb
@@ -50,6 +50,10 @@ module Owable
     end
 
     def update_board_cameos
+      boards.uniq.each { |b| cameo_authors_into(b) }
+    end
+
+    def cameo_authors_into(board)
       return unless board.authors_locked?
 
       # adjust for the fact that the associations are managed separately

--- a/app/controllers/api/v1/boards_controller.rb
+++ b/app/controllers/api/v1/boards_controller.rb
@@ -42,7 +42,7 @@ class Api::V1::BoardsController < Api::ApiController
       .ordered_by_id
       .with_reply_count
       .select('posts.*')
-      .includes(:board, :joined_authors, :section)
+      .includes(:joined_authors, main_post_board: [:board, :section])
     posts = paginate(queryset, per_page: 25)
     render json: { results: posts }
   end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -65,7 +65,13 @@ class Api::V1::PostsController < Api::ApiController
     section_id = params[:section_id]&.to_i
     post_ids = params[:ordered_post_ids].map(&:to_i).uniq
 
-    post_boards = PostBoard.main.where(post_id: post_ids)
+    # Board pages pass the continuity whose ordering is being edited, since posts may be in
+    # it secondarily; without it, fall back to the posts' main continuities.
+    post_boards = if params[:board_id].present?
+      PostBoard.where(board_id: params[:board_id], post_id: post_ids)
+    else
+      PostBoard.main.where(post_id: post_ids)
+    end
     unless post_boards.count == post_ids.count
       missing_posts = post_ids - post_boards.pluck(:post_id)
       error = { message: "Some posts could not be found: #{missing_posts * ', '}" }
@@ -89,7 +95,7 @@ class Api::V1::PostsController < Api::ApiController
     end
 
     PostBoard.transaction do
-      section_scope = PostBoard.main.where(board_id: board.id, section_id: section_id)
+      section_scope = PostBoard.where(board_id: board.id, section_id: section_id)
       all_section_pbs = section_scope.ordered_in_section.to_a
       visible_post_ids = Post.where(id: all_section_pbs.map(&:post_id)).visible_to(current_user).pluck(:id).to_set
       post_id_set = post_ids.to_set
@@ -131,7 +137,7 @@ class Api::V1::PostsController < Api::ApiController
       end
     end
 
-    ordered = PostBoard.main.where(board_id: board.id, section_id: section_id).ordered_in_section.to_a
+    ordered = PostBoard.where(board_id: board.id, section_id: section_id).ordered_in_section.to_a
     visible_ids = Post.where(id: ordered.map(&:post_id)).visible_to(current_user).pluck(:id).to_set
     render json: { post_ids: ordered.map(&:post_id).select { |id| visible_ids.include?(id) } }
   end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -54,7 +54,7 @@ class Api::V1::PostsController < Api::ApiController
     end
   end
 
-  api :POST, '/posts/reorder', 'Update the order of posts. This is an unstable feature, and may be moved or renamed; it should not be trusted.'
+  api :POST, '/posts/reorder', 'Update the order of posts within their main continuity. This is an unstable feature, and may be moved or renamed; it should not be trusted.'
   error 401, "You must be logged in"
   error 403, "Continuity is not editable by the user"
   error 404, "Post IDs could not be found"
@@ -64,76 +64,76 @@ class Api::V1::PostsController < Api::ApiController
   def reorder
     section_id = params[:section_id]&.to_i
     post_ids = params[:ordered_post_ids].map(&:to_i).uniq
-    posts = Post.where(id: post_ids)
-    posts_count = posts.count
-    unless posts_count == post_ids.count
-      missing_posts = post_ids - posts.pluck(:id)
+
+    post_boards = PostBoard.main.where(post_id: post_ids)
+    unless post_boards.count == post_ids.count
+      missing_posts = post_ids - post_boards.pluck(:post_id)
       error = { message: "Some posts could not be found: #{missing_posts * ', '}" }
       render json: { errors: [error] }, status: :not_found and return
     end
 
-    boards = Board.where(id: posts.select(:board_id).distinct.pluck(:board_id))
-    unless boards.one?
+    board_ids = post_boards.distinct.pluck(:board_id)
+    unless board_ids.one?
       error = { message: 'Posts must be from one continuity' }
       render json: { errors: [error] }, status: :unprocessable_content and return
     end
 
-    board = boards.first
+    board = Board.find(board_ids.first)
     access_denied and return unless board.editable_by?(current_user)
 
-    post_section_ids = posts.select(:section_id).distinct.pluck(:section_id)
-    unless post_section_ids == [section_id] &&
+    pb_section_ids = post_boards.distinct.pluck(:section_id)
+    unless pb_section_ids == [section_id] &&
            (section_id.nil? || BoardSection.where(id: section_id, board_id: board.id).exists?)
       error = { message: 'Posts must be from one specified section in the continuity, or no section' }
       render json: { errors: [error] }, status: :unprocessable_content and return
     end
 
-    Post.transaction do
-      section_scope = Post.where(board_id: board.id, section_id: section_id)
-      all_section_posts = section_scope.ordered_in_section.to_a
-      visible_to_user_ids = section_scope.visible_to(current_user).pluck(:id).to_set
+    PostBoard.transaction do
+      section_scope = PostBoard.main.where(board_id: board.id, section_id: section_id)
+      all_section_pbs = section_scope.ordered_in_section.to_a
+      visible_post_ids = Post.where(id: all_section_pbs.map(&:post_id)).visible_to(current_user).pluck(:id).to_set
       post_id_set = post_ids.to_set
 
-      # Posts the editor can't read get anchored to the post in their request that preceded
-      # them in the original ordering, so a private post placed between two visible ones
-      # stays attached to its predecessor instead of being shoved to the bottom. Posts the
-      # editor can read but omitted from the request (the documented "subset reorder" case)
-      # still get appended at the end.
+      # Post_boards whose post the editor can't read get anchored to the post in their request that
+      # preceded them in the original ordering, so a private post placed between two visible ones
+      # stays attached to its predecessor instead of being shoved to the bottom. Posts the editor can
+      # read but omitted from the request (the documented "subset reorder" case) still append at the end.
       anchors = {}
       visible_omitted = []
       anchor_id = :start
-      all_section_posts.each do |post|
-        if post_id_set.include?(post.id)
-          anchor_id = post.id
-        elsif visible_to_user_ids.include?(post.id)
-          visible_omitted << post
+      all_section_pbs.each do |pb|
+        if post_id_set.include?(pb.post_id)
+          anchor_id = pb.post_id
+        elsif visible_post_ids.include?(pb.post_id)
+          visible_omitted << pb
         else
-          anchors[post.id] = anchor_id
+          anchors[pb.post_id] = anchor_id
         end
       end
 
       anchored_by = Hash.new { |h, k| h[k] = [] }
-      all_section_posts.each do |post|
-        anchored_by[anchors[post.id]] << post if anchors.key?(post.id)
+      all_section_pbs.each do |pb|
+        anchored_by[anchors[pb.post_id]] << pb if anchors.key?(pb.post_id)
       end
 
-      ordered_visible = posts.sort_by { |post| post_ids.index(post.id) }
+      ordered_visible = post_boards.to_a.sort_by { |pb| post_ids.index(pb.post_id) }
 
       new_order = anchored_by[:start].dup
-      ordered_visible.each do |post|
-        new_order << post
-        new_order.concat(anchored_by[post.id])
+      ordered_visible.each do |pb|
+        new_order << pb
+        new_order.concat(anchored_by[pb.post_id])
       end
       new_order.concat(visible_omitted)
 
-      new_order.each_with_index do |post, index|
-        next if post.section_order == index
-        post.update(section_order: index)
+      new_order.each_with_index do |pb, index|
+        next if pb.section_order == index
+        pb.update(section_order: index)
       end
     end
 
-    posts = Post.where(board_id: board.id, section_id: section_id).visible_to(current_user)
-    render json: { post_ids: posts.ordered_in_section.pluck(:id) }
+    ordered = PostBoard.main.where(board_id: board.id, section_id: section_id).ordered_in_section.to_a
+    visible_ids = Post.where(id: ordered.map(&:post_id)).visible_to(current_user).pluck(:id).to_set
+    render json: { post_ids: ordered.map(&:post_id).select { |id| visible_ids.include?(id) } }
   end
 
   private

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -87,8 +87,8 @@ class Api::V1::PostsController < Api::ApiController
     board = Board.find(board_ids.first)
     access_denied and return unless board.editable_by?(current_user)
 
-    pb_section_ids = post_boards.distinct.pluck(:section_id)
-    unless pb_section_ids == [section_id] &&
+    post_boards_section_ids = post_boards.distinct.pluck(:section_id)
+    unless post_boards_section_ids == [section_id] &&
            (section_id.nil? || BoardSection.where(id: section_id, board_id: board.id).exists?)
       error = { message: 'Posts must be from one specified section in the continuity, or no section' }
       render json: { errors: [error] }, status: :unprocessable_content and return

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::UsersController < Api::ApiController
   def posts
     post_ids = Post::Author.where(user: @user).pluck(:post_id)
     queryset = Post.privacy_public.where(id: post_ids).with_reply_count.select('posts.*')
-    posts = paginate queryset.includes(:board, :joined_authors, :section), per_page: 25
+    posts = paginate queryset.includes(:joined_authors, main_post_board: [:board, :section]), per_page: 25
     render json: { results: posts }
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -111,29 +111,30 @@ class ApplicationController < ActionController::Base
     select = if max
       <<~SQL.squish
         posts.*,
-        max(boards.name) as board_name,
+        max(main_boards.name) as board_name,
         max(users.username) as last_user_name,
         bool_or(users.deleted) as last_user_deleted,
-        max(board_sections.name) as section_name
+        max(main_sections.name) as section_name
         #{select}
       SQL
     else
       <<~SQL.squish
         posts.*,
-        boards.name as board_name,
+        main_boards.name as board_name,
         users.username as last_user_name,
         users.deleted as last_user_deleted,
-        board_sections.name as section_name
+        main_sections.name as section_name
         #{select}
       SQL
     end
 
     relation
       .select(select)
-      .joins(:board)
-      .left_joins(:section)
+      .joins("INNER JOIN post_boards main_pbs ON main_pbs.post_id = posts.id AND main_pbs.is_main = TRUE")
+      .joins("INNER JOIN boards main_boards ON main_boards.id = main_pbs.board_id")
+      .joins("LEFT JOIN board_sections main_sections ON main_sections.id = main_pbs.section_id")
       .joins(:last_user)
-      .includes(:authors)
+      .includes(:authors, main_post_board: [:board, :section])
       .with_has_content_warnings
       .with_reply_count
   end

--- a/app/controllers/board_sections_controller.rb
+++ b/app/controllers/board_sections_controller.rb
@@ -41,7 +41,7 @@ class BoardSectionsController < ApplicationController
     use_javascript('board_sections')
     gon.section_id = @board_section.id
     gon.board_id = @board_section.board_id
-    @section_posts = @board_section.posts.visible_to(current_user)
+    @posts = @board_section.posts.visible_to(current_user)
       .select('posts.*, post_boards.section_order as section_order')
       .ordered_in_section
   end

--- a/app/controllers/board_sections_controller.rb
+++ b/app/controllers/board_sections_controller.rb
@@ -40,7 +40,9 @@ class BoardSectionsController < ApplicationController
     @page_title = 'Edit ' + @board_section.name
     use_javascript('board_sections')
     gon.section_id = @board_section.id
-    @posts = @board_section.posts.visible_to(current_user).ordered_in_section
+    @section_posts = @board_section.posts.visible_to(current_user)
+      .select('posts.*, post_boards.section_order as section_order')
+      .ordered_in_section
   end
 
   def update

--- a/app/controllers/board_sections_controller.rb
+++ b/app/controllers/board_sections_controller.rb
@@ -40,6 +40,7 @@ class BoardSectionsController < ApplicationController
     @page_title = 'Edit ' + @board_section.name
     use_javascript('board_sections')
     gon.section_id = @board_section.id
+    gon.board_id = @board_section.board_id
     @section_posts = @board_section.posts.visible_to(current_user)
       .select('posts.*, post_boards.section_order as section_order')
       .ordered_in_section

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -57,7 +57,7 @@ class BoardsController < ApplicationController
     @page_title = @board.name
     @board_sections = @board.board_sections.ordered
     @board_sections = @board_sections.paginate(per_page: 25, page: page)
-    board_posts = @board.posts.where(section_id: nil)
+    board_posts = @board.posts.where(post_boards: { section_id: nil })
     if @board.ordered?
       board_posts = board_posts.ordered_in_section
     else
@@ -72,7 +72,12 @@ class BoardsController < ApplicationController
     @page_title = 'Edit Continuity: ' + @board.name
     use_javascript('boards/edit')
     @board_sections = @board.board_sections.ordered
-    @unsectioned_posts = @board.posts.where(section_id: nil).visible_to(current_user).ordered_in_section if @board.ordered?
+    return unless @board.ordered?
+    @unsectioned_posts = @board.posts
+      .where(post_boards: { section_id: nil })
+      .visible_to(current_user)
+      .select('posts.*, post_boards.section_order as section_order')
+      .ordered_in_section
   end
 
   def update
@@ -177,7 +182,8 @@ class BoardsController < ApplicationController
   def boards_from_relation(relation)
     sql = <<~SQL.squish
       boards.*,
-      (SELECT MAX(tagged_at) FROM posts WHERE posts.board_id = boards.id) AS tagged_at
+      (SELECT MAX(tagged_at) FROM posts INNER JOIN post_boards ON post_boards.post_id = posts.id
+       WHERE post_boards.board_id = boards.id AND post_boards.is_main = TRUE) AS tagged_at
     SQL
     relation
       .ordered

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -71,6 +71,7 @@ class BoardsController < ApplicationController
   def edit
     @page_title = 'Edit Continuity: ' + @board.name
     use_javascript('boards/edit')
+    gon.board_id = @board.id
     @board_sections = @board.board_sections.ordered
     return unless @board.ordered?
     @unsectioned_posts = @board.posts

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -3,7 +3,7 @@ class DraftsController < WritableController
   def create
     draft = make_draft
     redirect_to posts_path and return unless draft.post
-    redirect_to post_path(draft.post, page: :unread, anchor: :unread)
+    redirect_to post_path_with_continuity(draft.post, page: :unread, anchor: :unread)
   end
 
   def destroy
@@ -17,6 +17,6 @@ class DraftsController < WritableController
         array: draft&.errors&.full_messages,
       }
     end
-    redirect_to post_path(post_id, page: :unread, anchor: :unread)
+    redirect_to post_path_with_continuity(post_id, page: :unread, anchor: :unread)
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -16,7 +16,8 @@ class FavoritesController < ApplicationController
     board_favorites = @favorites.where(favorite_type: Board.to_s).select(:favorite_id)
     post_favorites = @favorites.where(favorite_type: Post.to_s).select(:favorite_id)
 
-    @posts = Post.where(id: author_posts).or(Post.where(id: post_favorites)).or(Post.where(board_id: board_favorites))
+    board_post_ids = PostBoard.where(board_id: board_favorites).select(:post_id)
+    @posts = Post.where(id: author_posts).or(Post.where(id: post_favorites)).or(Post.where(id: board_post_ids))
     @posts = @posts.not_ignored_by(current_user) if current_user&.hide_from_all
     @posts = posts_from_relation(@posts.ordered, with_unread: true)
     @hide_quicklinks = true

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -305,7 +305,9 @@ class PostsController < WritableController
     response.headers['X-Robots-Tag'] = 'noindex'
     @search_results = Post.ordered
     @search_results = @search_results.joins(:post_boards).where(post_boards: { board_id: params[:board_id] }) if params[:board_id].present?
-    @search_results = @search_results.where.not(id: PostBoard.where(board_id: params[:exclude_board_ids]).select(:post_id)) if params[:exclude_board_ids].present?
+    if params[:exclude_board_ids].present?
+      @search_results = @search_results.where.not(id: PostBoard.where(board_id: params[:exclude_board_ids]).select(:post_id))
+    end
     @search_results = @search_results.where(id: Setting.find(params[:setting_id]).post_tags.pluck(:post_id)) if params[:setting_id].present?
     if params[:subject].present?
       if params[:abbrev].present?

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -263,7 +263,7 @@ class PostsController < WritableController
       render :edit
     else
       flash[:success] = "Post updated."
-      redirect_to @post
+      redirect_to post_path_with_continuity(@post)
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -291,8 +291,8 @@ class PostsController < WritableController
 
     response.headers['X-Robots-Tag'] = 'noindex'
     @search_results = Post.ordered
-    @search_results = @search_results.where(board_id: params[:board_id]) if params[:board_id].present?
-    @search_results = @search_results.where.not(board_id: params[:exclude_board_ids]) if params[:exclude_board_ids].present?
+    @search_results = @search_results.joins(:post_boards).where(post_boards: { board_id: params[:board_id] }) if params[:board_id].present?
+    @search_results = @search_results.where.not(id: PostBoard.where(board_id: params[:exclude_board_ids]).select(:post_id)) if params[:exclude_board_ids].present?
     @search_results = @search_results.where(id: Setting.find(params[:setting_id]).post_tags.pluck(:post_id)) if params[:setting_id].present?
     if params[:subject].present?
       if params[:abbrev].present?

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -136,14 +136,21 @@ class PostsController < WritableController
     import_thread and return if params[:button_import].present?
     preview and return if params[:button_preview].present?
 
-    @post = current_user.posts.new(permitted_params)
+    @post = current_user.posts.new(permitted_params.except(:board_id, :section_id, :secondary_memberships))
     @post.settings = process_tags(Setting, obj_param: :post, id_param: :setting_ids)
     @post.content_warnings = process_tags(ContentWarning, obj_param: :post, id_param: :content_warning_ids)
     @post.labels = process_tags(Label, obj_param: :post, id_param: :label_ids)
     process_npc(@post, permitted_character_params)
 
     begin
-      @post.save!
+      Post.transaction do
+        @post.assign_continuities(
+          main_board_id: permitted_params[:board_id],
+          main_section_id: permitted_params[:section_id],
+          secondaries: permitted_params[:secondary_memberships],
+        )
+        @post.save!
+      end
     rescue ActiveRecord::RecordInvalid => e
       render_errors(@post, action: 'created', now: true, err: e)
 
@@ -219,8 +226,7 @@ class PostsController < WritableController
     change_authors_locked and return if params[:authors_locked].present?
     preview and return if params[:button_preview].present?
 
-    @post.assign_attributes(permitted_params)
-    @post.board ||= Board.find_by(id: Board::ID_SANDBOX)
+    @post.assign_attributes(permitted_params.except(:board_id, :section_id, :secondary_memberships))
     settings = process_tags(Setting, obj_param: :post, id_param: :setting_ids)
     warnings = process_tags(ContentWarning, obj_param: :post, id_param: :content_warning_ids)
     labels = process_tags(Label, obj_param: :post, id_param: :label_ids)
@@ -238,6 +244,13 @@ class PostsController < WritableController
         @post.content_warnings = warnings
         @post.labels = labels
         process_npc(@post, permitted_character_params)
+        if continuity_params_submitted?(permitted_params)
+          @post.assign_continuities(
+            main_board_id: permitted_params[:board_id].presence || Board::ID_SANDBOX,
+            main_section_id: permitted_params[:section_id],
+            secondaries: permitted_params[:secondary_memberships],
+          )
+        end
         @post.save!
         @post.author_for(current_user)&.update!(private_note: @post.private_note) if is_author
       end
@@ -538,10 +551,15 @@ class PostsController < WritableController
     redirect_to @post
   end
 
+  def continuity_params_submitted?(post_params)
+    [:board_id, :section_id, :secondary_memberships].any? { |k| post_params.key?(k) }
+  end
+
   def permitted_params(include_associations=true)
     allowed_params = [
       :board_id,
       :section_id,
+      :secondary_memberships,
       :privacy,
       :subject,
       :description,
@@ -560,6 +578,7 @@ class PostsController < WritableController
       allowed_params << {
         unjoined_author_ids: [],
         viewer_ids: [],
+        secondary_memberships: [:board_id, :section_id],
       }
     end
 

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -344,7 +344,7 @@ class RepliesController < WritableController
       render_errors(errored_reply, action: 'created', now: true, err: e)
 
       redirect_to posts_path and return unless errored_reply.post
-      redirect_to post_path(errored_reply.post) and return
+      redirect_to post_path_with_continuity(errored_reply.post) and return
     end
 
     flash[:success] = "#{'Reply'.pluralize(@multi_replies.length)} posted."

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -59,10 +59,10 @@ class RepliesController < WritableController
       flash[:success] = "Replies discarded."
       if editing_multi_reply?
         # Editing multi reply, going to redirect back to the reply I'm editing
-        redirect_to reply_path(@reply, anchor: "reply-#{@reply.id}")
+        redirect_to reply_path_with_continuity(@reply, anchor: "reply-#{@reply.id}")
       else
         # Posting a new multi reply, go back to unread
-        redirect_to post_path(params[:reply][:post_id], page: :unread, anchor: :unread)
+        redirect_to post_path_with_continuity(params[:reply][:post_id], page: :unread, anchor: :unread)
       end
       return
     end
@@ -118,7 +118,7 @@ class RepliesController < WritableController
   def destroy
     unless @reply.deletable_by?(current_user)
       flash[:error] = "You do not have permission to modify this reply."
-      redirect_to post_path(@reply.post) and return
+      redirect_to post_path_with_continuity(@reply.post) and return
     end
 
     previous_reply = @reply.send(:previous_reply)
@@ -129,10 +129,10 @@ class RepliesController < WritableController
       @reply.destroy!
     rescue ActiveRecord::RecordNotDestroyed => e
       render_errors(@reply, action: 'deleted', err: e)
-      redirect_to reply_path(@reply, anchor: "reply-#{@reply.id}")
+      redirect_to reply_path_with_continuity(@reply, anchor: "reply-#{@reply.id}")
     else
       flash[:success] = "Reply deleted."
-      redirect_to post_path(@reply.post, page: to_page)
+      redirect_to post_path_with_continuity(@reply.post, page: to_page)
     end
   end
 
@@ -219,7 +219,7 @@ class RepliesController < WritableController
   def require_edit_permission
     return if @reply.editable_by?(current_user)
     flash[:error] = "You do not have permission to modify this reply."
-    redirect_to post_path(@reply.post)
+    redirect_to post_path_with_continuity(@reply.post)
   end
 
   def get_multi_replies
@@ -348,7 +348,7 @@ class RepliesController < WritableController
     end
 
     flash[:success] = "#{'Reply'.pluralize(@multi_replies.length)} posted."
-    redirect_to reply_path(first_reply, anchor: "reply-#{first_reply.id}")
+    redirect_to reply_path_with_continuity(first_reply, anchor: "reply-#{first_reply.id}")
   end
 
   def editing_multi_reply?
@@ -379,7 +379,7 @@ class RepliesController < WritableController
       render :edit
     else
       flash[:success] = "Reply updated."
-      redirect_to reply_path(@reply, anchor: "reply-#{@reply.id}")
+      redirect_to reply_path_with_continuity(@reply, anchor: "reply-#{@reply.id}")
     end
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -60,7 +60,7 @@ class ReportsController < ApplicationController
       when 'subject'
         Arel.sql('LOWER(subject)')
       when 'continuity'
-        Arel.sql('LOWER(max(boards.name)), tagged_at desc')
+        Arel.sql('LOWER(max(main_boards.name)), tagged_at desc')
       else
         { first_updated_at: :desc }
     end

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -103,7 +103,9 @@ class WritableController < ApplicationController
       .left_outer_joins(:character_alias)
       .ordered
       .paginate(page: cur_page, per_page: per, total_entries: reply_count)
-    redirect_to post_path(@post, page: @replies.total_pages, per_page: per) and return if cur_page > @replies.total_pages
+    if cur_page > @replies.total_pages
+      redirect_to helpers.post_in_board_path(@post, @secondary_board, page: @replies.total_pages, per_page: per) and return
+    end
     use_javascript('paginator')
 
     @audits = @post.associated_audits.where(auditable_id: @replies.map(&:id)).group(:auditable_id).count

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -39,7 +39,16 @@ class WritableController < ApplicationController
     per = per_page
     cur_page ||= page(allow_special: true)
     @replies = @post.replies
+
+    # The continuity the post is being viewed through: its main one by default, or another
+    # via a /boards/:continuity_id/... URL. One it isn't in fails like an unknown post id.
+    # @secondary_board is only set for secondary continuities, keeping main-continuity links flat.
+    @post_board = @post.post_board_for(params[:continuity_id])
+    return continuity_not_found unless @post_board
+    @secondary_board = @post_board.board unless @post_board.is_main?
+
     @paginate_params = { controller: 'posts', action: 'show', id: @post.id }
+    @paginate_params[:continuity_id] = @secondary_board.id if @secondary_board
 
     if params[:at_id].present?
       reply = if params[:at_id] == 'unread' && logged_in?
@@ -102,8 +111,8 @@ class WritableController < ApplicationController
 
     calculate_reply_bookmarks(@replies)
 
-    @next_post = @post.next_post(current_user)
-    @prev_post = @post.prev_post(current_user)
+    @next_post = @post.next_post(current_user, @post_board)
+    @prev_post = @post.prev_post(current_user, @post_board)
 
     # show <link rel="canonical"> – for SEO stuff
     canon_params = {}
@@ -171,9 +180,35 @@ class WritableController < ApplicationController
     gon.no_icon_path = view_context.image_path('icons/no-icon.png')
   end
 
+  def continuity_not_found
+    flash[:error] = "Post could not be found."
+    redirect_to continuities_path
+  end
+
+  # The secondary continuity a post/reply is being acted on through (params[:continuity_id],
+  # from a /boards/... URL or a form's hidden field), or nil for the main one.
+  def secondary_board_for(post)
+    return if params[:continuity_id].blank?
+    pb = post.post_board_for(params[:continuity_id])
+    pb.board unless pb.nil? || pb.is_main?
+  end
+
+  # Drop-in replacements for post_path/reply_path that return the user to the continuity
+  # they came from. Like post_path, post_path_with_continuity also accepts a post id.
+  def post_path_with_continuity(post, **opts)
+    post = Post.find_by(id: post) || post unless post.is_a?(Post)
+    return post_path(post, **opts) unless post.is_a?(Post)
+    helpers.post_in_board_path(post, secondary_board_for(post), **opts)
+  end
+
+  def reply_path_with_continuity(reply, **opts)
+    helpers.reply_in_board_path(reply, secondary_board_for(reply.post), **opts)
+  end
+
   def og_data_for_post(post, page: 1, total_pages:, per_page: 25)
-    post_location = post.board.name
-    post_location += ' » ' + post.section.name if post.section.present?
+    post_board = @post_board || post.main_post_board
+    post_location = post_board.board.name
+    post_location += ' » ' + post_board.section.name if post_board.section.present?
 
     post_description = generate_short(post.description)
     post_description += ' ('

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -104,7 +104,7 @@ class WritableController < ApplicationController
       .ordered
       .paginate(page: cur_page, per_page: per, total_entries: reply_count)
     if cur_page > @replies.total_pages
-      redirect_to helpers.post_in_board_path(@post, @secondary_board, page: @replies.total_pages, per_page: per) and return
+      redirect_to helpers.post_in_continuity_path(@post, @secondary_board, page: @replies.total_pages, per_page: per) and return
     end
     use_javascript('paginator')
 
@@ -200,11 +200,11 @@ class WritableController < ApplicationController
   def post_path_with_continuity(post, **opts)
     post = Post.find_by(id: post) || post unless post.is_a?(Post)
     return post_path(post, **opts) unless post.is_a?(Post)
-    helpers.post_in_board_path(post, secondary_board_for(post), **opts)
+    helpers.post_in_continuity_path(post, secondary_board_for(post), **opts)
   end
 
   def reply_path_with_continuity(reply, **opts)
-    helpers.reply_in_board_path(reply, secondary_board_for(reply.post), **opts)
+    helpers.reply_in_continuity_path(reply, secondary_board_for(reply.post), **opts)
   end
 
   def og_data_for_post(post, page: 1, total_pages:, per_page: 25)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,8 +42,8 @@ module ApplicationHelper
     'icons/bullet_go_strong.png'
   end
 
-  def path_for(obj, path)
-    send (path + '_path') % obj.class.to_s.downcase, obj
+  def path_for(obj, path, **opts)
+    send (path + '_path') % obj.class.to_s.downcase, obj, **opts
   end
 
   def per_page_options(default=nil)

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -38,8 +38,22 @@ module PostHelper
       .ordered
   end
 
-  def unread_path(post, **kwargs)
-    post_path(post, page: 'unread', anchor: 'unread', **kwargs)
+  def unread_path(post, board=nil, **kwargs)
+    post_in_board_path(post, board, page: 'unread', anchor: 'unread', **kwargs)
+  end
+
+  # Path to a post viewed within the given continuity: nested under it when it's a
+  # secondary continuity for the post, the regular flat path when it's the post's main
+  # continuity or nil.
+  def post_in_board_path(post, board=nil, **opts)
+    return post_path(post, **opts) if board.nil? || board.id == post.board_id
+    continuity_post_path(board, post, **opts)
+  end
+
+  # As above; callers only pass secondary continuities (or nil), so no main check needed.
+  def reply_in_board_path(reply, board=nil, **opts)
+    return reply_path(reply, **opts) if board.nil?
+    continuity_reply_path(board, reply, **opts)
   end
 
   def anchored_continuity_path(post)

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -28,6 +28,16 @@ module PostHelper
     Board.where(id: obj.board_id).or(Board.where(authors_locked: false)).or(Board.where(id: authored_ids)).ordered
   end
 
+  def allowed_secondary_boards(post, user)
+    authored_ids = BoardAuthor.where(user: user).select(:board_id)
+    linked_ids = post.persisted? ? post.boards.where.not(id: post.board_id).pluck(:id) : []
+    Board.where(authors_locked: false)
+      .or(Board.where(id: authored_ids))
+      .or(Board.where(id: linked_ids))
+      .where.not(id: post.board_id)
+      .ordered
+  end
+
   def unread_path(post, **kwargs)
     post_path(post, page: 'unread', anchor: 'unread', **kwargs)
   end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -39,19 +39,19 @@ module PostHelper
   end
 
   def unread_path(post, board=nil, **kwargs)
-    post_in_board_path(post, board, page: 'unread', anchor: 'unread', **kwargs)
+    post_in_continuity_path(post, board, page: 'unread', anchor: 'unread', **kwargs)
   end
 
   # Path to a post viewed within the given continuity: nested under it when it's a
   # secondary continuity for the post, the regular flat path when it's the post's main
   # continuity or nil.
-  def post_in_board_path(post, board=nil, **opts)
+  def post_in_continuity_path(post, board=nil, **opts)
     return post_path(post, **opts) if board.nil? || board.id == post.board_id
     continuity_post_path(board, post, **opts)
   end
 
   # As above; callers only pass secondary continuities (or nil), so no main check needed.
-  def reply_in_board_path(reply, board=nil, **opts)
+  def reply_in_continuity_path(reply, board=nil, **opts)
     return reply_path(reply, **opts) if board.nil?
     continuity_reply_path(board, reply, **opts)
   end

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -10,15 +10,15 @@ module WritableHelper
 
   # Previous/next-post navigation stays inside the continuity being viewed.
   def adjacent_post_path(post)
-    post_in_board_path(post, @post_board.board)
+    post_in_continuity_path(post, @post_board.board)
   end
 
   def post_or_reply_link(reply)
     return unless reply.id.present?
     if reply.is_a?(Reply)
-      reply_in_board_path(reply, @secondary_board, anchor: "reply-#{reply.id}")
+      reply_in_continuity_path(reply, @secondary_board, anchor: "reply-#{reply.id}")
     else
-      post_in_board_path(reply, @secondary_board)
+      post_in_continuity_path(reply, @secondary_board)
     end
   end
 

--- a/app/helpers/writable_helper.rb
+++ b/app/helpers/writable_helper.rb
@@ -3,14 +3,23 @@ module WritableHelper
   def unread_warning
     return unless @replies.present?
     return if @replies.total_pages == page
-    unread_link = tag.a('(View unread)', href: unread_path(@post), class: 'unread-warning')
-    new_tab_link = tag.a('(New tab)', href: unread_path(@post), class: 'unread-warning', target: '_blank')
+    unread_link = tag.a('(View unread)', href: unread_path(@post, @secondary_board), class: 'unread-warning')
+    new_tab_link = tag.a('(New tab)', href: unread_path(@post, @secondary_board), class: 'unread-warning', target: '_blank')
     "You are not on the latest page of the thread #{unread_link} #{new_tab_link}"
+  end
+
+  # Previous/next-post navigation stays inside the continuity being viewed.
+  def adjacent_post_path(post)
+    post_in_board_path(post, @post_board.board)
   end
 
   def post_or_reply_link(reply)
     return unless reply.id.present?
-    post_or_reply_mem_link(id: reply.id, klass: reply.class)
+    if reply.is_a?(Reply)
+      reply_in_board_path(reply, @secondary_board, anchor: "reply-#{reply.id}")
+    else
+      post_in_board_path(reply, @secondary_board)
+    end
   end
 
   def post_or_reply_mem_link(id: nil, klass: nil)

--- a/app/jobs/split_post_job.rb
+++ b/app/jobs/split_post_job.rb
@@ -3,7 +3,7 @@ class SplitPostJob < ApplicationJob
   queue_as :low
 
   REPLY_ATTRS = [:character_id, :icon_id, :character_alias_id, :user_id, :content, :created_at, :updated_at, :editor_mode].map(&:to_s)
-  POST_ATTRS = [:board_id, :section_id, :privacy, :status, :authors_locked].map(&:to_s)
+  POST_ATTRS = [:privacy, :status, :authors_locked].map(&:to_s)
   POST_ASSOCS = [:setting_ids, :label_ids, :content_warning_ids].map(&:to_s) # Associations aren't attributes so they're handled separately
 
   def perform(reply_id, new_subject)
@@ -32,6 +32,8 @@ class SplitPostJob < ApplicationJob
     new_post.skip_edited = true
     new_post.is_import = true
     new_post.assign_attributes(old_post.attributes.slice(*POST_ATTRS))
+    new_post.board_id = old_post.board_id
+    new_post.section_id = old_post.section_id
     POST_ASSOCS.each do |assoc|
       new_post.send(assoc + "=", old_post.send(assoc))
     end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -6,7 +6,18 @@ class Board < ApplicationRecord
   ID_SANDBOX = 3
   ID_SITETESTING = 4
 
-  has_many :posts, dependent: false # This is handled in callbacks
+  has_many :post_boards, inverse_of: :board, dependent: false # This is handled in callbacks
+  has_many :posts, through: :post_boards do
+    # Translate section_id (formerly a posts column, now on post_boards) so callers
+    # can keep writing board.posts.where(section_id: …) as before.
+    def where(*args)
+      opts = args.first
+      return super unless opts.is_a?(Hash) && opts.key?(:section_id) && !opts.key?(:post_boards)
+      remaining = opts.except(:section_id)
+      base = remaining.empty? ? all : super(remaining, *args.drop(1))
+      base.where(post_boards: { section_id: opts[:section_id] })
+    end
+  end
   has_many :board_sections, dependent: :destroy
   has_many :favorites, as: :favorite, inverse_of: :favorite, dependent: :destroy
   has_many :views, class_name: 'BoardView', dependent: :destroy
@@ -50,7 +61,13 @@ class Board < ApplicationRecord
   private
 
   def move_posts_to_sandbox
-    UpdateModelJob.perform_later(Post.to_s, { board_id: id }, { board_id: ID_SANDBOX, section_id: nil }, audited_user_id)
+    UpdateModelJob.perform_later(
+      PostBoard.to_s,
+      { board_id: id, is_main: true },
+      { board_id: ID_SANDBOX, section_id: nil },
+      audited_user_id,
+    )
+    PostBoard.where(board_id: id, is_main: false).delete_all
   end
 
   def add_creator_to_authors
@@ -63,9 +80,9 @@ class Board < ApplicationRecord
       next if section.section_order == index
       section.update_columns(section_order: index) # rubocop:disable Rails/SkipsModelValidations
     end
-    posts.where(section_id: nil).ordered_in_section.each_with_index do |post, index|
-      next if post.section_order == index
-      post.update_columns(section_order: index) # rubocop:disable Rails/SkipsModelValidations
+    post_boards.where(section_id: nil).order(:section_order).each_with_index do |pb, index|
+      next if pb.section_order == index
+      pb.update_columns(section_order: index) # rubocop:disable Rails/SkipsModelValidations
     end
   end
 end

--- a/app/models/board_section.rb
+++ b/app/models/board_section.rb
@@ -4,7 +4,8 @@ class BoardSection < ApplicationRecord
   include Presentable
 
   belongs_to :board, inverse_of: :board_sections, optional: false
-  has_many :posts, inverse_of: :section, foreign_key: :section_id, dependent: false # This is handled in callbacks
+  has_many :post_boards, inverse_of: :section, foreign_key: :section_id, dependent: false # This is handled in callbacks
+  has_many :posts, through: :post_boards
 
   validates :name, presence: true, length: { maximum: 255 }
 
@@ -16,9 +17,8 @@ class BoardSection < ApplicationRecord
 
   def clear_section_ids
     # if the parent board is already being destroyed, we'll handle this in board#move_posts_to_sandbox
-    # this avoids intermediate Post callbacks triggered by the section_id change that have no board present
     return if destroyed_by_association&.active_record == Board
-    UpdateModelJob.perform_later(Post.to_s, { section_id: id }, { section_id: nil }, audited_user_id)
+    UpdateModelJob.perform_later(PostBoard.to_s, { section_id: id }, { section_id: nil }, audited_user_id)
   end
 
   def ordered_attributes

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -49,7 +49,6 @@ class Post < ApplicationRecord
   validate :validate_post_boards
 
   before_validation :set_last_user, on: :create
-  before_save :resolve_main_board_conflict
   before_create :build_initial_flat_post, :set_timestamps
   before_update :set_timestamps
   after_commit :notify_followers, on: :create
@@ -325,15 +324,29 @@ class Post < ApplicationRecord
     super
   end
 
-  delegate :board=, to: :ensure_main_post_board
+  # rubocop:disable Rails/Delegate -- delegate's generated nil-target guard is unreachable
+  # here (ensure_main_post_board always returns a membership), leaving permanently
+  # uncovered branches; explicit writers have no dead code.
+  def board=(value)
+    ensure_main_post_board.board = value
+  end
 
-  delegate :board_id=, to: :ensure_main_post_board
+  def board_id=(value)
+    ensure_main_post_board.board_id = value
+  end
 
-  delegate :section=, to: :ensure_main_post_board
+  def section=(value)
+    ensure_main_post_board.section = value
+  end
 
-  delegate :section_id=, to: :ensure_main_post_board
+  def section_id=(value)
+    ensure_main_post_board.section_id = value
+  end
 
-  delegate :section_order=, to: :ensure_main_post_board
+  def section_order=(value)
+    ensure_main_post_board.section_order = value
+  end
+  # rubocop:enable Rails/Delegate
 
   # board_id, section_id, and section_order have moved from posts to post_boards;
   # redirect raw column writes so callers that skip callbacks still find them.
@@ -454,14 +467,6 @@ class Post < ApplicationRecord
         errors.add(error.attribute, error.message)
       end
     end
-  end
-
-  # When the main board changes to one that's already a secondary, the partial unique
-  # index (post_id, is_main=TRUE) and the (post_id, board_id) index would both collide.
-  # Drop that secondary in the same transaction so the main row can move freely.
-  def resolve_main_board_conflict
-    return unless main_post_board&.board_id_changed? && main_post_board.board_id.present?
-    post_boards.where(is_main: false, board_id: main_post_board.board_id).destroy_all
   end
 
   # Adjacency is within post_board's continuity and section; the (post_id, board_id)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -445,11 +445,6 @@ class Post < ApplicationRecord
   end
 
   def validate_post_boards
-    # Force-load post_boards so validation sees DB state for existing posts where
-    # the has_many target wasn't otherwise populated (e.g. main was loaded only via
-    # the has_one :main_post_board cache).
-    post_boards.load if persisted? && !post_boards.loaded?
-
     candidates = post_boards.target.dup
     candidates << main_post_board if main_post_board && candidates.exclude?(main_post_board)
     active = candidates.reject(&:marked_for_destruction?)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -347,15 +347,22 @@ class Post < ApplicationRecord
     super(remaining)
   end
 
-  def prev_post(user)
-    adjacent_posts_for(user) do |relation|
-      relation.reverse_order.where('post_boards.section_order < ?', section_order).first
+  # The post's membership in the given continuity (its main one if none is given), or nil
+  # for a continuity the post isn't in — callers treat that as not found.
+  def post_board_for(board_id)
+    return main_post_board if board_id.blank?
+    post_boards.find_by(board_id: board_id)
+  end
+
+  def prev_post(user, post_board=main_post_board)
+    adjacent_posts_for(user, post_board) do |relation|
+      relation.reverse_order.where('post_boards.section_order < ?', post_board.section_order).first
     end
   end
 
-  def next_post(user)
-    adjacent_posts_for(user) do |relation|
-      relation.where('post_boards.section_order > ?', section_order).first
+  def next_post(user, post_board=main_post_board)
+    adjacent_posts_for(user, post_board) do |relation|
+      relation.where('post_boards.section_order > ?', post_board.section_order).first
     end
   end
 
@@ -457,12 +464,13 @@ class Post < ApplicationRecord
     post_boards.where(is_main: false, board_id: main_post_board.board_id).destroy_all
   end
 
-  def adjacent_posts_for(user)
-    pb = main_post_board
-    return unless pb&.board&.ordered?
-    return unless pb.section_id || pb.board.board_sections.empty?
+  # Adjacency is within post_board's continuity and section; the (post_id, board_id)
+  # unique index means the join yields one row per post, main or secondary.
+  def adjacent_posts_for(user, post_board=main_post_board)
+    return unless post_board&.board&.ordered?
+    return unless post_board.section_id || post_board.board.board_sections.empty?
     yield Post.joins(:post_boards)
-      .where(post_boards: { board_id: pb.board_id, section_id: pb.section_id, is_main: true })
+      .where(post_boards: { board_id: post_board.board_id, section_id: post_board.section_id })
       .visible_to(user)
       .ordered_in_section
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -390,7 +390,7 @@ class Post < ApplicationRecord
       end
     end
 
-    desired_ids = desired.map { |d| d[:board_id] }
+    desired_ids = desired.pluck(:board_id)
     post_boards.target.each do |pb|
       next if pb.marked_for_destruction?
       pb.mark_for_destruction unless desired_ids.include?(pb.board_id)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -46,9 +46,10 @@ class Post < ApplicationRecord
 
   validates :subject, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 255 }
-  validate :validate_main_post_board
+  validate :validate_post_boards
 
   before_validation :set_last_user, on: :create
+  before_save :resolve_main_board_conflict
   before_create :build_initial_flat_post, :set_timestamps
   before_update :set_timestamps
   after_commit :notify_followers, on: :create
@@ -358,6 +359,50 @@ class Post < ApplicationRecord
     end
   end
 
+  # Reconcile post_boards (main + secondaries) against the form's submitted state.
+  # Caller must wrap in a transaction with post.save!.
+  def assign_continuities(main_board_id:, main_section_id: nil, secondaries: nil)
+    main_id = main_board_id.presence&.to_i
+    desired = []
+    desired << { board_id: main_id, section_id: main_section_id.presence&.to_i, is_main: true } if main_id
+    Array(secondaries).each do |s|
+      bid = s[:board_id].to_i
+      next if bid.zero? || bid == main_id || desired.any? { |d| d[:board_id] == bid }
+      desired << { board_id: bid, section_id: s[:section_id].presence&.to_i, is_main: false }
+    end
+
+    post_boards.load if persisted?
+
+    # Pre-pass: demote any persisted is_main row that is NOT staying main, so the partial
+    # unique index (where: 'is_main = TRUE') can't collide while we update other rows.
+    if persisted?
+      post_boards.target.each do |pb|
+        next unless pb.persisted? && pb.is_main?
+        keep_as_main = desired.any? { |d| d[:board_id] == pb.board_id && d[:is_main] }
+        pb.update!(is_main: false) unless keep_as_main
+      end
+    end
+
+    desired_ids = desired.map { |d| d[:board_id] }
+    post_boards.target.each do |pb|
+      next if pb.marked_for_destruction?
+      pb.mark_for_destruction unless desired_ids.include?(pb.board_id)
+    end
+
+    desired.each do |d|
+      pb = post_boards.target.find { |x| x.board_id == d[:board_id] && !x.marked_for_destruction? }
+      if pb
+        pb.section_id = d[:section_id]
+        pb.is_main = d[:is_main]
+      else
+        post_boards.build(board_id: d[:board_id], section_id: d[:section_id], is_main: d[:is_main])
+      end
+    end
+
+    new_main = post_boards.target.find { |pb| pb.is_main && !pb.marked_for_destruction? }
+    association(:main_post_board).target = new_main
+  end
+
   private
 
   # Sums the word counts of the given replies, falling back to computing the
@@ -379,17 +424,37 @@ class Post < ApplicationRecord
     pb
   end
 
-  def validate_main_post_board
-    pb = main_post_board || post_boards.detect { |x| x.is_main && !x.marked_for_destruction? }
-    if pb.nil? || pb.marked_for_destruction? || (pb.board_id.blank? && pb.board.blank?)
+  def validate_post_boards
+    # Force-load post_boards so validation sees DB state for existing posts where
+    # the has_many target wasn't otherwise populated (e.g. main was loaded only via
+    # the has_one :main_post_board cache).
+    post_boards.load if persisted? && !post_boards.loaded?
+
+    candidates = post_boards.target.dup
+    candidates << main_post_board if main_post_board && candidates.exclude?(main_post_board)
+    active = candidates.reject(&:marked_for_destruction?)
+    main_pb = active.find(&:is_main)
+
+    if main_pb.nil? || (main_pb.board_id.blank? && main_pb.board.blank?)
       errors.add(:board, "must exist")
       return
     end
-    return if pb.valid?
-    pb.errors.each do |error|
-      next if error.attribute == :board && error.message == "must exist" # already handled above
-      errors.add(error.attribute, error.message)
+
+    active.each do |pb|
+      next if pb.valid?
+      pb.errors.each do |error|
+        next if pb == main_pb && error.attribute == :board && error.message == "must exist"
+        errors.add(error.attribute, error.message)
+      end
     end
+  end
+
+  # When the main board changes to one that's already a secondary, the partial unique
+  # index (post_id, is_main=TRUE) and the (post_id, board_id) index would both collide.
+  # Drop that secondary in the same transaction so the main row can move freely.
+  def resolve_main_board_conflict
+    return unless main_post_board&.board_id_changed? && main_post_board.board_id.present?
+    post_boards.where(is_main: false, board_id: main_post_board.board_id).destroy_all
   end
 
   def adjacent_posts_for(user)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Post < ApplicationRecord
   include Concealable
-  include Orderable
   include Owable
   include PgSearch::Model
   include Post::Status
@@ -9,8 +8,12 @@ class Post < ApplicationRecord
   include Viewable
   include Writable
 
-  belongs_to :board, inverse_of: :posts, optional: false
-  belongs_to :section, class_name: 'BoardSection', inverse_of: :posts, optional: true
+  has_many :post_boards, inverse_of: :post, dependent: :destroy, autosave: true, validate: false
+  has_many :boards, through: :post_boards
+  has_one :main_post_board, -> { where(is_main: true) }, class_name: 'PostBoard',
+    inverse_of: :post, autosave: true, validate: false, dependent: false # Destroyed via has_many :post_boards
+  has_one :board, through: :main_post_board, source: :board
+  has_one :section, through: :main_post_board, source: :section
   belongs_to :last_user, class_name: 'User', inverse_of: false, optional: false
   belongs_to :last_reply, class_name: 'Reply', inverse_of: false, optional: true
   has_one :flat_post, dependent: :destroy
@@ -43,7 +46,7 @@ class Post < ApplicationRecord
 
   validates :subject, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 255 }
-  validate :valid_board, :valid_board_section
+  validate :validate_main_post_board
 
   before_validation :set_last_user, on: :create
   before_create :build_initial_flat_post, :set_timestamps
@@ -51,7 +54,7 @@ class Post < ApplicationRecord
   after_commit :notify_followers, on: :create
   after_commit :invalidate_caches, on: :update
 
-  NON_EDITED_ATTRS = %w(id created_at updated_at edited_at tagged_at last_user_id last_reply_id section_order)
+  NON_EDITED_ATTRS = %w(id created_at updated_at edited_at tagged_at last_user_id last_reply_id)
   NON_TAGGED_ATTRS = %w(icon_id character_alias_id character_id)
   audited except: NON_EDITED_ATTRS, update_with_comment_only: false
   has_associated_audits
@@ -67,13 +70,15 @@ class Post < ApplicationRecord
 
   scope :ordered, -> { order(tagged_at: :desc).order(Arel.sql('lower(subject) asc'), id: :asc) }
 
-  scope :ordered_in_section, -> { order(section_order: :asc) }
+  scope :ordered_in_section, -> { order('post_boards.section_order ASC') }
 
   scope :ordered_by_id, -> { order(id: :asc) }
 
   scope :ordered_by_index, -> { order('index_posts.section_order asc') }
 
-  scope :no_tests, -> { where.not(board_id: Board::ID_SITETESTING) }
+  scope :no_tests, -> {
+    where.not(id: PostBoard.where(board_id: Board::ID_SITETESTING, is_main: true).select(:post_id))
+  }
 
   # rubocop:disable Style/TrailingCommaInArguments
   scope :with_has_content_warnings, -> {
@@ -114,7 +119,8 @@ class Post < ApplicationRecord
 
   scope :not_ignored_by, ->(user) {
     joins("LEFT JOIN post_views ON post_views.post_id = posts.id AND post_views.user_id = #{user.id}")
-      .joins("LEFT JOIN board_views on board_views.board_id = posts.board_id AND board_views.user_id = #{user.id}")
+      .joins("LEFT JOIN post_boards ON post_boards.post_id = posts.id AND post_boards.is_main = TRUE")
+      .joins("LEFT JOIN board_views ON board_views.board_id = post_boards.board_id AND board_views.user_id = #{user.id}")
       .where(post_views: { ignored: [nil, false] })
       .where(board_views: { ignored: [nil, false] })
   }
@@ -291,12 +297,65 @@ class Post < ApplicationRecord
     NotifyFollowersOfNewPostJob.perform_later(self.id, user.id)
   end
 
+  def board_id
+    return read_attribute(:board_id) if has_attribute?(:board_id)
+    main_post_board&.board_id
+  end
+
+  def section_id
+    return read_attribute(:section_id) if has_attribute?(:section_id)
+    main_post_board&.section_id
+  end
+
+  def section_order
+    return read_attribute(:section_order) if has_attribute?(:section_order)
+    main_post_board&.section_order
+  end
+
+  # has_one :through reads via DB query, which returns nil for unpersisted posts
+  # because post_id isn't set yet. Fall through to the in-memory main_post_board.
+  def board
+    return main_post_board&.board unless persisted?
+    super
+  end
+
+  def section
+    return main_post_board&.section unless persisted?
+    super
+  end
+
+  delegate :board=, to: :ensure_main_post_board
+
+  delegate :board_id=, to: :ensure_main_post_board
+
+  delegate :section=, to: :ensure_main_post_board
+
+  delegate :section_id=, to: :ensure_main_post_board
+
+  delegate :section_order=, to: :ensure_main_post_board
+
+  # board_id, section_id, and section_order have moved from posts to post_boards;
+  # redirect raw column writes so callers that skip callbacks still find them.
+  POST_BOARD_DELEGATED_COLUMNS = %i[board_id section_id section_order].freeze
+
+  def update_columns(attributes)
+    delegated = attributes.slice(*POST_BOARD_DELEGATED_COLUMNS)
+    remaining = attributes.except(*POST_BOARD_DELEGATED_COLUMNS)
+    main_post_board.update_columns(delegated) if delegated.any? && main_post_board # rubocop:disable Rails/SkipsModelValidations
+    return true if remaining.empty?
+    super(remaining)
+  end
+
   def prev_post(user)
-    adjacent_posts_for(user) { |relation| relation.reverse_order.find_by('section_order < ?', self.section_order) }
+    adjacent_posts_for(user) do |relation|
+      relation.reverse_order.where('post_boards.section_order < ?', section_order).first
+    end
   end
 
   def next_post(user)
-    adjacent_posts_for(user) { |relation| relation.find_by('section_order > ?', self.section_order) }
+    adjacent_posts_for(user) do |relation|
+      relation.where('post_boards.section_order > ?', section_order).first
+    end
   end
 
   private
@@ -311,23 +370,36 @@ class Post < ApplicationRecord
     cached + uncached
   end
 
+  def ensure_main_post_board
+    return main_post_board if main_post_board && !main_post_board.marked_for_destruction?
+    in_memory = post_boards.target.detect { |x| x.is_main && !x.marked_for_destruction? } if post_boards.loaded?
+    return in_memory if in_memory
+    pb = post_boards.build(is_main: true)
+    association(:main_post_board).target = pb
+    pb
+  end
+
+  def validate_main_post_board
+    pb = main_post_board || post_boards.detect { |x| x.is_main && !x.marked_for_destruction? }
+    if pb.nil? || pb.marked_for_destruction? || (pb.board_id.blank? && pb.board.blank?)
+      errors.add(:board, "must exist")
+      return
+    end
+    return if pb.valid?
+    pb.errors.each do |error|
+      next if error.attribute == :board && error.message == "must exist" # already handled above
+      errors.add(error.attribute, error.message)
+    end
+  end
+
   def adjacent_posts_for(user)
-    return unless board.ordered?
-    return unless section || board.board_sections.empty?
-    yield Post.where(board_id: self.board_id, section_id: self.section_id).visible_to(user).ordered_in_section
-  end
-
-  def valid_board
-    return unless board_id.present?
-    return unless new_record? || board_id_changed?
-    return if board.open_to?(user)
-    errors.add(:board, "is invalid – you must be able to write in it")
-  end
-
-  def valid_board_section
-    return unless section.present?
-    return if section.board_id == board_id
-    errors.add(:section, "must be in the post's board")
+    pb = main_post_board
+    return unless pb&.board&.ordered?
+    return unless pb.section_id || pb.board.board_sections.empty?
+    yield Post.joins(:post_boards)
+      .where(post_boards: { board_id: pb.board_id, section_id: pb.section_id, is_main: true })
+      .visible_to(user)
+      .ordered_in_section
   end
 
   def set_last_user
@@ -349,10 +421,6 @@ class Post < ApplicationRecord
 
   def skip_tagged
     (changed_attributes.keys - NON_TAGGED_ATTRS - NON_EDITED_ATTRS).empty?
-  end
-
-  def ordered_attributes
-    [:section_id, :board_id]
   end
 
   def build_initial_flat_post

--- a/app/models/post_board.rb
+++ b/app/models/post_board.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+class PostBoard < ApplicationRecord
+  include Orderable
+
+  belongs_to :post, inverse_of: :post_boards, optional: false
+  belongs_to :board, inverse_of: :post_boards, optional: false
+  belongs_to :section, class_name: 'BoardSection', inverse_of: :post_boards, optional: true
+
+  validates :post, uniqueness: { scope: :board }
+  validate :section_in_board
+  validate :user_writes_in_board
+
+  after_create :sync_board_cameos
+
+  scope :main, -> { where(is_main: true) }
+  scope :ordered_in_section, -> { order(section_order: :asc) }
+
+  private
+
+  def ordered_attributes
+    [:section_id, :board_id]
+  end
+
+  def section_in_board
+    return if section.nil?
+    return if section.board_id == board_id
+    errors.add(:section, "must belong to this continuity")
+  end
+
+  def user_writes_in_board
+    return unless board && post&.user
+    return unless new_record? || board_id_changed?
+    return if board.open_to?(post.user)
+    errors.add(:board, "is invalid – the post's author must be able to write in it")
+  end
+
+  def sync_board_cameos
+    return if is_main?
+    post.send(:cameo_authors_into, board)
+  end
+end

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -19,11 +19,12 @@ class PostPresenter
   end
 
   def includeless_json(post)
-    attrs = %w(id subject description created_at tagged_at status section_order)
+    attrs = %w(id subject description created_at tagged_at status)
     post_json = post.as_json_without_presenter(only: attrs)
     post_json.merge({
       board: post.board,
       section: post.section,
+      section_order: post.section_order,
       authors: post.joined_authors.ordered,
       num_replies: post.reply_count,
     })

--- a/app/services/post_importer.rb
+++ b/app/services/post_importer.rb
@@ -30,7 +30,7 @@ class PostImporter < Object
 
   def validate_duplicate!(board_id)
     subject = dreamwidth_doc.at_css('.entry .entry-title').text.strip
-    subj_post = Post.where(subject: subject, board_id: board_id).first
+    subj_post = Post.joins(:post_boards).where(subject: subject, post_boards: { board_id: board_id, is_main: true }).first
     return unless subj_post
     raise AlreadyImported.new("This thread has already been imported! " + ScrapePostJob.view_post(subj_post.id))
   end

--- a/app/services/post_scraper.rb
+++ b/app/services/post_scraper.rb
@@ -108,8 +108,9 @@ class PostScraper < Object
 
     # detect already imported
     # skip if it's a threaded import, unless a subject was given manually
-    if (@subject || !@threaded_import) && (subj_post = Post.find_by(subject: subject, board_id: @board_id))
-      raise AlreadyImportedError.new("This thread has already been imported", subj_post.id)
+    if @subject || !@threaded_import
+      subj_post = Post.joins(:post_boards).where(subject: subject, post_boards: { board_id: @board_id, is_main: true }).first
+      raise AlreadyImportedError.new("This thread has already been imported", subj_post.id) if subj_post
     end
 
     scraper = ReplyScraper.new(@post, console: @console_import)

--- a/app/services/reply/searcher.rb
+++ b/app/services/reply/searcher.rb
@@ -69,8 +69,12 @@ class Reply::Searcher < Generic::Searcher
       # Subqueries instead of pluck+IN so PG can use a hash/index join on
       # board_id rather than serializing a thousands-long id list and
       # falling off the index. Has caused statement_timeout in production.
-      @search_results = @search_results.where(post_id: PostBoard.where(board_id: board_id).select(:post_id)) if board_id.present?
-      @search_results = @search_results.where.not(post_id: PostBoard.where(board_id: exclude_board_ids).select(:post_id)) if exclude_board_ids.present?
+      if board_id.present?
+        @search_results = @search_results.where(post_id: PostBoard.where(board_id: board_id).select(:post_id))
+      end
+      if exclude_board_ids.present?
+        @search_results = @search_results.where.not(post_id: PostBoard.where(board_id: exclude_board_ids).select(:post_id))
+      end
     end
   end
 

--- a/app/services/reply/searcher.rb
+++ b/app/services/reply/searcher.rb
@@ -69,7 +69,7 @@ class Reply::Searcher < Generic::Searcher
       # Subqueries instead of pluck+IN so PG can use a hash/index join on
       # board_id rather than serializing a thousands-long id list and
       # falling off the index. Has caused statement_timeout in production.
-      if board_id.present?
+      if board_id.present?  # rubocop:disable Style/IfUnlessModifier
         @search_results = @search_results.where(post_id: PostBoard.where(board_id: board_id).select(:post_id))
       end
       if exclude_board_ids.present?

--- a/app/services/reply/searcher.rb
+++ b/app/services/reply/searcher.rb
@@ -65,12 +65,12 @@ class Reply::Searcher < Generic::Searcher
   def filter_parents(board_id, exclude_board_ids=nil)
     if @post
       @search_results = @search_results.where(post_id: @post.id)
-    else
+    elsif board_id.present? || exclude_board_ids.present?
       # Subqueries instead of pluck+IN so PG can use a hash/index join on
       # board_id rather than serializing a thousands-long id list and
       # falling off the index. Has caused statement_timeout in production.
-      @search_results = @search_results.where(post_id: Post.where(board_id: board_id).select(:id)) if board_id.present?
-      @search_results = @search_results.where.not(post_id: Post.where(board_id: exclude_board_ids).select(:id)) if exclude_board_ids.present?
+      @search_results = @search_results.where(post_id: PostBoard.where(board_id: board_id).select(:post_id)) if board_id.present?
+      @search_results = @search_results.where.not(post_id: PostBoard.where(board_id: exclude_board_ids).select(:post_id)) if exclude_board_ids.present?
     end
   end
 

--- a/app/services/reply/searcher.rb
+++ b/app/services/reply/searcher.rb
@@ -69,7 +69,7 @@ class Reply::Searcher < Generic::Searcher
       # Subqueries instead of pluck+IN so PG can use a hash/index join on
       # board_id rather than serializing a thousands-long id list and
       # falling off the index. Has caused statement_timeout in production.
-      if board_id.present?  # rubocop:disable Style/IfUnlessModifier
+      if board_id.present? # rubocop:disable Style/IfUnlessModifier
         @search_results = @search_results.where(post_id: PostBoard.where(board_id: board_id).select(:post_id))
       end
       if exclude_board_ids.present?

--- a/app/views/board_sections/edit.haml
+++ b/app/views/board_sections/edit.haml
@@ -12,7 +12,7 @@
     .editor-title Edit #{@board_section.name}
     = render 'editor', f: f
 
-- if @section_posts.present?
+- if @posts.present?
   %br
   %br
   - reset_cycle
@@ -27,7 +27,7 @@
         = image_tag "icons/accept.png", title: 'Saved', class: 'vmid', alt: ''
         Saved
     %ul.sortable.table-list
-      - @section_posts.each do |post|
+      - @posts.each do |post|
         %li.section-ordered{class: cycle('even', 'odd'), data: { id: post.id, type: post.class.to_s, order: post.section_order }}
           .section-ordered-handle
             = image_tag "icons/arrow_double.png", title: 'Reorder', class: 'disabled-arrow', alt: '↕'

--- a/app/views/board_sections/edit.haml
+++ b/app/views/board_sections/edit.haml
@@ -12,7 +12,7 @@
     .editor-title Edit #{@board_section.name}
     = render 'editor', f: f
 
-- if @posts.present?
+- if @section_posts.present?
   %br
   %br
   - reset_cycle
@@ -27,7 +27,7 @@
         = image_tag "icons/accept.png", title: 'Saved', class: 'vmid', alt: ''
         Saved
     %ul.sortable.table-list
-      - @posts.each do |post|
+      - @section_posts.each do |post|
         %li.section-ordered{class: cycle('even', 'odd'), data: { id: post.id, type: post.class.to_s, order: post.section_order }}
           .section-ordered-handle
             = image_tag "icons/arrow_double.png", title: 'Reorder', class: 'disabled-arrow', alt: '↕'

--- a/app/views/board_sections/show.haml
+++ b/app/views/board_sections/show.haml
@@ -22,4 +22,4 @@
   - content_for :post_list_description do
     = sanitize_simple_link_text(@board_section.description)
 
-= render 'posts/list', posts: @posts, hide_continuity: true
+= render 'posts/list', posts: @posts, hide_continuity: true, board: @board_section.board

--- a/app/views/boards/show.haml
+++ b/app/views/boards/show.haml
@@ -48,7 +48,7 @@
             %td.written-content{colspan: 5, class: cycle('even', 'odd')}= shortened_desc(section.description, section.id)
         - section_posts = posts_from_relation(section.posts.ordered_in_section, no_tests: false, with_pagination: false)
         - if section_posts.present?
-          = render partial: 'posts/list_item', collection: section_posts, as: :post, locals: { hide_continuity: true }
+          = render partial: 'posts/list_item', collection: section_posts, as: :post, locals: { hide_continuity: true, board: @board }
         - else
           %tr
             %td.centered.padding-10.no-posts{ class: cycle('even', 'odd'), colspan: 6 } — No posts yet —
@@ -56,7 +56,7 @@
           %td.continuity-spacer{colspan: 5}
 
       - if @board_sections.methods.include?(:total_pages) && @board_sections.current_page == @board_sections.total_pages
-        = render partial: 'posts/list_item', collection: @posts, as: :post, locals: { hide_continuity: true }
+        = render partial: 'posts/list_item', collection: @posts, as: :post, locals: { hide_continuity: true, board: @board }
 
     - if @board_sections.methods.include?(:total_pages) && @board_sections.total_pages > 1
       %tfoot
@@ -66,4 +66,4 @@
   - if @board.description.present?
     - content_for :post_list_description do
       = sanitize_written_content(@board.description)
-  = render 'posts/list', posts: @posts, hide_continuity: true
+  = render 'posts/list', posts: @posts, hide_continuity: true, board: @board

--- a/app/views/posts/_breadcrumbs.haml
+++ b/app/views/posts/_breadcrumbs.haml
@@ -1,12 +1,14 @@
--# locals: ( post:, subtitle: nil )
+-# locals: ( post:, subtitle: nil, post_board: nil )
 
+-# post_board is the membership whose continuity/section the trail shows; main by default.
+- post_board ||= post.main_post_board
 - content_for :breadcrumbs do
   = link_to "Continuities", continuities_path
   &raquo;
-  = link_to post.board.name, continuity_path(post.board)
-  - if post.section
+  = link_to post_board.board.name, continuity_path(post_board.board)
+  - if post_board.section
     &raquo;
-    = link_to post.section.name, board_section_path(post.section)
+    = link_to post_board.section.name, board_section_path(post_board.section)
   &raquo;
   - if subtitle.nil?
     %b= post.subject

--- a/app/views/posts/_list.haml
+++ b/app/views/posts/_list.haml
@@ -1,4 +1,4 @@
--# locals: ( posts:, table_class: '', hide_continuity: false, show_unread_count: false, check_box_name: nil, colored: false )
+-# locals: ( posts:, table_class: '', hide_continuity: false, show_unread_count: false, check_box_name: nil, colored: false, board: nil )
 
 - col_count = 5
 - col_count += 1 unless hide_continuity # Include continuity name

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -1,4 +1,4 @@
--# locals: ( post:, index: nil, hide_continuity: false, show_unread_count: false, check_box_name: nil, check_box_padding: false, colored: false, klass: cycle('even', 'odd') )
+-# locals: ( post:, index: nil, hide_continuity: false, show_unread_count: false, check_box_name: nil, check_box_padding: false, colored: false, board: nil, klass: cycle('even', 'odd') )
 
 %tr
   - replies_count = post.reply_count
@@ -16,15 +16,15 @@
   %td.post-subject.vtop{class: klass}
     - if logged_in?
       - if unread_post?(post, unread_ids) || (@show_unread && !opened_post?(post, opened_ids))
-        = link_to unread_path(post) do
+        = link_to unread_path(post, board) do
           = image_tag unread_img, class: 'vmid mobile-target', title: 'First Unread', alt: 'First Unread'
       - elsif @show_unread
-        = link_to unread_path(post) do
+        = link_to unread_path(post, board) do
           = image_tag lastlink_img, class: 'vmid mobile-target', title: 'First Unread', alt: 'Jump To End'
     - if logged_in? && @opened_ids.present? && @opened_ids.exclude?(post.id)
-      %b= link_to post.subject, post_path(post), title: strip_tags(post.description)
+      %b= link_to post.subject, post_in_board_path(post, board), title: strip_tags(post.description)
     - else
-      = link_to post.subject, post_path(post), title: strip_tags(post.description)
+      = link_to post.subject, post_in_board_path(post, board), title: strip_tags(post.description)
     - if !@hide_quicklinks && (!logged_in? || per_page > 0)
       - total_pages = (replies_count.to_f / per_page).ceil
       - if total_pages > 1
@@ -33,14 +33,14 @@
             - params = {}
             - total_pages.times do |index|
               - params[:page] = index + 1 unless index == 0
-              = link_to (index + 1), post_path(post, params)
+              = link_to (index + 1), post_in_board_path(post, board, **params)
           - else
-            = link_to 1, post_path(post)
-            = link_to 2, post_path(post, page: 2)
-            = link_to 3, post_path(post, page: 3)
+            = link_to 1, post_in_board_path(post, board)
+            = link_to 2, post_in_board_path(post, board, page: 2)
+            = link_to 3, post_in_board_path(post, board, page: 3)
             \...
             - (total_pages - 2).upto(total_pages) do |index|
-              = link_to index, post_path(post, page: index)
+              = link_to index, post_in_board_path(post, board, page: index)
   - unless hide_continuity
     %td.post-board.vtop{class: klass}
       = link_to anchored_continuity_path(post), title: post.section_name do

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -22,9 +22,9 @@
         = link_to unread_path(post, board) do
           = image_tag lastlink_img, class: 'vmid mobile-target', title: 'First Unread', alt: 'Jump To End'
     - if logged_in? && @opened_ids.present? && @opened_ids.exclude?(post.id)
-      %b= link_to post.subject, post_in_board_path(post, board), title: strip_tags(post.description)
+      %b= link_to post.subject, post_in_continuity_path(post, board), title: strip_tags(post.description)
     - else
-      = link_to post.subject, post_in_board_path(post, board), title: strip_tags(post.description)
+      = link_to post.subject, post_in_continuity_path(post, board), title: strip_tags(post.description)
     - if !@hide_quicklinks && (!logged_in? || per_page > 0)
       - total_pages = (replies_count.to_f / per_page).ceil
       - if total_pages > 1
@@ -33,14 +33,14 @@
             - params = {}
             - total_pages.times do |index|
               - params[:page] = index + 1 unless index == 0
-              = link_to (index + 1), post_in_board_path(post, board, **params)
+              = link_to (index + 1), post_in_continuity_path(post, board, **params)
           - else
-            = link_to 1, post_in_board_path(post, board)
-            = link_to 2, post_in_board_path(post, board, page: 2)
-            = link_to 3, post_in_board_path(post, board, page: 3)
+            = link_to 1, post_in_continuity_path(post, board)
+            = link_to 2, post_in_continuity_path(post, board, page: 2)
+            = link_to 3, post_in_continuity_path(post, board, page: 3)
             \...
             - (total_pages - 2).upto(total_pages) do |index|
-              = link_to index, post_in_board_path(post, board, page: index)
+              = link_to index, post_in_continuity_path(post, board, page: index)
   - unless hide_continuity
     %td.post-board.vtop{class: klass}
       = link_to anchored_continuity_path(post), title: post.section_name do

--- a/app/views/posts/_secondary_membership.haml
+++ b/app/views/posts/_secondary_membership.haml
@@ -12,4 +12,3 @@
         include_blank: '— Choose Section —'
   - else
     = hidden_field_tag "post[secondary_memberships][][section_id]", ''
-  

--- a/app/views/posts/_secondary_membership.haml
+++ b/app/views/posts/_secondary_membership.haml
@@ -1,0 +1,15 @@
+-# locals: ( post_board: )
+
+- board = post_board.board
+- sections = board.board_sections.ordered
+.secondary-membership-row{data: { board_id: board.id }}
+  %b= board.name
+  = hidden_field_tag "post[secondary_memberships][][board_id]", board.id
+  - if sections.any?
+    \  section:
+    = select_tag "post[secondary_memberships][][section_id]",
+        options_from_collection_for_select(sections, :id, :name, post_board.section_id),
+        include_blank: '— Choose Section —'
+  - else
+    = hidden_field_tag "post[secondary_memberships][][section_id]", ''
+  

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -2,6 +2,8 @@
 
 = form_for post, html: { id: 'post_form' } do |f|
   - content_for :form do
+    - if params[:continuity_id]
+      = hidden_field_tag :continuity_id, params[:continuity_id]
     - unless post.id.present? && !post.editable_by?(current_user)
       %button.view-button#rtf{type: 'button', class: ('selected' if @post.editor_mode == 'rtf')} Rich Text
       %button.view-button#md{type: 'button', class: ('selected' if @post.editor_mode == 'md')} Markdown

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -45,6 +45,14 @@
     #section{class: ('hidden' unless post.board&.board_sections&.exists?)}
       = f.label :section_id, 'Continuity section:'
       = f.select :section_id, options_from_collection_for_select(BoardSection.where(board_id: post.board_id).ordered, :id, :name, post.section_id), include_blank: '— Choose Section —'
+    = label_tag 'post_secondary_board_ids', 'Other continuities:'
+    - secondary_post_boards = post.persisted? ? post.post_boards.where(is_main: false).includes(:board, :section) : []
+    = select_tag 'post[secondary_board_ids][]',
+        options_from_collection_for_select(allowed_secondary_boards(post, current_user), :id, :name, secondary_post_boards.map(&:board_id)),
+        multiple: true, id: 'post_secondary_board_ids'
+    #secondary-sections
+      - secondary_post_boards.each do |pb|
+        = render partial: 'posts/secondary_membership', locals: { post_board: pb }
     = f.label :privacy, 'Privacy:'
     = f.select :privacy, options_from_collection_for_select(post_privacy_settings.to_a, :second, :first, post.privacy)
     #access_list

--- a/app/views/posts/show.haml
+++ b/app/views/posts/show.haml
@@ -1,4 +1,4 @@
-= render 'posts/breadcrumbs', post: @post
+= render 'posts/breadcrumbs', post: @post, post_board: @post_board
 
 %span.time-loaded= pretty_time(DateTime.now.in_time_zone)
 
@@ -177,10 +177,10 @@
 - if @prev_post || @next_post
   .post-navheader
     - if @next_post
-      = link_to post_path(@next_post), class: 'view-button-link' do
+      = link_to adjacent_post_path(@next_post), class: 'view-button-link' do
         .view-button Next Post &raquo;
     - if @prev_post
-      = link_to post_path(@prev_post), class: 'view-button-link float-left' do
+      = link_to adjacent_post_path(@prev_post), class: 'view-button-link float-left' do
         .view-button &laquo; Previous Post
 - if page.to_i == 1
   = render 'replies/single', reply: @post, split_ui: split_ui
@@ -197,10 +197,10 @@
   - if @prev_post || @next_post
     .post-navheader
       - if @next_post
-        = link_to post_path(@next_post), class: 'view-button-link' do
+        = link_to adjacent_post_path(@next_post), class: 'view-button-link' do
           .view-button Next Post &raquo;
       - if @prev_post
-        = link_to post_path(@prev_post), class: 'view-button-link float-left' do
+        = link_to adjacent_post_path(@prev_post), class: 'view-button-link float-left' do
           .view-button &laquo; Previous Post
 - if @post.on_hiatus? && (@replies.empty? || (@replies.last.id == @post.last_reply_id))
   .post-ender This Thread Is On Hiatus

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -45,10 +45,10 @@
             = image_tag "icons/link.png".freeze, title: 'Permalink'.freeze, alt: 'Permalink'.freeze
           - if !current_user.try(:default_hide_edit_delete_buttons) || params[:show_all_reply_buttons] == "true"
             - if reply.editable_by?(current_user) || (reply.is_a?(Post) && reply.metadata_editable_by?(current_user))
-              = link_to path_for(reply, 'edit_%s') do
+              = link_to path_for(reply, 'edit_%s', continuity_id: @secondary_board&.id) do
                 = image_tag "icons/pencil.png".freeze, title: 'Edit'.freeze, alt: 'Edit'.freeze
             - if reply.deletable_by?(current_user)
-              = link_to path_for(reply, '%s'), method: :delete, data: { confirm: "Are you sure you wish to delete this #{reply.class.to_s.downcase}?" } do
+              = link_to path_for(reply, '%s', continuity_id: @secondary_board&.id), method: :delete, data: { confirm: "Are you sure you wish to delete this #{reply.class.to_s.downcase}?" } do
                 = image_tag "icons/cross.png".freeze, title: 'Delete'.freeze, alt: 'Delete'.freeze
           - if reply.is_a?(Reply) && logged_in?
             - if !current_user.try(:default_hide_add_bookmark_button) || params[:show_all_reply_buttons] == "true"

--- a/app/views/replies/_write.haml
+++ b/app/views/replies/_write.haml
@@ -23,6 +23,8 @@
     = hidden_field_tag :allow_dupe, @allow_dupe
     - if params[:per_page]
       = hidden_field_tag :per_page, params[:per_page]
+    - if params[:continuity_id]
+      = hidden_field_tag :continuity_id, params[:continuity_id]
     #post-form-wrapper
       = f.text_area :content, class: 'tinymce'
       - unless current_user.id == reply.user_id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,10 @@ Rails.application.routes.draw do
       post :mark
       get :search
     end
+    # Board-scoped views of a post/reply, so a post reachable from a secondary
+    # continuity can present itself in that continuity's context. See Post#post_board_for.
+    resources :posts, only: :show
+    resources :replies, only: :show
   end
   resources :board_sections, except: :index
   resources :posts do

--- a/db/migrate/20260706200955_unify_post_boards.rb
+++ b/db/migrate/20260706200955_unify_post_boards.rb
@@ -16,31 +16,35 @@ class UnifyPostBoards < ActiveRecord::Migration[8.0]
       where: "is_main = TRUE",
       name: "index_post_boards_one_main_per_post"
 
-    execute <<-SQL
-INSERT INTO post_boards (post_id, board_id, section_id, section_order, is_main, created_at, updated_at)
-SELECT id, board_id, section_id, section_order, TRUE, NOW(), NOW()
-FROM posts;
+    execute <<~SQL.squish
+      INSERT INTO post_boards (post_id, board_id, section_id, section_order, is_main, created_at, updated_at)
+      SELECT id, board_id, section_id, section_order, TRUE, NOW(), NOW()
+      FROM posts;
     SQL
 
     remove_index :posts, name: "index_posts_on_board_id"
-    remove_column :posts, :section_order
-    remove_column :posts, :section_id
-    remove_column :posts, :board_id
+    change_table :posts, bulk: true do |t|
+      t.remove :section_order
+      t.remove :section_id
+      t.remove :board_id
+    end
   end
 
   def down
-    add_column :posts, :board_id, :integer
-    add_column :posts, :section_id, :integer
-    add_column :posts, :section_order, :integer
+    change_table :posts, bulk: true do |t|
+      t.integer :board_id
+      t.integer :section_id
+      t.integer :section_order
+    end
     add_index :posts, :board_id
 
-    execute <<-SQL
-UPDATE posts
-SET board_id = pb.board_id,
-    section_id = pb.section_id,
-    section_order = pb.section_order
-FROM post_boards pb
-WHERE pb.post_id = posts.id AND pb.is_main = TRUE;
+    execute <<~SQL.squish
+      UPDATE posts
+      SET board_id = pb.board_id,
+          section_id = pb.section_id,
+          section_order = pb.section_order
+      FROM post_boards pb
+      WHERE pb.post_id = posts.id AND pb.is_main = TRUE;
     SQL
 
     change_column_null :posts, :board_id, false

--- a/db/migrate/20260706200955_unify_post_boards.rb
+++ b/db/migrate/20260706200955_unify_post_boards.rb
@@ -1,0 +1,49 @@
+class UnifyPostBoards < ActiveRecord::Migration[8.0]
+  def up
+    create_table :post_boards do |t|
+      t.integer :post_id, null: false
+      t.integer :board_id, null: false
+      t.integer :section_id
+      t.integer :section_order
+      t.boolean :is_main, null: false, default: false
+      t.timestamps null: true
+    end
+
+    add_index :post_boards, [:post_id, :board_id], unique: true
+    add_index :post_boards, [:board_id, :section_id, :section_order],
+      name: "index_post_boards_on_board_section_order"
+    add_index :post_boards, :post_id, unique: true,
+      where: "is_main = TRUE",
+      name: "index_post_boards_one_main_per_post"
+
+    execute <<-SQL
+INSERT INTO post_boards (post_id, board_id, section_id, section_order, is_main, created_at, updated_at)
+SELECT id, board_id, section_id, section_order, TRUE, NOW(), NOW()
+FROM posts;
+    SQL
+
+    remove_index :posts, name: "index_posts_on_board_id"
+    remove_column :posts, :section_order
+    remove_column :posts, :section_id
+    remove_column :posts, :board_id
+  end
+
+  def down
+    add_column :posts, :board_id, :integer
+    add_column :posts, :section_id, :integer
+    add_column :posts, :section_order, :integer
+    add_index :posts, :board_id
+
+    execute <<-SQL
+UPDATE posts
+SET board_id = pb.board_id,
+    section_id = pb.section_id,
+    section_order = pb.section_order
+FROM post_boards pb
+WHERE pb.post_id = posts.id AND pb.is_main = TRUE;
+    SQL
+
+    change_column_null :posts, :board_id, false
+    drop_table :post_boards
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_06_200955) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -318,6 +318,19 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
     t.index ["user_id"], name: "index_post_authors_on_user_id"
   end
 
+  create_table "post_boards", force: :cascade do |t|
+    t.integer "post_id", null: false
+    t.integer "board_id", null: false
+    t.integer "section_id"
+    t.integer "section_order"
+    t.boolean "is_main", default: false, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["board_id", "section_id", "section_order"], name: "index_post_boards_on_board_section_order"
+    t.index ["post_id", "board_id"], name: "index_post_boards_on_post_id_and_board_id", unique: true
+    t.index ["post_id"], name: "index_post_boards_one_main_per_post", unique: true, where: "(is_main = true)"
+  end
+
   create_table "post_tags", id: :serial, force: :cascade do |t|
     t.integer "post_id", null: false
     t.integer "tag_id", null: false
@@ -350,7 +363,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
   end
 
   create_table "posts", id: :serial, force: :cascade do |t|
-    t.integer "board_id", null: false
     t.integer "user_id", null: false
     t.string "subject", null: false
     t.text "content"
@@ -360,8 +372,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "status", default: 0
-    t.integer "section_id"
-    t.integer "section_order"
     t.string "description"
     t.integer "last_user_id"
     t.integer "last_reply_id"
@@ -372,7 +382,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
     t.string "editor_mode"
     t.index "to_tsvector('english'::regconfig, COALESCE((subject)::text, ''::text))", name: "idx_fts_post_subject", using: :gin
     t.index "to_tsvector('english'::regconfig, COALESCE(content, ''::text))", name: "idx_fts_post_content", using: :gin
-    t.index ["board_id"], name: "index_posts_on_board_id"
     t.index ["character_id"], name: "index_posts_on_character_id"
     t.index ["created_at"], name: "index_posts_on_created_at"
     t.index ["icon_id"], name: "index_posts_on_icon_id"

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe Api::V1::PostsController do
         posts = [visible1, *hidden, visible2]
 
         posts.each(&:reload)
-        expect(posts.map(&:section_order).to eq([0, 1, 2, 3]
+        expect(posts.map(&:section_order).to eq([0, 1, 2, 3])
 
         api_login_as(coauthor)
         post :reorder, params: { ordered_post_ids: [visible2.id, visible1.id] }

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -342,27 +342,24 @@ RSpec.describe Api::V1::PostsController do
       end
 
       it "anchors multiple consecutive hidden posts to the same predecessor" do
+        user = create(:user)
         coauthor = create(:user)
-        board = create(:board, writers: [coauthor])
-        visible1 = create(:post, board: board, user: board.creator)
-        hidden1 = create(:post, board: board, user: board.creator, privacy: :private)
-        hidden2 = create(:post, board: board, user: board.creator, privacy: :private)
-        visible2 = create(:post, board: board, user: board.creator)
+        board = create(:board, creator: user, writers: [coauthor])
+        visible1 = create(:post, board: board, user: user)
+        hidden = create_list(:post, 2, board: board, user: user, privacy: :private)
+        visible2 = create(:post, board: board, user: user)
+        posts = [visible1, *hidden, visible2]
 
-        expect(visible1.reload.section_order).to eq(0)
-        expect(hidden1.reload.section_order).to eq(1)
-        expect(hidden2.reload.section_order).to eq(2)
-        expect(visible2.reload.section_order).to eq(3)
+        posts.each(&:reload)
+        expect(posts.map(&:section_order).to eq([0, 1, 2, 3]
 
         api_login_as(coauthor)
         post :reorder, params: { ordered_post_ids: [visible2.id, visible1.id] }
         expect(response).to have_http_status(200)
 
         # both hidden posts followed visible1 → they stay, in original order, right after it
-        expect(visible2.reload.section_order).to eq(0)
-        expect(visible1.reload.section_order).to eq(1)
-        expect(hidden1.reload.section_order).to eq(2)
-        expect(hidden2.reload.section_order).to eq(3)
+        posts.each(&:reload)
+        expect(posts.map(&:section_order).to eq([1, 2, 3, 0]
       end
 
       it "omits posts not visible to the editor from the response" do

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe Api::V1::PostsController do
 
         # both hidden posts followed visible1 → they stay, in original order, right after it
         posts.each(&:reload)
-        expect(posts.map(&:section_order).to eq([1, 2, 3, 0]
+        expect(posts.map(&:section_order)).to eq([1, 2, 3, 0])
       end
 
       it "omits posts not visible to the editor from the response" do

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -341,6 +341,30 @@ RSpec.describe Api::V1::PostsController do
         expect(visible1.reload.section_order).to eq(2)
       end
 
+      it "anchors multiple consecutive hidden posts to the same predecessor" do
+        coauthor = create(:user)
+        board = create(:board, writers: [coauthor])
+        visible1 = create(:post, board: board, user: board.creator)
+        hidden1 = create(:post, board: board, user: board.creator, privacy: :private)
+        hidden2 = create(:post, board: board, user: board.creator, privacy: :private)
+        visible2 = create(:post, board: board, user: board.creator)
+
+        expect(visible1.reload.section_order).to eq(0)
+        expect(hidden1.reload.section_order).to eq(1)
+        expect(hidden2.reload.section_order).to eq(2)
+        expect(visible2.reload.section_order).to eq(3)
+
+        api_login_as(coauthor)
+        post :reorder, params: { ordered_post_ids: [visible2.id, visible1.id] }
+        expect(response).to have_http_status(200)
+
+        # both hidden posts followed visible1 → they stay, in original order, right after it
+        expect(visible2.reload.section_order).to eq(0)
+        expect(visible1.reload.section_order).to eq(1)
+        expect(hidden1.reload.section_order).to eq(2)
+        expect(hidden2.reload.section_order).to eq(3)
+      end
+
       it "omits posts not visible to the editor from the response" do
         coauthor = create(:user)
         board = create(:board, writers: [coauthor])

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -577,5 +577,39 @@ RSpec.describe Api::V1::PostsController do
         expect(hidden.reload.section_order).to eq(2)
       end
     end
+
+    context "with board_id" do
+      it "reorders posts within the given continuity, including secondary memberships" do
+        user = create(:user)
+        board = create(:board, creator: user)
+        main_post = create(:post, board_id: board.id)
+        secondary_post = create(:post, board_id: create(:board).id)
+        secondary_post.post_boards.create!(board: board)
+
+        expect(main_post.post_boards.find_by(board: board).section_order).to eq(0)
+        expect(secondary_post.post_boards.find_by(board: board).section_order).to eq(1)
+
+        api_login_as(user)
+        post :reorder, params: { ordered_post_ids: [secondary_post.id, main_post.id], board_id: board.id }
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body).to eq({ 'post_ids' => [secondary_post.id, main_post.id] })
+        expect(secondary_post.post_boards.find_by(board: board).section_order).to eq(0)
+        expect(main_post.post_boards.find_by(board: board).section_order).to eq(1)
+
+        # ordering in the secondary post's own main continuity is untouched
+        expect(secondary_post.main_post_board.reload.section_order).to eq(0)
+      end
+
+      it "requires posts to be in the given continuity" do
+        user = create(:user)
+        board = create(:board, creator: user)
+        outsider = create(:post)
+
+        api_login_as(user)
+        post :reorder, params: { ordered_post_ids: [outsider.id], board_id: board.id }
+        expect(response).to have_http_status(404)
+        expect(response.parsed_body['errors'][0]['message']).to eq("Some posts could not be found: #{outsider.id}")
+      end
+    end
   end
 end

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe Api::V1::PostsController do
         posts = [visible1, *hidden, visible2]
 
         posts.each(&:reload)
-        expect(posts.map(&:section_order).to eq([0, 1, 2, 3])
+        expect(posts.map(&:section_order)).to eq([0, 1, 2, 3])
 
         api_login_as(coauthor)
         post :reorder, params: { ordered_post_ids: [visible2.id, visible1.id] }

--- a/spec/controllers/board_sections_controller_spec.rb
+++ b/spec/controllers/board_sections_controller_spec.rb
@@ -204,8 +204,8 @@ RSpec.describe BoardSectionsController do
       private_post = create(:post, board: board, section: section, user: coauthor, privacy: :private)
       login_as(board.creator)
       get :edit, params: { id: section.id }
-      expect(assigns(:posts)).to eq([visible_post])
-      expect(assigns(:posts)).not_to include(private_post)
+      expect(assigns(:section_posts)).to eq([visible_post])
+      expect(assigns(:section_posts)).not_to include(private_post)
     end
   end
 

--- a/spec/controllers/board_sections_controller_spec.rb
+++ b/spec/controllers/board_sections_controller_spec.rb
@@ -204,8 +204,8 @@ RSpec.describe BoardSectionsController do
       private_post = create(:post, board: board, section: section, user: coauthor, privacy: :private)
       login_as(board.creator)
       get :edit, params: { id: section.id }
-      expect(assigns(:section_posts)).to eq([visible_post])
-      expect(assigns(:section_posts)).not_to include(private_post)
+      expect(assigns(:posts)).to eq([visible_post])
+      expect(assigns(:posts)).not_to include(private_post)
     end
   end
 

--- a/spec/controllers/bookmarks/create_spec.rb
+++ b/spec/controllers/bookmarks/create_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe BookmarksController, 'POST create' do
     expect(flash[:error]).to eq("You must be logged in to view that page.")
   end
 
+  it "returns to the referring page" do
+    board = create(:board)
+    reply.post.post_boards.create!(board: board)
+    login_as(user)
+    request.env['HTTP_REFERER'] = continuity_post_url(board, reply.post)
+    post :create, params: { at_id: reply.id }
+    expect(response).to redirect_to(continuity_post_url(board, reply.post) + "#reply-#{reply.id}")
+    expect(flash[:success]).to eq("Bookmark added.")
+  end
+
   it "requires reply ID" do
     login
     post :create

--- a/spec/controllers/bookmarks/destroy_spec.rb
+++ b/spec/controllers/bookmarks/destroy_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe BookmarksController, 'DELETE destroy' do
     expect(flash[:error]).to eq("You must be logged in to view that page.")
   end
 
+  it "returns to the referring page" do
+    board = create(:board)
+    reply.post.post_boards.create!(board: board)
+    login_as(user)
+    request.env['HTTP_REFERER'] = continuity_post_url(board, reply.post)
+    delete :destroy, params: { id: bookmark.id }
+    expect(response).to redirect_to(continuity_post_url(board, reply.post) + "#reply-#{reply.id}")
+    expect(flash[:success]).to eq("Bookmark removed.")
+  end
+
   it "requires valid bookmark" do
     login
     delete :destroy, params: { id: -1 }

--- a/spec/controllers/drafts_controller_spec.rb
+++ b/spec/controllers/drafts_controller_spec.rb
@@ -9,6 +9,22 @@ RSpec.describe DraftsController do
       expect(response).to redirect_to(posts_url)
     end
 
+    it "returns to the continuity being viewed" do
+      user = create(:user)
+      reply_post = create(:post, user: user)
+      board = create(:board)
+      reply_post.post_boards.create!(board: board)
+      login_as(user)
+
+      post :create, params: {
+        button_draft: true,
+        reply: { post_id: reply_post.id, content: 'testcontent', editor_mode: 'html' },
+        continuity_id: board.id,
+      }
+      expect(response).to redirect_to(continuity_post_url(board, reply_post, page: :unread, anchor: :unread))
+      expect(flash[:success]).to eq("Draft saved.")
+    end
+
     it "creates a new draft if none exists" do
       user = create(:user)
       reply_post = create(:post, user: user)
@@ -95,5 +111,30 @@ RSpec.describe DraftsController do
     end
   end
 
-  describe 'DELETE destroy'
+  describe 'DELETE destroy' do
+    it "deletes the draft" do
+      user = create(:user)
+      reply_post = create(:post, user: user)
+      draft = create(:reply_draft, post: reply_post, user: user)
+      login_as(user)
+
+      delete :destroy, params: { id: draft.id, reply: { post_id: reply_post.id } }
+      expect(response).to redirect_to(post_url(reply_post, page: :unread, anchor: :unread))
+      expect(flash[:success]).to eq("Draft deleted.")
+      expect(ReplyDraft.count).to eq(0)
+    end
+
+    it "returns to the continuity being viewed" do
+      user = create(:user)
+      reply_post = create(:post, user: user)
+      board = create(:board)
+      reply_post.post_boards.create!(board: board)
+      draft = create(:reply_draft, post: reply_post, user: user)
+      login_as(user)
+
+      delete :destroy, params: { id: draft.id, reply: { post_id: reply_post.id }, continuity_id: board.id }
+      expect(response).to redirect_to(continuity_post_url(board, reply_post, page: :unread, anchor: :unread))
+      expect(flash[:success]).to eq("Draft deleted.")
+    end
+  end
 end

--- a/spec/controllers/posts/create_spec.rb
+++ b/spec/controllers/posts/create_spec.rb
@@ -450,6 +450,22 @@ RSpec.describe PostsController, 'POST create' do
       expect(PostTag.count).to eq(9)
     end
 
+    it "creates secondary continuities" do
+      board2 = create(:board)
+      post :create, params: {
+        post: {
+          subject: 'multi continuity post',
+          board_id: board.id,
+          secondary_memberships: [{ board_id: board2.id.to_s, section_id: '' }],
+        },
+      }
+      created = assigns(:post)
+      expect(response).to redirect_to(post_url(created))
+      expect(flash[:success]).to eq("Post created.")
+      expect(created.boards).to match_array([board, board2])
+      expect(created.board).to eq(board)
+    end
+
     it "creates NPCs" do
       expect {
         post :create, params: {

--- a/spec/controllers/posts/show_spec.rb
+++ b/spec/controllers/posts/show_spec.rb
@@ -352,5 +352,59 @@ RSpec.describe PostsController, 'GET show' do
       expect(assigns(:reply)).to be_nil
     end
   end
+
+  context "with continuity_id" do
+    let(:secondary) { create(:board) }
+
+    before(:each) { post.post_boards.create!(board: secondary) }
+
+    it "shows the post through the secondary continuity" do
+      get :show, params: { id: post.id, continuity_id: secondary.id }
+      expect(response).to have_http_status(200)
+      expect(assigns(:post_board)).to eq(post.post_board_for(secondary.id))
+      expect(assigns(:secondary_board)).to eq(secondary)
+      expect(assigns(:paginate_params)[:continuity_id]).to eq(secondary.id)
+    end
+
+    it "treats the main continuity as the default view" do
+      get :show, params: { id: post.id, continuity_id: post.board_id }
+      expect(response).to have_http_status(200)
+      expect(assigns(:secondary_board)).to be_nil
+      expect(assigns(:paginate_params)).not_to have_key(:continuity_id)
+    end
+
+    it "requires a continuity the post is in" do
+      get :show, params: { id: post.id, continuity_id: create(:board).id }
+      expect(response).to redirect_to(continuities_url)
+      expect(flash[:error]).to eq("Post could not be found.")
+    end
+
+    it "keeps the canonical URL on the main continuity" do
+      get :show, params: { id: post.id, continuity_id: secondary.id }
+      expect(assigns(:meta_canonical)).to eq(post_url(post))
+    end
+
+    it "calculates OpenGraph meta through the secondary continuity" do
+      user = create(:user, username: 'example user')
+      post = create(:post, subject: 'title', user: user, board: create(:board, name: 'board'))
+      other = create(:board, name: 'other continuity')
+      post.post_boards.create!(board: other)
+
+      get :show, params: { id: post.id, continuity_id: other.id }
+
+      meta_og = assigns(:meta_og)
+      expect(meta_og[:url]).to eq(post_url(post))
+      expect(meta_og[:title]).to eq('title · other continuity')
+    end
+
+    it "navigates between posts within the secondary continuity" do
+      secondary.update!(authors_locked: true)
+      nextp = create(:post, user: secondary.creator, board: secondary)
+
+      get :show, params: { id: post.id, continuity_id: secondary.id }
+      expect(assigns(:prev_post)).to be_nil
+      expect(assigns(:next_post)).to eq(nextp)
+    end
+  end
   # TODO WAY more tests
 end

--- a/spec/controllers/posts/update_spec.rb
+++ b/spec/controllers/posts/update_spec.rb
@@ -90,6 +90,15 @@ RSpec.describe PostsController, 'PUT update' do
     Post.auditing_enabled = false
   end
 
+  it "preserves the continuity being viewed on redirect" do
+    secondary = create(:board)
+    user_post.post_boards.create!(board: secondary)
+    login_as(user)
+    put :update, params: { id: user_post.id, post: { description: 'new' }, continuity_id: secondary.id }
+    expect(response).to redirect_to(continuity_post_url(secondary, user_post))
+    expect(flash[:success]).to eq("Post updated.")
+  end
+
   context "mark unread" do
     let(:unread_reply) { build(:reply, post: post) }
 

--- a/spec/controllers/replies/create_spec.rb
+++ b/spec/controllers/replies/create_spec.rb
@@ -543,7 +543,37 @@ RSpec.describe RepliesController, 'POST create' do
     expect(reply.reply_order).to eq(2)
   end
 
+  it "returns new replies to the continuity being viewed" do
+    user = create(:user)
+    reply_post = create(:post, user: user)
+    board = create(:board)
+    reply_post.post_boards.create!(board: board)
+    login_as(user)
+
+    post :create, params: { reply: { post_id: reply_post.id, content: 'test content!', editor_mode: 'html' }, continuity_id: board.id }
+    reply = reply_post.replies.ordered.last
+    expect(response).to redirect_to(continuity_reply_url(board, reply, anchor: "reply-#{reply.id}"))
+    expect(flash[:success]).to eq("Reply posted.")
+  end
+
   context "with button_discard_multi_reply" do
+    it "returns to the reply being edited in its continuity" do
+      user = create(:user)
+      reply = create(:reply, user: user)
+      board = create(:board)
+      reply.post.post_boards.create!(board: board)
+      login_as(user)
+
+      post :create, params: {
+        multi_replies_json: [{ id: reply.id }].to_json,
+        button_discard_multi_reply: true,
+        reply: { post_id: reply.post_id },
+        continuity_id: board.id,
+      }
+      expect(response).to redirect_to(continuity_reply_url(board, reply, anchor: "reply-#{reply.id}"))
+      expect(flash[:success]).to eq("Replies discarded.")
+    end
+
     it "returns to unread in the continuity being viewed" do
       user = create(:user)
       reply_post = create(:post, user: user)

--- a/spec/controllers/replies/create_spec.rb
+++ b/spec/controllers/replies/create_spec.rb
@@ -542,4 +542,24 @@ RSpec.describe RepliesController, 'POST create' do
     expect(reply.content).to eq(searchable)
     expect(reply.reply_order).to eq(2)
   end
+
+  context "with button_discard_multi_reply" do
+    it "returns to unread in the continuity being viewed" do
+      user = create(:user)
+      reply_post = create(:post, user: user)
+      board = create(:board)
+      reply_post.post_boards.create!(board: board)
+      login_as(user)
+
+      post :create, params: { reply: { post_id: reply_post.id }, button_discard_multi_reply: true, continuity_id: board.id }
+      expect(response).to redirect_to(continuity_post_url(board, reply_post, page: :unread, anchor: :unread))
+      expect(flash[:success]).to eq("Replies discarded.")
+    end
+
+    it "tolerates an unknown post" do
+      login
+      post :create, params: { reply: { post_id: 0 }, button_discard_multi_reply: true }
+      expect(response).to redirect_to(post_url(0, page: :unread, anchor: :unread))
+    end
+  end
 end

--- a/spec/controllers/replies/destroy_spec.rb
+++ b/spec/controllers/replies/destroy_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe RepliesController, 'DELETE destroy' do
     expect(Reply.find_by(id: reply.id)).to be_nil
   end
 
+  it "preserves the continuity being viewed on redirect" do
+    reply = create(:reply)
+    board = create(:board)
+    reply.post.post_boards.create!(board: board)
+    login_as(reply.user)
+    delete :destroy, params: { id: reply.id, continuity_id: board.id }
+    expect(response).to redirect_to(continuity_post_url(board, reply.post, page: 1))
+    expect(flash[:success]).to eq("Reply deleted.")
+  end
+
   it "succeeds for admin user" do
     reply = create(:reply)
     login_as(create(:admin_user))

--- a/spec/controllers/replies/destroy_spec.rb
+++ b/spec/controllers/replies/destroy_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe RepliesController, 'DELETE destroy' do
     expect(flash[:error]).to eq("You do not have permission to modify this reply.")
   end
 
+  it "keeps the continuity when denying permission" do
+    reply = create(:reply)
+    board = create(:board)
+    reply.post.post_boards.create!(board: board)
+    login
+    delete :destroy, params: { id: reply.id, continuity_id: board.id }
+    expect(response).to redirect_to(continuity_post_url(board, reply.post))
+    expect(flash[:error]).to eq("You do not have permission to modify this reply.")
+  end
+
   it "succeeds for reply creator" do
     reply = create(:reply)
     login_as(reply.user)
@@ -145,5 +155,20 @@ RSpec.describe RepliesController, 'DELETE destroy' do
     expect(response).to redirect_to(reply_url(reply, anchor: "reply-#{reply.id}"))
     expect(flash[:error]).to eq("Reply could not be deleted.")
     expect(post.reload.replies).to eq([reply])
+  end
+
+  it "keeps the continuity on destroy failure" do
+    post = create(:post)
+    reply = create(:reply, user: post.user, post: post)
+    board = create(:board)
+    post.post_boards.create!(board: board)
+    login_as(post.user)
+
+    allow(Reply).to receive(:find_by).and_call_original
+    allow(Reply).to receive(:find_by).with({ id: reply.id.to_s }).and_return(reply)
+    allow(reply).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed, 'fake error')
+
+    delete :destroy, params: { id: reply.id, continuity_id: board.id }
+    expect(response).to redirect_to(continuity_reply_url(board, reply, anchor: "reply-#{reply.id}"))
   end
 end

--- a/spec/controllers/replies/show_spec.rb
+++ b/spec/controllers/replies/show_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe RepliesController, 'GET show' do
     expect(assigns(:javascripts)).to include('posts/show')
   end
 
+  it "shows the reply through a secondary continuity" do
+    board = create(:board)
+    reply.post.post_boards.create!(board: board)
+    get :show, params: { id: reply.id, continuity_id: board.id }
+    expect(response).to have_http_status(200)
+    expect(assigns(:secondary_board)).to eq(board)
+  end
+
+  it "requires a continuity the post is in" do
+    get :show, params: { id: reply.id, continuity_id: create(:board).id }
+    expect(response).to redirect_to(continuities_url)
+    expect(flash[:error]).to eq("Post could not be found.")
+  end
+
   it "works for reader accounts" do
     login_as(create(:reader_user))
     get :show, params: { id: reply.id }

--- a/spec/controllers/replies/update_spec.rb
+++ b/spec/controllers/replies/update_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe RepliesController, 'PUT update' do
     expect(flash[:error]).to eq("You do not have permission to modify this reply.")
   end
 
+  it "keeps the continuity when denying edit permission" do
+    reply = create(:reply)
+    board = create(:board)
+    reply.post.post_boards.create!(board: board)
+    login
+    put :update, params: { id: reply.id, continuity_id: board.id }
+    expect(response).to redirect_to(continuity_post_url(board, reply.post))
+    expect(flash[:error]).to eq("You do not have permission to modify this reply.")
+  end
+
   it "requires notes from moderators" do
     reply = create(:reply)
     login_as(create(:admin_user))

--- a/spec/controllers/replies/update_spec.rb
+++ b/spec/controllers/replies/update_spec.rb
@@ -99,6 +99,36 @@ RSpec.describe RepliesController, 'PUT update' do
     expect(reply.character_alias_id).to eq(calias.id)
   end
 
+  it "preserves the continuity being viewed on redirect" do
+    user = create(:user)
+    reply = create(:reply, user: user)
+    board = create(:board)
+    reply.post.post_boards.create!(board: board)
+    login_as(user)
+
+    put :update, params: { id: reply.id, reply: { content: 'new content' }, continuity_id: board.id }
+    expect(response).to redirect_to(continuity_reply_url(board, reply, anchor: "reply-#{reply.id}"))
+    expect(flash[:success]).to eq("Reply updated.")
+  end
+
+  it "redirects flat when the viewed continuity is the main one" do
+    user = create(:user)
+    reply = create(:reply, user: user)
+    login_as(user)
+
+    put :update, params: { id: reply.id, reply: { content: 'new content' }, continuity_id: reply.post.board_id }
+    expect(response).to redirect_to(reply_url(reply, anchor: "reply-#{reply.id}"))
+  end
+
+  it "redirects flat for a continuity the post is not in" do
+    user = create(:user)
+    reply = create(:reply, user: user)
+    login_as(user)
+
+    put :update, params: { id: reply.id, reply: { content: 'new content' }, continuity_id: create(:board).id }
+    expect(response).to redirect_to(reply_url(reply, anchor: "reply-#{reply.id}"))
+  end
+
   it "preserves reply_order" do
     reply_post = create(:post)
     login_as(reply_post.user)

--- a/spec/helpers/post_helper_spec.rb
+++ b/spec/helpers/post_helper_spec.rb
@@ -1,34 +1,34 @@
 RSpec.describe PostHelper do
-  describe "#post_in_board_path" do
+  describe "#post_in_continuity_path" do
     let(:post) { create(:post) }
 
     it "gives the flat path with no continuity" do
-      expect(helper.post_in_board_path(post)).to eq(post_path(post))
-      expect(helper.post_in_board_path(post, nil, page: 2)).to eq(post_path(post, page: 2))
+      expect(helper.post_in_continuity_path(post)).to eq(post_path(post))
+      expect(helper.post_in_continuity_path(post, nil, page: 2)).to eq(post_path(post, page: 2))
     end
 
     it "gives the flat path for the post's main continuity" do
-      expect(helper.post_in_board_path(post, post.board)).to eq(post_path(post))
+      expect(helper.post_in_continuity_path(post, post.board)).to eq(post_path(post))
     end
 
     it "nests under a secondary continuity" do
       board = create(:board)
       post.post_boards.create!(board: board)
-      expect(helper.post_in_board_path(post, board, page: 2)).to eq(continuity_post_path(board, post, page: 2))
+      expect(helper.post_in_continuity_path(post, board, page: 2)).to eq(continuity_post_path(board, post, page: 2))
     end
   end
 
-  describe "#reply_in_board_path" do
+  describe "#reply_in_continuity_path" do
     let(:reply) { create(:reply) }
 
     it "gives the flat path with no continuity" do
       html = reply_path(reply, anchor: "reply-#{reply.id}")
-      expect(helper.reply_in_board_path(reply, nil, anchor: "reply-#{reply.id}")).to eq(html)
+      expect(helper.reply_in_continuity_path(reply, nil, anchor: "reply-#{reply.id}")).to eq(html)
     end
 
     it "nests under a continuity" do
       board = create(:board)
-      expect(helper.reply_in_board_path(reply, board)).to eq(continuity_reply_path(board, reply))
+      expect(helper.reply_in_continuity_path(reply, board)).to eq(continuity_reply_path(board, reply))
     end
   end
 

--- a/spec/helpers/post_helper_spec.rb
+++ b/spec/helpers/post_helper_spec.rb
@@ -1,4 +1,51 @@
 RSpec.describe PostHelper do
+  describe "#post_in_board_path" do
+    let(:post) { create(:post) }
+
+    it "gives the flat path with no continuity" do
+      expect(helper.post_in_board_path(post)).to eq(post_path(post))
+      expect(helper.post_in_board_path(post, nil, page: 2)).to eq(post_path(post, page: 2))
+    end
+
+    it "gives the flat path for the post's main continuity" do
+      expect(helper.post_in_board_path(post, post.board)).to eq(post_path(post))
+    end
+
+    it "nests under a secondary continuity" do
+      board = create(:board)
+      post.post_boards.create!(board: board)
+      expect(helper.post_in_board_path(post, board, page: 2)).to eq(continuity_post_path(board, post, page: 2))
+    end
+  end
+
+  describe "#reply_in_board_path" do
+    let(:reply) { create(:reply) }
+
+    it "gives the flat path with no continuity" do
+      html = reply_path(reply, anchor: "reply-#{reply.id}")
+      expect(helper.reply_in_board_path(reply, nil, anchor: "reply-#{reply.id}")).to eq(html)
+    end
+
+    it "nests under a continuity" do
+      board = create(:board)
+      expect(helper.reply_in_board_path(reply, board)).to eq(continuity_reply_path(board, reply))
+    end
+  end
+
+  describe "#unread_path" do
+    let(:post) { create(:post) }
+
+    it "defaults to the flat unread path" do
+      expect(helper.unread_path(post)).to eq(post_path(post, page: 'unread', anchor: 'unread'))
+    end
+
+    it "nests under a secondary continuity" do
+      board = create(:board)
+      html = continuity_post_path(board, post, page: 'unread', anchor: 'unread')
+      expect(helper.unread_path(post, board)).to eq(html)
+    end
+  end
+
   describe "#author_links" do
     let(:post) { create(:post) }
 

--- a/spec/helpers/writable_helper_spec.rb
+++ b/spec/helpers/writable_helper_spec.rb
@@ -272,11 +272,30 @@ RSpec.describe WritableHelper do
       expect(helper.post_or_reply_link(reply)).to be_nil
     end
 
-    it "delegates to post_or_reply_mem_link" do
+    it "handles a reply" do
       reply = create(:reply)
-      allow(helper).to receive(:post_or_reply_mem_link).and_call_original
-      expect(helper).to receive(:post_or_reply_mem_link).with(id: reply.id, klass: Reply)
-      helper.post_or_reply_link(reply)
+      html = reply_path(reply, anchor: "reply-#{reply.id}")
+      expect(helper.post_or_reply_link(reply)).to eq(html)
+    end
+
+    it "handles a post" do
+      post = create(:post)
+      expect(helper.post_or_reply_link(post)).to eq(post_path(post))
+    end
+
+    it "links a reply within the secondary continuity being viewed" do
+      reply = create(:reply)
+      board = create(:board)
+      assign(:secondary_board, board)
+      html = continuity_reply_path(board, reply, anchor: "reply-#{reply.id}")
+      expect(helper.post_or_reply_link(reply)).to eq(html)
+    end
+
+    it "links a post within the secondary continuity being viewed" do
+      post = create(:post)
+      board = create(:board)
+      assign(:secondary_board, board)
+      expect(helper.post_or_reply_link(post)).to eq(continuity_post_path(board, post))
     end
   end
 

--- a/spec/models/post_board_spec.rb
+++ b/spec/models/post_board_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe PostBoard do
+  describe "validations" do
+    it "requires a unique post and continuity pair" do
+      post = create(:post)
+      membership = post.post_boards.build(board: post.board)
+      expect(membership).not_to be_valid
+      expect(membership.errors[:post]).to be_present
+    end
+
+    it "requires the section to belong to the continuity" do
+      post = create(:post)
+      board = create(:board)
+      section = create(:board_section, board: create(:board))
+      membership = post.post_boards.build(board: board, section: section)
+      expect(membership).not_to be_valid
+      expect(membership.errors[:section]).to include("must belong to this continuity")
+    end
+
+    it "requires the post's author to be able to write in the continuity" do
+      post = create(:post)
+      locked = create(:board, authors_locked: true)
+      membership = post.post_boards.build(board: locked)
+      expect(membership).not_to be_valid
+      expect(membership.errors[:board]).to be_present
+    end
+
+    it "allows the post's author as a continuity writer" do
+      post = create(:post)
+      board = create(:board, authors_locked: true, writers: [post.user])
+      membership = post.post_boards.build(board: board)
+      expect(membership).to be_valid
+    end
+  end
+
+  describe "#sync_board_cameos" do
+    it "adds the post's other authors as cameos on locked secondary continuities" do
+      post = create(:post)
+      coauthor = create(:reply, post: post).user
+      board = create(:board, authors_locked: true, writers: [post.user])
+      post.post_boards.create!(board: board)
+      expect(board.board_authors.where(cameo: true).pluck(:user_id)).to include(coauthor.id)
+    end
+
+    it "does not add cameos to open continuities" do
+      post = create(:post)
+      coauthor = create(:reply, post: post).user
+      board = create(:board)
+      post.post_boards.create!(board: board)
+      expect(board.board_authors.where(cameo: true).pluck(:user_id)).not_to include(coauthor.id)
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1358,6 +1358,55 @@ RSpec.describe Post do
       expect(first.prev_post(user)).to be_nil
       expect(last.next_post(user)).to be_nil
     end
+
+    it "navigates within a secondary continuity when given its membership" do
+      other_board = create(:board, creator: user, authors_locked: true)
+      prev = create(:post, user: user, board: other_board)
+      post = create(:post, user: user, board: board, section: section)
+      post.post_boards.create!(board: other_board)
+      nextp = create(:post, user: user, board: other_board)
+
+      post_board = post.post_board_for(other_board.id)
+      expect(post.prev_post(user, post_board)).to eq(prev)
+      expect(post.next_post(user, post_board)).to eq(nextp)
+
+      # the default (main continuity) chain is unaffected
+      expect(post.prev_post(user)).to be_nil
+      expect(post.next_post(user)).to be_nil
+    end
+
+    it "includes posts there secondarily when navigating a continuity" do
+      board.update!(authors_locked: true)
+      prev = create(:post, user: user, board: board)
+      secondary = create(:post, user: user, board: create(:board, creator: user))
+      secondary.post_boards.create!(board: board)
+      post = create(:post, user: user, board: board)
+
+      expect(post.prev_post(user)).to eq(secondary)
+      expect(secondary.prev_post(user, secondary.post_board_for(board.id))).to eq(prev)
+      expect(secondary.next_post(user, secondary.post_board_for(board.id))).to eq(post)
+    end
+  end
+
+  describe "#post_board_for" do
+    it "returns the main membership with no continuity" do
+      post = create(:post)
+      expect(post.post_board_for(nil)).to eq(post.main_post_board)
+      expect(post.post_board_for('')).to eq(post.main_post_board)
+    end
+
+    it "returns the membership for a secondary continuity" do
+      post = create(:post)
+      board = create(:board)
+      membership = post.post_boards.create!(board: board)
+      expect(post.post_board_for(board.id)).to eq(membership)
+      expect(post.post_board_for(board.id.to_s)).to eq(membership)
+    end
+
+    it "returns nil for a continuity the post is not in" do
+      post = create(:post)
+      expect(post.post_board_for(create(:board).id)).to be_nil
+    end
   end
 
   context "scopes" do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1409,6 +1409,137 @@ RSpec.describe Post do
     end
   end
 
+  describe "#assign_continuities" do
+    let(:user) { create(:user) }
+    let(:board) { create(:board, creator: user) }
+    let(:board2) { create(:board, creator: user) }
+    let(:post) { create(:post, user: user, board: board) }
+
+    it "adds secondary continuities" do
+      post.assign_continuities(main_board_id: board.id, secondaries: [{ board_id: board2.id.to_s, section_id: '' }])
+      post.save!
+      post.reload
+      expect(post.boards).to match_array([board, board2])
+      expect(post.board).to eq(board)
+      expect(post.post_boards.find_by(board: board2).is_main).to eq(false)
+    end
+
+    it "skips blank, duplicate, and main-duplicating secondaries" do
+      post.assign_continuities(
+        main_board_id: board.id,
+        secondaries: [
+          { board_id: '' },
+          { board_id: board.id.to_s },
+          { board_id: board2.id.to_s },
+          { board_id: board2.id.to_s },
+        ],
+      )
+      post.save!
+      expect(post.reload.boards).to match_array([board, board2])
+    end
+
+    it "removes omitted secondaries" do
+      post.post_boards.create!(board: board2)
+      post.assign_continuities(main_board_id: board.id)
+      post.save!
+      expect(post.reload.boards).to eq([board])
+    end
+
+    it "moves the post to a new main continuity" do
+      post.assign_continuities(main_board_id: board2.id)
+      post.save!
+      post.reload
+      expect(post.board).to eq(board2)
+      expect(post.boards).to eq([board2])
+    end
+
+    it "promotes a secondary continuity to main" do
+      post.post_boards.create!(board: board2)
+      post.assign_continuities(main_board_id: board2.id, secondaries: [{ board_id: board.id }])
+      post.save!
+      post.reload
+      expect(post.board).to eq(board2)
+      expect(post.post_boards.find_by(board: board).is_main).to eq(false)
+      expect(post.boards).to match_array([board, board2])
+    end
+
+    it "updates a secondary's section" do
+      section2 = create(:board_section, board: board2)
+      membership = post.post_boards.create!(board: board2)
+      post.assign_continuities(main_board_id: board.id, secondaries: [{ board_id: board2.id.to_s, section_id: section2.id.to_s }])
+      post.save!
+      expect(membership.reload.section).to eq(section2)
+    end
+  end
+
+  describe "continuity membership plumbing" do
+    let(:user) { create(:user) }
+    let(:board) { create(:board, creator: user) }
+
+    it "rejects moving the main continuity directly onto an existing secondary" do
+      # promoting a secondary to main is assign_continuities' job; the raw writer refuses
+      # rather than creating a duplicate membership
+      board2 = create(:board, creator: user)
+      post = create(:post, user: user, board: board)
+      post.post_boards.create!(board: board2)
+      post.board = board2
+      expect(post).not_to be_valid
+      expect(post.errors[:post]).to be_present
+    end
+
+    it "reuses the in-memory main membership for repeated writes" do
+      post = Post.new(user: user)
+      post.board = board
+      post.section_order = 2
+      expect(post.post_boards.size).to eq(1)
+      expect(post.board).to eq(board)
+    end
+
+    it "exposes board and section on unpersisted posts" do
+      section = create(:board_section, board: board)
+      post = Post.new(user: user, board: board, section: section)
+      expect(post.board).to eq(board)
+      expect(post.section).to eq(section)
+    end
+
+    it "prefers selected columns over the membership attributes" do
+      post = create(:post, board: board)
+      fetched = Post.select("posts.*, 99 AS board_id, 98 AS section_id").find(post.id)
+      expect(fetched.board_id).to eq(99)
+      expect(fetched.section_id).to eq(98)
+    end
+
+    it "requires a main continuity" do
+      post = create(:post, board: board)
+      post.main_post_board.mark_for_destruction
+      expect(post).not_to be_valid
+      expect(post.errors[:board]).to include("must exist")
+    end
+
+    it "adds errors from invalid memberships" do
+      post = create(:post, board: board)
+      locked = create(:board, authors_locked: true) # post's author can't write there
+      post.post_boards.build(board: locked)
+      expect(post).not_to be_valid
+      expect(post.errors[:board]).to be_present
+    end
+
+    describe "#update_columns" do
+      it "redirects membership columns to the main membership" do
+        post = create(:post, board: board)
+        post.update_columns(section_order: 5) # rubocop:disable Rails/SkipsModelValidations
+        expect(post.main_post_board.reload.section_order).to eq(5)
+      end
+
+      it "splits membership columns from post columns" do
+        post = create(:post, board: board)
+        post.update_columns(subject: 'new subject', section_order: 7) # rubocop:disable Rails/SkipsModelValidations
+        expect(post.reload.subject).to eq('new subject')
+        expect(post.main_post_board.reload.section_order).to eq(7)
+      end
+    end
+  end
+
   context "scopes" do
     it "scopes unignored posts properly" do
       reader = create(:user)

--- a/spec/requests/boards_spec.rb
+++ b/spec/requests/boards_spec.rb
@@ -31,6 +31,27 @@ RSpec.describe "Continuities" do
       end
     end
 
+    it "renders read state and page links for listed posts" do
+      paged = create(:post, subject: "Paged Thread")
+      paged.post_boards.create!(board: board)
+      create_list(:reply, 7, post: paged, user: paged.user)
+      read_post = create(:post, board: board, subject: "Read Thread")
+      create_list(:reply, 2, post: read_post, user: read_post.user)
+
+      user = login
+      read_post.mark_read(user)
+
+      get "/boards/#{board.id}", params: { per_page: 1 }
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        # unopened post links bold, through the continuity being browsed, incl. page links
+        expect(response.body).to include("/boards/#{board.id}/posts/#{paged.id}?page=2")
+        expect(response.body).to include("/boards/#{board.id}/posts/#{paged.id}?page=7")
+        # opened post keeps flat main-continuity page links
+        expect(response.body).to include("/posts/#{read_post.id}?page=2")
+      end
+    end
+
     it "shows unfavorite" do
       user = login
       create(:favorite, user: user, favorite: board)

--- a/spec/requests/boards_spec.rb
+++ b/spec/requests/boards_spec.rb
@@ -17,6 +17,20 @@ RSpec.describe "Continuities" do
       expect(response).to render_template(:show)
     end
 
+    it "links posts through the continuity being browsed" do
+      shared = create(:post, subject: "Shared Thread")
+      shared.post_boards.create!(board: board)
+      native = create(:post, board: board, subject: "Native Thread")
+
+      get "/boards/#{board.id}"
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response.body).to include("/boards/#{board.id}/posts/#{shared.id}")
+        expect(response.body).to include("/posts/#{native.id}")
+        expect(response.body).not_to include("/boards/#{board.id}/posts/#{native.id}")
+      end
+    end
+
     it "shows unfavorite" do
       user = login
       create(:favorite, user: user, favorite: board)

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -2,11 +2,12 @@ RSpec.describe "Post" do
   describe "continuity-scoped display" do
     it "renders a post through a secondary continuity with its navigation" do
       user = create(:user, password: known_test_password)
-      board = create(:board, creator: user, authors_locked: true, name: "Browsed Continuity")
-      create(:post, user: user, board: board, subject: "First Thread")
+      board = create(:board, creator: user, name: "Browsed Continuity")
+      arc = create(:board_section, board: board, name: "Arc One")
+      create(:post, user: user, board: board, section: arc, subject: "First Thread")
       shared = create(:post, user: user, board: create(:board, creator: user), subject: "Shared Thread", status: :complete)
-      shared.post_boards.create!(board: board)
-      create(:post, user: user, board: board, subject: "Third Thread")
+      shared.post_boards.create!(board: board, section: arc)
+      create(:post, user: user, board: board, section: arc, subject: "Third Thread")
       login(user)
 
       get "/boards/#{board.id}/posts/#{shared.id}"
@@ -14,6 +15,7 @@ RSpec.describe "Post" do
         expect(response).to have_http_status(200)
         expect(response).to render_template(:show)
         expect(response.body).to include("Browsed Continuity")
+        expect(response.body).to include("Arc One")
         expect(response.body).to include("Previous Post")
         expect(response.body).to include("Next Post")
         expect(response.body).to include("Here Ends This Thread")
@@ -25,8 +27,10 @@ RSpec.describe "Post" do
       board = create(:board, creator: user)
       other = create(:board, creator: user, name: "Second Home")
       section = create(:board_section, board: other, name: "Away Arc")
+      plain = create(:board, creator: user, name: "Plain Home")
       target = create(:post, user: user, board: board)
       target.post_boards.create!(board: other, section: section)
+      target.post_boards.create!(board: plain)
       login(user)
 
       get "/posts/#{target.id}/edit", params: { continuity_id: other.id }
@@ -35,6 +39,7 @@ RSpec.describe "Post" do
         expect(response.body).to include("Other continuities")
         expect(response.body).to include("Second Home")
         expect(response.body).to include("Away Arc")
+        expect(response.body).to include("Plain Home")
       end
     end
   end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,4 +1,44 @@
 RSpec.describe "Post" do
+  describe "continuity-scoped display" do
+    it "renders a post through a secondary continuity with its navigation" do
+      user = create(:user, password: known_test_password)
+      board = create(:board, creator: user, authors_locked: true, name: "Browsed Continuity")
+      create(:post, user: user, board: board, subject: "First Thread")
+      shared = create(:post, user: user, board: create(:board, creator: user), subject: "Shared Thread", status: :complete)
+      shared.post_boards.create!(board: board)
+      create(:post, user: user, board: board, subject: "Third Thread")
+      login(user)
+
+      get "/boards/#{board.id}/posts/#{shared.id}"
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:show)
+        expect(response.body).to include("Browsed Continuity")
+        expect(response.body).to include("Previous Post")
+        expect(response.body).to include("Next Post")
+        expect(response.body).to include("Here Ends This Thread")
+      end
+    end
+
+    it "renders the post editor with its secondary memberships" do
+      user = create(:user, password: known_test_password)
+      board = create(:board, creator: user)
+      other = create(:board, creator: user, name: "Second Home")
+      section = create(:board_section, board: other, name: "Away Arc")
+      target = create(:post, user: user, board: board)
+      target.post_boards.create!(board: other, section: section)
+      login(user)
+
+      get "/posts/#{target.id}/edit", params: { continuity_id: other.id }
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response.body).to include("Other continuities")
+        expect(response.body).to include("Second Home")
+        expect(response.body).to include("Away Arc")
+      end
+    end
+  end
+
   describe "hidden list" do
     it "shows hidden posts" do
       user = login

--- a/spec/requests/replies_spec.rb
+++ b/spec/requests/replies_spec.rb
@@ -1,4 +1,21 @@
 RSpec.describe "Reply" do
+  describe "edit form" do
+    it "carries the continuity being viewed" do
+      user = create(:user, password: known_test_password)
+      reply = create(:reply, user: user)
+      board = create(:board)
+      reply.post.post_boards.create!(board: board)
+      login(user)
+
+      get "/replies/#{reply.id}/edit", params: { continuity_id: board.id }
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response.body).to include('name="continuity_id"')
+        expect(response.body).to include("value=\"#{board.id}\"")
+      end
+    end
+  end
+
   describe "search" do
     it "works" do
       create(:reply, content: "Sample reply")


### PR DESCRIPTION
## Summary

Posts can now belong to any number of continuities: one **main** continuity (as before) plus optional **secondary** memberships. A post can then be browsed, navigated, and shared *through* any continuity it belongs to, while keeping a single canonical identity.

Three pieces, mirroring the commits:

1. **Many-to-many model** — `posts.board_id/section_id/section_order` move to a new `post_boards` join table (`is_main` flag; per-membership section and ordering).
2. **Editor support** — an "Other continuities" multi-select on the post form, with a per-continuity section picker.
3. **Continuity-scoped viewing** — nested show routes `/boards/:continuity_id/posts/:id` (and `/replies/:id`), used by board pages when a post is there secondarily (not mandatory; if `boards/:continuity_id` is absent links will work as before pointing to the main continuity).

## Database

- New `post_boards` table: unique `(post_id, board_id)`; a partial unique index enforces exactly one `is_main` membership per post; `section_id`/`section_order` live per membership, so each continuity orders the post independently.
- The migration backfills a main membership for every existing post, then drops the old `posts` columns. Reversible.
- `Post#board_id/#section_id/#section_order` (readers and writers) delegate to the main membership, so the vast majority of existing code and queries are untouched.

## Behavior when viewing through a secondary continuity

- **Links**: a continuity's page links its posts through itself — nested URL iff the membership is secondary; a post's own main continuity always uses the plain flat URL.
- **Breadcrumbs, prev/next, pagination, reply permalinks** all follow the viewed continuity; prev/next chains include posts that are in the continuity secondarily.
- **Edit round-trips**: editing/deleting a reply, or editing the post itself, returns you to the continuity you came from.
- **Failure mode**: a continuity the post isn't in fails exactly like an unknown post id.
- **SEO**: `rel=canonical` and `og:url` always point at the flat main-continuity URL (no duplicate content); the OG title reflects the viewed continuity.
- **Unread tracking is unchanged**: read state is per-post (`Post::View`); the never-opened fallback still reads the main continuity's `BoardView`.
- **Reordering**: the reorder API takes an explicit `board_id`, so a continuity's edit pages can reorder posts that belong to it secondarily (each membership's ordering is independent).

## Testing

- New specs: membership resolution (`Post#post_board_for`), adjacency within secondary continuities (including mixed main/secondary chains), nested show (context assigns, canonical, OG, not-found), redirect round-trips for reply update/destroy and post update, reorder with explicit `board_id`, and the path helpers.

## Screenshots

*(1) The post editor's new "Other continuities" field:*
<img width="1280" height="757" alt="4-editor-other-continuities" src="https://github.com/user-attachments/assets/77570098-ccc8-4b11-97de-93f10d19a9d0" />

*(2) The same post listed on its main continuity's page and on a secondary continuity's page:*
<img width="1280" height="657" alt="5-silmaril-board-listing" src="https://github.com/user-attachments/assets/db0ce30e-77f1-4040-a1f9-43adb8dd696a" />
<img width="1280" height="757" alt="3-crossover-board-listing" src="https://github.com/user-attachments/assets/cb44401e-65a1-4d72-9172-022a893d09d8" />

*(3) The post viewed flat — its main continuity's breadcrumb:*
<img width="1280" height="757" alt="1-flat-main-continuity" src="https://github.com/user-attachments/assets/c8edb264-1d9e-4aa5-8ef0-9367f1fa5ee5" />

*(4) …and viewed through the secondary continuity (`/boards/10/posts/38`) — that continuity's breadcrumb, with prev/next navigating its section:*
<img width="1280" height="757" alt="2-viewed-through-secondary" src="https://github.com/user-attachments/assets/d7f63295-f3a0-44fc-9a15-e020a0d7fc99" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
