### PR TITLE
Preserve notifications page on mark; add per-page setting

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,7 +6,7 @@ class NotificationsController < ApplicationController
     @page_title = "Notifications"
     @notifications = current_user.notifications.visible_to(current_user).ordered
     @notifications = @notifications.not_ignored_by(current_user) if current_user&.hide_from_all
-    @notifications = @notifications.order(:created_at).paginate(page: page)
+    @notifications = @notifications.order(:created_at).paginate(page: page, per_page: notifications_per_page)
 
     post_ids = @notifications.map(&:post_id).compact_blank
     @posts = posts_from_relation(Post.where(id: post_ids), with_pagination: false).index_by(&:id)
@@ -26,10 +26,25 @@ class NotificationsController < ApplicationController
         notifications.destroy_all
       else
         flash[:error] = "Could not perform unknown action."
-        redirect_to notifications_path and return
+        redirect_to notifications_path(page: current_page) and return
     end
 
     flash[:success] = "Notifications updated"
-    redirect_to notifications_path
+    redirect_to notifications_path(page: current_page)
+  end
+
+  private
+
+  # Preserve the page the user was on so marking/deleting keeps them in place,
+  # while leaving page 1 as a clean /notifications URL.
+  def current_page
+    page > 1 ? page : nil
+  end
+
+  def notifications_per_page
+    per = current_user.notifications_per_page || 25
+    per = 100 if per.to_i > 100
+    per = 25 if per.to_i.zero?
+    per.to_i
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -250,6 +250,7 @@ class UsersController < ApplicationController
       :password_confirmation,
       :email_notifications,
       :per_page,
+      :notifications_per_page,
       :timezone,
       :icon_picker_grouping,
       :default_view,

--- a/app/views/notifications/index.haml
+++ b/app/views/notifications/index.haml
@@ -1,5 +1,6 @@
 .content-header Notifications
 = form_tag mark_notifications_path, method: :post do
+  = hidden_field_tag :page, page
   %table
     %thead
       %tr

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -32,6 +32,9 @@
         = f.check_box :favorite_notifications
         = f.label :favorite_notifications, 'Notify when a favorited author makes a new post'
     %div
+      .sub= f.label :notifications_per_page, 'Paging'
+      %div{class: cycle('even', 'odd')}= f.select(:notifications_per_page, per_page_options(current_user.notifications_per_page))
+    %div
       .sub= f.label :timezone, 'Time zone'
       %div{class: cycle('even', 'odd')}= f.select(:timezone, timezone_options(current_user.timezone))
     %div

--- a/db/migrate/20260716000000_add_notifications_per_page_to_users.rb
+++ b/db/migrate/20260716000000_add_notifications_per_page_to_users.rb
@@ -1,0 +1,5 @@
+class AddNotificationsPerPageToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :notifications_per_page, :integer, default: 25
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_16_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -504,6 +504,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
     t.boolean "default_hide_edit_delete_buttons", default: false
     t.boolean "default_hide_add_bookmark_button", default: false
     t.boolean "moiety_colors_unread", default: false
+    t.integer "notifications_per_page", default: 25
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe NotificationsController do
       expect(flash[:error]).not_to be_present
     end
 
+    it "respects the notifications_per_page setting" do
+      user.update!(notifications_per_page: 10)
+      create_list(:notification, 15, user: user)
+      login_as(user)
+      get :index
+      expect(assigns(:notifications).per_page).to eq(10)
+      expect(assigns(:notifications).size).to eq(10)
+      expect(flash[:error]).not_to be_present
+    end
+
     it "respects post visibility" do
       create(:notification, user: user, notification_type: :new_favorite_post, post: create(:post, privacy: :private))
       create(:notification, user: user, notification_type: :new_favorite_post, post: create(:post, privacy: :access_list))
@@ -146,6 +156,18 @@ RSpec.describe NotificationsController do
         login_as(notification.user)
         post :mark, params: { marked_ids: [notification.id.to_s], commit: "Mark Unread" }
         expect(notification.reload.unread).to eq(true)
+      end
+
+      it "redirects back to the page the user was on" do
+        login_as(notification.user)
+        post :mark, params: { marked_ids: [notification.id.to_s], commit: "Mark Unread", page: 11 }
+        expect(response).to redirect_to(notifications_url(page: 11))
+      end
+
+      it "redirects to the first page without a page param" do
+        login_as(notification.user)
+        post :mark, params: { marked_ids: [notification.id.to_s], commit: "Mark Unread", page: 1 }
+        expect(response).to redirect_to(notifications_url)
       end
     end
 


### PR DESCRIPTION
Marking notifications read/unread/deleted previously redirected to the first page of notifications, losing the user's place when acting on a later page. The mark form now submits the current page and the controller redirects back to it (page 1 stays a clean /notifications URL).

Also add a separate notifications_per_page user setting (default 25) so the number of notifications shown per page can be configured independently of the posts-per-page setting.

https://discord.com/channels/521407923629457428/608751226364100619/1526649500544929843

Claude-Session: https://claude.ai/code/session_01N65s218z4Lmiy7onb5J6Dn