### PR TITLE
Bump loofah to 2.25.2 for allowed_uri? advisories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.1)


### PR DESCRIPTION
Lockfile-only bump of loofah 2.25.1 → 2.25.2 (transitive via rails-html-sanitizer, constraint `~> 2.25` already satisfied).

Clears the two advisories added to ruby-advisory-db this week — "Loofah `allowed_uri?` does not detect `javascript:` URIs split by numeric character references without semicolons" and the named-whitespace variant — which have turned the bundler-audit workflow red on every branch (e.g. #2871) since the last green run on July 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)