### PR TITLE
Tag wrangling: canonical tags, wrangler roles, spoiler taggings and user suggestions

### DIFF
--- a/app/concerns/permissible.rb
+++ b/app/concerns/permissible.rb
@@ -5,6 +5,7 @@ module Permissible
   IMPORTER = 3
   SUSPENDED = 4
   READONLY = 5
+  WRANGLER = 6
 
   MOD_PERMS = [
     :edit_posts,
@@ -20,10 +21,22 @@ module Permissible
     :create_news,
   ]
 
+  # Scoping to assigned Settings is applied separately, by Tag#wrangleable_by?.
+  WRANGLER_PERMS = [
+    :wrangle_tags,
+  ]
+
+  ADMIN_ONLY_PERMS = [
+    :wrangle_tags_global,
+    :delete_tags,
+  ]
+
   def has_permission?(permission)
     return false unless role_id
     return true if admin?
+    return false if ADMIN_ONLY_PERMS.include?(permission)
     return true if importer? && permission == :import_posts
+    return true if wrangler? && WRANGLER_PERMS.include?(permission)
     return false unless mod?
     MOD_PERMS.include?(permission)
   end
@@ -38,6 +51,10 @@ module Permissible
 
   def importer?
     role_id == IMPORTER
+  end
+
+  def wrangler?
+    role_id == WRANGLER
   end
 
   def suspended?

--- a/app/controllers/tag_suggestions_controller.rb
+++ b/app/controllers/tag_suggestions_controller.rb
@@ -34,7 +34,7 @@ class TagSuggestionsController < ApplicationController
 
     case outcome
       when :already_visible
-        flash[:error] = "That tag is already on this post."
+        flash[:error] = "Tag is already applied to this post."
         redirect_to post_path(@post)
       when :invalid
         @suggestion = record
@@ -44,27 +44,27 @@ class TagSuggestionsController < ApplicationController
       else
         # :created, :endorsed and :silently_deduped are indistinguishable to the
         # suggester on purpose; see TagSuggestion.submit.
-        flash[:success] = "Thanks — your suggestion has been sent to the author."
+        flash[:success] = "Suggestion recorded. The post author will review it."
         redirect_to post_path(@post)
     end
   end
 
   def accept
     @suggestion.accept!(resolver: current_user)
-    flash[:success] = "Added #{@suggestion.tag_display_name}."
+    flash[:success] = "Tag #{@suggestion.tag_display_name} applied."
     redirect_to tag_suggestions_path
   end
 
   def reject
     @suggestion.reject!(resolver: current_user)
-    flash[:success] = "Declined #{@suggestion.tag_display_name}. Nobody can suggest it on this post again."
+    flash[:success] = "Tag #{@suggestion.tag_display_name} declined. It cannot be suggested on this post again."
     redirect_to tag_suggestions_path
   end
 
   def allow_again
     name = @suggestion.tag_display_name
     @suggestion.allow_again!
-    flash[:success] = "#{name} can be suggested again."
+    flash[:success] = "Tag #{name} may be suggested again."
     redirect_to tag_suggestions_path
   end
 
@@ -86,7 +86,7 @@ class TagSuggestionsController < ApplicationController
 
   def require_author
     return if @suggestion.post.user_id == current_user.id
-    flash[:error] = "You do not have permission to do that."
+    flash[:error] = "You do not have permission to resolve this suggestion."
     redirect_to tag_suggestions_path
   end
 end

--- a/app/controllers/tag_suggestions_controller.rb
+++ b/app/controllers/tag_suggestions_controller.rb
@@ -3,6 +3,7 @@ class TagSuggestionsController < ApplicationController
   before_action :login_required
   before_action :readonly_forbidden
   before_action :find_post, only: [:new, :create]
+  before_action :require_open_post, only: [:new]
   before_action :find_suggestion, only: [:accept, :reject, :allow_again]
   before_action :require_author, only: [:accept, :reject, :allow_again]
 
@@ -35,6 +36,9 @@ class TagSuggestionsController < ApplicationController
     case outcome
       when :already_visible
         flash[:error] = "Tag is already applied to this post."
+        redirect_to post_path(@post)
+      when :not_accepted
+        flash[:error] = "This post does not accept tag suggestions."
         redirect_to post_path(@post)
       when :invalid
         @suggestion = record
@@ -75,6 +79,12 @@ class TagSuggestionsController < ApplicationController
     return if @post&.visible_to?(current_user)
     flash[:error] = "Post could not be found."
     redirect_to posts_path
+  end
+
+  def require_open_post
+    return if @post.allow_tag_suggestions?
+    flash[:error] = "This post does not accept tag suggestions."
+    redirect_to post_path(@post)
   end
 
   def find_suggestion

--- a/app/controllers/tag_suggestions_controller.rb
+++ b/app/controllers/tag_suggestions_controller.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+class TagSuggestionsController < ApplicationController
+  before_action :login_required
+  before_action :readonly_forbidden
+  before_action :find_post, only: [:new, :create]
+  before_action :find_suggestion, only: [:accept, :reject, :allow_again]
+  before_action :require_author, only: [:accept, :reject, :allow_again]
+
+  def index
+    @page_title = "Suggested Tags"
+    @suggestions = TagSuggestion.where(post_id: current_user.posts.select(:id)).includes(:post, :user, :tag).ordered
+    @pending = @suggestions.select(&:pending?)
+    @endorsements = @suggestions.select(&:endorsed?)
+    @resolved = @suggestions.select { |suggestion| suggestion.accepted? || suggestion.rejected? }
+  end
+
+  def new
+    @page_title = "Suggest a Tag"
+    @suggestion = TagSuggestion.new(post: @post)
+  end
+
+  def create
+    tag = Tag.find_by(id: params.dig(:tag_suggestion, :tag_id))
+    record, outcome = TagSuggestion.submit(
+      post: @post,
+      user: current_user,
+      tag: tag,
+      tag_type: tag ? nil : params.dig(:tag_suggestion, :tag_type).presence,
+      tag_name: tag ? nil : params.dig(:tag_suggestion, :tag_name).presence,
+      note: params.dig(:tag_suggestion, :note).presence,
+      spoiler: params.dig(:tag_suggestion, :spoiler) == '1',
+      reveal_after_reply_order: params.dig(:tag_suggestion, :reveal_after_reply_order).presence,
+    )
+
+    case outcome
+      when :already_visible
+        flash[:error] = "That tag is already on this post."
+        redirect_to post_path(@post)
+      when :invalid
+        @suggestion = record
+        flash.now[:error] = { message: "Suggestion could not be saved", array: record.errors.full_messages }
+        @page_title = "Suggest a Tag"
+        render :new
+      else
+        # :created, :endorsed and :silently_deduped are indistinguishable to the
+        # suggester on purpose; see TagSuggestion.submit.
+        flash[:success] = "Thanks — your suggestion has been sent to the author."
+        redirect_to post_path(@post)
+    end
+  end
+
+  def accept
+    @suggestion.accept!(resolver: current_user)
+    flash[:success] = "Added #{@suggestion.tag_display_name}."
+    redirect_to tag_suggestions_path
+  end
+
+  def reject
+    @suggestion.reject!(resolver: current_user)
+    flash[:success] = "Declined #{@suggestion.tag_display_name}. Nobody can suggest it on this post again."
+    redirect_to tag_suggestions_path
+  end
+
+  def allow_again
+    name = @suggestion.tag_display_name
+    @suggestion.allow_again!
+    flash[:success] = "#{name} can be suggested again."
+    redirect_to tag_suggestions_path
+  end
+
+  private
+
+  def find_post
+    @post = Post.find_by(id: params[:post_id])
+    return if @post&.visible_to?(current_user)
+    flash[:error] = "Post could not be found."
+    redirect_to posts_path
+  end
+
+  def find_suggestion
+    @suggestion = TagSuggestion.find_by(id: params[:id])
+    return if @suggestion
+    flash[:error] = "Suggestion could not be found."
+    redirect_to tag_suggestions_path
+  end
+
+  def require_author
+    return if @suggestion.post.user_id == current_user.id
+    flash[:error] = "You do not have permission to do that."
+    redirect_to tag_suggestions_path
+  end
+end

--- a/app/controllers/tag_wranglings_controller.rb
+++ b/app/controllers/tag_wranglings_controller.rb
@@ -27,7 +27,7 @@ class TagWranglingsController < ApplicationController
       when 'unwrangleable' then mark_unwrangleable
       when 'merge' then merge_into_target
       else
-        flash[:error] = "Unknown wrangling action."
+        flash[:error] = "Unrecognized wrangling action."
         redirect_to tag_wranglings_path
     end
   end
@@ -57,30 +57,30 @@ class TagWranglingsController < ApplicationController
 
   def mark_canonical
     @tag.update!(canonical: true)
-    flash[:success] = "#{@tag.name} marked canonical."
+    flash[:success] = "Tag #{@tag.name} marked canonical."
     redirect_to tag_wranglings_path(type: params[:type])
   end
 
   def mark_unwrangleable
     @tag.update!(unwrangleable: true)
-    flash[:success] = "#{@tag.name} will be skipped."
+    flash[:success] = "Tag #{@tag.name} marked unwrangleable."
     redirect_to tag_wranglings_path(type: params[:type])
   end
 
   def merge_into_target
     target = Tag.find_by(id: params[:merger_id])
     if target.nil? || target.type != @tag.type
-      flash[:error] = "Select a tag of the same type to merge into."
+      flash[:error] = "Merge target must be an existing tag of the same type."
       redirect_to tag_wranglings_path(type: params[:type]) and return
     end
     return not_permitted unless target.wrangleable_by?(current_user)
 
     if params[:destroy_loser].present? && current_user.has_permission?(:delete_tags)
       target.merge_with(@tag)
-      flash[:success] = "Merged and deleted #{@tag.name}."
+      flash[:success] = "Tag #{@tag.name} merged into #{target.name} and deleted."
     else
       target.merge_as_synonym(@tag)
-      flash[:success] = "#{@tag.name} is now a synonym of #{target.name}."
+      flash[:success] = "Tag #{@tag.name} is now a synonym of #{target.name}."
     end
     redirect_to tag_wranglings_path(type: params[:type])
   end

--- a/app/controllers/tag_wranglings_controller.rb
+++ b/app/controllers/tag_wranglings_controller.rb
@@ -56,8 +56,12 @@ class TagWranglingsController < ApplicationController
   end
 
   def mark_canonical
-    @tag.update!(canonical: true)
-    flash[:success] = "Tag #{@tag.name} marked canonical."
+    if @tag.synonym?
+      flash[:error] = "A synonym cannot be marked canonical. Remove the synonym relationship first."
+    else
+      @tag.update!(canonical: true)
+      flash[:success] = "Tag #{@tag.name} marked canonical."
+    end
     redirect_to tag_wranglings_path(type: params[:type])
   end
 
@@ -69,11 +73,13 @@ class TagWranglingsController < ApplicationController
 
   def merge_into_target
     target = Tag.find_by(id: params[:merger_id])
-    if target.nil? || target.type != @tag.type
-      flash[:error] = "Merge target must be an existing tag of the same type."
+    return invalid_merge_target if target.nil? || target.type != @tag.type || target.id == @tag.id
+    return not_permitted unless target.wrangleable_by?(current_user)
+
+    if target.synonym?
+      flash[:error] = "Merge target #{target.name} is itself a synonym. Merge into its canonical tag instead."
       redirect_to tag_wranglings_path(type: params[:type]) and return
     end
-    return not_permitted unless target.wrangleable_by?(current_user)
 
     if params[:destroy_loser].present? && current_user.has_permission?(:delete_tags)
       target.merge_with(@tag)
@@ -82,6 +88,11 @@ class TagWranglingsController < ApplicationController
       target.merge_as_synonym(@tag)
       flash[:success] = "Tag #{@tag.name} is now a synonym of #{target.name}."
     end
+    redirect_to tag_wranglings_path(type: params[:type])
+  end
+
+  def invalid_merge_target
+    flash[:error] = "Merge target must be a different existing tag of the same type."
     redirect_to tag_wranglings_path(type: params[:type])
   end
 

--- a/app/controllers/tag_wranglings_controller.rb
+++ b/app/controllers/tag_wranglings_controller.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+class TagWranglingsController < ApplicationController
+  before_action :login_required
+  before_action :readonly_forbidden
+  before_action :require_wrangler
+
+  def index
+    @page_title = "Tag Wrangling"
+    @type = params[:type].presence
+    if @type && Tag::TYPES.exclude?(@type)
+      flash[:error] = "Invalid filter"
+      redirect_to tag_wranglings_path and return
+    end
+
+    @coverage = TagWrangling::Coverage.new(type: @type)
+    @clusters = TagWrangling::DuplicateClusters.new(type: @type).clusters
+    @tags = queue_scope.paginate(page: page, per_page: 25)
+  end
+
+  def update
+    @tag = Tag.find_by(id: params[:id])
+    return tag_not_found unless @tag
+    return not_permitted unless @tag.wrangleable_by?(current_user)
+
+    case params[:commit_action]
+      when 'canonical' then mark_canonical
+      when 'unwrangleable' then mark_unwrangleable
+      when 'merge' then merge_into_target
+      else
+        flash[:error] = "Unknown wrangling action."
+        redirect_to tag_wranglings_path
+    end
+  end
+
+  private
+
+  def require_wrangler
+    return if current_user.has_permission?(:wrangle_tags)
+    return if current_user.has_permission?(:wrangle_tags_global)
+    flash[:error] = "You do not have permission to wrangle tags."
+    redirect_to root_path
+  end
+
+  def queue_scope
+    scope = Tag.awaiting_wrangling.select('tags.*, (SELECT COUNT(*) FROM post_tags WHERE post_tags.tag_id = tags.id) AS post_count')
+    scope = scope.where(type: @type) if @type
+    scope = scope.where(id: wrangleable_ids) unless current_user.has_permission?(:wrangle_tags_global)
+    scope.order(Arel.sql('post_count DESC'), name: :asc)
+  end
+
+  def wrangleable_ids
+    setting_ids = WranglingAssignment.scope_ids_for(current_user)
+    return [] if setting_ids.empty?
+    co_tagged = PostTag.where(post_id: PostTag.where(tag_id: setting_ids).select(:post_id)).select(:tag_id)
+    Tag.where(id: co_tagged).or(Tag.where(id: setting_ids)).select(:id)
+  end
+
+  def mark_canonical
+    @tag.update!(canonical: true)
+    flash[:success] = "#{@tag.name} marked canonical."
+    redirect_to tag_wranglings_path(type: params[:type])
+  end
+
+  def mark_unwrangleable
+    @tag.update!(unwrangleable: true)
+    flash[:success] = "#{@tag.name} will be skipped."
+    redirect_to tag_wranglings_path(type: params[:type])
+  end
+
+  def merge_into_target
+    target = Tag.find_by(id: params[:merger_id])
+    if target.nil? || target.type != @tag.type
+      flash[:error] = "Select a tag of the same type to merge into."
+      redirect_to tag_wranglings_path(type: params[:type]) and return
+    end
+    return not_permitted unless target.wrangleable_by?(current_user)
+
+    if params[:destroy_loser].present? && current_user.has_permission?(:delete_tags)
+      target.merge_with(@tag)
+      flash[:success] = "Merged and deleted #{@tag.name}."
+    else
+      target.merge_as_synonym(@tag)
+      flash[:success] = "#{@tag.name} is now a synonym of #{target.name}."
+    end
+    redirect_to tag_wranglings_path(type: params[:type])
+  end
+
+  def tag_not_found
+    flash[:error] = "Tag could not be found."
+    redirect_to tag_wranglings_path
+  end
+
+  def not_permitted
+    flash[:error] = "You do not have permission to wrangle this tag."
+    redirect_to tag_wranglings_path
+  end
+end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -135,9 +135,7 @@ class TagsController < ApplicationController
   def permitted_params
     permitted = [:type, :description, :owned]
     permitted.insert(0, :user_id) if current_user.admin? || @tag.user == current_user
-    if current_user.admin? || @tag.user == current_user || @tag.wrangleable_by?(current_user)
-      permitted.insert(0, :name)
-    end
+    permitted.insert(0, :name) if current_user.admin? || @tag.user == current_user || @tag.wrangleable_by?(current_user)
     params.fetch(:tag, {}).permit(permitted)
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -28,7 +28,7 @@ class TagsController < ApplicationController
     response.headers['X-Robots-Tag'] = 'noindex' if @view
 
     if @view == 'posts'
-      posts = @tag.posts.ordered
+      posts = @tag.unspoilered_posts.ordered
       posts = posts.not_ignored_by(current_user) if current_user&.hide_from_all
       @posts = posts_from_relation(posts)
     elsif @view == 'characters'

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -54,7 +54,9 @@ class TagsController < ApplicationController
 
     begin
       Tag.transaction do
-        @tag.parent_settings = process_tags(Setting, obj_param: :tag, id_param: :parent_setting_ids) if @tag.is_a?(Setting)
+        if @tag.is_a?(Setting) && @tag.hierarchy_editable_by?(current_user)
+          @tag.parent_settings = process_tags(Setting, obj_param: :tag, id_param: :parent_setting_ids)
+        end
         @tag.save!
       end
     rescue ActiveRecord::RecordInvalid => e
@@ -132,7 +134,10 @@ class TagsController < ApplicationController
 
   def permitted_params
     permitted = [:type, :description, :owned]
-    permitted.insert(0, :name, :user_id) if current_user.admin? || @tag.user == current_user
+    permitted.insert(0, :user_id) if current_user.admin? || @tag.user == current_user
+    if current_user.admin? || @tag.user == current_user || @tag.wrangleable_by?(current_user)
+      permitted.insert(0, :name)
+    end
     params.fetch(:tag, {}).permit(permitted)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -267,6 +267,7 @@ class UsersController < ApplicationController
       :hide_from_all,
       :hide_warnings,
       :allow_tag_suggestions,
+      :reveal_spoiler_tags,
       :hide_hiatused_tags_owed,
       :public_bookmarks,
       :ignore_unread_daily_report,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -266,6 +266,7 @@ class UsersController < ApplicationController
       :visible_unread,
       :hide_from_all,
       :hide_warnings,
+      :allow_tag_suggestions,
       :hide_hiatused_tags_owed,
       :public_bookmarks,
       :ignore_unread_daily_report,

--- a/app/helpers/notification_helper.rb
+++ b/app/helpers/notification_helper.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 module NotificationHelper
   NOTIFICATION_MESSAGES = {
-    'import_success'       => 'Post import succeeded',
-    'import_fail'          => 'Post import failed',
-    'new_favorite_post'    => 'An author you favorited has written a new post',
-    'joined_favorite_post' => 'An author you favorited has joined a post',
+    'import_success'         => 'Post import succeeded',
+    'import_fail'            => 'Post import failed',
+    'new_favorite_post'      => 'An author you favorited has written a new post',
+    'joined_favorite_post'   => 'An author you favorited has joined a post',
+    'wrangling_scope_merged' => 'Your tag wrangling scope has changed',
+    'tag_suggested'          => 'A reader suggested a tag on your post',
   }
 
   def subject_for_type(notification_type)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -37,10 +37,15 @@ class Notification < ApplicationRecord
     Notification.create!(user: user, notification_type: type, post: post, error_msg: error)
   end
 
+  # Only meaningful for notifications about a post's own content: having read
+  # the post says nothing about whether you have seen a tag suggested on it.
+  PRE_READ_EXEMPT_TYPES = ['tag_suggested'].freeze
+
   private
 
   def check_read
     return unless post
+    return if PRE_READ_EXEMPT_TYPES.include?(notification_type)
     view = Post::View.find_by(user: user, post: post)
     return unless view&.read_at
     self.read_at = view.read_at

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -27,6 +27,8 @@ class Notification < ApplicationRecord
     import_fail: 1,
     new_favorite_post: 2,
     joined_favorite_post: 3,
+    wrangling_scope_merged: 4,
+    tag_suggested: 5,
   }
 
   attr_accessor :skip_email

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -28,6 +28,8 @@ class Post < ApplicationRecord
 
   has_many :post_tags, inverse_of: :post, dependent: :destroy
   has_many :tag_suggestions, inverse_of: :post, dependent: :destroy
+
+  before_validation :default_tag_suggestions_from_user, on: :create
   has_many :labels, -> { ordered_by_post_tag }, through: :post_tags, source: :label, dependent: :destroy
   has_many :settings, -> { ordered_by_post_tag }, through: :post_tags, source: :setting, dependent: :destroy
   has_many :content_warnings, -> { ordered_by_post_tag }, through: :post_tags, source: :content_warning,
@@ -239,7 +241,7 @@ class Post < ApplicationRecord
   # instead of PostTag#revealed_to? in a loop.
   def visible_post_tags_for(user)
     read_order = read_reply_order_for(user)
-    post_tags.includes(:tag).select { |post_tag| post_tag.revealed_to?(user, read_reply_order: read_order) }
+    post_tags.includes(:tag).order(:id).select { |post_tag| post_tag.revealed_to?(user, read_reply_order: read_order) }
   end
 
   def visible_tags_for(user, klass)
@@ -324,6 +326,12 @@ class Post < ApplicationRecord
   # must not include spoilered taggings.
   def unspoilered_content_warnings
     content_warnings.where(post_tags: { spoiler: false })
+  end
+
+  def default_tag_suggestions_from_user
+    return if allow_tag_suggestions_changed?
+    return if user.nil?
+    self.allow_tag_suggestions = user.allow_tag_suggestions
   end
 
   def reply_count

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -317,7 +317,13 @@ class Post < ApplicationRecord
 
   def has_content_warnings?
     return read_attribute(:has_content_warnings) if has_attribute?(:has_content_warnings)
-    content_warnings.exists?
+    unspoilered_content_warnings.exists?
+  end
+
+  # Listings and tooltips are seen by readers at any point in the post, so they
+  # must not include spoilered taggings.
+  def unspoilered_content_warnings
+    content_warnings.where(post_tags: { spoiler: false })
   end
 
   def reply_count

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -208,6 +208,44 @@ class Post < ApplicationRecord
     end
   end
 
+  # How far into this post the user has read, as a reply_order.
+  #
+  # Derived from post_views.read_at, a timestamp, so a reader who opened the
+  # thread when it was short and returned after 200 new replies resolves to a
+  # high reply_order without having read the intervening replies. Adequate for
+  # spoiler-hiding, but not a guarantee.
+  def read_reply_order_for(user)
+    return nil if user.nil?
+    return @read_reply_order[user.id] if defined?(@read_reply_order) && @read_reply_order.key?(user.id)
+
+    @read_reply_order ||= {}
+    @read_reply_order[user.id] = begin
+      viewed_at = last_read(user) || board.last_read(user)
+      if viewed_at.nil?
+        nil
+      else
+        replies.where(created_at: ..viewed_at).maximum(:reply_order) || 0
+      end
+    end
+  end
+
+  def last_reply_order
+    return @last_reply_order if defined?(@last_reply_order)
+    @last_reply_order = replies.maximum(:reply_order)
+  end
+
+  # Resolves the reader's position once rather than per tagging; use this
+  # instead of PostTag#revealed_to? in a loop.
+  def visible_post_tags_for(user)
+    read_order = read_reply_order_for(user)
+    post_tags.includes(:tag).select { |post_tag| post_tag.revealed_to?(user, read_reply_order: read_order) }
+  end
+
+  def hidden_spoiler_tag_count_for(user)
+    read_order = read_reply_order_for(user)
+    post_tags.count { |post_tag| !post_tag.revealed_to?(user, read_reply_order: read_order) }
+  end
+
   def hide_warnings_for(user)
     view_for(user).update(warnings_hidden: true)
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -27,6 +27,7 @@ class Post < ApplicationRecord
   has_many :bookmarked_replies, -> { ordered }, through: :bookmarks, source: :reply, dependent: :destroy
 
   has_many :post_tags, inverse_of: :post, dependent: :destroy
+  has_many :tag_suggestions, inverse_of: :post, dependent: :destroy
   has_many :labels, -> { ordered_by_post_tag }, through: :post_tags, source: :label, dependent: :destroy
   has_many :settings, -> { ordered_by_post_tag }, through: :post_tags, source: :setting, dependent: :destroy
   has_many :content_warnings, -> { ordered_by_post_tag }, through: :post_tags, source: :content_warning,
@@ -239,6 +240,10 @@ class Post < ApplicationRecord
   def visible_post_tags_for(user)
     read_order = read_reply_order_for(user)
     post_tags.includes(:tag).select { |post_tag| post_tag.revealed_to?(user, read_reply_order: read_order) }
+  end
+
+  def visible_tags_for(user, klass)
+    visible_post_tags_for(user).map(&:tag).grep(klass)
   end
 
   def hidden_spoiler_tag_count_for(user)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -211,46 +211,19 @@ class Post < ApplicationRecord
     end
   end
 
-  # How far into this post the user has read, as a reply_order.
-  #
-  # Derived from post_views.read_at, a timestamp, so a reader who opened the
-  # thread when it was short and returned after 200 new replies resolves to a
-  # high reply_order without having read the intervening replies. Adequate for
-  # spoiler-hiding, but not a guarantee.
-  def read_reply_order_for(user)
-    return nil if user.nil?
-    return @read_reply_order[user.id] if defined?(@read_reply_order) && @read_reply_order.key?(user.id)
-
-    @read_reply_order ||= {}
-    @read_reply_order[user.id] = begin
-      viewed_at = last_read(user) || board.last_read(user)
-      if viewed_at.nil?
-        nil
-      else
-        replies.where(created_at: ..viewed_at).maximum(:reply_order) || 0
-      end
-    end
+  # All taggings for display, spoilered ones included; the view decides which
+  # are rendered expanded. Ordered by tagging id to match the previous display
+  # order.
+  def displayable_post_tags
+    post_tags.includes(:tag).order(:id)
   end
 
-  def last_reply_order
-    return @last_reply_order if defined?(@last_reply_order)
-    @last_reply_order = replies.maximum(:reply_order)
+  def displayable_tags(klass)
+    displayable_post_tags.map(&:tag).grep(klass)
   end
 
-  # Resolves the reader's position once rather than per tagging; use this
-  # instead of PostTag#revealed_to? in a loop.
-  def visible_post_tags_for(user)
-    read_order = read_reply_order_for(user)
-    post_tags.includes(:tag).order(:id).select { |post_tag| post_tag.revealed_to?(user, read_reply_order: read_order) }
-  end
-
-  def visible_tags_for(user, klass)
-    visible_post_tags_for(user).map(&:tag).grep(klass)
-  end
-
-  def hidden_spoiler_tag_count_for(user)
-    read_order = read_reply_order_for(user)
-    post_tags.count { |post_tag| !post_tag.revealed_to?(user, read_reply_order: read_order) }
+  def spoiler_post_tag_count
+    post_tags.count(&:spoiler?)
   end
 
   def hide_warnings_for(user)

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -10,6 +10,10 @@ class PostTag < ApplicationRecord
   validates :reveal_after_reply_order, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
   validate :reveal_threshold_requires_spoiler
 
+  # Without a fixed threshold, "the end of the post" moves every time a reply
+  # is added, so a tag would disappear again for a reader who had caught up.
+  before_validation :fix_reveal_threshold, on: :create
+
   scope :spoilered, -> { where(spoiler: true) }
   scope :unspoilered, -> { where(spoiler: false) }
 
@@ -38,5 +42,11 @@ class PostTag < ApplicationRecord
   def reveal_threshold_requires_spoiler
     return if reveal_after_reply_order.nil? || spoiler?
     errors.add(:reveal_after_reply_order, "requires the tagging to be marked as a spoiler")
+  end
+
+  def fix_reveal_threshold
+    return unless spoiler?
+    return if reveal_after_reply_order.present?
+    self.reveal_after_reply_order = post&.last_reply_order
   end
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -37,6 +37,6 @@ class PostTag < ApplicationRecord
 
   def reveal_threshold_requires_spoiler
     return if reveal_after_reply_order.nil? || spoiler?
-    errors.add(:reveal_after_reply_order, "only applies to a tagging marked as a spoiler")
+    errors.add(:reveal_after_reply_order, "requires the tagging to be marked as a spoiler")
   end
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -8,45 +8,36 @@ class PostTag < ApplicationRecord
 
   validates :post, uniqueness: { scope: :tag }
   validates :reveal_after_reply_order, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
-  validate :reveal_threshold_requires_spoiler
-
-  # Without a fixed threshold, "the end of the post" moves every time a reply
-  # is added, so a tag would disappear again for a reader who had caught up.
-  before_validation :fix_reveal_threshold, on: :create
+  validate :content_warnings_are_not_spoilerable
 
   scope :spoilered, -> { where(spoiler: true) }
   scope :unspoilered, -> { where(spoiler: false) }
 
   # Spoilered taggings are excluded from tag -> post listings entirely, so a
-  # spoilered post does not appear under that tag.
+  # spoilered post does not appear under that tag. This is the one part of the
+  # feature the client cannot be trusted with.
   scope :for_reverse_lookup, -> { unspoilered }
 
-  # A nil reveal_after_reply_order means "reveal at the end of the post as it
-  # currently stands".
-  def revealed_to?(user, read_reply_order: nil)
+  # Whether the tagging is displayed already expanded. Reveal is otherwise a
+  # reader action: reading position plays no part.
+  def expanded_for?(user)
     return true unless spoiler?
     return false if user.nil?
+    return true if user.reveal_spoiler_tags?
     return true if post.user_id == user.id
-    return true if user.has_permission?(:edit_posts)
+    user.has_permission?(:edit_posts)
+  end
 
-    read_order = read_reply_order.nil? ? post.read_reply_order_for(user) : read_reply_order
-    return false if read_order.nil?
-
-    threshold = reveal_after_reply_order || post.last_reply_order
-    return true if threshold.nil? # no replies yet, so the end is the post itself
-    read_order >= threshold
+  # Descriptive rather than a gate: the reply from which the tag applies.
+  def applies_from_reply_order
+    reveal_after_reply_order
   end
 
   private
 
-  def reveal_threshold_requires_spoiler
-    return if reveal_after_reply_order.nil? || spoiler?
-    errors.add(:reveal_after_reply_order, "requires the tagging to be marked as a spoiler")
-  end
-
-  def fix_reveal_threshold
+  def content_warnings_are_not_spoilerable
     return unless spoiler?
-    return if reveal_after_reply_order.present?
-    self.reveal_after_reply_order = post&.last_reply_order
+    return unless tag.is_a?(ContentWarning)
+    errors.add(:spoiler, "cannot be set on a content warning, which must be visible before the content it warns about")
   end
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -7,4 +7,36 @@ class PostTag < ApplicationRecord
   belongs_to :label, foreign_key: :tag_id, inverse_of: :post_tags, optional: true
 
   validates :post, uniqueness: { scope: :tag }
+  validates :reveal_after_reply_order, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+  validate :reveal_threshold_requires_spoiler
+
+  scope :spoilered, -> { where(spoiler: true) }
+  scope :unspoilered, -> { where(spoiler: false) }
+
+  # Spoilered taggings are excluded from tag -> post listings entirely, so a
+  # spoilered post does not appear under that tag.
+  scope :for_reverse_lookup, -> { unspoilered }
+
+  # A nil reveal_after_reply_order means "reveal at the end of the post as it
+  # currently stands".
+  def revealed_to?(user, read_reply_order: nil)
+    return true unless spoiler?
+    return false if user.nil?
+    return true if post.user_id == user.id
+    return true if user.has_permission?(:edit_posts)
+
+    read_order = read_reply_order.nil? ? post.read_reply_order_for(user) : read_reply_order
+    return false if read_order.nil?
+
+    threshold = reveal_after_reply_order || post.last_reply_order
+    return true if threshold.nil? # no replies yet, so the end is the post itself
+    read_order >= threshold
+  end
+
+  private
+
+  def reveal_threshold_requires_spoiler
+    return if reveal_after_reply_order.nil? || spoiler?
+    errors.add(:reveal_after_reply_order, "only applies to a tagging marked as a spoiler")
+  end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,9 +1,20 @@
 # frozen_string_literal: true
 class Setting < Tag
-  has_many :parent_setting_tags, class_name: 'Tag::SettingTag', foreign_key: :tag_id, inverse_of: :parent_setting, dependent: :destroy
-  has_many :child_setting_tags, class_name: 'Tag::SettingTag', foreign_key: :tagged_id, inverse_of: :child_setting, dependent: :destroy
+  has_many :parent_setting_tags, class_name: 'Tag::MetaTag', foreign_key: :tag_id, inverse_of: :parent_setting, dependent: :destroy
+  has_many :child_setting_tags, class_name: 'Tag::MetaTag', foreign_key: :tagged_id, inverse_of: :child_setting, dependent: :destroy
 
   has_many :parent_settings, -> { ordered_by_tag_tag }, class_name: 'Setting', through: :child_setting_tags,
     source: :parent_setting, dependent: :destroy
   has_many :child_settings, class_name: 'Setting', through: :parent_setting_tags, source: :child_setting, dependent: :destroy
+
+  has_many :wrangling_assignments, inverse_of: :setting, dependent: :destroy
+  has_many :wranglers, through: :wrangling_assignments, source: :user
+
+  def descendant_ids
+    Tag::MetaTag.descendant_ids_of(self)
+  end
+
+  def ancestor_ids
+    Tag::MetaTag.ancestor_ids_of(self)
+  end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 class Setting < Tag
-  has_many :parent_setting_tags, class_name: 'Tag::MetaTag', foreign_key: :tag_id, inverse_of: :parent_setting, dependent: :destroy
-  has_many :child_setting_tags, class_name: 'Tag::MetaTag', foreign_key: :tagged_id, inverse_of: :child_setting, dependent: :destroy
+  # Confirmed edges only, so the hierarchy shown in the editor matches the one
+  # traversal walks.
+  has_many :parent_setting_tags, -> { confirmed }, class_name: 'Tag::MetaTag', foreign_key: :tag_id,
+    inverse_of: :parent_setting, dependent: :destroy
+  has_many :child_setting_tags, -> { confirmed }, class_name: 'Tag::MetaTag', foreign_key: :tagged_id,
+    inverse_of: :child_setting, dependent: :destroy
 
   has_many :parent_settings, -> { ordered_by_tag_tag }, class_name: 'Setting', through: :child_setting_tags,
     source: :parent_setting, dependent: :destroy

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -20,6 +20,8 @@ class Tag < ApplicationRecord
 
   TYPES = %w(Setting Label ContentWarning GalleryGroup)
   HIERARCHICAL_TYPES = %w(Setting Label)
+  # GalleryGroup tags attach to galleries, not posts.
+  POST_TYPES = %w(Setting Label ContentWarning)
 
   validates :name, :type, presence: true
   validates :name, uniqueness: { scope: :type }
@@ -71,7 +73,7 @@ class Tag < ApplicationRecord
     return true if user.has_permission?(:wrangle_tags_global)
     return false unless user.has_permission?(:wrangle_tags)
 
-    wrangling_setting_ids = WranglingAssignment.scope_ids_for(user)
+    wrangling_setting_ids = user.wrangling_scope_ids
     return false if wrangling_setting_ids.empty?
     return wrangling_setting_ids.include?(id) if is_a?(Setting)
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -124,6 +124,12 @@ class Tag < ApplicationRecord
     characters.count
   end
 
+  # Reverse lookup excludes spoilered taggings, so a post spoilered under this
+  # tag does not appear in its listings.
+  def unspoilered_posts
+    posts.where(post_tags: { spoiler: false })
+  end
+
   def synonym?
     merger_id.present?
   end
@@ -156,6 +162,9 @@ class Tag < ApplicationRecord
 
   # Destroys the loser rather than keeping it as a synonym; admin-only.
   def merge_with(other_tag)
+    raise ArgumentError, "Cannot merge a tag into itself" if other_tag == self
+    raise ArgumentError, "Cannot merge across tag types" if other_tag.type != type
+
     transaction do
       absorb_taggings_from(other_tag)
       WranglingAssignment.reassign_for_merge(source: other_tag, target: self) if is_a?(Setting)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,10 +10,30 @@ class Tag < ApplicationRecord
   has_many :gallery_tags, dependent: :destroy, inverse_of: :tag
   has_many :galleries, through: :gallery_tags, dependent: :destroy
 
+  belongs_to :merger, class_name: 'Tag', optional: true, inverse_of: :mergers
+  has_many :mergers, class_name: 'Tag', inverse_of: :merger, dependent: :nullify
+
+  has_many :parent_meta_tags, class_name: 'Tag::MetaTag', inverse_of: :parent_tag, dependent: :destroy
+  has_many :child_meta_tags, class_name: 'Tag::MetaTag', foreign_key: :tagged_id, inverse_of: :child_tag, dependent: :destroy
+  has_many :child_tags, through: :parent_meta_tags, source: :child_tag
+  has_many :parent_tags, through: :child_meta_tags, source: :parent_tag
+
   TYPES = %w(Setting Label ContentWarning GalleryGroup)
+  HIERARCHICAL_TYPES = %w(Setting Label)
 
   validates :name, :type, presence: true
   validates :name, uniqueness: { scope: :type }
+  validate :merger_is_a_valid_synonym_target
+
+  # `canonical` is a wrangling annotation and must never gate behaviour; search,
+  # filtering, autocomplete and display treat canonical and non-canonical tags
+  # identically. `merger_id` is what changes behaviour.
+  scope :canonical, -> { where(canonical: true) }
+  scope :noncanonical, -> { where(canonical: false) }
+  scope :synonymous, -> { where.not(merger_id: nil) }
+  scope :nonsynonymous, -> { where(merger_id: nil) }
+  scope :wrangleable, -> { nonsynonymous.where(unwrangleable: false) }
+  scope :awaiting_wrangling, -> { wrangleable.noncanonical }
 
   scope :ordered_by_type, -> { order(type: :desc, name: :asc) }
 
@@ -39,9 +59,33 @@ class Tag < ApplicationRecord
     return false unless user
     return true if deletable_by?(user)
     return true if user.has_permission?(:edit_tags)
+    return true if wrangleable_by?(user)
     return false if user.read_only?
     return false unless is_a?(Setting)
     !owned?
+  end
+
+  def wrangleable_by?(user)
+    return false unless user
+    return false if user.read_only?
+    return true if user.has_permission?(:wrangle_tags_global)
+    return false unless user.has_permission?(:wrangle_tags)
+
+    wrangling_setting_ids = WranglingAssignment.scope_ids_for(user)
+    return false if wrangling_setting_ids.empty?
+    return wrangling_setting_ids.include?(id) if is_a?(Setting)
+
+    PostTag.where(tag_id: id)
+      .where(post_id: PostTag.where(tag_id: wrangling_setting_ids).select(:post_id))
+      .exists?
+  end
+
+  # Gated more tightly than #editable_by?: with assignments cascading down the
+  # graph, re-parenting a tag changes who may wrangle it.
+  def hierarchy_editable_by?(user)
+    return false unless user
+    return false unless hierarchical?
+    wrangleable_by?(user)
   end
 
   def deletable_by?(user)
@@ -80,23 +124,71 @@ class Tag < ApplicationRecord
     characters.count
   end
 
+  def synonym?
+    merger_id.present?
+  end
+
+  # Chains are one level deep by validation, so this never recurses.
+  def canonical_tag
+    merger || self
+  end
+
+  def hierarchical?
+    HIERARCHICAL_TYPES.include?(type)
+  end
+
+  # Re-points every tagging onto this tag and leaves the loser as a synonym, so
+  # links to it still resolve.
+  def merge_as_synonym(other_tag)
+    raise ArgumentError, "Cannot merge a tag into itself" if other_tag == self
+    raise ArgumentError, "Cannot merge across tag types" if other_tag.type != type
+
+    transaction do
+      absorb_taggings_from(other_tag)
+      # Re-pointing the loser's own synonyms keeps chains one level deep.
+      Tag.where(merger_id: other_tag.id).update_all(merger_id: self.id) # rubocop:disable Rails/SkipsModelValidations
+      WranglingAssignment.reassign_for_merge(source: other_tag, target: self) if is_a?(Setting)
+      update!(canonical: true) unless canonical?
+      other_tag.update!(merger_id: self.id, canonical: false)
+    end
+    self
+  end
+
+  # Destroys the loser rather than keeping it as a synonym; admin-only.
   def merge_with(other_tag)
     transaction do
-      # rubocop:disable Rails/SkipsModelValidations
-      UserTag.where(tag_id: other_tag.id).where(user_id: user_tags.select(:user_id).distinct.pluck(:user_id)).delete_all
-      UserTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
-      PostTag.where(tag_id: other_tag.id).where(post_id: post_tags.select(:post_id).distinct.pluck(:post_id)).delete_all
-      PostTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
-      CharacterTag.where(tag_id: other_tag.id).where(character_id: character_tags.select(:character_id).distinct.pluck(:character_id)).delete_all
-      CharacterTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
-      GalleryTag.where(tag_id: other_tag.id).where(gallery_id: gallery_tags.select(:gallery_id).distinct.pluck(:gallery_id)).delete_all
-      GalleryTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
-      Tag::SettingTag.where(tag_id: other_tag.id, tagged_id: self.id).delete_all
-      Tag::SettingTag.where(tag_id: self.id, tagged_id: other_tag.id).delete_all
-      Tag::SettingTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
-      Tag::SettingTag.where(tagged_id: other_tag.id).update_all(tagged_id: self.id)
+      absorb_taggings_from(other_tag)
+      WranglingAssignment.reassign_for_merge(source: other_tag, target: self) if is_a?(Setting)
       other_tag.destroy
-      # rubocop:enable Rails/SkipsModelValidations
     end
+  end
+
+  private
+
+  # Drops rows that would collide with a tagging self already has.
+  def absorb_taggings_from(other_tag)
+    # rubocop:disable Rails/SkipsModelValidations
+    UserTag.where(tag_id: other_tag.id).where(user_id: user_tags.select(:user_id).distinct.pluck(:user_id)).delete_all
+    UserTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
+    PostTag.where(tag_id: other_tag.id).where(post_id: post_tags.select(:post_id).distinct.pluck(:post_id)).delete_all
+    PostTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
+    CharacterTag.where(tag_id: other_tag.id).where(character_id: character_tags.select(:character_id).distinct.pluck(:character_id)).delete_all
+    CharacterTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
+    GalleryTag.where(tag_id: other_tag.id).where(gallery_id: gallery_tags.select(:gallery_id).distinct.pluck(:gallery_id)).delete_all
+    GalleryTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
+    Tag::MetaTag.where(tag_id: other_tag.id, tagged_id: self.id).delete_all
+    Tag::MetaTag.where(tag_id: self.id, tagged_id: other_tag.id).delete_all
+    Tag::MetaTag.where(tag_id: other_tag.id).update_all(tag_id: self.id)
+    Tag::MetaTag.where(tagged_id: other_tag.id).update_all(tagged_id: self.id)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  def merger_is_a_valid_synonym_target
+    return if merger.nil?
+
+    errors.add(:merger, "cannot be the tag itself") if merger_id == id
+    errors.add(:merger, "must be the same type of tag") if merger.type != type
+    errors.add(:merger, "must itself be canonical") unless merger.canonical?
+    errors.add(:canonical, "cannot be set on a tag that is a synonym of another") if canonical?
   end
 end

--- a/app/models/tag/meta_tag.rb
+++ b/app/models/tag/meta_tag.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+class Tag::MetaTag < ApplicationRecord
+  self.table_name = 'tag_tags'
+
+  belongs_to :child_tag, class_name: 'Tag', foreign_key: :tagged_id, inverse_of: :child_meta_tags, optional: true
+  belongs_to :parent_tag, class_name: 'Tag', foreign_key: :tag_id, inverse_of: :parent_meta_tags, optional: true
+  belongs_to :child_setting, class_name: 'Setting', foreign_key: :tagged_id, inverse_of: :child_setting_tags, optional: true
+  belongs_to :parent_setting, class_name: 'Setting', foreign_key: :tag_id, inverse_of: :parent_setting_tags, optional: true
+
+  scope :confirmed, -> { where(suggested: false) }
+  scope :suggested, -> { where(suggested: true) }
+
+  validates :child_tag, uniqueness: { scope: :parent_tag }
+  validate :tags_share_a_type
+  validate :edge_does_not_close_a_cycle
+
+  def self.ancestor_ids_of(tag)
+    walk_ids(tag, start_column: :tagged_id, next_column: :tag_id)
+  end
+
+  def self.descendant_ids_of(tag)
+    walk_ids(tag, start_column: :tag_id, next_column: :tagged_id)
+  end
+
+  # Cycle-safe: rows predating the cycle validation, or created by an import,
+  # must not be able to hang the traversal.
+  def self.walk_ids(tag, start_column:, next_column:)
+    return [] if tag.nil? || tag.id.nil?
+
+    id = connection.quote(tag.id)
+    sql = <<~SQL.squish
+      WITH RECURSIVE walk(id, path, cycle) AS (
+        SELECT #{id}::integer, ARRAY[#{id}::integer], false
+        UNION ALL
+        SELECT tag_tags.#{next_column}, walk.path || tag_tags.#{next_column}, tag_tags.#{next_column} = ANY(walk.path)
+        FROM tag_tags
+        JOIN walk ON tag_tags.#{start_column} = walk.id
+        WHERE NOT walk.cycle AND tag_tags.suggested = false
+      )
+      SELECT DISTINCT id FROM walk WHERE id != #{id}
+    SQL
+
+    connection.select_values(sql).map(&:to_i)
+  end
+  private_class_method :walk_ids
+
+  private
+
+  def tags_share_a_type
+    return if child_tag.nil? || parent_tag.nil?
+    return if child_tag.type == parent_tag.type
+    errors.add(:base, "Implications can only connect tags of the same type.")
+  end
+
+  def edge_does_not_close_a_cycle
+    return if child_tag.nil? || parent_tag.nil?
+
+    if child_tag == parent_tag
+      errors.add(:base, "A tag cannot imply itself.")
+      return
+    end
+
+    return unless Tag::MetaTag.ancestor_ids_of(parent_tag).include?(child_tag.id)
+    errors.add(
+      :base,
+      "#{parent_tag.name} already implies #{child_tag.name}, directly or indirectly, so this would create a loop.",
+    )
+  end
+end

--- a/app/models/tag/meta_tag.rb
+++ b/app/models/tag/meta_tag.rb
@@ -40,8 +40,26 @@ class Tag::MetaTag < ApplicationRecord
     SELECT DISTINCT id FROM walk WHERE id != ?
   SQL
 
+  # Includes suggested edges, so an edge that would close a cycle once
+  # confirmed is rejected at the point it is proposed.
+  ANCESTOR_ANY_SQL = <<~SQL.squish
+    WITH RECURSIVE walk(id, path, cycle) AS (
+      SELECT ?::integer, ARRAY[?::integer], false
+      UNION ALL
+      SELECT tag_tags.tag_id, walk.path || tag_tags.tag_id, tag_tags.tag_id = ANY(walk.path)
+      FROM tag_tags
+      JOIN walk ON tag_tags.tagged_id = walk.id
+      WHERE NOT walk.cycle
+    )
+    SELECT DISTINCT id FROM walk WHERE id != ?
+  SQL
+
   def self.ancestor_ids_of(tag)
     walk_ids(tag, ANCESTOR_SQL)
+  end
+
+  def self.any_ancestor_ids_of(tag)
+    walk_ids(tag, ANCESTOR_ANY_SQL)
   end
 
   def self.descendant_ids_of(tag)
@@ -74,7 +92,7 @@ class Tag::MetaTag < ApplicationRecord
       return
     end
 
-    return unless Tag::MetaTag.ancestor_ids_of(parent_tag).include?(child_tag.id)
+    return unless Tag::MetaTag.any_ancestor_ids_of(parent_tag).include?(child_tag.id)
     errors.add(
       :base,
       "#{parent_tag.name} already implies #{child_tag.name}. This implication would create a cycle.",

--- a/app/models/tag/meta_tag.rb
+++ b/app/models/tag/meta_tag.rb
@@ -14,33 +14,47 @@ class Tag::MetaTag < ApplicationRecord
   validate :tags_share_a_type
   validate :edge_does_not_close_a_cycle
 
+  # Written out per direction rather than interpolating column names, so no
+  # identifier ever reaches the query as a substitution.
+  ANCESTOR_SQL = <<~SQL.squish
+    WITH RECURSIVE walk(id, path, cycle) AS (
+      SELECT ?::integer, ARRAY[?::integer], false
+      UNION ALL
+      SELECT tag_tags.tag_id, walk.path || tag_tags.tag_id, tag_tags.tag_id = ANY(walk.path)
+      FROM tag_tags
+      JOIN walk ON tag_tags.tagged_id = walk.id
+      WHERE NOT walk.cycle AND tag_tags.suggested = false
+    )
+    SELECT DISTINCT id FROM walk WHERE id != ?
+  SQL
+
+  DESCENDANT_SQL = <<~SQL.squish
+    WITH RECURSIVE walk(id, path, cycle) AS (
+      SELECT ?::integer, ARRAY[?::integer], false
+      UNION ALL
+      SELECT tag_tags.tagged_id, walk.path || tag_tags.tagged_id, tag_tags.tagged_id = ANY(walk.path)
+      FROM tag_tags
+      JOIN walk ON tag_tags.tag_id = walk.id
+      WHERE NOT walk.cycle AND tag_tags.suggested = false
+    )
+    SELECT DISTINCT id FROM walk WHERE id != ?
+  SQL
+
   def self.ancestor_ids_of(tag)
-    walk_ids(tag, start_column: :tagged_id, next_column: :tag_id)
+    walk_ids(tag, ANCESTOR_SQL)
   end
 
   def self.descendant_ids_of(tag)
-    walk_ids(tag, start_column: :tag_id, next_column: :tagged_id)
+    walk_ids(tag, DESCENDANT_SQL)
   end
 
   # Cycle-safe: rows predating the cycle validation, or created by an import,
   # must not be able to hang the traversal.
-  def self.walk_ids(tag, start_column:, next_column:)
+  def self.walk_ids(tag, sql)
     return [] if tag.nil? || tag.id.nil?
 
-    id = connection.quote(tag.id)
-    sql = <<~SQL.squish
-      WITH RECURSIVE walk(id, path, cycle) AS (
-        SELECT #{id}::integer, ARRAY[#{id}::integer], false
-        UNION ALL
-        SELECT tag_tags.#{next_column}, walk.path || tag_tags.#{next_column}, tag_tags.#{next_column} = ANY(walk.path)
-        FROM tag_tags
-        JOIN walk ON tag_tags.#{start_column} = walk.id
-        WHERE NOT walk.cycle AND tag_tags.suggested = false
-      )
-      SELECT DISTINCT id FROM walk WHERE id != #{id}
-    SQL
-
-    connection.select_values(sql).map(&:to_i)
+    query = sanitize_sql_array([sql, tag.id, tag.id, tag.id])
+    connection.select_values(query).map(&:to_i)
   end
   private_class_method :walk_ids
 

--- a/app/models/tag/meta_tag.rb
+++ b/app/models/tag/meta_tag.rb
@@ -63,7 +63,7 @@ class Tag::MetaTag < ApplicationRecord
   def tags_share_a_type
     return if child_tag.nil? || parent_tag.nil?
     return if child_tag.type == parent_tag.type
-    errors.add(:base, "Implications can only connect tags of the same type.")
+    errors.add(:base, "An implication requires both tags to be of the same type.")
   end
 
   def edge_does_not_close_a_cycle
@@ -77,7 +77,7 @@ class Tag::MetaTag < ApplicationRecord
     return unless Tag::MetaTag.ancestor_ids_of(parent_tag).include?(child_tag.id)
     errors.add(
       :base,
-      "#{parent_tag.name} already implies #{child_tag.name}, directly or indirectly, so this would create a loop.",
+      "#{parent_tag.name} already implies #{child_tag.name}. This implication would create a cycle.",
     )
   end
 end

--- a/app/models/tag/setting_tag.rb
+++ b/app/models/tag/setting_tag.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-class Tag::SettingTag < ApplicationRecord
-  self.table_name = 'tag_tags'
-
-  belongs_to :child_setting, class_name: 'Setting', foreign_key: :tagged_id, inverse_of: :child_setting_tags, optional: true
-  belongs_to :parent_setting, class_name: 'Setting', foreign_key: :tag_id, inverse_of: :parent_setting_tags, optional: true
-
-  validates :child_setting, uniqueness: { scope: :parent_setting }
-end

--- a/app/models/tag_suggestion.rb
+++ b/app/models/tag_suggestion.rb
@@ -13,8 +13,9 @@ class TagSuggestion < ApplicationRecord
 
   enum :status, { pending: 0, accepted: 1, rejected: 2, endorsed: 3 }
 
-  validates :tag_type, inclusion: { in: Tag::TYPES, allow_nil: true }
+  validates :tag_type, inclusion: { in: Tag::POST_TYPES, allow_nil: true }
   validate :names_exactly_one_tag
+  validate :tag_is_a_post_tag
   validate :suggester_is_not_the_author, on: :create
   validate :post_accepts_suggestions, on: :create
   validate :within_rate_limits, on: :create
@@ -30,6 +31,9 @@ class TagSuggestion < ApplicationRecord
   #
   # Returns [record_or_nil, outcome].
   def self.submit(post:, user:, tag: nil, tag_type: nil, tag_name: nil, note: nil, spoiler: false, reveal_after_reply_order: nil)
+    # Checked before the endorsement path, which creates unconditionally.
+    return [nil, :not_accepted] unless post.allow_tag_suggestions?
+
     # A proposed name that already exists is a suggestion of that tag. Without
     # this, re-proposing a rejected tag as a "new" name walks past the block.
     if tag.nil? && tag_type.present? && tag_name.present?
@@ -126,6 +130,12 @@ class TagSuggestion < ApplicationRecord
   end
 
   private
+
+  def tag_is_a_post_tag
+    return if tag.nil?
+    return if Tag::POST_TYPES.include?(tag.type)
+    errors.add(:base, "#{tag.type} tags cannot be applied to posts.")
+  end
 
   def names_exactly_one_tag
     has_existing = tag_id.present?

--- a/app/models/tag_suggestion.rb
+++ b/app/models/tag_suggestion.rb
@@ -106,7 +106,10 @@ class TagSuggestion < ApplicationRecord
   def accept!(resolver:)
     transaction do
       tag_record = tag || Tag.create!(type: tag_type, name: tag_name, user: user)
-      PostTag.find_or_create_by!(post: post, tag: tag_record)
+      tagging = PostTag.find_or_initialize_by(post: post, tag: tag_record)
+      tagging.spoiler = spoiler
+      tagging.reveal_after_reply_order = reveal_after_reply_order
+      tagging.save!
       update!(
         status: :accepted, resolved_by: resolver, resolved_at: Time.zone.now,
         tag: tag_record, tag_type: nil, tag_name: nil,

--- a/app/models/tag_suggestion.rb
+++ b/app/models/tag_suggestion.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+# A reader proposing a tag on someone else's post. Rejection blocks the tag on
+# that post for everyone, not just the original suggester.
+class TagSuggestion < ApplicationRecord
+  MAX_PENDING_PER_USER = 20
+  MAX_PENDING_PER_POST = 10
+
+  belongs_to :post, inverse_of: :tag_suggestions, optional: false
+  belongs_to :user, inverse_of: :tag_suggestions, optional: false
+  belongs_to :tag, optional: true
+  belongs_to :resolved_by, class_name: 'User', optional: true
+
+  enum :status, { pending: 0, accepted: 1, rejected: 2, endorsed: 3 }
+
+  validates :tag_type, inclusion: { in: Tag::TYPES, allow_nil: true }
+  validate :names_exactly_one_tag
+  validate :suggester_is_not_the_author, on: :create
+  validate :post_accepts_suggestions, on: :create
+  validate :within_rate_limits, on: :create
+
+  scope :awaiting_author, -> { pending }
+  scope :ordered, -> { order(created_at: :desc) }
+
+  # Deduplication must never reveal a tagging or a rejection the suggester
+  # cannot already see: "that tag is already on this post" would expose a hidden
+  # spoiler tagging, and "that was already rejected" would expose the author's
+  # decision. Any collision the suggester could not observe returns the ordinary
+  # confirmation rather than an error.
+  #
+  # Returns [record_or_nil, outcome].
+  def self.submit(post:, user:, tag: nil, tag_type: nil, tag_name: nil, note: nil, spoiler: false, reveal_after_reply_order: nil)
+    existing_tagging = matching_tagging(post: post, tag: tag, tag_type: tag_type, tag_name: tag_name)
+
+    if existing_tagging
+      read_order = post.read_reply_order_for(user)
+      return [nil, :already_visible] if existing_tagging.revealed_to?(user, read_reply_order: read_order)
+      return [endorse(post: post, user: user, tagging: existing_tagging, note: note), :endorsed]
+    end
+
+    # Covers a pending duplicate and a standing rejection alike.
+    prior = matching_suggestion(post: post, tag: tag, tag_type: tag_type, tag_name: tag_name)
+    return [nil, :silently_deduped] if prior
+
+    record = new(
+      post: post, user: user, tag: tag, tag_type: tag_type, tag_name: tag_name,
+      note: note, spoiler: spoiler, reveal_after_reply_order: reveal_after_reply_order,
+    )
+    return [record, :invalid] unless record.save
+
+    Notification.notify_user(post.user, :tag_suggested, post: post)
+    [record, :created]
+  end
+
+  def self.matching_tagging(post:, tag:, tag_type:, tag_name:)
+    if tag
+      post.post_tags.detect { |post_tag| post_tag.tag_id == tag.id }
+    else
+      post.post_tags.detect do |post_tag|
+        post_tag.tag&.type == tag_type && post_tag.tag&.name&.casecmp?(tag_name.to_s)
+      end
+    end
+  end
+  private_class_method :matching_tagging
+
+  def self.matching_suggestion(post:, tag:, tag_type:, tag_name:)
+    if tag
+      where(post_id: post.id, tag_id: tag.id).first
+    else
+      where(post_id: post.id, tag_id: nil, tag_type: tag_type, tag_name: tag_name).first
+    end
+  end
+  private_class_method :matching_suggestion
+
+  def self.endorse(post:, user:, tagging:, note:)
+    existing = where(post_id: post.id, tag_id: tagging.tag_id).first
+    return existing if existing
+
+    create!(
+      post: post, user: user, tag_id: tagging.tag_id, note: note,
+      status: :endorsed, resolved_at: Time.zone.now,
+    )
+  end
+  private_class_method :endorse
+
+  def tag_display_name
+    tag&.name || tag_name
+  end
+
+  def tag_display_type
+    tag&.type || tag_type
+  end
+
+  # Endorsements need no accept or reject action.
+  def actionable?
+    pending?
+  end
+
+  def accept!(resolver:)
+    transaction do
+      tag_record = tag || Tag.create!(type: tag_type, name: tag_name, user: user)
+      PostTag.find_or_create_by!(post: post, tag: tag_record)
+      update!(status: :accepted, resolved_by: resolver, resolved_at: Time.zone.now, tag: tag_record)
+    end
+  end
+
+  def reject!(resolver:)
+    update!(status: :rejected, resolved_by: resolver, resolved_at: Time.zone.now)
+  end
+
+  def allow_again!
+    destroy!
+  end
+
+  private
+
+  def names_exactly_one_tag
+    has_existing = tag_id.present?
+    has_proposed = tag_type.present? && tag_name.present?
+    return if has_existing ^ has_proposed
+    errors.add(:base, "A suggestion must name either an existing tag or a new tag name, not both.")
+  end
+
+  def suggester_is_not_the_author
+    return if post.nil? || user.nil?
+    return unless post.user_id == user.id
+    errors.add(:base, "You can tag your own post directly.")
+  end
+
+  def post_accepts_suggestions
+    return if post.nil?
+    return if post.allow_tag_suggestions?
+    errors.add(:base, "This author is not accepting tag suggestions.")
+  end
+
+  def within_rate_limits
+    return if user.nil? || post.nil?
+
+    if TagSuggestion.pending.where(user_id: user.id).count >= MAX_PENDING_PER_USER
+      errors.add(:base, "You have too many suggestions awaiting a response.")
+    end
+
+    return unless TagSuggestion.pending.where(post_id: post.id).count >= MAX_PENDING_PER_POST
+    errors.add(:base, "This post already has as many pending suggestions as it can hold.")
+  end
+end

--- a/app/models/tag_suggestion.rb
+++ b/app/models/tag_suggestion.rb
@@ -128,29 +128,29 @@ class TagSuggestion < ApplicationRecord
     has_existing = tag_id.present?
     has_proposed = tag_type.present? && tag_name.present?
     return if has_existing ^ has_proposed
-    errors.add(:base, "A suggestion must name either an existing tag or a new tag name, not both.")
+    errors.add(:base, "A suggestion must name exactly one of an existing tag or a new tag name.")
   end
 
   def suggester_is_not_the_author
     return if post.nil? || user.nil?
     return unless post.user_id == user.id
-    errors.add(:base, "You can tag your own post directly.")
+    errors.add(:base, "An author must tag their own post directly.")
   end
 
   def post_accepts_suggestions
     return if post.nil?
     return if post.allow_tag_suggestions?
-    errors.add(:base, "This author is not accepting tag suggestions.")
+    errors.add(:base, "This post does not accept tag suggestions.")
   end
 
   def within_rate_limits
     return if user.nil? || post.nil?
 
     if TagSuggestion.pending.where(user_id: user.id).count >= MAX_PENDING_PER_USER
-      errors.add(:base, "You have too many suggestions awaiting a response.")
+      errors.add(:base, "Limit of #{MAX_PENDING_PER_USER} pending suggestions per user reached.")
     end
 
     return unless TagSuggestion.pending.where(post_id: post.id).count >= MAX_PENDING_PER_POST
-    errors.add(:base, "This post already has as many pending suggestions as it can hold.")
+    errors.add(:base, "Limit of #{MAX_PENDING_PER_POST} pending suggestions per post reached.")
   end
 end

--- a/app/models/tag_suggestion.rb
+++ b/app/models/tag_suggestion.rb
@@ -44,8 +44,7 @@ class TagSuggestion < ApplicationRecord
     existing_tagging = matching_tagging(post: post, tag: tag, tag_type: tag_type, tag_name: tag_name)
 
     if existing_tagging
-      read_order = post.read_reply_order_for(user)
-      return [nil, :already_visible] if existing_tagging.revealed_to?(user, read_reply_order: read_order)
+      return [nil, :already_visible] if existing_tagging.expanded_for?(user)
       return [endorse(post: post, user: user, tagging: existing_tagging, note: note), :endorsed]
     end
 

--- a/app/models/tag_suggestion.rb
+++ b/app/models/tag_suggestion.rb
@@ -30,6 +30,13 @@ class TagSuggestion < ApplicationRecord
   #
   # Returns [record_or_nil, outcome].
   def self.submit(post:, user:, tag: nil, tag_type: nil, tag_name: nil, note: nil, spoiler: false, reveal_after_reply_order: nil)
+    # A proposed name that already exists is a suggestion of that tag. Without
+    # this, re-proposing a rejected tag as a "new" name walks past the block.
+    if tag.nil? && tag_type.present? && tag_name.present?
+      tag = Tag.where(type: tag_type).find_by(name: tag_name)
+      tag_type = tag_name = nil if tag
+    end
+
     existing_tagging = matching_tagging(post: post, tag: tag, tag_type: tag_type, tag_name: tag_name)
 
     if existing_tagging
@@ -100,7 +107,10 @@ class TagSuggestion < ApplicationRecord
     transaction do
       tag_record = tag || Tag.create!(type: tag_type, name: tag_name, user: user)
       PostTag.find_or_create_by!(post: post, tag: tag_record)
-      update!(status: :accepted, resolved_by: resolver, resolved_at: Time.zone.now, tag: tag_record)
+      update!(
+        status: :accepted, resolved_by: resolver, resolved_at: Time.zone.now,
+        tag: tag_record, tag_type: nil, tag_name: nil,
+      )
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,12 @@ class User < ApplicationRecord
   has_many :wrangled_settings, through: :wrangling_assignments, source: :setting
   has_many :tag_suggestions, inverse_of: :user, dependent: :destroy
 
+  # Memoized per instance: Tag#editable_by? is called once per row on tag
+  # listings, and resolving the scope walks the setting graph.
+  def wrangling_scope_ids
+    @wrangling_scope_ids ||= WranglingAssignment.scope_ids_for(self)
+  end
+
   has_many :bookmarks, inverse_of: :user, dependent: :destroy
   has_many :bookmarked_replies, through: :bookmarks, source: :reply, dependent: :destroy
   has_many :bookmarked_posts, -> { ordered }, through: :bookmarks, source: :post, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,10 @@ class User < ApplicationRecord
   has_many :user_tags, inverse_of: :user, dependent: :destroy
   has_many :content_warnings, -> { ordered_by_user_tag }, through: :user_tags, source: :content_warning, dependent: :destroy
 
+  has_many :wrangling_assignments, inverse_of: :user, dependent: :destroy
+  has_many :wrangled_settings, through: :wrangling_assignments, source: :setting
+  has_many :tag_suggestions, inverse_of: :user, dependent: :destroy
+
   has_many :bookmarks, inverse_of: :user, dependent: :destroy
   has_many :bookmarked_replies, through: :bookmarks, source: :reply, dependent: :destroy
   has_many :bookmarked_posts, -> { ordered }, through: :bookmarks, source: :post, dependent: :destroy

--- a/app/models/wrangling_assignment.rb
+++ b/app/models/wrangling_assignment.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+class WranglingAssignment < ApplicationRecord
+  belongs_to :user, inverse_of: :wrangling_assignments, optional: false
+  belongs_to :setting, inverse_of: :wrangling_assignments, optional: false
+
+  validates :user_id, uniqueness: { scope: :setting_id }
+  validate :setting_is_a_setting
+
+  # Assigned settings plus everything below them in the implication graph.
+  def self.scope_ids_for(user)
+    return [] if user.nil?
+
+    direct_ids = where(user_id: user.id).pluck(:setting_id)
+    return [] if direct_ids.empty?
+
+    descendants = Setting.where(id: direct_ids).flat_map(&:descendant_ids)
+    (direct_ids + descendants).uniq
+  end
+
+  def self.reassign_for_merge(source:, target:)
+    return if source.id == target.id
+
+    losing = where(setting_id: source.id).to_a
+    return if losing.empty?
+
+    already_assigned = where(setting_id: target.id).pluck(:user_id).to_set
+
+    transaction do
+      losing.each do |assignment|
+        if already_assigned.include?(assignment.user_id)
+          assignment.destroy!
+        else
+          assignment.update!(setting: target)
+        end
+      end
+    end
+
+    notify_of_merge(losing.map(&:user_id) | already_assigned.to_a, source: source, target: target)
+  end
+
+  def self.notify_of_merge(user_ids, source:, target:)
+    User.where(id: user_ids).find_each do |user|
+      Notification.notify_user(
+        user,
+        :wrangling_scope_merged,
+        error: "The setting #{source.name} was merged into #{target.name}, which changes what you wrangle.",
+      )
+    end
+  end
+  private_class_method :notify_of_merge
+
+  private
+
+  def setting_is_a_setting
+    return if setting.nil?
+    errors.add(:setting, "must be a setting") unless setting.is_a?(Setting)
+  end
+end

--- a/app/models/wrangling_assignment.rb
+++ b/app/models/wrangling_assignment.rb
@@ -43,7 +43,7 @@ class WranglingAssignment < ApplicationRecord
       Notification.notify_user(
         user,
         :wrangling_scope_merged,
-        error: "The setting #{source.name} was merged into #{target.name}, which changes what you wrangle.",
+        error: "Setting #{source.name} was merged into #{target.name}. Your wrangling scope has changed.",
       )
     end
   end

--- a/app/services/tag_wrangling/coverage.rb
+++ b/app/services/tag_wrangling/coverage.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Progress weighted by usage rather than by tag count. The raw number of
+# unwrangled tags barely moves for a long time and is a discouraging number to
+# show a volunteer; the share of actual taggings covered moves quickly.
+class TagWrangling::Coverage
+  CACHE_TTL = 15.minutes
+
+  def initialize(type: nil)
+    @type = type
+  end
+
+  def canonical_taggings
+    counts[:canonical]
+  end
+
+  def total_taggings
+    counts[:total]
+  end
+
+  def percentage
+    return 100.0 if total_taggings.zero?
+    ((canonical_taggings.to_f / total_taggings) * 100).round(1)
+  end
+
+  def remaining_tags
+    counts[:remaining]
+  end
+
+  private
+
+  def counts
+    @counts ||= Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) do
+      scope = PostTag.joins(:tag)
+      scope = scope.where(tags: { type: @type }) if @type
+      {
+        total: scope.count,
+        canonical: scope.where(tags: { canonical: true }).count,
+        remaining: tag_scope.awaiting_wrangling.count,
+      }
+    end
+  end
+
+  def tag_scope
+    @type ? Tag.where(type: @type) : Tag.all
+  end
+
+  def cache_key
+    "tag_wrangling/coverage/#{@type || 'all'}/#{Tag.maximum(:updated_at).to_i}"
+  end
+end

--- a/app/services/tag_wrangling/duplicate_clusters.rb
+++ b/app/services/tag_wrangling/duplicate_clusters.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Groups tags whose names collapse to the same normalized form. Computed and
+# cached rather than stored in a column, so the normalization can be tuned
+# without a migration.
+class TagWrangling::DuplicateClusters
+  CACHE_TTL = 15.minutes
+  MAX_CLUSTERS = 25
+
+  def initialize(type: nil)
+    @type = type
+  end
+
+  def clusters
+    @clusters ||= Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) { build_clusters }
+  end
+
+  def self.normalize(name)
+    name.to_s
+      .downcase
+      .gsub(/[^a-z0-9]+/, ' ')
+      .strip
+      .split
+      .map { |word| word.sub(/(?<=.{3})(?:es|s)\z/, '') }
+      .join(' ')
+  end
+
+  private
+
+  def build_clusters
+    scope = Tag.wrangleable
+    scope = scope.where(type: @type) if @type
+
+    grouped = scope.pluck(:id, :name, :type).group_by do |(_id, name, type)|
+      [type, self.class.normalize(name)]
+    end
+
+    grouped
+      .select { |_key, rows| rows.size > 1 }
+      .first(MAX_CLUSTERS)
+      .map do |(type, normalized), rows|
+        {
+          type: type,
+          normalized: normalized,
+          tag_ids: rows.map(&:first),
+          names: rows.map { |row| row[1] },
+        }
+      end
+  end
+
+  def cache_key
+    "tag_wrangling/duplicate_clusters/#{@type || 'all'}/#{Tag.maximum(:updated_at).to_i}/#{Tag.count}"
+  end
+end

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -12,7 +12,7 @@
     - unless post.privacy_public?
       = privacy_icon(post.privacy.to_sym, dark_layout: current_user&.layout_darkmode?)
     - if !current_user.try(:hide_warnings) && post.has_content_warnings?
-      = image_tag "icons/exclamation.png", class: 'vmid', title: "Content Warning: " + post.content_warnings.pluck(:name).join(', '), alt: 'Has Warnings'
+      = image_tag "icons/exclamation.png", class: 'vmid', title: "Content Warning: " + post.unspoilered_content_warnings.pluck(:name).join(', '), alt: 'Has Warnings'
   %td.post-subject.vtop{class: klass}
     - if logged_in?
       - if unread_post?(post, unread_ids) || (@show_unread && !opened_post?(post, opened_ids))

--- a/app/views/posts/_tag_row.haml
+++ b/app/views/posts/_tag_row.haml
@@ -1,0 +1,20 @@
+-# locals: (klass:, label:)
+- taggings = @post.displayable_post_tags.select { |post_tag| post_tag.tag.is_a?(klass) }
+- if taggings.present?
+  - plain, spoilered = taggings.partition { |post_tag| post_tag.expanded_for?(current_user) }
+  %tr
+    %th.sub.width-150= label
+    %td{class: cycle('odd', 'even')}
+      - if plain.present?
+        = safe_join(plain.map { |post_tag| link_to post_tag.tag.name, tag_path(post_tag.tag) }, ', ')
+      - if spoilered.present?
+        %details.spoiler-tags
+          %summary
+            #{spoilered.length} spoiler #{'tag'.pluralize(spoilered.length)}
+          %ul
+            - spoilered.each do |post_tag|
+              %li
+                = link_to post_tag.tag.name, tag_path(post_tag.tag)
+                - if post_tag.applies_from_reply_order.present?
+                  %span.subber
+                    from reply #{post_tag.applies_from_reply_order}

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -57,21 +57,34 @@
               = surround '(', ')' do
                 = link_to "#{count} #{'time'.pluralize(count)}", search_replies_path(post_id: @post.id, character_id: character.id, commit: true, sort: :created_new)
 
-    - if @post.settings.present?
+    - visible_settings = @post.visible_tags_for(current_user, Setting)
+    - if visible_settings.present?
       %tr
         %th.sub.width-150 Setting
-        - setting_links = @post.settings.ordered_by_post_tag.map { |tag| link_to tag.name, tag_path(tag) }
+        - setting_links = visible_settings.map { |tag| link_to tag.name, tag_path(tag) }
         %td{class: cycle('odd', 'even')}= safe_join(setting_links, ', ')
-    - if @post.content_warnings.present?
+    - visible_warnings = @post.visible_tags_for(current_user, ContentWarning)
+    - if visible_warnings.present?
       %tr
         %th.sub.width-150 Content Warnings
-        - warning_links = @post.content_warnings.ordered_by_post_tag.map { |tag| link_to tag.name, tag_path(tag) }
+        - warning_links = visible_warnings.map { |tag| link_to tag.name, tag_path(tag) }
         %td{class: cycle('odd', 'even')}= safe_join(warning_links, ', ')
-    - if @post.labels.present?
+    - visible_labels = @post.visible_tags_for(current_user, Label)
+    - if visible_labels.present?
       %tr
         %th.sub.width-150 Labels
-        - label_links = @post.labels.ordered_by_post_tag.map { |tag| link_to tag.name, tag_path(tag) }
+        - label_links = visible_labels.map { |tag| link_to tag.name, tag_path(tag) }
         %td{class: cycle('odd', 'even')}= safe_join(label_links, ', ')
+    - hidden_count = @post.hidden_spoiler_tag_count_for(current_user)
+    - if hidden_count > 0
+      %tr
+        %th.sub.width-150 Spoiler Tags
+        %td{class: cycle('odd', 'even')}
+          #{hidden_count} #{"tag".pluralize(hidden_count)} hidden until you have read further.
+    - if current_user && @post.allow_tag_suggestions? && @post.user_id != current_user.id && !current_user.read_only?
+      %tr
+        %th.sub.width-150 Tags
+        %td{class: cycle('odd', 'even')}= link_to "Suggest a tag", new_post_tag_suggestion_path(@post)
     %tr
       %th.sub.width-150.vtop Word Count
       %td{class: cycle('odd', 'even')}

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -57,30 +57,9 @@
               = surround '(', ')' do
                 = link_to "#{count} #{'time'.pluralize(count)}", search_replies_path(post_id: @post.id, character_id: character.id, commit: true, sort: :created_new)
 
-    - visible_settings = @post.visible_tags_for(current_user, Setting)
-    - if visible_settings.present?
-      %tr
-        %th.sub.width-150 Setting
-        - setting_links = visible_settings.map { |tag| link_to tag.name, tag_path(tag) }
-        %td{class: cycle('odd', 'even')}= safe_join(setting_links, ', ')
-    - visible_warnings = @post.visible_tags_for(current_user, ContentWarning)
-    - if visible_warnings.present?
-      %tr
-        %th.sub.width-150 Content Warnings
-        - warning_links = visible_warnings.map { |tag| link_to tag.name, tag_path(tag) }
-        %td{class: cycle('odd', 'even')}= safe_join(warning_links, ', ')
-    - visible_labels = @post.visible_tags_for(current_user, Label)
-    - if visible_labels.present?
-      %tr
-        %th.sub.width-150 Labels
-        - label_links = visible_labels.map { |tag| link_to tag.name, tag_path(tag) }
-        %td{class: cycle('odd', 'even')}= safe_join(label_links, ', ')
-    - hidden_count = current_user ? @post.hidden_spoiler_tag_count_for(current_user) : 0
-    - if hidden_count > 0
-      %tr
-        %th.sub.width-150 Spoiler Tags
-        %td{class: cycle('odd', 'even')}
-          #{hidden_count} spoiler #{"tag".pluralize(hidden_count)} hidden until you have read further into this post.
+    = render 'tag_row', klass: Setting, label: 'Setting'
+    = render 'tag_row', klass: ContentWarning, label: 'Content Warnings'
+    = render 'tag_row', klass: Label, label: 'Labels'
     - if current_user && @post.allow_tag_suggestions? && @post.user_id != current_user.id && !current_user.read_only?
       %tr
         %th.sub.width-150 Tags

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -80,7 +80,7 @@
       %tr
         %th.sub.width-150 Spoiler Tags
         %td{class: cycle('odd', 'even')}
-          #{hidden_count} #{"tag".pluralize(hidden_count)} hidden until you have read further.
+          #{hidden_count} spoiler #{"tag".pluralize(hidden_count)} hidden until you have read further into this post.
     - if current_user && @post.allow_tag_suggestions? && @post.user_id != current_user.id && !current_user.read_only?
       %tr
         %th.sub.width-150 Tags

--- a/app/views/posts/stats.haml
+++ b/app/views/posts/stats.haml
@@ -75,7 +75,7 @@
         %th.sub.width-150 Labels
         - label_links = visible_labels.map { |tag| link_to tag.name, tag_path(tag) }
         %td{class: cycle('odd', 'even')}= safe_join(label_links, ', ')
-    - hidden_count = @post.hidden_spoiler_tag_count_for(current_user)
+    - hidden_count = current_user ? @post.hidden_spoiler_tag_count_for(current_user) : 0
     - if hidden_count > 0
       %tr
         %th.sub.width-150 Spoiler Tags

--- a/app/views/tag_suggestions/index.haml
+++ b/app/views/tag_suggestions/index.haml
@@ -1,0 +1,73 @@
+- content_for :breadcrumbs do
+  %b Suggested Tags
+
+%table
+  %thead
+    %tr
+      %th.table-title{colspan: 5} Awaiting Your Decision
+    %tr
+      %th.sub Post
+      %th.sub Tag
+      %th.sub Suggested by
+      %th.sub Note
+      %th.sub Actions
+  %tbody
+    - if @pending.empty?
+      %tr
+        %td.padding-10{colspan: 5} Nothing waiting.
+    - @pending.each do |suggestion|
+      %tr{class: cycle('even', 'odd')}
+        %td= link_to suggestion.post.subject, post_path(suggestion.post)
+        %td
+          = suggestion.tag_display_name
+          %span.subber= suggestion.tag_display_type
+          - if suggestion.spoiler?
+            %span.subber (spoiler)
+        %td= link_to suggestion.user.username, user_path(suggestion.user)
+        %td= suggestion.note
+        %td
+          = button_to "Add", accept_tag_suggestion_path(suggestion), method: :post, class: 'button'
+          = button_to "Decline", reject_tag_suggestion_path(suggestion), method: :post, class: 'button'
+
+%table
+  %thead
+    %tr
+      %th.table-title{colspan: 3} Endorsements
+    %tr
+      %th.sub Post
+      %th.sub Tag
+      %th.sub Endorsed by
+  %tbody
+    - if @endorsements.empty?
+      %tr
+        %td.padding-10{colspan: 3} No endorsements yet.
+    - @endorsements.each do |suggestion|
+      %tr{class: cycle('even', 'odd')}
+        %td= link_to suggestion.post.subject, post_path(suggestion.post)
+        %td= suggestion.tag_display_name
+        %td= link_to suggestion.user.username, user_path(suggestion.user)
+
+%p.subber
+  A reader reached for a tag you had already applied. Nothing to do — it just means the tag reads the way you intended.
+
+%table
+  %thead
+    %tr
+      %th.table-title{colspan: 4} Resolved
+    %tr
+      %th.sub Post
+      %th.sub Tag
+      %th.sub Outcome
+      %th.sub Actions
+  %tbody
+    - if @resolved.empty?
+      %tr
+        %td.padding-10{colspan: 4} Nothing resolved yet.
+    - @resolved.each do |suggestion|
+      %tr{class: cycle('even', 'odd')}
+        %td= link_to suggestion.post.subject, post_path(suggestion.post)
+        %td= suggestion.tag_display_name
+        %td= suggestion.status.titlecase
+        %td
+          - if suggestion.rejected?
+            = button_to "Allow again", allow_again_tag_suggestion_path(suggestion), method: :delete, class: 'button'

--- a/app/views/tag_suggestions/index.haml
+++ b/app/views/tag_suggestions/index.haml
@@ -4,7 +4,7 @@
 %table
   %thead
     %tr
-      %th.table-title{colspan: 5} Awaiting Your Decision
+      %th.table-title{colspan: 5} Pending Suggestions
     %tr
       %th.sub Post
       %th.sub Tag
@@ -14,7 +14,7 @@
   %tbody
     - if @pending.empty?
       %tr
-        %td.padding-10{colspan: 5} Nothing waiting.
+        %td.padding-10{colspan: 5} No pending suggestions.
     - @pending.each do |suggestion|
       %tr{class: cycle('even', 'odd')}
         %td= link_to suggestion.post.subject, post_path(suggestion.post)
@@ -26,7 +26,7 @@
         %td= link_to suggestion.user.username, user_path(suggestion.user)
         %td= suggestion.note
         %td
-          = button_to "Add", accept_tag_suggestion_path(suggestion), method: :post, class: 'button'
+          = button_to "Apply", accept_tag_suggestion_path(suggestion), method: :post, class: 'button'
           = button_to "Decline", reject_tag_suggestion_path(suggestion), method: :post, class: 'button'
 
 %table
@@ -40,7 +40,7 @@
   %tbody
     - if @endorsements.empty?
       %tr
-        %td.padding-10{colspan: 3} No endorsements yet.
+        %td.padding-10{colspan: 3} No endorsements.
     - @endorsements.each do |suggestion|
       %tr{class: cycle('even', 'odd')}
         %td= link_to suggestion.post.subject, post_path(suggestion.post)
@@ -48,7 +48,7 @@
         %td= link_to suggestion.user.username, user_path(suggestion.user)
 
 %p.subber
-  A reader reached for a tag you had already applied. Nothing to do — it just means the tag reads the way you intended.
+  An endorsement records that a reader independently suggested a tag already applied to the post. No action is required.
 
 %table
   %thead
@@ -62,7 +62,7 @@
   %tbody
     - if @resolved.empty?
       %tr
-        %td.padding-10{colspan: 4} Nothing resolved yet.
+        %td.padding-10{colspan: 4} No resolved suggestions.
     - @resolved.each do |suggestion|
       %tr{class: cycle('even', 'odd')}
         %td= link_to suggestion.post.subject, post_path(suggestion.post)
@@ -70,4 +70,4 @@
         %td= suggestion.status.titlecase
         %td
           - if suggestion.rejected?
-            = button_to "Allow again", allow_again_tag_suggestion_path(suggestion), method: :delete, class: 'button'
+            = button_to "Permit again", allow_again_tag_suggestion_path(suggestion), method: :delete, class: 'button'

--- a/app/views/tag_suggestions/new.haml
+++ b/app/views/tag_suggestions/new.haml
@@ -10,13 +10,11 @@
         %th.table-title{colspan: 2} Suggest a Tag
     %tbody
       %tr
-        %td.sub Existing tag
-        %td= f.select :tag_id, options_from_collection_for_select(Tag.wrangleable.ordered_by_name.limit(200), :id, :name), include_blank: '— none —'
-      %tr
-        %td.sub New tag
+        %td.sub Tag
         %td
-          = f.select :tag_type, options_for_select(Tag::TYPES), include_blank: '— type —'
+          = f.select :tag_type, options_for_select(Tag::POST_TYPES), include_blank: '— type —'
           = f.text_field :tag_name, placeholder: 'Tag name'
+          .subber An existing tag with this name and type is suggested as that tag.
       %tr
         %td.sub Note
         %td= f.text_area :note, rows: 3, placeholder: 'Optional. Shown to the post author.'

--- a/app/views/tag_suggestions/new.haml
+++ b/app/views/tag_suggestions/new.haml
@@ -13,21 +13,21 @@
         %td.sub Existing tag
         %td= f.select :tag_id, options_from_collection_for_select(Tag.wrangleable.ordered_by_name.limit(200), :id, :name), include_blank: '— none —'
       %tr
-        %td.sub Or a new tag
+        %td.sub New tag
         %td
           = f.select :tag_type, options_for_select(Tag::TYPES), include_blank: '— type —'
           = f.text_field :tag_name, placeholder: 'Tag name'
       %tr
-        %td.sub Why?
-        %td= f.text_area :note, rows: 3, placeholder: 'Optional note for the author'
+        %td.sub Note
+        %td= f.text_area :note, rows: 3, placeholder: 'Optional. Shown to the post author.'
       %tr
         %td.sub Spoiler
         %td
           = f.check_box :spoiler
-          = f.label :spoiler, 'This tag spoils the post'
-          = f.number_field :reveal_after_reply_order, placeholder: 'Reveal after reply #'
+          = f.label :spoiler, 'Tag reveals a spoiler'
+          = f.number_field :reveal_after_reply_order, placeholder: 'Reveal after reply number'
       %tr
         %td{colspan: 2}= f.submit "Suggest", class: 'button'
 
 %p.subber
-  The author decides whether to add this. If they decline, it cannot be suggested on this post again.
+  The post author decides whether to apply the tag. A declined tag cannot be suggested on this post again.

--- a/app/views/tag_suggestions/new.haml
+++ b/app/views/tag_suggestions/new.haml
@@ -1,0 +1,33 @@
+- content_for :breadcrumbs do
+  = link_to @post.subject, post_path(@post)
+  &raquo;
+  %b Suggest a Tag
+
+= form_for @suggestion, url: post_tag_suggestions_path(@post), method: :post do |f|
+  %table
+    %thead
+      %tr
+        %th.table-title{colspan: 2} Suggest a Tag
+    %tbody
+      %tr
+        %td.sub Existing tag
+        %td= f.select :tag_id, options_from_collection_for_select(Tag.wrangleable.ordered_by_name.limit(200), :id, :name), include_blank: '— none —'
+      %tr
+        %td.sub Or a new tag
+        %td
+          = f.select :tag_type, options_for_select(Tag::TYPES), include_blank: '— type —'
+          = f.text_field :tag_name, placeholder: 'Tag name'
+      %tr
+        %td.sub Why?
+        %td= f.text_area :note, rows: 3, placeholder: 'Optional note for the author'
+      %tr
+        %td.sub Spoiler
+        %td
+          = f.check_box :spoiler
+          = f.label :spoiler, 'This tag spoils the post'
+          = f.number_field :reveal_after_reply_order, placeholder: 'Reveal after reply #'
+      %tr
+        %td{colspan: 2}= f.submit "Suggest", class: 'button'
+
+%p.subber
+  The author decides whether to add this. If they decline, it cannot be suggested on this post again.

--- a/app/views/tag_wranglings/index.haml
+++ b/app/views/tag_wranglings/index.haml
@@ -1,0 +1,75 @@
+- content_for :breadcrumbs do
+  %b Tag Wrangling
+
+%table
+  %thead
+    %tr
+      %th.table-title{colspan: 5} Tag Wrangling
+    %tr
+      %th.subber.padding-10{colspan: 5}
+        = form_tag tag_wranglings_path, method: :get do
+          = select_tag :type, options_for_select(Tag::TYPES, @type), include_blank: '— All Types —', id: 'wrangling-type'
+          = submit_tag "Filter", class: 'button'
+  %tbody
+    %tr
+      %td.padding-10{colspan: 5}
+        %b Coverage:
+        #{@coverage.percentage}%
+        of #{number_with_delimiter(@coverage.total_taggings)} taggings use a canonical tag.
+        %span.subber #{number_with_delimiter(@coverage.remaining_tags)} tags not yet reviewed.
+
+- if @clusters.present?
+  %table
+    %thead
+      %tr
+        %th.table-title{colspan: 2} Possible Duplicates
+      %tr
+        %th.sub Normalized
+        %th.sub Tags
+    %tbody
+      - @clusters.each do |cluster|
+        %tr{class: cycle('even', 'odd')}
+          %td= cluster[:normalized]
+          %td
+            - cluster[:names].each_with_index do |name, index|
+              = link_to name, tag_path(cluster[:tag_ids][index])
+              = ' · ' unless index == cluster[:names].length - 1
+
+%table
+  %thead
+    %tr
+      %th.table-title{colspan: 4} Awaiting Review
+    %tr
+      %th.sub Name
+      %th.sub Type
+      %th.sub Posts
+      %th.sub Actions
+  %tbody
+    - if @tags.empty?
+      %tr
+        %td.padding-10{colspan: 4} Nothing is waiting for you here.
+    - @tags.each do |tag|
+      %tr{class: cycle('even', 'odd')}
+        %td= link_to tag.name, tag_path(tag)
+        %td= tag.type
+        %td= tag.post_count
+        %td
+          = form_tag tag_wrangling_path(tag), method: :patch, class: 'wrangling-actions' do
+            = hidden_field_tag :type, @type
+            = hidden_field_tag :commit_action, 'canonical'
+            = submit_tag "Canonical", class: 'button'
+          = form_tag tag_wrangling_path(tag), method: :patch, class: 'wrangling-actions' do
+            = hidden_field_tag :type, @type
+            = hidden_field_tag :commit_action, 'unwrangleable'
+            = submit_tag "Skip", class: 'button'
+          = form_tag tag_wrangling_path(tag), method: :patch, class: 'wrangling-actions' do
+            = hidden_field_tag :type, @type
+            = hidden_field_tag :commit_action, 'merge'
+            = text_field_tag :merger_id, nil, placeholder: 'Merge into tag ID'
+            - if current_user.has_permission?(:delete_tags)
+              = check_box_tag :destroy_loser
+              = label_tag :destroy_loser, 'delete'
+            = submit_tag "Merge", class: 'button'
+  %tfoot
+    %tr
+      %td{colspan: 4}= render 'posts/paginator', paginated: @tags

--- a/app/views/tag_wranglings/index.haml
+++ b/app/views/tag_wranglings/index.haml
@@ -14,15 +14,14 @@
     %tr
       %td.padding-10{colspan: 5}
         %b Coverage:
-        #{@coverage.percentage}%
-        of #{number_with_delimiter(@coverage.total_taggings)} taggings use a canonical tag.
-        %span.subber #{number_with_delimiter(@coverage.remaining_tags)} tags not yet reviewed.
+        #{@coverage.percentage}% of #{number_with_delimiter(@coverage.total_taggings)} taggings use a canonical tag.
+        %span.subber #{number_with_delimiter(@coverage.remaining_tags)} tags not reviewed.
 
 - if @clusters.present?
   %table
     %thead
       %tr
-        %th.table-title{colspan: 2} Possible Duplicates
+        %th.table-title{colspan: 2} Candidate Duplicates
       %tr
         %th.sub Normalized
         %th.sub Tags
@@ -38,7 +37,7 @@
 %table
   %thead
     %tr
-      %th.table-title{colspan: 4} Awaiting Review
+      %th.table-title{colspan: 4} Unreviewed Tags
     %tr
       %th.sub Name
       %th.sub Type
@@ -47,7 +46,7 @@
   %tbody
     - if @tags.empty?
       %tr
-        %td.padding-10{colspan: 4} Nothing is waiting for you here.
+        %td.padding-10{colspan: 4} No tags await review.
     - @tags.each do |tag|
       %tr{class: cycle('even', 'odd')}
         %td= link_to tag.name, tag_path(tag)
@@ -57,18 +56,18 @@
           = form_tag tag_wrangling_path(tag), method: :patch, class: 'wrangling-actions' do
             = hidden_field_tag :type, @type
             = hidden_field_tag :commit_action, 'canonical'
-            = submit_tag "Canonical", class: 'button'
+            = submit_tag "Mark canonical", class: 'button'
           = form_tag tag_wrangling_path(tag), method: :patch, class: 'wrangling-actions' do
             = hidden_field_tag :type, @type
             = hidden_field_tag :commit_action, 'unwrangleable'
-            = submit_tag "Skip", class: 'button'
+            = submit_tag "Mark unwrangleable", class: 'button'
           = form_tag tag_wrangling_path(tag), method: :patch, class: 'wrangling-actions' do
             = hidden_field_tag :type, @type
             = hidden_field_tag :commit_action, 'merge'
-            = text_field_tag :merger_id, nil, placeholder: 'Merge into tag ID'
+            = text_field_tag :merger_id, nil, placeholder: 'Target tag ID'
             - if current_user.has_permission?(:delete_tags)
               = check_box_tag :destroy_loser
-              = label_tag :destroy_loser, 'delete'
+              = label_tag :destroy_loser, 'delete source tag'
             = submit_tag "Merge", class: 'button'
   %tfoot
     %tr

--- a/app/views/tags/_editor.haml
+++ b/app/views/tags/_editor.haml
@@ -19,7 +19,7 @@
   .checkbox-field{class: cycle('even', 'odd')}
     = f.check_box :owned
     = f.label :owned, 'Tag belongs to owner'
-- if f.object.is_a?(Setting)
+- if f.object.is_a?(Setting) && f.object.hierarchy_editable_by?(current_user)
   %div
     .sub= f.label :parent_settings
     %div{class: cycle('even', 'odd')}= tag_select(@tag, f, :parent_settings, data: { tag_id: f.object.id })

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -79,6 +79,11 @@
         = f.check_box :hide_warnings
         = f.label :hide_warnings, "Hide content warnings"
     %div
+      .sub Tag suggestions
+      .checkbox-field{class: cycle('even', 'odd')}
+        = f.check_box :allow_tag_suggestions
+        = f.label :allow_tag_suggestions, "Allow readers to suggest tags on new posts"
+    %div
       .sub= f.label :default_editor
       - editor_modes = { 'Rich Text': 'rtf', HTML: 'html', Markdown: 'md' }
       %div{class: cycle('even', 'odd')}= f.select(:default_editor, options_for_select(editor_modes, current_user.default_editor))

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -84,6 +84,11 @@
         = f.check_box :allow_tag_suggestions
         = f.label :allow_tag_suggestions, "Allow readers to suggest tags on new posts"
     %div
+      .sub Spoiler tags
+      .checkbox-field{class: cycle('even', 'odd')}
+        = f.check_box :reveal_spoiler_tags
+        = f.label :reveal_spoiler_tags, "Show spoiler tags without clicking to reveal them"
+    %div
       .sub= f.label :default_editor
       - editor_modes = { 'Rich Text': 'rtf', HTML: 'html', Markdown: 'md' }
       %div{class: cycle('even', 'odd')}= f.select(:default_editor, options_for_select(editor_modes, current_user.default_editor))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,19 @@ Rails.application.routes.draw do
   # Blocks
   resources :blocks, except: [:show]
 
+  # Tag wrangling
+  resources :tag_wranglings, only: [:index, :update]
+  resources :tag_suggestions, only: [:index] do
+    member do
+      post :accept
+      post :reject
+      delete :allow_again
+    end
+  end
+  resources :posts, only: [] do
+    resources :tag_suggestions, only: [:new, :create]
+  end
+
   # API
   namespace :api do
     namespace :v1 do

--- a/db/migrate/20171111163658_canon_refactor.rb
+++ b/db/migrate/20171111163658_canon_refactor.rb
@@ -16,9 +16,9 @@ class CanonRefactor < ActiveRecord::Migration[5.0]
       setting.characters << new_chars
 
       # update all non-loop Canon > Settings relationships to be Setting > Settings
-      same_tag = Tag::SettingTag.where(tag_id: canon.id, tagged_id: setting.id).first
+      same_tag = Tag::MetaTag.where(tag_id: canon.id, tagged_id: setting.id).first
       same_tag.destroy! if same_tag.present?
-      Tag::SettingTag.where(tag_id: canon.id).update_all(tag_id: setting.id)
+      Tag::MetaTag.where(tag_id: canon.id).update_all(tag_id: setting.id)
 
       # death to the canon
       canon.destroy!

--- a/db/migrate/20260803120000_add_wrangling_to_tags.rb
+++ b/db/migrate/20260803120000_add_wrangling_to_tags.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class AddWranglingToTags < ActiveRecord::Migration[8.0]
+  def change
+    change_table :tags, bulk: true do |t|
+      t.column :canonical, :boolean, default: false, null: false
+      t.column :unwrangleable, :boolean, default: false, null: false
+      t.column :merger_id, :integer, null: true
+    end
+
+    add_index :tags, :merger_id
+    add_index :tags, [:type, :canonical]
+    add_foreign_key :tags, :tags, column: :merger_id
+  end
+end

--- a/db/migrate/20260803120100_add_spoilers_to_post_tags.rb
+++ b/db/migrate/20260803120100_add_spoilers_to_post_tags.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class AddSpoilersToPostTags < ActiveRecord::Migration[8.0]
+  def change
+    change_table :post_tags, bulk: true do |t|
+      t.column :spoiler, :boolean, default: false, null: false
+      t.column :reveal_after_reply_order, :integer, null: true
+    end
+
+    add_index :post_tags, [:tag_id, :post_id], where: "spoiler = false", name: "index_post_tags_unspoilered"
+  end
+end

--- a/db/migrate/20260803120200_create_wrangling_assignments.rb
+++ b/db/migrate/20260803120200_create_wrangling_assignments.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class CreateWranglingAssignments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :wrangling_assignments do |t|
+      t.integer :user_id, null: false
+      t.integer :setting_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :wrangling_assignments, [:user_id, :setting_id], unique: true
+    add_index :wrangling_assignments, :setting_id
+    add_foreign_key :wrangling_assignments, :users
+    add_foreign_key :wrangling_assignments, :tags, column: :setting_id
+  end
+end

--- a/db/migrate/20260803120300_create_tag_suggestions.rb
+++ b/db/migrate/20260803120300_create_tag_suggestions.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+class CreateTagSuggestions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :tag_suggestions do |t|
+      t.integer :post_id, null: false
+      t.integer :user_id, null: false
+      t.integer :tag_id, null: true
+      t.string :tag_type, null: true
+      t.citext :tag_name, null: true
+      t.integer :status, null: false, default: 0
+      t.integer :resolved_by_id, null: true
+      t.datetime :resolved_at, null: true
+      t.text :note, null: true
+      t.boolean :spoiler, null: false, default: false
+      t.integer :reveal_after_reply_order, null: true
+
+      t.timestamps
+    end
+
+    add_index :tag_suggestions, [:post_id, :status]
+    add_index :tag_suggestions, :user_id
+
+    # Keyed on the post and tag, never the suggester. Two partial indexes: a
+    # suggestion names either an existing tag or a proposed name, never both.
+    add_index :tag_suggestions, [:post_id, :tag_id],
+      unique: true, where: "tag_id IS NOT NULL", name: "index_tag_suggestions_on_post_and_tag"
+    add_index :tag_suggestions, [:post_id, :tag_type, :tag_name],
+      unique: true, where: "tag_id IS NULL", name: "index_tag_suggestions_on_post_and_name"
+
+    add_foreign_key :tag_suggestions, :posts
+    add_foreign_key :tag_suggestions, :users
+    add_foreign_key :tag_suggestions, :tags
+    add_foreign_key :tag_suggestions, :users, column: :resolved_by_id
+  end
+end

--- a/db/migrate/20260803120400_add_allow_tag_suggestions.rb
+++ b/db/migrate/20260803120400_add_allow_tag_suggestions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AddAllowTagSuggestions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :posts, :allow_tag_suggestions, :boolean, default: true, null: false
+    add_column :users, :allow_tag_suggestions, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20260803140000_make_tag_tags_suggested_not_null.rb
+++ b/db/migrate/20260803140000_make_tag_tags_suggested_not_null.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class MakeTagTagsSuggestedNotNull < ActiveRecord::Migration[8.0]
+  def up
+    execute("UPDATE tag_tags SET suggested = false WHERE suggested IS NULL")
+    change_table :tag_tags, bulk: true do |t|
+      t.change_null :suggested, false
+      t.change_default :suggested, from: nil, to: false
+    end
+  end
+
+  def down
+    change_column_null :tag_tags, :suggested, true
+  end
+end

--- a/db/migrate/20260804100000_add_reveal_spoiler_tags_to_users.rb
+++ b/db/migrate/20260804100000_add_reveal_spoiler_tags_to_users.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddRevealSpoilerTagsToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :reveal_spoiler_tags, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_03_120400) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_03_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -452,7 +452,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_03_120400) do
   create_table "tag_tags", id: :serial, force: :cascade do |t|
     t.integer "tagged_id", null: false
     t.integer "tag_id", null: false
-    t.boolean "suggested", default: false
+    t.boolean "suggested", default: false, null: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["tag_id"], name: "index_tag_tags_on_tag_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_03_120400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -324,7 +324,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
     t.boolean "suggested", default: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
+    t.boolean "spoiler", default: false, null: false
+    t.integer "reveal_after_reply_order"
     t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id", "post_id"], name: "index_post_tags_unspoilered", where: "(spoiler = false)"
     t.index ["tag_id"], name: "index_post_tags_on_tag_id"
   end
 
@@ -370,6 +373,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
     t.boolean "authors_locked", default: false
     t.integer "character_alias_id"
     t.string "editor_mode"
+    t.boolean "allow_tag_suggestions", default: true, null: false
     t.index "to_tsvector('english'::regconfig, COALESCE((subject)::text, ''::text))", name: "idx_fts_post_subject", using: :gin
     t.index "to_tsvector('english'::regconfig, COALESCE(content, ''::text))", name: "idx_fts_post_content", using: :gin
     t.index ["board_id"], name: "index_posts_on_board_id"
@@ -425,6 +429,26 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
     t.index ["user_id"], name: "index_report_views_on_user_id"
   end
 
+  create_table "tag_suggestions", force: :cascade do |t|
+    t.integer "post_id", null: false
+    t.integer "user_id", null: false
+    t.integer "tag_id"
+    t.string "tag_type"
+    t.citext "tag_name"
+    t.integer "status", default: 0, null: false
+    t.integer "resolved_by_id"
+    t.datetime "resolved_at"
+    t.text "note"
+    t.boolean "spoiler", default: false, null: false
+    t.integer "reveal_after_reply_order"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id", "status"], name: "index_tag_suggestions_on_post_id_and_status"
+    t.index ["post_id", "tag_id"], name: "index_tag_suggestions_on_post_and_tag", unique: true, where: "(tag_id IS NOT NULL)"
+    t.index ["post_id", "tag_type", "tag_name"], name: "index_tag_suggestions_on_post_and_name", unique: true, where: "(tag_id IS NULL)"
+    t.index ["user_id"], name: "index_tag_suggestions_on_user_id"
+  end
+
   create_table "tag_tags", id: :serial, force: :cascade do |t|
     t.integer "tagged_id", null: false
     t.integer "tag_id", null: false
@@ -443,7 +467,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
     t.string "type"
     t.text "description"
     t.boolean "owned", default: false
+    t.boolean "canonical", default: false, null: false
+    t.boolean "unwrangleable", default: false, null: false
+    t.integer "merger_id"
+    t.index ["merger_id"], name: "index_tags_on_merger_id"
     t.index ["name"], name: "index_tags_on_name"
+    t.index ["type", "canonical"], name: "index_tags_on_type_and_canonical"
     t.index ["type"], name: "index_tags_on_type"
   end
 
@@ -504,7 +533,25 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
     t.boolean "default_hide_edit_delete_buttons", default: false
     t.boolean "default_hide_add_bookmark_button", default: false
     t.boolean "moiety_colors_unread", default: false
+    t.boolean "allow_tag_suggestions", default: true, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end
+
+  create_table "wrangling_assignments", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "setting_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["setting_id"], name: "index_wrangling_assignments_on_setting_id"
+    t.index ["user_id", "setting_id"], name: "index_wrangling_assignments_on_user_id_and_setting_id", unique: true
+  end
+
+  add_foreign_key "tag_suggestions", "posts"
+  add_foreign_key "tag_suggestions", "tags"
+  add_foreign_key "tag_suggestions", "users"
+  add_foreign_key "tag_suggestions", "users", column: "resolved_by_id"
+  add_foreign_key "tags", "tags", column: "merger_id"
+  add_foreign_key "wrangling_assignments", "tags", column: "setting_id"
+  add_foreign_key "wrangling_assignments", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_03_140000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_04_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -534,6 +534,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_03_140000) do
     t.boolean "default_hide_add_bookmark_button", default: false
     t.boolean "moiety_colors_unread", default: false
     t.boolean "allow_tag_suggestions", default: true, null: false
+    t.boolean "reveal_spoiler_tags", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/db/seeds/tag.rb
+++ b/db/seeds/tag.rb
@@ -56,7 +56,7 @@ GalleryTag.create!([
 ])
 
 puts "Attaching settings to each other..."
-Tag::SettingTag.create!([
+Tag::MetaTag.create!([
   { tagged_id: 6, tag_id: 12 },
   { tagged_id: 12, tag_id: 5 },
   { tagged_id: 8, tag_id: 5 },

--- a/doc/rfcs/001-tag-wrangling.md
+++ b/doc/rfcs/001-tag-wrangling.md
@@ -406,6 +406,44 @@ preference, reading position is a convenience that reveals tags automatically at
 the point they stop being disclosures. It is not an access control, and MUST NOT
 be described as one to authors. Authors mark *when*; readers choose *whether*.
 
+**Rendering.** Reveal SHOULD be resolved on the client rather than by omitting
+markup on the server. The server renders every tagging into the document, with
+spoilered ones inside a collapsed disclosure element; the reader's preference
+sets whether it starts open.
+
+This follows a pattern the codebase already uses. `app/views/posts/show.haml:35`
+wraps author content warnings in `%details`/`%summary`, which gives
+click-to-reveal with no JavaScript at all. Building on it means the feature
+degrades correctly: with scripting unavailable the tags are still collapsed and
+still expandable. JavaScript is then needed only to apply the stored preference
+without a round trip, and `gon` already carries per-user state to the client
+(`app/controllers/application_controller.rb:213`).
+
+The benefit is that the tag markup stops varying per reader. Reveal becomes
+presentational, so it does not enter any fragment cache key, and rendering a
+post no longer needs the reader's position resolved before the tags can be
+emitted.
+
+**The tradeoff MUST be stated plainly to authors, because it is a real one.**
+Rendering server-side and omitting withheld tags means the tag names are absent
+from the page. Rendering client-side means the names are present in the document
+for every reader, including logged-out ones, and are readable from source or
+developer tools without expanding anything. This is consistent with the position
+taken above, that the gate is a default and not an access boundary, but it is a
+stronger claim than the initial implementation makes, and adopting it is a
+visible change in what a spoiler tag guarantees. Authors MUST be told that a
+spoiler tag hides the tag from the page as displayed, not from the page as
+transmitted.
+
+Two things MUST remain server-side regardless, because the client cannot
+enforce them:
+
+1. Reverse-lookup exclusion. A listing that omits a post cannot be reconstructed
+   client-side, and this is the mechanism that keeps a tag page from disclosing
+   the post.
+2. API redaction, per section 6.3. The API's consumer is a program, and shipping
+   names for the client to hide is meaningless there.
+
 **Alternate paradigm.** A simpler model is available: define a spoiler tagging
 purely as one the reader must proactively reveal, and drop reading position
 entirely. This would remove `reveal_after_reply_order`, the dependency on
@@ -502,6 +540,10 @@ value rather than presented as a list to be completed:
 15. Readers get a `reveal_spoiler_tags` preference, and any reader may expand a
     withheld tagging. The reading-position gate sets the default state, not an
     access boundary. Deferred to a later phase; see section 6.5.
+16. Reveal is resolved on the client, using the `%details`/`%summary` pattern
+    already used for content warnings, so it degrades without JavaScript and
+    does not vary the markup per reader. Reverse-lookup exclusion and API
+    redaction remain server-side. Deferred with 15.
 
 ## 10. Open items
 

--- a/doc/rfcs/001-tag-wrangling.md
+++ b/doc/rfcs/001-tag-wrangling.md
@@ -1,0 +1,574 @@
+# RFC 001: Tag Wrangling Interfaces
+
+**Status:** Draft
+**Author:** @l1n
+**Created:** 2026-08-03
+
+## Summary
+
+Glowfic's tag namespace is globally writable and has no canonicalization. Any
+logged-in user creates permanent, site-wide tags as a side effect of tagging
+their own post, and nothing merges the duplicates afterwards except an
+admin-only model method with no interface attached to it.
+
+This RFC proposes three related pieces of work:
+
+1. **A tag graph** — canonical tags, synonyms, and the wrangler role needed to
+   maintain them.
+2. **User-suggested tags** — a way for readers to propose tags on posts they
+   don't own, with the author retaining control.
+3. **Spoiler tags** — taggings that stay hidden until a reader has actually read
+   far enough into the post to have hit the thing being tagged.
+
+They are proposed together because they share a data model change: a tagging
+(`PostTag`) needs to become a first-class record with state, rather than a bare
+join row.
+
+## Background: how tags work today
+
+The tag system is a single-table STI hierarchy on `tags`:
+
+- `Tag` (`app/models/tag.rb`) with `TYPES = %w(Setting Label ContentWarning GalleryGroup)`.
+- `tags.name` is `citext`, uniqueness scoped to `type`, so `Bar Fight` and
+  `bar fight` are already the same tag within a type.
+- Every tag has `user_id NOT NULL` — a creator — plus an `owned` boolean used by
+  `Setting`.
+- `Setting` alone has hierarchy, via `Tag::SettingTag` (`parent_settings` /
+  `child_settings`). `Label`, `ContentWarning`, and `GalleryGroup` are flat.
+
+Worth noting early, because it changes the cost of one proposal below: the table
+behind `Tag::SettingTag` is already called `tag_tags`, with generic `tag_id` /
+`tagged_id` columns and no type constraint. Only the *model* restricts it to
+`Setting`. It also carries an unused `suggested` boolean, referenced nowhere in
+the codebase.
+
+Tags reach posts through `Taggable#process_tags` (`app/concerns/taggable.rb`).
+The form submits a mix of existing tag IDs and new names prefixed with `_`; the
+concern resolves the existing ones, case-insensitively matches the new names
+against what already exists, and constructs `klass.new(user: current_user, ...)`
+for whatever is left. **Creating a global tag requires no permission beyond
+being able to edit the post you are tagging.**
+
+Two facts constrain everything below:
+
+- **Nobody but an admin can currently curate tags.** `Tag#editable_by?` grants
+  edit rights to the creator, to `:edit_tags` holders, and — for unowned
+  `Setting`s only — to any non-readonly logged-in user. But `:edit_tags` and
+  `:delete_tags` are *commented out* of `MOD_PERMS` in
+  `app/concerns/permissible.rb:17-18`, so in practice only admins hold them.
+- **`Tag#merge_with` already exists** and correctly re-points `UserTag`,
+  `PostTag`, `CharacterTag`, `GalleryTag`, and `Tag::SettingTag`, de-duplicating
+  as it goes. It is sound; it simply has no UI and no notion of which tag *should*
+  survive.
+
+There is also directly relevant precedent for progressive reveal. `post_views`
+carries `read_at` and `warnings_hidden`; `Post#show_warnings_for?` gates the
+content-warning interstitial per user, `Post#hide_warnings_for` records the
+dismissal, and changing a post's warnings resets `warnings_hidden` for every
+viewer (`app/models/post.rb:364`). Reading position is derivable today:
+`Post#last_seen_reply_for` maps a user's `read_at` onto a concrete reply, and
+`replies.reply_order` gives a stable index within a post.
+
+## Prior art: AO3
+
+Relevant pieces of `otwcode/otwarchive`, since it is the largest working
+implementation of this problem:
+
+- **Canonical + merger.** `tags.canonical` is a boolean; a non-canonical tag
+  points at its canonical form through `merger_id` (`belongs_to :merger`), and
+  `mergers` is the reverse. Synonymy is a pointer, not a separate table.
+- **Two independent hierarchies.** `MetaTagging` (`meta_tags` / `sub_tags`)
+  expresses "this tag implies that broader tag"; `CommonTagging`
+  (`parents` / `children`) expresses cross-type containment, e.g. a Character
+  belonging to a Fandom. Glowfic's `Tag::SettingTag` is the same shape as the
+  latter.
+- **Wrangling is assigned, not ambient.** `WranglingAssignment` is a
+  `user_id` × `fandom_id` join: wranglers own bins of work rather than the whole
+  namespace. `WranglingGuideline` puts written policy in the app itself, and
+  `LastWranglingActivity` tracks staleness.
+- **`unwrangleable`** marks tags deliberately left alone, so the queue can
+  distinguish "not yet done" from "will not be done".
+- **Denormalized filters.** `FilterTagging` / `FilterCount` maintain a
+  materialized index so that searching a canonical tag also finds works tagged
+  with its synonyms and sub-tags, without a recursive query per search.
+
+Worth being explicit about what AO3 does *not* have, since it is often assumed:
+there is no general "suggest a tag on someone else's work" flow. Users add
+freeform tags to their own works and wranglers canonicalize afterwards. The
+`*_nomination` models (`TagNomination`, `FandomNomination`, …) belong to tag
+sets and challenges, not to open works. The user-suggestion design below is
+therefore glowfic-specific and has no upstream implementation to copy.
+
+## Problem statement
+
+1. **Duplicate proliferation.** Nothing prevents `Bar Fight`, `Barfight`, and
+   `bar-fight` from coexisting as three `Label`s. Citext collapses case only.
+2. **No curation path.** The one tool that exists (`merge_with`) is unreachable
+   without a Rails console.
+3. **Readers cannot contribute.** A reader who notices a post needs a content
+   warning has no in-app way to say so.
+4. **Tags spoil posts.** A tag is metadata about the whole post, displayed up
+   front. `Character Death` or a late-arriving setting is a spoiler for a reader
+   on reply 3 of 400. Authors currently choose between tagging accurately and
+   not spoiling, and accuracy loses.
+
+## Proposal
+
+### 1. Tag graph and the wrangler role
+
+Add to `tags`:
+
+| column | type | notes |
+| --- | --- | --- |
+| `canonical` | `boolean`, default `false`, not null | curated, preferred form |
+| `merger_id` | `integer`, FK → `tags.id`, nullable | synonym pointer |
+| `unwrangleable` | `boolean`, default `false`, not null | deliberately skipped |
+
+Constraints worth enforcing in the model rather than discovering later:
+
+- A tag with `merger_id` set must not be `canonical`.
+- `merger_id` must point at a tag of the same `type`.
+- Synonym chains resolve one level only — a merger must itself be canonical.
+  This is the rule AO3 relies on, and it keeps resolution a single join.
+
+`Tag#merge_with` stays as the mechanism, but synonyming becomes the default
+outcome: merging sets `merger_id` on the loser rather than destroying it, so
+existing links and bookmarks to the old tag still resolve. Because this is a
+behavioural change to `merge_with`'s current contract (it calls
+`other_tag.destroy`), it lands as a *new* method rather than a mutation of the
+existing one, and both remain available — the wrangling UI offers "merge as
+synonym" as the primary action and "merge and delete" as an admin-only
+secondary. Deletion stays the rare case, for tags that should never have existed
+rather than tags that are duplicates.
+
+**Hierarchy generalizes beyond `Setting`.** `Label` gains the parent/child
+structure `Setting` has, which is what makes implication ("tagging X implies Y")
+possible and is a prerequisite for most of the wrangling wins. This costs no
+migration: `Tag::SettingTag` becomes `Tag::MetaTag` over the same `tag_tags`
+table, with the `Setting`-typed associations replaced by polymorphic-by-type
+ones and a validation that both sides share a `type`. `Setting`'s
+`parent_settings` / `child_settings` associations stay as named wrappers so
+existing callers don't change.
+
+Cross-type implication (a `Setting` implying a `ContentWarning`, say) is
+deliberately *not* proposed here. AO3 has it via `CommonTagging` and it is
+useful, but it raises questions about who owns the implied tag that same-type
+implication does not. Deferred.
+
+**`tag_tags.suggested` gets a meaning.** The unused column becomes the
+proposed-but-unconfirmed state for an implication edge. An edge with
+`suggested = true` is recorded but not yet in force: it does not imply anything
+at query time, and it appears in a confirmation queue.
+
+This falls out of the scoped/global split. A `WRANGLER` scoped to one Setting
+will routinely notice implications that reach outside it — most usefully "this
+Setting implies this `ContentWarning`" — and has no authority to assert them.
+Rather than blocking on an admin or letting the scope be bypassed, they record a
+suggested edge and an admin holding `:wrangle_tags_global` confirms or discards
+it. Same-scope edges are created already-confirmed and never enter the queue.
+
+**The canonical invariant.** Nothing user-facing may depend on `canonical`.
+Search, filtering, autocomplete, and display all behave identically for a
+canonical and a non-canonical tag; `canonical` is an annotation *for wranglers*,
+recording that a human has looked at this tag and blessed its form. What
+actually changes behaviour is `merger_id`, and that is only ever set by an
+explicit merge.
+
+This invariant is what makes the rollout below survivable. There is no
+`canonical = true` backfill — every tag starts non-canonical and is promoted by
+hand — so on day one the wrangling queue *is* the entire corpus. That is
+tolerable precisely because an uncanonical tag is not a degraded tag. If
+canonicalization ever gates behaviour, this decision has to be revisited first.
+
+**Roles.** Rather than uncommenting `:edit_tags` / `:delete_tags` into
+`MOD_PERMS` — which hands the whole namespace to every mod — add *two* roles to
+`Permissible`, mirroring the split AO3 runs between wranglers and wrangling
+supervisors (`:tag_wrangler` plus a supervisor tier):
+
+- **`WRANGLER`** — a new role holding `:wrangle_tags`, scoped by
+  `WranglingAssignment`. May canonicalize, synonym, and edit tags within their
+  assigned Settings and those Settings' descendants.
+- **Global wrangling is an admin capability, not a role.** `:wrangle_tags_global`
+  and unscoped `:edit_tags` go to admins. This covers the tags that belong to no
+  Setting — `Label`s spanning settings, and all `ContentWarning`s — and is the
+  escalation path when a merge spans two wranglers' assignments.
+
+`:delete_tags` stays admin-only in both cases. Deletion is destructive and
+rarely the right answer once synonyms exist.
+
+Two things are being decided here and they are worth separating. The global tier
+is *distinct* from the scoped one — it is not an "unassigned" bucket inside
+`WRANGLER` — because the global tags have the widest blast radius, content
+warnings above all, and should not be editable by everyone handed a single
+Setting to look after. But distinct does not require a third role: a separate
+role only pays for itself when its membership is larger than the admin group,
+and there is no reason to expect that here. If global wrangling ever becomes a
+bottleneck on admin availability, promoting the capability to its own role is a
+small change, because the permission is already named separately from the role
+that holds it.
+
+**Scope.** AO3 scopes wranglers by fandom. The closest glowfic analogue is not
+the continuity but the **`Setting`** — a Setting *is* the world a post takes
+place in, which is what a fandom is on AO3, whereas a `Board` is closer to a
+posting venue. So: `WranglingAssignment(user_id, setting_id)`, with `setting_id`
+referencing a `Setting`-typed tag.
+
+Two consequences fall out of scoping this way, both of them arguments in favour:
+
+- `Setting` already has hierarchy, and **an assignment cascades to descendant
+  settings automatically**. A wrangler responsible for a broad world inherits
+  its sub-worlds without a second assignment, which is exactly the containment
+  AO3 gets from `meta_tags` and has to maintain by hand.
+- The scope is itself a wrangled object. **Merging two duplicate Settings merges
+  the bin of work** — both wranglers end up assigned to the survivor, and both
+  are notified that their scope changed. Scopes collapsing into one is the
+  accepted cost of keeping assignments consistent with the tag graph rather than
+  drifting from it; the notification is what keeps it from happening behind the
+  backs of the people it affects. Notification rather than an approval step,
+  because an approval gate would let one wrangler block another's legitimate
+  merge. Reuse the existing `Notification` model rather than inventing a
+  channel.
+
+Automatic inheritance has two prerequisites that do not exist today, and both
+should be treated as blocking rather than as follow-ups:
+
+**The Setting graph has no cycle guard.** `Tag::SettingTag` validates only
+uniqueness of child within parent; nothing prevents A → B → A. With inheritance,
+resolving a wrangler's scope becomes a graph traversal, and a cycle makes it
+non-terminating. **The hierarchy editor rejects cycle-closing edges outright**,
+with a validation on `Tag::MetaTag` rather than a check in the controller, so
+the constraint holds for imports and console work too. Scope resolution should
+*still* use a cycle-detecting recursive CTE as a belt-and-braces measure against
+rows that predate the validation.
+
+Rejecting rather than recording-and-ignoring does change the behaviour of an
+editor ordinary users touch today: a save that previously succeeded can now fail
+with a validation error. That is the right trade — a silently-ignored edge is a
+lie about the state of the graph — but it needs a comprehensible error message,
+not a bare "is invalid". This is worth fixing regardless, since a cycle is
+already a latent hazard for anything walking `parent_settings`; inheritance is
+what makes it acute.
+
+**Editing the hierarchy becomes a privilege escalation.** Once an assignment
+cascades, attaching Setting X as a child of Setting Y hands Y's wrangler
+authority over X. Today `Tag#editable_by?` lets *any* non-readonly logged-in
+user edit an unowned `Setting`, and `tags_controller#update:57` sets
+`parent_settings` straight from `process_tags`. So under automatic inheritance,
+an ordinary user could restructure the graph to expand or contract a wrangler's
+scope. Editing `parent_settings` has to become wrangler-gated before inheritance
+ships; the general "anyone may edit an unowned Setting" affordance can stay for
+name and description.
+
+The awkward case is a tag that appears across many unrelated Settings — most
+`Label`s, and every `ContentWarning`. Those need a global wrangler tier that is
+not assignment-scoped; assignment governs Settings and the tags that cluster
+within them, not the whole namespace.
+
+**Queue interface.** `/tags/wrangling`, wrangler-only:
+
+- Non-canonical, non-synonym tags, ordered by usage count descending, filterable
+  by type and by board.
+- Inline actions per row: mark canonical, merge into an existing canonical tag
+  (autocomplete), mark unwrangleable.
+- Bulk select for the common case of many near-identical spellings.
+- A "recently created" view, since the cheapest moment to catch a duplicate is
+  when it is first used.
+
+**Deferred:** the `FilterTagging` equivalent. Until glowfic has enough tags for
+synonym-aware search to be slow, resolving `merger_id` at query time with a join
+is sufficient, and a denormalized index is a large amount of invalidation
+machinery to maintain. Revisit if tag search becomes a hotspot.
+
+### 2. User-suggested tags
+
+New model `TagSuggestion`:
+
+| column | type | notes |
+| --- | --- | --- |
+| `post_id` | integer, not null | |
+| `user_id` | integer, not null | suggester |
+| `tag_id` | integer, nullable | existing tag, if any |
+| `tag_type` | string, nullable | with `tag_name`, for a proposed new tag |
+| `tag_name` | citext, nullable | |
+| `status` | integer, not null | `pending` / `accepted` / `rejected` |
+| `resolved_by_id` | integer, nullable | |
+| `resolved_at` | datetime, nullable | |
+| `note` | text, nullable | optional short rationale |
+
+Exactly one of `tag_id` or (`tag_type`, `tag_name`) must be present.
+
+**Flow.** A logged-in, non-readonly user opens "Suggest a tag" on a post they do
+not own, picks an existing tag or proposes a name, optionally adds a note. The
+post author sees a badge on their own post and a list under their user menu;
+accepting creates the `PostTag` (and the `Tag`, if new, attributed to the
+*suggester* as creator, consistent with `process_tags` today).
+
+**Rejection blocks globally**, not per suggester. Once an author rejects a tag
+on a post, nobody may suggest that tag on that post again. The alternative —
+blocking only the original suggester — means an author can be asked the same
+question by a stream of different readers, which is the failure mode that makes
+authors switch suggestions off entirely.
+
+Two details this implies:
+
+- The block is keyed on `(post_id, tag_id)`, or on `(post_id, tag_type,
+  lower(tag_name))` for a proposed new tag, so re-proposing the same name as a
+  "new" tag does not slip past a rejection. `tags.name` being `citext` handles
+  the casing for existing tags; proposed names need the comparison done
+  explicitly since no `Tag` row exists yet.
+- Rejection must be reversible by the author. A rejected suggestion is a
+  standing decision, not a permanent one — authors change their minds, and a
+  post's content changes under it. The author's own view of rejected
+  suggestions needs an "allow again" action.
+
+**Spoiler taggings are suggestible**, and this is where suggestions and spoilers
+interact badly if built naively. A reader past a reveal threshold is exactly the
+person positioned to notice a missing spoiler tag, so the suggestion form
+carries the same `spoiler` and `reveal_after_reply_order` fields the author's
+own tagging form does.
+
+The leak is not in the suggestion itself — pending suggestions are visible only
+to the author, so nothing is exposed to other readers by construction. The leak
+is in **deduplication feedback**. If a reader who has not reached the threshold
+suggests a tag that is *already applied as a hidden spoiler tagging*, the
+obvious response — "that tag is already on this post" — reveals the spoiler. The
+same applies to the global rejection block: "that tag was already suggested and
+rejected" tells the reader the tag was contemplated.
+
+So the dedup check must be **read-state aware**, and must fail open rather than
+informatively. Where a collision exists that the suggester is not entitled to
+know about, accept the suggestion normally and show the ordinary confirmation.
+The suggester learns nothing.
+
+**The author sees it as an endorsement, not a redundant suggestion.** A reader
+independently arriving at a tag the author already applied is useful signal —
+it says the tag is legible, that a real reader reached for the same words — so
+the author's view should record it as corroboration of the existing tagging
+rather than as a pending item needing a decision. Endorsements need no accept or
+reject action; they accumulate against the tagging.
+
+This is also the better answer to a worry the redundant-suggestion framing
+created. Showing an author "someone suggested a tag you already have, hidden as
+a spoiler" tells them their spoiler tagging is discoverable by inference.
+Showing them "a reader endorsed this tag" says the same thing about legibility
+without inviting them to conclude their spoiler leaked — because it did not. The
+reader guessed; that is what the endorsement records.
+
+This constraint is the reason pending suggestions should stay author-visible
+only. If a future change surfaces them more widely — a public "suggested tags"
+list, say — every one of these rules has to be re-derived, and the reveal rule
+must apply to the suggestion list too.
+
+**Author control.** Per-post `allow_tag_suggestions` (default on) and a per-user
+default in settings. Authors who do not want the interaction should be able to
+turn it off entirely rather than field the notifications.
+
+**Abuse handling.** This is the feature most likely to be misused, so:
+
+- Readonly and suspended users cannot suggest, reusing `readonly_forbidden`.
+- Per-user rate limit on pending suggestions, plus a cap per post.
+- Existing user ignore lists suppress suggestions from ignored users.
+- Repeated rejected suggestions to the same author are a mod-visible signal.
+
+**Content warnings, and the limit of this feature.** The strongest motivation
+for suggestions is a reader hitting untagged material that should have carried a
+warning. It is tempting to let mods apply a `ContentWarning` over an author's
+rejection, and this RFC explicitly does **not** propose that: authors retain
+creative control over their own posts, including over tags they decline.
+
+The consequence should be stated plainly rather than left implicit. A reader who
+believes a post needs a warning the author refuses has no recourse *within the
+tag system*; their recourse is the existing out-of-band mod report, which is a
+site-rules matter and deliberately a heavier instrument. `ContentWarning`
+suggestions are therefore ordinary suggestions with no special powers attached —
+the only accommodation is that a rejected `ContentWarning` suggestion is worth
+surfacing to mods as a signal, without granting them the ability to act on it
+unilaterally.
+
+### 3. Spoiler tags
+
+Make the tagging, not the tag, carry the spoiler state. `Character Death` is
+not inherently a spoiler; it is a spoiler *on this post, until reply 200*.
+
+Add to `post_tags`:
+
+| column | type | notes |
+| --- | --- | --- |
+| `spoiler` | boolean, default `false`, not null | |
+| `reveal_after_reply_order` | integer, nullable | reveal once the reader has read past this reply |
+
+`spoiler` with a null `reveal_after_reply_order` means "reveal only when the
+reader has reached the end of the post as it currently stands".
+
+**Resolution.** A tagging is revealed to a user when any of:
+
+- the user is the post's author or a mod;
+- `spoiler` is false;
+- the user's furthest-read reply order ≥ `reveal_after_reply_order`.
+
+Reading position comes from the existing `post_views.read_at` via
+`Post#last_seen_reply_for`, which already resolves a timestamp to a reply.
+Logged-out users have no `post_view` and therefore see no spoiler taggings.
+
+A caveat that should be designed for rather than discovered: `read_at` is a
+*timestamp*, so a reader who opened a thread while it was short and returned
+after 200 new replies has a `read_at` that maps to a high `reply_order` without
+having read the intervening replies. This is acceptable for spoiler-hiding —
+the failure mode is revealing slightly early to someone who skipped ahead, which
+is what skipping ahead means — but it should not be described to users as a
+guarantee.
+
+**Leakage is the hard part.** Hiding the tag on the post page is easy and
+insufficient. If a spoiler tagging still participates in tag → post listings,
+then the tag page for `Character Death` lists the post and the spoiler is out.
+Options:
+
+- **(a) Exclude spoiler taggings from reverse lookup entirely.** Simple,
+  leak-free, and it costs the tag its discoverability — the post genuinely does
+  not appear under a tag it genuinely has.
+- **(b) Filter per viewer.** Correct, but it makes every tag listing depend on
+  the current user's read state across every post in the result set. Expensive
+  and hard to cache.
+- **(c) Include, but behind an explicit opt-in.** A user preference —
+  "show posts under spoiler tags" — defaulting to off, plus an interstitial on
+  the tag page.
+
+**Recommendation: (a) for the first implementation, with (c) as a follow-up.**
+(b) should be rejected outright; the caching cost is not worth it. Authors
+should be told plainly in the UI that marking a tagging as a spoiler removes the
+post from that tag's listings, because the alternative is authors believing they
+get both discoverability and secrecy.
+
+**Reuse the content-warning interstitial.** The reveal UI should follow the
+existing pattern rather than inventing a second one: where spoiler taggings
+exist but are not yet revealed, show a neutral count ("3 spoiler tags") that
+expands on click, and record the choice the way `hide_warnings_for` does. Note
+that per `app/models/post.rb:364`, changing a post's warnings resets
+`warnings_hidden` for all viewers; the equivalent reset for spoiler taggings is
+*not* wanted, since re-hiding a tag a reader has already seen achieves nothing.
+
+**API behaviour: hide, do not omit.** `apipie` exposes post tags, so the reveal
+rule has to apply there or the API is simply the leak by another route. But the
+right treatment differs from the HTML view: an unrevealed tagging is *redacted*,
+not dropped. The serialized entry stays in the array with its identity withheld:
+
+```json
+{ "id": null, "type": "Label", "spoiler": true, "revealed": false }
+```
+
+The reasoning is that the API's consumer is a program, not a reader. Omitting
+entries makes the array length lie, so a client cannot distinguish "no tags" from
+"tags it may not see", and any client computing counts silently gets them wrong.
+Redaction keeps the shape honest while withholding the content. Authenticated
+requests resolve `revealed` against the requesting user's read position exactly
+as the web view does; anonymous requests have no read state and so see every
+spoiler tagging redacted.
+
+## Schema summary
+
+```
+tags            + canonical:boolean, merger_id:integer, unwrangleable:boolean
+post_tags       + spoiler:boolean, reveal_after_reply_order:integer
+posts           + allow_tag_suggestions:boolean
+users           + allow_tag_suggestions:boolean (default for new posts)
+tag_suggestions        new table (see above)
+wrangling_assignments  new table (user_id, setting_id)
+tag_tags        unchanged — generalizing Tag::SettingTag to Tag::MetaTag is a
+                model-only change, and the existing `suggested` column is
+                adopted as the unconfirmed-implication state
+```
+
+`post_tags` gaining columns is the change with the widest blast radius: it is
+currently a bare join table and several queries treat it as one. Those need
+auditing before the migration, not after.
+
+The `tag_tags.suggested` column already exists, is unused, and is adopted here
+as the unconfirmed state for an implication edge (see above). Since it currently
+defaults to `false` and no rows set it, existing edges are correctly interpreted
+as confirmed with no data migration.
+
+## Rollout
+
+1. Tag graph columns + model constraints, no UI. **No backfill** — every tag
+   starts non-canonical and is promoted by hand. This is only viable because of
+   the canonical invariant above: an uncanonical tag behaves exactly like a
+   canonical one, so "unwrangled" is a backlog, not a defect.
+2. Wrangler roles and queue interface. Run it manually for a while; the queue's
+   shape will be wrong in ways that are only visible in use.
+
+Because the queue starts as the whole corpus, it has to be ordered by value
+rather than presented as a list to be finished:
+
+- Default ordering by usage count descending, so the tags on the most posts get
+  a decision first.
+- Duplicate-suspect clustering — group tags whose names are near-matches under a
+  normalization (case, whitespace, punctuation, simple pluralization), since
+  those are both the highest-value merges and the easiest calls. Computed and
+  cached rather than stored as a column, so the normalization can be tuned
+  without a migration; invalidated on tag create, rename, and merge.
+- Surface progress as *coverage weighted by usage* — "canonical tags account for
+  N% of taggings" — not as a count of tags remaining. The raw remaining count
+  will look unmoving for a long time and is a discouraging number to show a
+  volunteer.
+3. Spoiler taggings. Self-contained, and the most immediately valuable to
+   authors.
+4. User suggestions last, once there is a wrangler group able to absorb the
+   moderation load it generates.
+
+## Resolved
+
+Decisions taken on the questions this draft opened with:
+
+- **`Label` gains hierarchy.** Generalize `Tag::SettingTag` to `Tag::MetaTag`;
+  no migration required. Cross-type implication deferred.
+- **Wrangler assignments scope by `Setting`**, not by `Board` — a Setting is the
+  structural analogue of an AO3 fandom. Global tags (`Label`s that span
+  settings, all `ContentWarning`s) need an unscoped wrangler tier alongside it.
+- **Mods cannot override an author's rejection of a `ContentWarning`.** Authors
+  keep creative control; the escalation path stays the existing out-of-band mod
+  report.
+- **Merging synonyms by default, deletion retained.** Both behaviours stay
+  available, with synonyming as the primary action and delete as admin-only.
+- **The API redacts spoiler taggings rather than omitting them**, so array
+  shapes and counts stay truthful for programmatic consumers.
+- **No canonical backfill; canonicalization is entirely manual.** Viable only
+  under the canonical invariant — nothing user-facing may depend on `canonical`.
+- **One new role plus an admin capability.** `WRANGLER` is Setting-scoped;
+  global wrangling (`:wrangle_tags_global`, covering cross-setting `Label`s and
+  all `ContentWarning`s) is an admin capability rather than a third role. The
+  tiers stay distinct — global is not an unassigned bucket inside `WRANGLER` —
+  but the permission is named separately from the role holding it, so promoting
+  it later is cheap.
+- **`tag_tags.suggested` is adopted** as the unconfirmed-implication state,
+  which is how a scoped wrangler proposes an edge reaching outside their scope.
+- **A rejected suggestion blocks that tag on that post for everyone**, reversible
+  by the author.
+- **Assignments inherit down the Setting hierarchy automatically**, gated on
+  adding a cycle guard and on making hierarchy edits wrangler-only.
+- **Assignments follow a merged Setting**, collapsing both wranglers onto the
+  survivor.
+- **Duplicate clustering is computed and cached**, not a stored column.
+- **Spoiler taggings are suggestible**, with a read-state-aware dedup check that
+  fails open rather than revealing a collision.
+- **Cycle-closing hierarchy edges are rejected** by model validation, not
+  recorded and ignored.
+- **A merge that collapses two wranglers' scopes notifies both**, via the
+  existing `Notification` model; no approval gate.
+- **A suggestion colliding with an unseen tagging is recorded as an
+  endorsement** of the existing tagging, needing no author action.
+
+## Next steps
+
+Every question this draft opened with has been answered; what remains is
+sequencing rather than design. The rollout section above is the intended order,
+and the two prerequisites for automatic inheritance — the cycle validation and
+wrangler-gating of `parent_settings` — should be broken out as their own tickets
+ahead of step 2, since both are small, independently useful, and block the role
+work.
+
+One thing to settle at implementation time rather than here: endorsements need a
+home in the schema. They are close enough to `TagSuggestion` to reuse it with a
+fourth `status` (`endorsed`), and different enough — no decision pending, no
+rejection possible, aggregate rather than individual interest — that a separate
+counter on `post_tags` may read better. Decide it against the queries the
+author's view actually needs.

--- a/doc/rfcs/001-tag-wrangling.md
+++ b/doc/rfcs/001-tag-wrangling.md
@@ -289,6 +289,10 @@ taggings, expandable on request. Note that changing a post's warnings resets
 reset for spoiler taggings is not wanted, as re-hiding a tagging a reader has
 already seen achieves nothing.
 
+Because the count is expandable by any reader, the reading-position gate is a
+default rather than an enforcement boundary. Section 6.5 makes this explicit
+rather than leaving it as an artefact of the presentation.
+
 **API.** `apipie` exposes post tags, so the reveal rule MUST apply there.
 Unrevealed taggings are redacted rather than omitted:
 
@@ -365,6 +369,62 @@ system, and must use the existing out-of-band report, which is a site-rules
 matter. A declined `ContentWarning` suggestion MAY be surfaced to mods as a
 signal without conferring authority to act on it.
 
+### 6.5 Reader-controlled reveal
+
+Deferred: not required for the initial implementation, specified here because it
+changes one cost assessment in section 6.3 and should not be designed twice.
+
+Reader tolerance for disclosure varies widely, from readers who want to know
+nothing about a story in advance to readers who treat tags as advertising and
+prefer to be told everything. Section 6.3 gates reveal on reading position
+alone, which encodes a single policy for every reader. The intent of marking a
+tagging as a spoiler is to describe *when* the tagged material arrives, not to
+decide on the reader's behalf whether they want to know.
+
+Two mechanisms are specified, and they compose:
+
+1. **Preference.** `users.reveal_spoiler_tags`, default false. When true,
+   spoiler taggings are revealed to that user regardless of reading position.
+2. **Click to reveal.** An unrevealed tagging renders as a count that any
+   reader MAY expand, whatever their preference. Persistence MAY follow the
+   `warnings_hidden` pattern, or MAY be per-request; the choice does not affect
+   the rest of this section.
+
+**Effect on reverse lookup.** This is the substantive consequence. Section 6.3
+rejects per-viewer filtering because it makes a tag listing depend on the
+requesting user's read state across every post in the result set, which is
+uncacheable. A preference does not have that shape: it is a single boolean on
+the user, so a listing has exactly two variants and both are cacheable. Option 3
+of section 6.3 therefore becomes affordable once the preference exists.
+
+Accordingly, when `reveal_spoiler_tags` is set, spoilered taggings MAY
+participate in tag-to-post listings for that user. Exclusion MUST remain the
+default, and any cache key for a tag listing MUST incorporate the preference.
+
+**Effect on the position gate.** Once a reader can expand the count or set the
+preference, reading position is a convenience that reveals tags automatically at
+the point they stop being disclosures. It is not an access control, and MUST NOT
+be described as one to authors. Authors mark *when*; readers choose *whether*.
+
+**Alternate paradigm.** A simpler model is available: define a spoiler tagging
+purely as one the reader must proactively reveal, and drop reading position
+entirely. This would remove `reveal_after_reply_order`, the dependency on
+`post_views.read_at`, and the timestamp limitation in section 6.3, at the cost
+of requiring a reader who has finished the post to keep expanding tags that no
+longer disclose anything to them. The two models are not far apart in
+implementation: the position gate is what decides the *initial* state of the
+control. This RFC specifies the position gate with reader override, but adopting
+the simpler model instead is a live option, and is cheaper to adopt before
+`reveal_after_reply_order` has data in it than after.
+
+**Content warnings.** A spoilered `ContentWarning` is in tension with the
+purpose of a content warning, since a warning withheld until the reader reaches
+the material has not warned anyone. A reader who sets `reveal_spoiler_tags` for
+plot reasons also opts into seeing spoilered warnings, which is coherent; the
+reader who most needs the warning is the one who has not set it. Whether
+`ContentWarning` taggings may be spoilered at all is recorded as an open item in
+section 10 rather than decided here.
+
 ## 7. Schema summary
 
 ```
@@ -375,6 +435,9 @@ users                  + allow_tag_suggestions
 tag_suggestions        new
 wrangling_assignments  new (user_id, setting_id)
 tag_tags               unchanged; `suggested` adopted per section 6.1
+
+deferred, section 6.5:
+users                  + reveal_spoiler_tags
 ```
 
 `post_tags` is currently a bare join table and several queries treat it as one.
@@ -392,6 +455,9 @@ correctly interpreted as confirmed without a data migration.
 3. Spoiler taggings. Self-contained and the most immediately useful to authors.
 4. Suggestions, once a wrangler group exists to absorb the resulting moderation
    load.
+5. Reader-controlled reveal, per section 6.5. Independent of steps 2 and 4, and
+   SHOULD be sequenced against step 3 rather than long after it, since it
+   determines whether `reveal_after_reply_order` is worth retaining.
 
 The two prerequisites in section 6.2, cycle validation and restriction of
 `parent_settings` editing, SHOULD be implemented ahead of step 2. Both are
@@ -433,8 +499,24 @@ value rather than presented as a list to be completed:
 13. A suggestion colliding with a tagging the suggester cannot observe is
     recorded as an endorsement.
 14. Mods cannot override an author's rejection of a `ContentWarning`.
+15. Readers get a `reveal_spoiler_tags` preference, and any reader may expand a
+    withheld tagging. The reading-position gate sets the default state, not an
+    access boundary. Deferred to a later phase; see section 6.5.
 
 ## 10. Open items
+
+**May a `ContentWarning` tagging be spoilered?** A warning withheld until the
+reader reaches the material has not warned anyone, and the reader it fails is
+precisely the one who has not opted into seeing spoilers. Options: forbid
+spoilering `ContentWarning` taggings; permit it but always reveal them to
+readers who have not opted out; or permit it unrestricted and treat the choice
+as the author's. This blocks nothing in the initial implementation, since
+nothing prevents the tagging today, but it SHOULD be settled before section 6.5
+ships, as that is the point at which the reader's own preference starts
+governing what they see.
+
+**Position gate or pure click-to-reveal?** Section 6.5 records both. The
+decision is cheaper before `reveal_after_reply_order` accumulates data.
 
 Endorsements require a schema decision at implementation time. They are close
 enough to `TagSuggestion` to reuse it with an additional status, and different

--- a/doc/rfcs/001-tag-wrangling.md
+++ b/doc/rfcs/001-tag-wrangling.md
@@ -13,8 +13,8 @@ This document specifies three related additions to the glowfic tag system:
    together with the roles required to maintain it.
 2. Tag suggestions, allowing a reader to propose a tag on a post they do not
    own, with the post author retaining the decision.
-3. Spoiler taggings, which remain hidden from a reader until that reader has
-   read far enough into the post to have encountered the tagged material.
+3. Spoiler taggings, which are displayed collapsed and expanded by the reader,
+   for elements of the fiction a reader may prefer not to know in advance.
 
 The three are specified together because they share one schema change: a
 tagging must become a record carrying state rather than a bare join row.
@@ -107,9 +107,12 @@ has no upstream implementation to follow.
    reachable only from a console.
 3. **No reader contribution path.** A reader who observes that a post requires
    a content warning has no in-application means of saying so.
-4. **Tags disclose plot.** A tag describes the whole post and is displayed
-   before it. `Character Death` is a disclosure to a reader on reply 3 of 400.
-   Authors must currently choose between accurate tagging and non-disclosure.
+4. **Tags disclose plot, and readers differ on whether that matters.** A tag
+   describes the whole post and is displayed before it, so `Character Death` is
+   a disclosure to a reader on reply 3 of 400. Some readers avoid tags entirely
+   for this reason; others read tags precisely to decide what to read, and
+   regard the journey rather than the surprise as the point. Authors currently
+   choose between accurate tagging and non-disclosure on every reader's behalf.
 
 ## 6. Design
 
@@ -242,29 +245,52 @@ The following columns are added to `post_tags`:
 | `spoiler` | boolean, not null, default false | Tagging is withheld |
 | `reveal_after_reply_order` | integer, nullable | Reveal threshold |
 
-A spoiler tagging created without an explicit `reveal_after_reply_order` MUST
-have the threshold fixed to the post's last `reply_order` at the time the
-tagging is created. Resolving "the end of the post" dynamically would move the
-threshold every time a reply is added, so a tagging would become visible to a
-reader who had caught up and then hidden again on the next reply. The fixed
-threshold also matches author intent, which is to withhold the tag until the
-point the tagged material has been reached.
+**A spoiler tagging is one the reader must proactively reveal.** It is displayed
+collapsed, and expanded on request. Reveal is a reader action, not a state the
+server computes from how far they have read.
 
-A tagging is revealed to a user when any of the following holds:
+An earlier draft of this document gated reveal on reading position, so that a
+tagging became visible once the reader passed the reply it described. Reader
+feedback rejected that model on three grounds, all of which stand:
+
+1. **It serves nobody.** A reader avoiding disclosure does not read tags; a
+   reader who wants warnings does read them. A tag that appears only after the
+   material has been read assists neither.
+2. **It leaks by omission.** Auto-revealing after the fact tells the reader
+   something the author did not choose to tell them. If `Character Death`
+   appears once and no further tag follows, the reader has learned that the
+   death they just read was the only one. Withholding a tag until it is
+   redundant does not merely fail to protect; it converts the tag into a
+   statement about the rest of the post.
+3. **It reads as backwards.** The natural reading of "hidden until you have read
+   far enough" is that a warning arrives after the content it warns about.
+
+`reveal_after_reply_order` is retained, but its meaning changes: it is
+**descriptive, not a gate**. It records that a tag applies to the post from a
+given reply onwards, and is displayed alongside the tag once revealed. This is
+the part of the original design readers found valuable, because it distinguishes
+a element that runs through a whole thread from one that appears late, which is
+a distinction flat tagging cannot express. It also gives a natural anchor for
+linking a reader to the point where the tag begins to apply.
+
+A tagging is displayed expanded, without the reader acting, when any of:
 
 1. The user is the post author or holds `:edit_posts`.
 2. `spoiler` is false.
-3. The user's furthest-read `reply_order` is greater than or equal to
-   `reveal_after_reply_order`.
+3. The user has set the preference in section 6.5.
 
-Reading position derives from `post_views.read_at`. A user with no `post_view`,
-including any logged-out user, MUST NOT be shown spoiler taggings.
+No other condition expands it. In particular, reading position does not.
 
-**Limitation.** `read_at` is a timestamp. A reader who opened a post while it
-was short and returned after 200 further replies resolves to a high
-`reply_order` without having read the intervening replies. The failure mode is
-revealing early to a reader who skipped ahead. This is acceptable for
-non-disclosure but is not a guarantee and MUST NOT be described to users as one.
+**`ContentWarning` taggings MUST NOT be spoilered.** A warning exists to tell a
+reader about content before they reach it; a warning the reader must first
+discover cannot do that, and one revealed after the fact has failed entirely.
+There is no way to have content warnings without warning people about the
+content. The `spoiler` column therefore applies only to `Setting` and `Label`
+taggings, enforced by validation rather than by convention.
+
+This also disposes of the sharpest objection to the feature. Spoilering is for
+elements of the fiction a reader may or may not want to know in advance. It is
+not a mechanism for softening warnings, and must not become one.
 
 **Reverse lookup.** Hiding a tagging on the post page is not sufficient. If a
 spoiler tagging participates in tag-to-post listings, the tag page discloses the
@@ -444,24 +470,17 @@ enforce them:
 2. API redaction, per section 6.3. The API's consumer is a program, and shipping
    names for the client to hide is meaningless there.
 
-**Alternate paradigm.** A simpler model is available: define a spoiler tagging
-purely as one the reader must proactively reveal, and drop reading position
-entirely. This would remove `reveal_after_reply_order`, the dependency on
-`post_views.read_at`, and the timestamp limitation in section 6.3, at the cost
-of requiring a reader who has finished the post to keep expanding tags that no
-longer disclose anything to them. The two models are not far apart in
-implementation: the position gate is what decides the *initial* state of the
-control. This RFC specifies the position gate with reader override, but adopting
-the simpler model instead is a live option, and is cheaper to adopt before
-`reveal_after_reply_order` has data in it than after.
+**No dependency on reading position.** Because reveal is a reader action,
+nothing in this feature reads `post_views.read_at`. Removing that dependency
+also removes the timestamp limitation an earlier draft carried, whereby a reader
+who opened a post while it was short and returned much later resolved to a
+reading position they had not actually reached.
 
-**Content warnings.** A spoilered `ContentWarning` is in tension with the
-purpose of a content warning, since a warning withheld until the reader reaches
-the material has not warned anyone. A reader who sets `reveal_spoiler_tags` for
-plot reasons also opts into seeing spoilered warnings, which is coherent; the
-reader who most needs the warning is the one who has not set it. Whether
-`ContentWarning` taggings may be spoilered at all is recorded as an open item in
-section 10 rather than decided here.
+**Skip links.** Since `reveal_after_reply_order` is descriptive, a revealed
+tagging carries a usable anchor: the reply from which the tag applies. Linking
+it lets a reader jump to the point where an element enters the post. This is
+cheap once the datum is displayed rather than consumed as a gate, and is worth
+building at the same time.
 
 ## 7. Schema summary
 
@@ -493,9 +512,9 @@ correctly interpreted as confirmed without a data migration.
 3. Spoiler taggings. Self-contained and the most immediately useful to authors.
 4. Suggestions, once a wrangler group exists to absorb the resulting moderation
    load.
-5. Reader-controlled reveal, per section 6.5. Independent of steps 2 and 4, and
-   SHOULD be sequenced against step 3 rather than long after it, since it
-   determines whether `reveal_after_reply_order` is worth retaining.
+5. Reader-controlled reveal, per section 6.5: the `reveal_spoiler_tags`
+   preference and client-side expansion. Step 3 is of limited use without it,
+   since expansion is the only way a reader sees a spoiler tagging at all.
 
 The two prerequisites in section 6.2, cycle validation and restriction of
 `parent_settings` editing, SHOULD be implemented ahead of step 2. Both are
@@ -538,27 +557,27 @@ value rather than presented as a list to be completed:
     recorded as an endorsement.
 14. Mods cannot override an author's rejection of a `ContentWarning`.
 15. Readers get a `reveal_spoiler_tags` preference, and any reader may expand a
-    withheld tagging. The reading-position gate sets the default state, not an
-    access boundary. Deferred to a later phase; see section 6.5.
+    withheld tagging.
 16. Reveal is resolved on the client, using the `%details`/`%summary` pattern
     already used for content warnings, so it degrades without JavaScript and
     does not vary the markup per reader. Reverse-lookup exclusion and API
-    redaction remain server-side. Deferred with 15.
+    redaction remain server-side.
+17. Reveal is a reader action. Reading position does not expand a tagging, and
+    the feature reads no reading state at all. Revised after reader feedback;
+    see section 6.3.
+18. `reveal_after_reply_order` is descriptive rather than a gate: it records the
+    reply from which a tag applies, is shown once the tag is revealed, and
+    anchors a skip link.
+19. `ContentWarning` taggings cannot be spoilered, enforced by validation.
 
 ## 10. Open items
 
-**May a `ContentWarning` tagging be spoilered?** A warning withheld until the
-reader reaches the material has not warned anyone, and the reader it fails is
-precisely the one who has not opted into seeing spoilers. Options: forbid
-spoilering `ContentWarning` taggings; permit it but always reveal them to
-readers who have not opted out; or permit it unrestricted and treat the choice
-as the author's. This blocks nothing in the initial implementation, since
-nothing prevents the tagging today, but it SHOULD be settled before section 6.5
-ships, as that is the point at which the reader's own preference starts
-governing what they see.
-
-**Position gate or pure click-to-reveal?** Section 6.5 records both. The
-decision is cheaper before `reveal_after_reply_order` accumulates data.
+**Should a reader be able to see that a post has spoiler tags at all?** The
+collapsed control necessarily discloses that some number of tags exist and are
+withheld. For a sufficiently disclosure-averse reader that count is itself
+information, and a preference to suppress the control entirely may be wanted
+alongside the preference to expand it. Not specified here because it is not
+clear the demand exists.
 
 Endorsements require a schema decision at implementation time. They are close
 enough to `TagSuggestion` to reuse it with an additional status, and different

--- a/doc/rfcs/001-tag-wrangling.md
+++ b/doc/rfcs/001-tag-wrangling.md
@@ -3,572 +3,432 @@
 **Status:** Draft
 **Author:** @l1n
 **Created:** 2026-08-03
+**Implementation:** glowfic-constellation/glowfic#2877
 
-## Summary
+## 1. Abstract
 
-Glowfic's tag namespace is globally writable and has no canonicalization. Any
-logged-in user creates permanent, site-wide tags as a side effect of tagging
-their own post, and nothing merges the duplicates afterwards except an
-admin-only model method with no interface attached to it.
+This document specifies three related additions to the glowfic tag system:
 
-This RFC proposes three related pieces of work:
+1. A tag graph providing canonical tags, synonyms, and same-type implication,
+   together with the roles required to maintain it.
+2. Tag suggestions, allowing a reader to propose a tag on a post they do not
+   own, with the post author retaining the decision.
+3. Spoiler taggings, which remain hidden from a reader until that reader has
+   read far enough into the post to have encountered the tagged material.
 
-1. **A tag graph** — canonical tags, synonyms, and the wrangler role needed to
-   maintain them.
-2. **User-suggested tags** — a way for readers to propose tags on posts they
-   don't own, with the author retaining control.
-3. **Spoiler tags** — taggings that stay hidden until a reader has actually read
-   far enough into the post to have hit the thing being tagged.
+The three are specified together because they share one schema change: a
+tagging must become a record carrying state rather than a bare join row.
 
-They are proposed together because they share a data model change: a tagging
-(`PostTag`) needs to become a first-class record with state, rather than a bare
-join row.
+## 2. Terminology
 
-## Background: how tags work today
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY in this document are
+to be interpreted as described in RFC 2119.
 
-The tag system is a single-table STI hierarchy on `tags`:
+- **Tag** — a row in `tags`, of type `Setting`, `Label`, `ContentWarning`, or
+  `GalleryGroup`.
+- **Tagging** — the association of a tag with a post; a row in `post_tags`.
+- **Canonical tag** — a tag a wrangler has reviewed and accepted as the
+  preferred form.
+- **Synonym** — a non-canonical tag pointing at the canonical tag that
+  supersedes it.
+- **Implication** — a directed edge asserting that tagging the child implies
+  the parent.
+- **Wrangler** — a user holding curation rights over some set of tags.
 
-- `Tag` (`app/models/tag.rb`) with `TYPES = %w(Setting Label ContentWarning GalleryGroup)`.
-- `tags.name` is `citext`, uniqueness scoped to `type`, so `Bar Fight` and
-  `bar fight` are already the same tag within a type.
-- Every tag has `user_id NOT NULL` — a creator — plus an `owned` boolean used by
-  `Setting`.
-- `Setting` alone has hierarchy, via `Tag::SettingTag` (`parent_settings` /
-  `child_settings`). `Label`, `ContentWarning`, and `GalleryGroup` are flat.
+## 3. Current implementation
 
-Worth noting early, because it changes the cost of one proposal below: the table
-behind `Tag::SettingTag` is already called `tag_tags`, with generic `tag_id` /
-`tagged_id` columns and no type constraint. Only the *model* restricts it to
-`Setting`. It also carries an unused `suggested` boolean, referenced nowhere in
-the codebase.
+Tags are single-table inheritance over `tags`:
 
-Tags reach posts through `Taggable#process_tags` (`app/concerns/taggable.rb`).
-The form submits a mix of existing tag IDs and new names prefixed with `_`; the
-concern resolves the existing ones, case-insensitively matches the new names
-against what already exists, and constructs `klass.new(user: current_user, ...)`
-for whatever is left. **Creating a global tag requires no permission beyond
-being able to edit the post you are tagging.**
+- `Tag::TYPES` is `Setting`, `Label`, `ContentWarning`, `GalleryGroup`.
+- `tags.name` is `citext`, unique per `type`. Case variants are already
+  collapsed within a type.
+- Every tag has a non-null `user_id` and an `owned` boolean used by `Setting`.
+- Only `Setting` has hierarchy, through `Tag::SettingTag`.
 
-Two facts constrain everything below:
+Tags reach posts through `Taggable#process_tags`. The form submits existing tag
+IDs alongside new names prefixed with `_`. The concern resolves the former,
+case-insensitively matches the latter against existing tags, and constructs new
+records for the remainder. Creating a site-wide tag therefore requires no
+permission beyond the ability to edit the post being tagged.
 
-- **Nobody but an admin can currently curate tags.** `Tag#editable_by?` grants
-  edit rights to the creator, to `:edit_tags` holders, and — for unowned
-  `Setting`s only — to any non-readonly logged-in user. But `:edit_tags` and
-  `:delete_tags` are *commented out* of `MOD_PERMS` in
-  `app/concerns/permissible.rb:17-18`, so in practice only admins hold them.
-- **`Tag#merge_with` already exists** and correctly re-points `UserTag`,
-  `PostTag`, `CharacterTag`, `GalleryTag`, and `Tag::SettingTag`, de-duplicating
-  as it goes. It is sound; it simply has no UI and no notion of which tag *should*
-  survive.
+Two properties of the current implementation constrain the design:
 
-There is also directly relevant precedent for progressive reveal. `post_views`
-carries `read_at` and `warnings_hidden`; `Post#show_warnings_for?` gates the
-content-warning interstitial per user, `Post#hide_warnings_for` records the
-dismissal, and changing a post's warnings resets `warnings_hidden` for every
-viewer (`app/models/post.rb:364`). Reading position is derivable today:
-`Post#last_seen_reply_for` maps a user's `read_at` onto a concrete reply, and
-`replies.reply_order` gives a stable index within a post.
+1. **Curation is effectively admin-only.** `Tag#editable_by?` grants rights to
+   the tag creator, to holders of `:edit_tags`, and, for unowned `Setting`s, to
+   any non-readonly logged-in user. `:edit_tags` and `:delete_tags` are
+   commented out of `MOD_PERMS` in `app/concerns/permissible.rb:17-18`.
+2. **`Tag#merge_with` exists and is correct.** It re-points `UserTag`,
+   `PostTag`, `CharacterTag`, `GalleryTag`, and `Tag::SettingTag`,
+   de-duplicating as it does so. It has no interface and no concept of which
+   tag should survive.
 
-## Prior art: AO3
+The table behind `Tag::SettingTag` is named `tag_tags` and carries generic
+`tag_id` and `tagged_id` columns with no type constraint. Only the model
+restricts it to `Setting`. It also carries an unused `suggested` boolean.
 
-Relevant pieces of `otwcode/otwarchive`, since it is the largest working
-implementation of this problem:
+Reading position is already recorded. `post_views` carries `read_at` and
+`warnings_hidden`; `Post#show_warnings_for?` gates the content-warning
+interstitial per user; `Post#hide_warnings_for` records dismissal; and changing
+a post's warnings resets `warnings_hidden` for all viewers
+(`app/models/post.rb:364`). `Post#last_seen_reply_for` maps a `read_at`
+timestamp onto a reply, and `replies.reply_order` orders replies within a post.
 
-- **Canonical + merger.** `tags.canonical` is a boolean; a non-canonical tag
-  points at its canonical form through `merger_id` (`belongs_to :merger`), and
-  `mergers` is the reverse. Synonymy is a pointer, not a separate table.
-- **Two independent hierarchies.** `MetaTagging` (`meta_tags` / `sub_tags`)
-  expresses "this tag implies that broader tag"; `CommonTagging`
-  (`parents` / `children`) expresses cross-type containment, e.g. a Character
-  belonging to a Fandom. Glowfic's `Tag::SettingTag` is the same shape as the
-  latter.
-- **Wrangling is assigned, not ambient.** `WranglingAssignment` is a
-  `user_id` × `fandom_id` join: wranglers own bins of work rather than the whole
-  namespace. `WranglingGuideline` puts written policy in the app itself, and
-  `LastWranglingActivity` tracks staleness.
-- **`unwrangleable`** marks tags deliberately left alone, so the queue can
-  distinguish "not yet done" from "will not be done".
-- **Denormalized filters.** `FilterTagging` / `FilterCount` maintain a
-  materialized index so that searching a canonical tag also finds works tagged
-  with its synonyms and sub-tags, without a recursive query per search.
+## 4. Prior art
 
-Worth being explicit about what AO3 does *not* have, since it is often assumed:
-there is no general "suggest a tag on someone else's work" flow. Users add
-freeform tags to their own works and wranglers canonicalize afterwards. The
-`*_nomination` models (`TagNomination`, `FandomNomination`, …) belong to tag
-sets and challenges, not to open works. The user-suggestion design below is
-therefore glowfic-specific and has no upstream implementation to copy.
+Relevant mechanisms in `otwcode/otwarchive`:
 
-## Problem statement
+- **Canonical and merger.** `tags.canonical` is a boolean. A non-canonical tag
+  points at its canonical form through `merger_id`. Synonymy is a pointer, not
+  a table.
+- **Two hierarchies.** `MetaTagging` expresses implication between tags of the
+  same kind. `CommonTagging` expresses cross-type containment, such as a
+  Character belonging to a Fandom.
+- **Assigned wrangling.** `WranglingAssignment` joins a user to a fandom, so
+  wranglers hold bounded scopes rather than the whole namespace.
+  `WranglingGuideline` publishes policy in-application.
+  `LastWranglingActivity` records staleness.
+- **`unwrangleable`** distinguishes tags deliberately left alone from tags not
+  yet reviewed.
+- **Denormalized filters.** `FilterTagging` and `FilterCount` maintain a
+  materialized index so that a search for a canonical tag also returns works
+  tagged with its synonyms and sub-tags.
+
+AO3 has no general mechanism for suggesting tags on another user's work. Users
+add freeform tags to their own works and wranglers canonicalize afterwards. The
+`*_nomination` models belong to tag sets and challenges. Section 6.4 therefore
+has no upstream implementation to follow.
+
+## 5. Problem statement
 
 1. **Duplicate proliferation.** Nothing prevents `Bar Fight`, `Barfight`, and
-   `bar-fight` from coexisting as three `Label`s. Citext collapses case only.
-2. **No curation path.** The one tool that exists (`merge_with`) is unreachable
-   without a Rails console.
-3. **Readers cannot contribute.** A reader who notices a post needs a content
-   warning has no in-app way to say so.
-4. **Tags spoil posts.** A tag is metadata about the whole post, displayed up
-   front. `Character Death` or a late-arriving setting is a spoiler for a reader
-   on reply 3 of 400. Authors currently choose between tagging accurately and
-   not spoiling, and accuracy loses.
+   `bar-fight` from coexisting as three distinct `Label`s. `citext` collapses
+   case only.
+2. **No curation interface.** The sole existing tool, `merge_with`, is
+   reachable only from a console.
+3. **No reader contribution path.** A reader who observes that a post requires
+   a content warning has no in-application means of saying so.
+4. **Tags disclose plot.** A tag describes the whole post and is displayed
+   before it. `Character Death` is a disclosure to a reader on reply 3 of 400.
+   Authors must currently choose between accurate tagging and non-disclosure.
 
-## Proposal
+## 6. Design
 
-### 1. Tag graph and the wrangler role
+### 6.1 Tag graph
 
-Add to `tags`:
+The following columns are added to `tags`:
 
-| column | type | notes |
+| Column | Type | Description |
 | --- | --- | --- |
-| `canonical` | `boolean`, default `false`, not null | curated, preferred form |
-| `merger_id` | `integer`, FK → `tags.id`, nullable | synonym pointer |
-| `unwrangleable` | `boolean`, default `false`, not null | deliberately skipped |
+| `canonical` | boolean, not null, default false | Reviewed and accepted form |
+| `merger_id` | integer, nullable, FK to `tags.id` | Synonym pointer |
+| `unwrangleable` | boolean, not null, default false | Deliberately skipped |
 
-Constraints worth enforcing in the model rather than discovering later:
+The following constraints MUST hold:
 
-- A tag with `merger_id` set must not be `canonical`.
-- `merger_id` must point at a tag of the same `type`.
-- Synonym chains resolve one level only — a merger must itself be canonical.
-  This is the rule AO3 relies on, and it keeps resolution a single join.
+- A tag with `merger_id` set MUST NOT be canonical.
+- `merger_id` MUST reference a tag of the same `type`.
+- A merger MUST itself be canonical. Synonym chains are therefore one level
+  deep and resolve in a single join.
 
-`Tag#merge_with` stays as the mechanism, but synonyming becomes the default
-outcome: merging sets `merger_id` on the loser rather than destroying it, so
-existing links and bookmarks to the old tag still resolve. Because this is a
-behavioural change to `merge_with`'s current contract (it calls
-`other_tag.destroy`), it lands as a *new* method rather than a mutation of the
-existing one, and both remain available — the wrangling UI offers "merge as
-synonym" as the primary action and "merge and delete" as an admin-only
-secondary. Deletion stays the rare case, for tags that should never have existed
-rather than tags that are duplicates.
+**Invariant: `canonical` MUST NOT gate behaviour.** Search, filtering,
+autocomplete, and display MUST treat canonical and non-canonical tags
+identically. `canonical` records that a human has reviewed the tag. `merger_id`
+is the only column that alters behaviour, and it is set only by an explicit
+merge.
 
-**Hierarchy generalizes beyond `Setting`.** `Label` gains the parent/child
-structure `Setting` has, which is what makes implication ("tagging X implies Y")
-possible and is a prerequisite for most of the wrangling wins. This costs no
-migration: `Tag::SettingTag` becomes `Tag::MetaTag` over the same `tag_tags`
-table, with the `Setting`-typed associations replaced by polymorphic-by-type
-ones and a validation that both sides share a `type`. `Setting`'s
-`parent_settings` / `child_settings` associations stay as named wrappers so
-existing callers don't change.
+This invariant is what makes the rollout in section 8 viable. No backfill is
+performed, so every tag begins non-canonical and the queue initially contains
+the entire corpus. That is a backlog rather than a defect only for as long as
+the invariant holds. Any proposal to gate behaviour on `canonical` MUST revisit
+this decision first.
 
-Cross-type implication (a `Setting` implying a `ContentWarning`, say) is
-deliberately *not* proposed here. AO3 has it via `CommonTagging` and it is
-useful, but it raises questions about who owns the implied tag that same-type
-implication does not. Deferred.
+**Merging.** Synonyming is the default outcome: the merge re-points every
+tagging onto the surviving tag and sets `merger_id` on the other, so existing
+links continue to resolve. This is a change to the contract of `merge_with`,
+which destroys its argument, so it is introduced as a separate method. Both
+remain available. The interface SHOULD present synonyming as the primary action
+and destructive merge as an admin-only secondary action, for tags that should
+never have existed rather than tags that are duplicates.
 
-**`tag_tags.suggested` gets a meaning.** The unused column becomes the
-proposed-but-unconfirmed state for an implication edge. An edge with
-`suggested = true` is recorded but not yet in force: it does not imply anything
-at query time, and it appears in a confirmation queue.
+**Implication.** `Tag::SettingTag` becomes `Tag::MetaTag` over the same
+`tag_tags` table, and `Label` gains the hierarchy `Setting` has. Both sides of
+an edge MUST share a `type`. No migration is required; `Setting`'s existing
+associations are retained as named wrappers.
 
-This falls out of the scoped/global split. A `WRANGLER` scoped to one Setting
-will routinely notice implications that reach outside it — most usefully "this
-Setting implies this `ContentWarning`" — and has no authority to assert them.
-Rather than blocking on an admin or letting the scope be bypassed, they record a
-suggested edge and an admin holding `:wrangle_tags_global` confirms or discards
-it. Same-scope edges are created already-confirmed and never enter the queue.
+Cross-type implication is out of scope. AO3 provides it through
+`CommonTagging`, but it raises questions of ownership over the implied tag that
+same-type implication does not.
 
-**The canonical invariant.** Nothing user-facing may depend on `canonical`.
-Search, filtering, autocomplete, and display all behave identically for a
-canonical and a non-canonical tag; `canonical` is an annotation *for wranglers*,
-recording that a human has looked at this tag and blessed its form. What
-actually changes behaviour is `merger_id`, and that is only ever set by an
-explicit merge.
+**Unconfirmed implications.** `tag_tags.suggested` is adopted as the
+proposed-but-unconfirmed state. An edge with `suggested = true` MUST NOT imply
+anything at query time and MUST appear in a confirmation queue. A wrangler
+scoped to one Setting will observe implications reaching outside that scope,
+most commonly that a Setting implies a ContentWarning, and holds no authority to
+assert them. Such an edge is recorded as suggested and is confirmed or discarded
+by a holder of `:wrangle_tags_global`. Edges within scope are created confirmed.
 
-This invariant is what makes the rollout below survivable. There is no
-`canonical = true` backfill — every tag starts non-canonical and is promoted by
-hand — so on day one the wrangling queue *is* the entire corpus. That is
-tolerable precisely because an uncanonical tag is not a degraded tag. If
-canonicalization ever gates behaviour, this decision has to be revisited first.
+### 6.2 Roles and scoping
 
-**Roles.** Rather than uncommenting `:edit_tags` / `:delete_tags` into
-`MOD_PERMS` — which hands the whole namespace to every mod — add *two* roles to
-`Permissible`, mirroring the split AO3 runs between wranglers and wrangling
-supervisors (`:tag_wrangler` plus a supervisor tier):
+Two tiers are defined:
 
-- **`WRANGLER`** — a new role holding `:wrangle_tags`, scoped by
-  `WranglingAssignment`. May canonicalize, synonym, and edit tags within their
-  assigned Settings and those Settings' descendants.
-- **Global wrangling is an admin capability, not a role.** `:wrangle_tags_global`
-  and unscoped `:edit_tags` go to admins. This covers the tags that belong to no
-  Setting — `Label`s spanning settings, and all `ContentWarning`s — and is the
-  escalation path when a merge spans two wranglers' assignments.
+- **`WRANGLER`** — a role holding `:wrangle_tags`, scoped by
+  `WranglingAssignment`. May canonicalize, synonym, and edit tags within
+  assigned Settings and their descendants.
+- **Global wrangling** — `:wrangle_tags_global` and unscoped `:edit_tags`,
+  held by admins. Covers tags belonging to no Setting: `Label`s spanning
+  settings, and all `ContentWarning`s. Also the escalation path when a merge
+  crosses two assignments.
 
-`:delete_tags` stays admin-only in both cases. Deletion is destructive and
-rarely the right answer once synonyms exist.
+`:delete_tags` remains admin-only in both tiers.
 
-Two things are being decided here and they are worth separating. The global tier
-is *distinct* from the scoped one — it is not an "unassigned" bucket inside
-`WRANGLER` — because the global tags have the widest blast radius, content
-warnings above all, and should not be editable by everyone handed a single
-Setting to look after. But distinct does not require a third role: a separate
-role only pays for itself when its membership is larger than the admin group,
-and there is no reason to expect that here. If global wrangling ever becomes a
-bottleneck on admin availability, promoting the capability to its own role is a
-small change, because the permission is already named separately from the role
-that holds it.
+The two tiers are distinct: global tags have the widest blast radius and MUST
+NOT be editable by every holder of a single Setting assignment. The global tier
+is nevertheless a capability rather than a third role, because a distinct role
+pays for itself only when its membership exceeds the admin group. The permission
+is named separately from the role holding it, so promotion to a role later is a
+small change.
 
-**Scope.** AO3 scopes wranglers by fandom. The closest glowfic analogue is not
-the continuity but the **`Setting`** — a Setting *is* the world a post takes
-place in, which is what a fandom is on AO3, whereas a `Board` is closer to a
-posting venue. So: `WranglingAssignment(user_id, setting_id)`, with `setting_id`
-referencing a `Setting`-typed tag.
+**Scope.** `WranglingAssignment` joins a user to a `Setting`. A Setting is the
+structural analogue of an AO3 fandom, being the world a post is set in, whereas
+a Board is a posting venue.
 
-Two consequences fall out of scoping this way, both of them arguments in favour:
+Assignments cascade to descendant Settings automatically. Two properties follow:
 
-- `Setting` already has hierarchy, and **an assignment cascades to descendant
-  settings automatically**. A wrangler responsible for a broad world inherits
-  its sub-worlds without a second assignment, which is exactly the containment
-  AO3 gets from `meta_tags` and has to maintain by hand.
-- The scope is itself a wrangled object. **Merging two duplicate Settings merges
-  the bin of work** — both wranglers end up assigned to the survivor, and both
-  are notified that their scope changed. Scopes collapsing into one is the
-  accepted cost of keeping assignments consistent with the tag graph rather than
-  drifting from it; the notification is what keeps it from happening behind the
-  backs of the people it affects. Notification rather than an approval step,
-  because an approval gate would let one wrangler block another's legitimate
-  merge. Reuse the existing `Notification` model rather than inventing a
-  channel.
+- A wrangler responsible for a broad world inherits its sub-worlds without a
+  second assignment.
+- The scope is itself a wrangled object. Merging two Settings merges the
+  assignments onto the survivor, and both wranglers MUST be notified.
+  Notification rather than approval, because an approval gate would allow one
+  wrangler to block another's legitimate merge.
 
-Automatic inheritance has two prerequisites that do not exist today, and both
-should be treated as blocking rather than as follow-ups:
+Cascading has two prerequisites, both blocking:
 
-**The Setting graph has no cycle guard.** `Tag::SettingTag` validates only
-uniqueness of child within parent; nothing prevents A → B → A. With inheritance,
-resolving a wrangler's scope becomes a graph traversal, and a cycle makes it
-non-terminating. **The hierarchy editor rejects cycle-closing edges outright**,
-with a validation on `Tag::MetaTag` rather than a check in the controller, so
-the constraint holds for imports and console work too. Scope resolution should
-*still* use a cycle-detecting recursive CTE as a belt-and-braces measure against
-rows that predate the validation.
+1. **Cycle rejection.** `tag_tags` has no cycle guard. Scope resolution is a
+   graph traversal and a cycle makes it non-terminating. Cycle-closing edges
+   MUST be rejected by model validation rather than recorded and ignored, since
+   a silently ignored edge misrepresents the graph. Traversal SHOULD
+   additionally use a cycle-detecting recursive CTE, to tolerate rows predating
+   the validation. Rejection changes the behaviour of an editor ordinary users
+   reach, so the validation message MUST identify the conflicting edge.
+2. **Hierarchy editing becomes privilege escalation.** With cascading,
+   attaching Setting X below Setting Y grants Y's wrangler authority over X.
+   `Tag#editable_by?` currently permits any non-readonly logged-in user to edit
+   an unowned `Setting`, and `tags_controller#update` assigns `parent_settings`
+   directly. Editing `parent_settings` MUST therefore be restricted to
+   wranglers. Editing name and description MAY remain open.
 
-Rejecting rather than recording-and-ignoring does change the behaviour of an
-editor ordinary users touch today: a save that previously succeeded can now fail
-with a validation error. That is the right trade — a silently-ignored edge is a
-lie about the state of the graph — but it needs a comprehensible error message,
-not a bare "is invalid". This is worth fixing regardless, since a cycle is
-already a latent hazard for anything walking `parent_settings`; inheritance is
-what makes it acute.
+**Queue interface.** `/tags/wrangling`, restricted to wranglers:
 
-**Editing the hierarchy becomes a privilege escalation.** Once an assignment
-cascades, attaching Setting X as a child of Setting Y hands Y's wrangler
-authority over X. Today `Tag#editable_by?` lets *any* non-readonly logged-in
-user edit an unowned `Setting`, and `tags_controller#update:57` sets
-`parent_settings` straight from `process_tags`. So under automatic inheritance,
-an ordinary user could restructure the graph to expand or contract a wrangler's
-scope. Editing `parent_settings` has to become wrangler-gated before inheritance
-ships; the general "anyone may edit an unowned Setting" affordance can stay for
-name and description.
+- Non-canonical, non-synonym tags, ordered by usage descending, filterable by
+  type.
+- Per-row actions: mark canonical, merge into a canonical tag, mark
+  unwrangleable.
+- Clusters of names sharing a normalized form, which are both the highest-value
+  merges and the least ambiguous decisions.
 
-The awkward case is a tag that appears across many unrelated Settings — most
-`Label`s, and every `ContentWarning`. Those need a global wrangler tier that is
-not assignment-scoped; assignment governs Settings and the tags that cluster
-within them, not the whole namespace.
+A denormalized filter index equivalent to AO3's `FilterTagging` is out of
+scope. Resolving `merger_id` at query time is sufficient until tag search
+becomes a measured bottleneck.
 
-**Queue interface.** `/tags/wrangling`, wrangler-only:
+### 6.3 Spoiler taggings
 
-- Non-canonical, non-synonym tags, ordered by usage count descending, filterable
-  by type and by board.
-- Inline actions per row: mark canonical, merge into an existing canonical tag
-  (autocomplete), mark unwrangleable.
-- Bulk select for the common case of many near-identical spellings.
-- A "recently created" view, since the cheapest moment to catch a duplicate is
-  when it is first used.
+Spoiler state belongs to the tagging, not the tag. `Character Death` is not
+inherently a disclosure; it is a disclosure on a given post until a given reply.
 
-**Deferred:** the `FilterTagging` equivalent. Until glowfic has enough tags for
-synonym-aware search to be slow, resolving `merger_id` at query time with a join
-is sufficient, and a denormalized index is a large amount of invalidation
-machinery to maintain. Revisit if tag search becomes a hotspot.
+The following columns are added to `post_tags`:
 
-### 2. User-suggested tags
-
-New model `TagSuggestion`:
-
-| column | type | notes |
+| Column | Type | Description |
 | --- | --- | --- |
-| `post_id` | integer, not null | |
-| `user_id` | integer, not null | suggester |
-| `tag_id` | integer, nullable | existing tag, if any |
-| `tag_type` | string, nullable | with `tag_name`, for a proposed new tag |
-| `tag_name` | citext, nullable | |
-| `status` | integer, not null | `pending` / `accepted` / `rejected` |
-| `resolved_by_id` | integer, nullable | |
-| `resolved_at` | datetime, nullable | |
-| `note` | text, nullable | optional short rationale |
+| `spoiler` | boolean, not null, default false | Tagging is withheld |
+| `reveal_after_reply_order` | integer, nullable | Reveal threshold |
 
-Exactly one of `tag_id` or (`tag_type`, `tag_name`) must be present.
+A null `reveal_after_reply_order` on a spoiler tagging means the tagging is
+revealed only once the reader has reached the end of the post as it currently
+stands.
 
-**Flow.** A logged-in, non-readonly user opens "Suggest a tag" on a post they do
-not own, picks an existing tag or proposes a name, optionally adds a note. The
-post author sees a badge on their own post and a list under their user menu;
-accepting creates the `PostTag` (and the `Tag`, if new, attributed to the
-*suggester* as creator, consistent with `process_tags` today).
+A tagging is revealed to a user when any of the following holds:
 
-**Rejection blocks globally**, not per suggester. Once an author rejects a tag
-on a post, nobody may suggest that tag on that post again. The alternative —
-blocking only the original suggester — means an author can be asked the same
-question by a stream of different readers, which is the failure mode that makes
-authors switch suggestions off entirely.
+1. The user is the post author or holds `:edit_posts`.
+2. `spoiler` is false.
+3. The user's furthest-read `reply_order` is greater than or equal to
+   `reveal_after_reply_order`.
 
-Two details this implies:
+Reading position derives from `post_views.read_at`. A user with no `post_view`,
+including any logged-out user, MUST NOT be shown spoiler taggings.
 
-- The block is keyed on `(post_id, tag_id)`, or on `(post_id, tag_type,
-  lower(tag_name))` for a proposed new tag, so re-proposing the same name as a
-  "new" tag does not slip past a rejection. `tags.name` being `citext` handles
-  the casing for existing tags; proposed names need the comparison done
-  explicitly since no `Tag` row exists yet.
-- Rejection must be reversible by the author. A rejected suggestion is a
-  standing decision, not a permanent one — authors change their minds, and a
-  post's content changes under it. The author's own view of rejected
-  suggestions needs an "allow again" action.
+**Limitation.** `read_at` is a timestamp. A reader who opened a post while it
+was short and returned after 200 further replies resolves to a high
+`reply_order` without having read the intervening replies. The failure mode is
+revealing early to a reader who skipped ahead. This is acceptable for
+non-disclosure but is not a guarantee and MUST NOT be described to users as one.
 
-**Spoiler taggings are suggestible**, and this is where suggestions and spoilers
-interact badly if built naively. A reader past a reveal threshold is exactly the
-person positioned to notice a missing spoiler tag, so the suggestion form
-carries the same `spoiler` and `reveal_after_reply_order` fields the author's
-own tagging form does.
+**Reverse lookup.** Hiding a tagging on the post page is not sufficient. If a
+spoiler tagging participates in tag-to-post listings, the tag page discloses the
+post. Three options were considered:
 
-The leak is not in the suggestion itself — pending suggestions are visible only
-to the author, so nothing is exposed to other readers by construction. The leak
-is in **deduplication feedback**. If a reader who has not reached the threshold
-suggests a tag that is *already applied as a hidden spoiler tagging*, the
-obvious response — "that tag is already on this post" — reveals the spoiler. The
-same applies to the global rejection block: "that tag was already suggested and
-rejected" tells the reader the tag was contemplated.
+1. Exclude spoiler taggings from reverse lookup entirely. Leak-free. The post
+   does not appear under a tag it holds.
+2. Filter per viewer. Correct, but makes every tag listing depend on the
+   requesting user's read state across every post in the result set, and is
+   therefore uncacheable.
+3. Include behind an explicit opt-in preference, defaulting to off.
 
-So the dedup check must be **read-state aware**, and must fail open rather than
-informatively. Where a collision exists that the suggester is not entitled to
-know about, accept the suggestion normally and show the ordinary confirmation.
-The suggester learns nothing.
+Option 1 is specified. Option 2 is rejected on cost. Option 3 MAY follow. The
+interface MUST state that marking a tagging as a spoiler removes the post from
+that tag's listings, since authors would otherwise assume they retain both
+discoverability and non-disclosure.
 
-**The author sees it as an endorsement, not a redundant suggestion.** A reader
-independently arriving at a tag the author already applied is useful signal —
-it says the tag is legible, that a real reader reached for the same words — so
-the author's view should record it as corroboration of the existing tagging
-rather than as a pending item needing a decision. Endorsements need no accept or
-reject action; they accumulate against the tagging.
+**Presentation.** The reveal interface SHOULD follow the existing content
+warning pattern rather than introduce a second one: a neutral count of withheld
+taggings, expandable on request. Note that changing a post's warnings resets
+`warnings_hidden` for all viewers (`app/models/post.rb:364`); the equivalent
+reset for spoiler taggings is not wanted, as re-hiding a tagging a reader has
+already seen achieves nothing.
 
-This is also the better answer to a worry the redundant-suggestion framing
-created. Showing an author "someone suggested a tag you already have, hidden as
-a spoiler" tells them their spoiler tagging is discoverable by inference.
-Showing them "a reader endorsed this tag" says the same thing about legibility
-without inviting them to conclude their spoiler leaked — because it did not. The
-reader guessed; that is what the endorsement records.
-
-This constraint is the reason pending suggestions should stay author-visible
-only. If a future change surfaces them more widely — a public "suggested tags"
-list, say — every one of these rules has to be re-derived, and the reveal rule
-must apply to the suggestion list too.
-
-**Author control.** Per-post `allow_tag_suggestions` (default on) and a per-user
-default in settings. Authors who do not want the interaction should be able to
-turn it off entirely rather than field the notifications.
-
-**Abuse handling.** This is the feature most likely to be misused, so:
-
-- Readonly and suspended users cannot suggest, reusing `readonly_forbidden`.
-- Per-user rate limit on pending suggestions, plus a cap per post.
-- Existing user ignore lists suppress suggestions from ignored users.
-- Repeated rejected suggestions to the same author are a mod-visible signal.
-
-**Content warnings, and the limit of this feature.** The strongest motivation
-for suggestions is a reader hitting untagged material that should have carried a
-warning. It is tempting to let mods apply a `ContentWarning` over an author's
-rejection, and this RFC explicitly does **not** propose that: authors retain
-creative control over their own posts, including over tags they decline.
-
-The consequence should be stated plainly rather than left implicit. A reader who
-believes a post needs a warning the author refuses has no recourse *within the
-tag system*; their recourse is the existing out-of-band mod report, which is a
-site-rules matter and deliberately a heavier instrument. `ContentWarning`
-suggestions are therefore ordinary suggestions with no special powers attached —
-the only accommodation is that a rejected `ContentWarning` suggestion is worth
-surfacing to mods as a signal, without granting them the ability to act on it
-unilaterally.
-
-### 3. Spoiler tags
-
-Make the tagging, not the tag, carry the spoiler state. `Character Death` is
-not inherently a spoiler; it is a spoiler *on this post, until reply 200*.
-
-Add to `post_tags`:
-
-| column | type | notes |
-| --- | --- | --- |
-| `spoiler` | boolean, default `false`, not null | |
-| `reveal_after_reply_order` | integer, nullable | reveal once the reader has read past this reply |
-
-`spoiler` with a null `reveal_after_reply_order` means "reveal only when the
-reader has reached the end of the post as it currently stands".
-
-**Resolution.** A tagging is revealed to a user when any of:
-
-- the user is the post's author or a mod;
-- `spoiler` is false;
-- the user's furthest-read reply order ≥ `reveal_after_reply_order`.
-
-Reading position comes from the existing `post_views.read_at` via
-`Post#last_seen_reply_for`, which already resolves a timestamp to a reply.
-Logged-out users have no `post_view` and therefore see no spoiler taggings.
-
-A caveat that should be designed for rather than discovered: `read_at` is a
-*timestamp*, so a reader who opened a thread while it was short and returned
-after 200 new replies has a `read_at` that maps to a high `reply_order` without
-having read the intervening replies. This is acceptable for spoiler-hiding —
-the failure mode is revealing slightly early to someone who skipped ahead, which
-is what skipping ahead means — but it should not be described to users as a
-guarantee.
-
-**Leakage is the hard part.** Hiding the tag on the post page is easy and
-insufficient. If a spoiler tagging still participates in tag → post listings,
-then the tag page for `Character Death` lists the post and the spoiler is out.
-Options:
-
-- **(a) Exclude spoiler taggings from reverse lookup entirely.** Simple,
-  leak-free, and it costs the tag its discoverability — the post genuinely does
-  not appear under a tag it genuinely has.
-- **(b) Filter per viewer.** Correct, but it makes every tag listing depend on
-  the current user's read state across every post in the result set. Expensive
-  and hard to cache.
-- **(c) Include, but behind an explicit opt-in.** A user preference —
-  "show posts under spoiler tags" — defaulting to off, plus an interstitial on
-  the tag page.
-
-**Recommendation: (a) for the first implementation, with (c) as a follow-up.**
-(b) should be rejected outright; the caching cost is not worth it. Authors
-should be told plainly in the UI that marking a tagging as a spoiler removes the
-post from that tag's listings, because the alternative is authors believing they
-get both discoverability and secrecy.
-
-**Reuse the content-warning interstitial.** The reveal UI should follow the
-existing pattern rather than inventing a second one: where spoiler taggings
-exist but are not yet revealed, show a neutral count ("3 spoiler tags") that
-expands on click, and record the choice the way `hide_warnings_for` does. Note
-that per `app/models/post.rb:364`, changing a post's warnings resets
-`warnings_hidden` for all viewers; the equivalent reset for spoiler taggings is
-*not* wanted, since re-hiding a tag a reader has already seen achieves nothing.
-
-**API behaviour: hide, do not omit.** `apipie` exposes post tags, so the reveal
-rule has to apply there or the API is simply the leak by another route. But the
-right treatment differs from the HTML view: an unrevealed tagging is *redacted*,
-not dropped. The serialized entry stays in the array with its identity withheld:
+**API.** `apipie` exposes post tags, so the reveal rule MUST apply there.
+Unrevealed taggings are redacted rather than omitted:
 
 ```json
 { "id": null, "type": "Label", "spoiler": true, "revealed": false }
 ```
 
-The reasoning is that the API's consumer is a program, not a reader. Omitting
-entries makes the array length lie, so a client cannot distinguish "no tags" from
-"tags it may not see", and any client computing counts silently gets them wrong.
-Redaction keeps the shape honest while withholding the content. Authenticated
-requests resolve `revealed` against the requesting user's read position exactly
-as the web view does; anonymous requests have no read state and so see every
-spoiler tagging redacted.
+Omission would make the array length misrepresent the post, so a client could
+not distinguish "no tags" from "tags withheld", and any client computing counts
+would be silently wrong. Authenticated requests resolve `revealed` against the
+requesting user. Anonymous requests hold no read state and receive every spoiler
+tagging redacted.
 
-## Schema summary
+### 6.4 Tag suggestions
+
+A `TagSuggestion` record carries: post, suggester, either an existing tag or a
+proposed type and name, status, resolver, resolution timestamp, an optional
+note, and the spoiler fields from section 6.3. Exactly one of the existing tag
+or the proposed name MUST be present.
+
+**Flow.** A logged-in, non-readonly user proposes a tag on a post they do not
+own. The post author sees pending suggestions and accepts or declines them.
+Acceptance creates the tagging, and creates the tag if proposed, attributed to
+the suggester, consistent with `process_tags`.
+
+**Author control.** A per-post `allow_tag_suggestions` flag and a per-user
+default govern whether a post accepts suggestions.
+
+**Rejection scope.** A declined tag MUST NOT be suggestible on that post by any
+user, not merely by the original suggester. Per-suggester blocking permits an
+author to be asked the same question by a succession of readers, which is the
+condition that causes authors to disable suggestions entirely. Two consequences:
+
+- The block is keyed on `(post_id, tag_id)`, or on
+  `(post_id, tag_type, lower(tag_name))` for a proposed name, so that
+  re-proposing a declined tag as a new name does not bypass it. `citext` covers
+  existing tags; proposed names require explicit comparison, as no `Tag` row
+  exists.
+- Rejection MUST be reversible by the author. A rejection is a standing
+  decision, not a permanent one.
+
+**Deduplication and disclosure.** The disclosure risk is not the suggestion but
+the deduplication response. "That tag is already on this post" discloses a
+withheld spoiler tagging. "That tag was already declined" discloses the author's
+decision. Deduplication MUST therefore be read-state aware and MUST fail open:
+where a collision exists that the suggester is not entitled to observe, the
+request returns the ordinary confirmation and no error.
+
+Where the collision is a tagging the suggester cannot see, the record is stored
+as an **endorsement**: a reader independently proposed a tag already applied.
+Endorsements require no author action and accumulate against the tagging.
+Endorsement is also the correct presentation for the author, because reporting a
+redundant suggestion would invite the author to infer that their spoiler tagging
+had been disclosed, which it has not.
+
+Pending suggestions are visible only to the post author. Any future change
+surfacing them more widely MUST re-derive these rules and apply the reveal rule
+of section 6.3 to the suggestion list.
+
+**Abuse controls.** Readonly and suspended users MUST NOT suggest. Per-user and
+per-post caps on pending suggestions apply. Existing ignore lists suppress
+suggestions from ignored users.
+
+**Content warnings.** Mods MUST NOT apply a `ContentWarning` over an author's
+rejection. Authors retain control of their own posts, including of tags they
+decline. The consequence is stated explicitly: a reader who believes a post
+requires a warning the author has declined has no recourse within the tag
+system, and must use the existing out-of-band report, which is a site-rules
+matter. A declined `ContentWarning` suggestion MAY be surfaced to mods as a
+signal without conferring authority to act on it.
+
+## 7. Schema summary
 
 ```
-tags            + canonical:boolean, merger_id:integer, unwrangleable:boolean
-post_tags       + spoiler:boolean, reveal_after_reply_order:integer
-posts           + allow_tag_suggestions:boolean
-users           + allow_tag_suggestions:boolean (default for new posts)
-tag_suggestions        new table (see above)
-wrangling_assignments  new table (user_id, setting_id)
-tag_tags        unchanged — generalizing Tag::SettingTag to Tag::MetaTag is a
-                model-only change, and the existing `suggested` column is
-                adopted as the unconfirmed-implication state
+tags                   + canonical, unwrangleable, merger_id
+post_tags              + spoiler, reveal_after_reply_order
+posts                  + allow_tag_suggestions
+users                  + allow_tag_suggestions
+tag_suggestions        new
+wrangling_assignments  new (user_id, setting_id)
+tag_tags               unchanged; `suggested` adopted per section 6.1
 ```
 
-`post_tags` gaining columns is the change with the widest blast radius: it is
-currently a bare join table and several queries treat it as one. Those need
-auditing before the migration, not after.
+`post_tags` is currently a bare join table and several queries treat it as one.
+Those queries MUST be audited before the migration.
 
-The `tag_tags.suggested` column already exists, is unused, and is adopted here
-as the unconfirmed state for an implication edge (see above). Since it currently
-defaults to `false` and no rows set it, existing edges are correctly interpreted
-as confirmed with no data migration.
+`tag_tags.suggested` defaults to false and no rows set it, so existing edges are
+correctly interpreted as confirmed without a data migration.
 
-## Rollout
+## 8. Rollout
 
-1. Tag graph columns + model constraints, no UI. **No backfill** — every tag
-   starts non-canonical and is promoted by hand. This is only viable because of
-   the canonical invariant above: an uncanonical tag behaves exactly like a
-   canonical one, so "unwrangled" is a backlog, not a defect.
-2. Wrangler roles and queue interface. Run it manually for a while; the queue's
-   shape will be wrong in ways that are only visible in use.
+1. Tag graph columns and model constraints, without interface. No backfill;
+   every tag begins non-canonical. Viable only under the invariant in
+   section 6.1.
+2. Wrangler role and queue interface.
+3. Spoiler taggings. Self-contained and the most immediately useful to authors.
+4. Suggestions, once a wrangler group exists to absorb the resulting moderation
+   load.
 
-Because the queue starts as the whole corpus, it has to be ordered by value
-rather than presented as a list to be finished:
+The two prerequisites in section 6.2, cycle validation and restriction of
+`parent_settings` editing, SHOULD be implemented ahead of step 2. Both are
+small, independently useful, and block the role work.
 
-- Default ordering by usage count descending, so the tags on the most posts get
-  a decision first.
-- Duplicate-suspect clustering — group tags whose names are near-matches under a
-  normalization (case, whitespace, punctuation, simple pluralization), since
-  those are both the highest-value merges and the easiest calls. Computed and
-  cached rather than stored as a column, so the normalization can be tuned
-  without a migration; invalidated on tag create, rename, and merge.
-- Surface progress as *coverage weighted by usage* — "canonical tags account for
-  N% of taggings" — not as a count of tags remaining. The raw remaining count
-  will look unmoving for a long time and is a discouraging number to show a
-  volunteer.
-3. Spoiler taggings. Self-contained, and the most immediately valuable to
-   authors.
-4. User suggestions last, once there is a wrangler group able to absorb the
-   moderation load it generates.
+Because the queue initially contains the entire corpus, it MUST be ordered by
+value rather than presented as a list to be completed:
 
-## Resolved
+- Default ordering by usage count descending.
+- Clustering of near-identical names under a normalization covering case,
+  whitespace, punctuation, and simple pluralization. Computed and cached rather
+  than stored, so the normalization can be adjusted without a migration.
+  Invalidated on tag creation, rename, and merge.
+- Progress reported as coverage weighted by usage, not as a count of remaining
+  tags. The remaining count will not move perceptibly for a long period.
 
-Decisions taken on the questions this draft opened with:
+## 9. Resolved decisions
 
-- **`Label` gains hierarchy.** Generalize `Tag::SettingTag` to `Tag::MetaTag`;
-  no migration required. Cross-type implication deferred.
-- **Wrangler assignments scope by `Setting`**, not by `Board` — a Setting is the
-  structural analogue of an AO3 fandom. Global tags (`Label`s that span
-  settings, all `ContentWarning`s) need an unscoped wrangler tier alongside it.
-- **Mods cannot override an author's rejection of a `ContentWarning`.** Authors
-  keep creative control; the escalation path stays the existing out-of-band mod
-  report.
-- **Merging synonyms by default, deletion retained.** Both behaviours stay
-  available, with synonyming as the primary action and delete as admin-only.
-- **The API redacts spoiler taggings rather than omitting them**, so array
-  shapes and counts stay truthful for programmatic consumers.
-- **No canonical backfill; canonicalization is entirely manual.** Viable only
-  under the canonical invariant — nothing user-facing may depend on `canonical`.
-- **One new role plus an admin capability.** `WRANGLER` is Setting-scoped;
-  global wrangling (`:wrangle_tags_global`, covering cross-setting `Label`s and
-  all `ContentWarning`s) is an admin capability rather than a third role. The
-  tiers stay distinct — global is not an unassigned bucket inside `WRANGLER` —
-  but the permission is named separately from the role holding it, so promoting
-  it later is cheap.
-- **`tag_tags.suggested` is adopted** as the unconfirmed-implication state,
-  which is how a scoped wrangler proposes an edge reaching outside their scope.
-- **A rejected suggestion blocks that tag on that post for everyone**, reversible
-  by the author.
-- **Assignments inherit down the Setting hierarchy automatically**, gated on
-  adding a cycle guard and on making hierarchy edits wrangler-only.
-- **Assignments follow a merged Setting**, collapsing both wranglers onto the
-  survivor.
-- **Duplicate clustering is computed and cached**, not a stored column.
-- **Spoiler taggings are suggestible**, with a read-state-aware dedup check that
-  fails open rather than revealing a collision.
-- **Cycle-closing hierarchy edges are rejected** by model validation, not
-  recorded and ignored.
-- **A merge that collapses two wranglers' scopes notifies both**, via the
-  existing `Notification` model; no approval gate.
-- **A suggestion colliding with an unseen tagging is recorded as an
-  endorsement** of the existing tagging, needing no author action.
+1. `Label` gains hierarchy. `Tag::SettingTag` becomes `Tag::MetaTag`; no
+   migration. Cross-type implication deferred.
+2. Wrangling assignments scope by `Setting`, not by `Board`.
+3. Global wrangling is an admin capability, not a third role, while remaining a
+   distinct tier.
+4. No canonical backfill. Canonicalization is manual, under the invariant that
+   `canonical` gates nothing.
+5. Merging produces synonyms by default. Destructive merge is retained,
+   admin-only.
+6. Assignments inherit down the Setting hierarchy automatically, conditional on
+   the two prerequisites in section 6.2.
+7. Assignments follow a merged Setting and notify both wranglers. No approval
+   gate.
+8. Cycle-closing edges are rejected by validation.
+9. Duplicate clustering is computed and cached, not stored.
+10. The API redacts withheld spoiler taggings rather than omitting them.
+11. A rejected suggestion blocks that tag on that post for all users, and is
+    reversible by the author.
+12. Spoiler taggings are suggestible. Deduplication is read-state aware and
+    fails open.
+13. A suggestion colliding with a tagging the suggester cannot observe is
+    recorded as an endorsement.
+14. Mods cannot override an author's rejection of a `ContentWarning`.
 
-## Next steps
+## 10. Open items
 
-Every question this draft opened with has been answered; what remains is
-sequencing rather than design. The rollout section above is the intended order,
-and the two prerequisites for automatic inheritance — the cycle validation and
-wrangler-gating of `parent_settings` — should be broken out as their own tickets
-ahead of step 2, since both are small, independently useful, and block the role
-work.
-
-One thing to settle at implementation time rather than here: endorsements need a
-home in the schema. They are close enough to `TagSuggestion` to reuse it with a
-fourth `status` (`endorsed`), and different enough — no decision pending, no
-rejection possible, aggregate rather than individual interest — that a separate
-counter on `post_tags` may read better. Decide it against the queries the
-author's view actually needs.
+Endorsements require a schema decision at implementation time. They are close
+enough to `TagSuggestion` to reuse it with an additional status, and different
+enough, in carrying no pending decision and being of aggregate rather than
+individual interest, that a counter on `post_tags` may be preferable. The
+decision SHOULD be made against the queries the author's view requires.

--- a/doc/rfcs/001-tag-wrangling.md
+++ b/doc/rfcs/001-tag-wrangling.md
@@ -242,9 +242,13 @@ The following columns are added to `post_tags`:
 | `spoiler` | boolean, not null, default false | Tagging is withheld |
 | `reveal_after_reply_order` | integer, nullable | Reveal threshold |
 
-A null `reveal_after_reply_order` on a spoiler tagging means the tagging is
-revealed only once the reader has reached the end of the post as it currently
-stands.
+A spoiler tagging created without an explicit `reveal_after_reply_order` MUST
+have the threshold fixed to the post's last `reply_order` at the time the
+tagging is created. Resolving "the end of the post" dynamically would move the
+threshold every time a reply is added, so a tagging would become visible to a
+reader who had caught up and then hidden again on the next reply. The fixed
+threshold also matches author intent, which is to withhold the tag until the
+point the tagged material has been reached.
 
 A tagging is revealed to a user when any of the following holds:
 
@@ -347,6 +351,11 @@ of section 6.3 to the suggestion list.
 **Abuse controls.** Readonly and suspended users MUST NOT suggest. Per-user and
 per-post caps on pending suggestions apply. Existing ignore lists suppress
 suggestions from ignored users.
+
+**Suggestible types.** Only `Setting`, `Label`, and `ContentWarning` may be
+suggested. `GalleryGroup` tags attach to galleries, not posts, and a tagging
+referencing one would be surfaced by none of `Post#settings`, `#labels`, or
+`#content_warnings`.
 
 **Content warnings.** Mods MUST NOT apply a `ContentWarning` over an author's
 rejection. Authors retain control of their own posts, including of tags they

--- a/script/seed_dumper.rb
+++ b/script/seed_dumper.rb
@@ -14,7 +14,7 @@ EXCLUDED_SCHEMA = {
   Setting: ['created_at', 'updated_at', 'description'],
   CharacterTag: ['created_at', 'updated_at'],
   GalleryTag: ['created_at', 'updated_at'],
-  Tag::SettingTag => ['created_at', 'updated_at', 'suggested'],
+  Tag::MetaTag => ['created_at', 'updated_at', 'suggested'],
   PostTag: ['created_at', 'updated_at', 'suggested'],
   'Audited::Audit': [],
   Post::Author => ['created_at', 'updated_at'],
@@ -24,7 +24,7 @@ EXCLUDED_SCHEMA = {
 
 MODELS = [
   Icon, Template, Character, CharacterAlias, Gallery, CharactersGallery, GalleriesIcon, Post, Reply, ContentWarning, GalleryGroup,
-  Setting, CharacterTag, GalleryTag, Tag::SettingTag, PostTag, Post::View,
+  Setting, CharacterTag, GalleryTag, Tag::MetaTag, PostTag, Post::View,
 ]
 
 FILES = {
@@ -38,7 +38,7 @@ FILES = {
   # Reply: [Reply],
   Tag: [
     ContentWarning, GalleryGroup, Setting, 'puts "Assigning tags to characters..."', CharacterTag, 'puts "Assigning tags to galleries..."',
-    GalleryTag, 'puts "Attaching settings to each other..."', Tag::SettingTag, 'puts "Attaching tags to posts..."', PostTag,
+    GalleryTag, 'puts "Attaching settings to each other..."', Tag::MetaTag, 'puts "Attaching tags to posts..."', PostTag,
   ],
 }
 

--- a/shell.nix
+++ b/shell.nix
@@ -17,7 +17,21 @@
 
 let
   # Ruby 3.4.x
-  ruby = pkgs.ruby_3_4;
+  #
+  # main pins Ruby 3.4.10 in Gemfile/.ruby-version, and bundler hard-fails on a
+  # patch-level mismatch. No nixpkgs channel ships 3.4.10 yet (unstable is on
+  # 3.4.9, nixos-25.05 on 3.4.7), so override the source on the pinned 3.4.8
+  # derivation rather than bumping the whole pin — keeps postgres/node/etc
+  # identical. Drop this override once nixpkgs catches up to >= 3.4.10.
+  rubyVersion = "3.4.10";
+  ruby = pkgs.ruby_3_4.overrideAttrs (old: {
+    name = "ruby-${rubyVersion}";
+    version = rubyVersion;
+    src = pkgs.fetchurl {
+      url = "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-${rubyVersion}.tar.gz";
+      sha256 = "1v19qjffzx50pnnglyqiynmk0cawzvcdymnx8x1x3whl583jvvpc";
+    };
+  });
 
   # Chrome path - only evaluated on Linux
   chromePath = if pkgs.stdenv.isLinux then "${pkgs.chromium}/bin/chromium" else "";
@@ -57,8 +71,11 @@ pkgs.mkShell {
   ];
 
   shellHook = ''
-    # Set up gem installation to local directory
-    export GEM_HOME="$PWD/.gems"
+    # Set up gem installation to local directory.
+    # Keyed by Ruby version: native extensions link against a specific Ruby, so
+    # a version bump would otherwise silently poison the shared gemset. This
+    # keeps the old gemset intact for branches still pinned to it.
+    export GEM_HOME="$PWD/.gems-${rubyVersion}"
     export PATH="$GEM_HOME/bin:$PATH"
     mkdir -p "$GEM_HOME"
 

--- a/spec/controllers/tag_suggestions_controller_spec.rb
+++ b/spec/controllers/tag_suggestions_controller_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe TagSuggestionsController do
       expect {
         post :create, params: { post_id: post_record.id, tag_suggestion: { tag_id: tag.id } }
       }.to change { TagSuggestion.count }.by(1)
-      expect(flash[:success]).to eq("Thanks — your suggestion has been sent to the author.")
+      expect(flash[:success]).to eq("Suggestion recorded. The post author will review it.")
     end
 
     it "reports a tag the suggester can already see" do
       PostTag.create!(post: post_record, tag: tag)
       login_as(reader)
       post :create, params: { post_id: post_record.id, tag_suggestion: { tag_id: tag.id } }
-      expect(flash[:error]).to eq("That tag is already on this post.")
+      expect(flash[:error]).to eq("Tag is already applied to this post.")
     end
 
     it "gives the same confirmation for a silently deduped suggestion" do
@@ -54,7 +54,7 @@ RSpec.describe TagSuggestionsController do
       expect {
         post :create, params: { post_id: post_record.id, tag_suggestion: { tag_id: tag.id } }
       }.not_to change { TagSuggestion.count }
-      expect(flash[:success]).to eq("Thanks — your suggestion has been sent to the author.")
+      expect(flash[:success]).to eq("Suggestion recorded. The post author will review it.")
       expect(flash[:error]).to be_nil
     end
 
@@ -86,7 +86,7 @@ RSpec.describe TagSuggestionsController do
       get :index
 
       expect(assigns(:resolved)).to match_array([rejected, accepted])
-      expect(response.body).to include("Allow again")
+      expect(response.body).to include("Permit again")
     end
 
     it "separates endorsements from pending decisions" do
@@ -107,7 +107,7 @@ RSpec.describe TagSuggestionsController do
     it "refuses a user who is not the author" do
       login_as(reader)
       post :accept, params: { id: suggestion.id }
-      expect(flash[:error]).to eq("You do not have permission to do that.")
+      expect(flash[:error]).to eq("You do not have permission to resolve this suggestion.")
       expect(suggestion.reload).to be_pending
     end
 

--- a/spec/controllers/tag_suggestions_controller_spec.rb
+++ b/spec/controllers/tag_suggestions_controller_spec.rb
@@ -1,0 +1,139 @@
+RSpec.describe TagSuggestionsController do
+  render_views
+
+  let(:author) { create(:user) }
+  let(:reader) { create(:user) }
+  let(:post_record) { create(:post, user: author) }
+  let(:tag) { create(:label) }
+
+  describe "GET new" do
+    it "requires login" do
+      get :new, params: { post_id: post_record.id }
+      expect(response).to redirect_to(root_url)
+    end
+
+    it "refuses readonly users" do
+      login_as(create(:reader_user))
+      get :new, params: { post_id: post_record.id }
+      expect(response).to redirect_to(continuities_path)
+    end
+
+    it "handles a missing post" do
+      login_as(reader)
+      get :new, params: { post_id: -1 }
+      expect(flash[:error]).to eq("Post could not be found.")
+    end
+
+    it "succeeds" do
+      login_as(reader)
+      get :new, params: { post_id: post_record.id }
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "POST create" do
+    it "creates a suggestion" do
+      login_as(reader)
+      expect {
+        post :create, params: { post_id: post_record.id, tag_suggestion: { tag_id: tag.id } }
+      }.to change { TagSuggestion.count }.by(1)
+      expect(flash[:success]).to eq("Thanks — your suggestion has been sent to the author.")
+    end
+
+    it "reports a tag the suggester can already see" do
+      PostTag.create!(post: post_record, tag: tag)
+      login_as(reader)
+      post :create, params: { post_id: post_record.id, tag_suggestion: { tag_id: tag.id } }
+      expect(flash[:error]).to eq("That tag is already on this post.")
+    end
+
+    it "gives the same confirmation for a silently deduped suggestion" do
+      TagSuggestion.create!(post: post_record, user: create(:user), tag: tag, status: :rejected)
+      login_as(reader)
+
+      expect {
+        post :create, params: { post_id: post_record.id, tag_suggestion: { tag_id: tag.id } }
+      }.not_to change { TagSuggestion.count }
+      expect(flash[:success]).to eq("Thanks — your suggestion has been sent to the author.")
+      expect(flash[:error]).to be_nil
+    end
+
+    it "re-renders on invalid input" do
+      post_record.update!(allow_tag_suggestions: false)
+      login_as(reader)
+      post :create, params: { post_id: post_record.id, tag_suggestion: { tag_id: tag.id } }
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe "GET index" do
+    it "shows only the current user's posts' suggestions" do
+      mine = TagSuggestion.create!(post: post_record, user: reader, tag: tag)
+      TagSuggestion.create!(post: create(:post), user: reader, tag: create(:label))
+      login_as(author)
+
+      get :index
+      expect(assigns(:pending)).to eq([mine])
+    end
+
+    it "lists resolved suggestions with an allow-again action for rejections" do
+      rejected = TagSuggestion.create!(post: post_record, user: reader, tag: tag)
+      rejected.reject!(resolver: author)
+      accepted = TagSuggestion.create!(post: post_record, user: reader, tag: create(:label))
+      accepted.accept!(resolver: author)
+      login_as(author)
+
+      get :index
+
+      expect(assigns(:resolved)).to match_array([rejected, accepted])
+      expect(response.body).to include("Allow again")
+    end
+
+    it "separates endorsements from pending decisions" do
+      create_list(:reply, 2, post: post_record, user: author)
+      PostTag.create!(post: post_record, tag: tag, spoiler: true)
+      TagSuggestion.submit(post: post_record, user: reader, tag: tag)
+      login_as(author)
+
+      get :index
+      expect(assigns(:endorsements).length).to eq(1)
+      expect(assigns(:pending)).to be_empty
+    end
+  end
+
+  describe "resolution" do
+    let!(:suggestion) { TagSuggestion.create!(post: post_record, user: reader, tag: tag) }
+
+    it "refuses a user who is not the author" do
+      login_as(reader)
+      post :accept, params: { id: suggestion.id }
+      expect(flash[:error]).to eq("You do not have permission to do that.")
+      expect(suggestion.reload).to be_pending
+    end
+
+    it "accepts" do
+      login_as(author)
+      post :accept, params: { id: suggestion.id }
+      expect(post_record.reload.labels).to eq([tag])
+    end
+
+    it "rejects" do
+      login_as(author)
+      post :reject, params: { id: suggestion.id }
+      expect(suggestion.reload).to be_rejected
+    end
+
+    it "allows a rejected tag to be suggested again" do
+      suggestion.reject!(resolver: author)
+      login_as(author)
+      delete :allow_again, params: { id: suggestion.id }
+      expect(TagSuggestion.find_by(id: suggestion.id)).to be_nil
+    end
+
+    it "handles a missing suggestion" do
+      login_as(author)
+      post :accept, params: { id: -1 }
+      expect(flash[:error]).to eq("Suggestion could not be found.")
+    end
+  end
+end

--- a/spec/controllers/tag_suggestions_controller_spec.rb
+++ b/spec/controllers/tag_suggestions_controller_spec.rb
@@ -59,10 +59,26 @@ RSpec.describe TagSuggestionsController do
     end
 
     it "re-renders on invalid input" do
+      login_as(reader)
+      post :create, params: { post_id: post_record.id, tag_suggestion: { tag_name: '' } }
+      expect(response).to render_template(:new)
+    end
+
+    it "redirects when the post does not accept suggestions" do
       post_record.update!(allow_tag_suggestions: false)
       login_as(reader)
-      post :create, params: { post_id: post_record.id, tag_suggestion: { tag_id: tag.id } }
-      expect(response).to render_template(:new)
+
+      expect {
+        post :create, params: { post_id: post_record.id, tag_suggestion: { tag_id: tag.id } }
+      }.not_to change { TagSuggestion.count }
+      expect(flash[:error]).to eq("This post does not accept tag suggestions.")
+    end
+
+    it "does not offer the form when the post does not accept suggestions" do
+      post_record.update!(allow_tag_suggestions: false)
+      login_as(reader)
+      get :new, params: { post_id: post_record.id }
+      expect(flash[:error]).to eq("This post does not accept tag suggestions.")
     end
   end
 

--- a/spec/controllers/tag_wranglings_controller_spec.rb
+++ b/spec/controllers/tag_wranglings_controller_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe TagWranglingsController do
     it "refuses a merge across types" do
       login_as(create(:admin_user))
       patch :update, params: { id: setting.id, commit_action: 'merge', merger_id: create(:label).id }
-      expect(flash[:error]).to eq("Select a tag of the same type to merge into.")
+      expect(flash[:error]).to eq("Merge target must be an existing tag of the same type.")
     end
 
     it "refuses a tag outside the wrangler's scope" do
@@ -152,7 +152,7 @@ RSpec.describe TagWranglingsController do
     it "rejects an unknown action" do
       login_as(wrangler)
       patch :update, params: { id: setting.id, commit_action: 'explode' }
-      expect(flash[:error]).to eq("Unknown wrangling action.")
+      expect(flash[:error]).to eq("Unrecognized wrangling action.")
     end
   end
 end

--- a/spec/controllers/tag_wranglings_controller_spec.rb
+++ b/spec/controllers/tag_wranglings_controller_spec.rb
@@ -129,10 +129,41 @@ RSpec.describe TagWranglingsController do
       expect(Tag.find_by(id: setting.id)).to be_nil
     end
 
+    it "refuses a merge of a tag into itself" do
+      login_as(create(:admin_user))
+      patch :update, params: { id: setting.id, commit_action: 'merge', merger_id: setting.id, destroy_loser: '1' }
+
+      expect(Tag.find_by(id: setting.id)).to be_present
+      expect(flash[:error]).to eq("Merge target must be a different existing tag of the same type.")
+    end
+
+    it "refuses to mark a synonym canonical" do
+      canonical = create(:setting, canonical: true)
+      setting.update!(merger: canonical)
+      login_as(create(:admin_user))
+
+      patch :update, params: { id: setting.id, commit_action: 'canonical' }
+
+      expect(setting.reload).not_to be_canonical
+      expect(flash[:error]).to include("synonym cannot be marked canonical")
+    end
+
+    it "refuses to merge into a tag that is itself a synonym" do
+      canonical = create(:setting, canonical: true)
+      synonym = create(:setting)
+      synonym.update!(merger: canonical)
+      login_as(create(:admin_user))
+
+      patch :update, params: { id: setting.id, commit_action: 'merge', merger_id: synonym.id }
+
+      expect(setting.reload.merger).to be_nil
+      expect(flash[:error]).to include("itself a synonym")
+    end
+
     it "refuses a merge across types" do
       login_as(create(:admin_user))
       patch :update, params: { id: setting.id, commit_action: 'merge', merger_id: create(:label).id }
-      expect(flash[:error]).to eq("Merge target must be an existing tag of the same type.")
+      expect(flash[:error]).to eq("Merge target must be a different existing tag of the same type.")
     end
 
     it "refuses a tag outside the wrangler's scope" do

--- a/spec/controllers/tag_wranglings_controller_spec.rb
+++ b/spec/controllers/tag_wranglings_controller_spec.rb
@@ -1,0 +1,158 @@
+RSpec.describe TagWranglingsController do
+  render_views
+
+  let(:wrangler) { create(:wrangler_user) }
+  let(:setting) { create(:setting) }
+
+  def assign_scope
+    create(:wrangling_assignment, user: wrangler, setting: setting)
+  end
+
+  describe "GET index" do
+    it "requires login" do
+      get :index
+      expect(response).to redirect_to(root_url)
+    end
+
+    it "refuses an ordinary user" do
+      login_as(create(:user))
+      get :index
+      expect(response).to redirect_to(root_path)
+      expect(flash[:error]).to eq("You do not have permission to wrangle tags.")
+    end
+
+    it "refuses a mod" do
+      login_as(create(:mod_user))
+      get :index
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "succeeds for a wrangler" do
+      assign_scope
+      login_as(wrangler)
+      get :index
+      expect(response).to have_http_status(200)
+    end
+
+    it "succeeds for an admin with no assignments" do
+      login_as(create(:admin_user))
+      get :index
+      expect(response).to have_http_status(200)
+    end
+
+    it "rejects an invalid type filter" do
+      login_as(create(:admin_user))
+      get :index, params: { type: 'NotAType' }
+      expect(response).to redirect_to(tag_wranglings_path)
+      expect(flash[:error]).to eq("Invalid filter")
+    end
+
+    it "shows only tags within a wrangler's scope" do
+      assign_scope
+      in_scope = create(:label)
+      create(:post, settings: [setting], labels: [in_scope])
+      out_of_scope = create(:label)
+      login_as(wrangler)
+
+      get :index
+      expect(assigns(:tags)).to include(in_scope)
+      expect(assigns(:tags)).not_to include(out_of_scope)
+    end
+
+    it "surfaces clusters of near-identical names" do
+      login_as(create(:admin_user))
+      create(:label, name: 'Bar Fight')
+      create(:label, name: 'bar fights')
+      create(:label, name: 'Unrelated')
+
+      get :index, params: { type: 'Label' }
+
+      expect(assigns(:clusters)).to be_present
+      expect(assigns(:clusters).first[:names]).to match_array(['Bar Fight', 'bar fights'])
+    end
+
+    it "orders the queue by usage" do
+      login_as(create(:admin_user))
+      rare = create(:label)
+      common = create(:label)
+      create(:post, labels: [rare])
+      create_list(:post, 3, labels: [common])
+
+      get :index, params: { type: 'Label' }
+      expect(assigns(:tags).first).to eq(common)
+    end
+  end
+
+  describe "PATCH update" do
+    before(:each) { assign_scope }
+
+    it "marks a tag canonical" do
+      login_as(wrangler)
+      patch :update, params: { id: setting.id, commit_action: 'canonical' }
+      expect(setting.reload).to be_canonical
+    end
+
+    it "marks a tag unwrangleable" do
+      login_as(wrangler)
+      patch :update, params: { id: setting.id, commit_action: 'unwrangleable' }
+      expect(setting.reload).to be_unwrangleable
+    end
+
+    it "merges as a synonym by default" do
+      target = create(:setting)
+      create(:wrangling_assignment, user: wrangler, setting: target)
+      login_as(wrangler)
+
+      patch :update, params: { id: setting.id, commit_action: 'merge', merger_id: target.id }
+
+      expect(setting.reload.merger).to eq(target)
+      expect(Tag.find_by(id: setting.id)).to be_present
+    end
+
+    it "does not let a wrangler destroy the loser" do
+      target = create(:setting)
+      create(:wrangling_assignment, user: wrangler, setting: target)
+      login_as(wrangler)
+
+      patch :update, params: { id: setting.id, commit_action: 'merge', merger_id: target.id, destroy_loser: '1' }
+
+      expect(Tag.find_by(id: setting.id)).to be_present
+      expect(setting.reload.merger).to eq(target)
+    end
+
+    it "lets an admin destroy the loser" do
+      target = create(:setting)
+      login_as(create(:admin_user))
+
+      patch :update, params: { id: setting.id, commit_action: 'merge', merger_id: target.id, destroy_loser: '1' }
+
+      expect(Tag.find_by(id: setting.id)).to be_nil
+    end
+
+    it "refuses a merge across types" do
+      login_as(create(:admin_user))
+      patch :update, params: { id: setting.id, commit_action: 'merge', merger_id: create(:label).id }
+      expect(flash[:error]).to eq("Select a tag of the same type to merge into.")
+    end
+
+    it "refuses a tag outside the wrangler's scope" do
+      other = create(:setting)
+      login_as(wrangler)
+      patch :update, params: { id: other.id, commit_action: 'canonical' }
+      expect(other.reload).not_to be_canonical
+      expect(flash[:error]).to eq("You do not have permission to wrangle this tag.")
+    end
+
+    it "handles a missing tag" do
+      login_as(wrangler)
+      patch :update, params: { id: -1, commit_action: 'canonical' }
+      expect(flash[:error]).to eq("Tag could not be found.")
+    end
+
+    it "rejects an unknown action" do
+      login_as(wrangler)
+      patch :update, params: { id: setting.id, commit_action: 'explode' }
+      expect(flash[:error]).to eq("Unknown wrangling action.")
+    end
+  end
+end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -402,14 +402,25 @@ RSpec.describe TagsController do
       expect(tag.reload.name).to eq(name)
     end
 
-    it "allows update of setting tags" do
+    it "allows a wrangler to update setting tags" do
       tag = create(:setting)
       parent_tag = create(:setting)
-      login_as(tag.user)
+      wrangler = create(:wrangler_user)
+      create(:wrangling_assignment, user: wrangler, setting: tag)
+      login_as(wrangler)
       expect(tag.parent_settings).to be_empty
       put :update, params: { id: tag.id, tag: { name: 'newname', parent_setting_ids: ["", parent_tag.id.to_s] } }
       expect(tag.reload.name).to eq('newname')
       expect(Setting.find(tag.id).parent_settings).to eq([parent_tag])
+    end
+
+    it "ignores hierarchy changes from a user who cannot wrangle the tag" do
+      tag = create(:setting)
+      parent_tag = create(:setting)
+      login_as(tag.user)
+      put :update, params: { id: tag.id, tag: { name: 'newname', parent_setting_ids: ["", parent_tag.id.to_s] } }
+      expect(tag.reload.name).to eq('newname')
+      expect(Setting.find(tag.id).parent_settings).to be_empty
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -53,6 +53,21 @@ FactoryBot.define do
     factory :reader_user do
       role_id { 5 }
     end
+
+    factory :wrangler_user do
+      role_id { 6 }
+    end
+  end
+
+  factory :wrangling_assignment do
+    user
+    setting
+  end
+
+  factory :tag_suggestion do
+    post
+    user
+    tag { association(:label) }
   end
 
   factory :board do

--- a/spec/helpers/notification_helper_spec.rb
+++ b/spec/helpers/notification_helper_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe NotificationHelper do
+  describe "#subject_for_type" do
+    it "has a subject for every notification type" do
+      missing = Notification.notification_types.keys.reject { |type| subject_for_type(type) }
+      expect(missing).to be_empty
+    end
+  end
+end

--- a/spec/models/post_tag_spec.rb
+++ b/spec/models/post_tag_spec.rb
@@ -107,5 +107,24 @@ RSpec.describe PostTag do
 
       expect(PostTag.for_reverse_lookup.where(tag_id: tag.id)).to eq([visible])
     end
+
+    it "omits a spoilered post from the tag's post listing" do
+      listed = create(:post)
+      PostTag.create!(post: listed, tag: tag)
+      hidden = create(:post)
+      PostTag.create!(post: hidden, tag: tag, spoiler: true)
+
+      expect(tag.posts).to include(hidden)
+      expect(tag.unspoilered_posts).to eq([listed])
+    end
+
+    it "omits spoilered content warnings from post listings" do
+      warning = create(:content_warning)
+      PostTag.create!(post: post, tag: warning, spoiler: true)
+
+      expect(post.content_warnings).to eq([warning])
+      expect(post.unspoilered_content_warnings).to be_empty
+      expect(post.has_content_warnings?).to eq(false)
+    end
   end
 end

--- a/spec/models/post_tag_spec.rb
+++ b/spec/models/post_tag_spec.rb
@@ -3,100 +3,55 @@ RSpec.describe PostTag do
   let(:post) { create(:post, user: author) }
   let(:tag) { create(:label) }
 
-  def read_to(user, reply)
-    post.mark_read(user, at_time: reply.created_at)
-  end
-
-  describe "#revealed_to?" do
-    it "reveals a non-spoiler tagging to anyone, including logged out" do
+  describe "#expanded_for?" do
+    it "expands a non-spoiler tagging for anyone, including logged out" do
       tagging = PostTag.create!(post: post, tag: tag)
-      expect(tagging.revealed_to?(nil)).to eq(true)
-      expect(tagging.revealed_to?(create(:user))).to eq(true)
+      expect(tagging.expanded_for?(nil)).to eq(true)
+      expect(tagging.expanded_for?(create(:user))).to eq(true)
     end
 
-    it "hides a spoiler tagging from a logged out viewer" do
+    it "collapses a spoiler tagging for a logged out viewer" do
       tagging = PostTag.create!(post: post, tag: tag, spoiler: true)
-      expect(tagging.revealed_to?(nil)).to eq(false)
+      expect(tagging.expanded_for?(nil)).to eq(false)
     end
 
-    it "always reveals to the post author" do
-      tagging = PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: 99)
-      expect(tagging.revealed_to?(author)).to eq(true)
+    it "always expands for the post author" do
+      tagging = PostTag.create!(post: post, tag: tag, spoiler: true)
+      expect(tagging.expanded_for?(author)).to eq(true)
     end
 
-    it "hides from a reader who has not reached the threshold" do
-      replies = create_list(:reply, 3, post: post, user: author)
-      tagging = PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: 2)
-      reader = create(:user)
-      read_to(reader, replies.first)
-
-      expect(tagging.revealed_to?(reader)).to eq(false)
-    end
-
-    it "reveals to a reader who has passed the threshold" do
+    it "collapses for an ordinary reader regardless of how far they have read" do
       replies = create_list(:reply, 3, post: post, user: author)
       tagging = PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: 1)
       reader = create(:user)
-      read_to(reader, replies.last)
+      post.mark_read(reader, at_time: replies.last.created_at)
 
-      expect(tagging.revealed_to?(reader)).to eq(true)
+      expect(tagging.expanded_for?(reader)).to eq(false)
     end
 
-    it "hides from a reader who has never opened the post" do
-      create_list(:reply, 2, post: post, user: author)
+    it "expands for a reader who has opted in" do
       tagging = PostTag.create!(post: post, tag: tag, spoiler: true)
-      expect(tagging.revealed_to?(create(:user))).to eq(false)
-    end
-
-    it "with no threshold reveals only at the end of the post" do
-      replies = create_list(:reply, 3, post: post, user: author)
-      tagging = PostTag.create!(post: post, tag: tag, spoiler: true)
-      reader = create(:user)
-
-      read_to(reader, replies.first)
-      expect(tagging.revealed_to?(reader)).to eq(false)
-
-      read_to(reader, replies.last)
-      expect(tagging.reload.revealed_to?(reader)).to eq(true)
+      reader = create(:user, reveal_spoiler_tags: true)
+      expect(tagging.expanded_for?(reader)).to eq(true)
     end
   end
 
-  describe "reveal threshold" do
-    it "fixes a nil threshold at the post's current end so visibility does not flip-flop" do
-      replies = create_list(:reply, 3, post: post, user: author)
-      tagging = PostTag.create!(post: post, tag: tag, spoiler: true)
-      expect(tagging.reveal_after_reply_order).to eq(replies.last.reply_order)
-
-      reader = create(:user)
-      read_to(reader, replies.last)
-      expect(tagging.revealed_to?(reader)).to eq(true)
-
-      create(:reply, post: post, user: author)
-      expect(tagging.reload.revealed_to?(reader)).to eq(true)
-    end
-
-    it "leaves an explicit threshold alone" do
-      create_list(:reply, 3, post: post, user: author)
-      tagging = PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: 1)
-      expect(tagging.reveal_after_reply_order).to eq(1)
-    end
-  end
-
-  describe "validations" do
-    it "rejects a reveal threshold without the spoiler flag" do
-      tagging = PostTag.new(post: post, tag: tag, spoiler: false, reveal_after_reply_order: 3)
+  describe "content warnings" do
+    it "cannot be spoilered" do
+      warning = create(:content_warning)
+      tagging = PostTag.new(post: post, tag: warning, spoiler: true)
       expect(tagging).not_to be_valid
+      expect(tagging.errors.full_messages.join).to include("content warning")
     end
 
-    it "rejects a negative reveal threshold" do
-      tagging = PostTag.new(post: post, tag: tag, spoiler: true, reveal_after_reply_order: -1)
-      expect(tagging).not_to be_valid
+    it "can carry a from-reply note without being a spoiler" do
+      warning = create(:content_warning)
+      expect(PostTag.new(post: post, tag: warning, reveal_after_reply_order: 3)).to be_valid
     end
   end
 
   describe "post-level helpers" do
-    it "splits visible tags by type and counts what stays hidden" do
-      replies = create_list(:reply, 3, post: post, user: author)
+    it "splits taggings by type and counts the spoilered ones" do
       label = create(:label)
       setting = create(:setting)
       warning = create(:content_warning)
@@ -104,19 +59,15 @@ RSpec.describe PostTag do
       PostTag.create!(post: post, tag: setting, spoiler: true, reveal_after_reply_order: 3)
       PostTag.create!(post: post, tag: warning)
 
-      reader = create(:user)
-      read_to(reader, replies.first)
-
-      expect(post.visible_tags_for(reader, Label)).to eq([label])
-      expect(post.visible_tags_for(reader, ContentWarning)).to eq([warning])
-      expect(post.visible_tags_for(reader, Setting)).to be_empty
-      expect(post.hidden_spoiler_tag_count_for(reader)).to eq(1)
+      expect(post.displayable_tags(Label)).to eq([label])
+      expect(post.displayable_tags(ContentWarning)).to eq([warning])
+      expect(post.displayable_tags(Setting)).to eq([setting])
+      expect(post.spoiler_post_tag_count).to eq(1)
     end
 
-    it "shows the author everything with nothing hidden" do
+    it "includes spoilered taggings in the displayable set, collapsed by the view" do
       PostTag.create!(post: post, tag: tag, spoiler: true)
-      expect(post.visible_tags_for(author, Label)).to eq([tag])
-      expect(post.hidden_spoiler_tag_count_for(author)).to eq(0)
+      expect(post.displayable_tags(Label)).to eq([tag])
     end
   end
 
@@ -137,15 +88,6 @@ RSpec.describe PostTag do
 
       expect(tag.posts).to include(hidden)
       expect(tag.unspoilered_posts).to eq([listed])
-    end
-
-    it "omits spoilered content warnings from post listings" do
-      warning = create(:content_warning)
-      PostTag.create!(post: post, tag: warning, spoiler: true)
-
-      expect(post.content_warnings).to eq([warning])
-      expect(post.unspoilered_content_warnings).to be_empty
-      expect(post.has_content_warnings?).to eq(false)
     end
   end
 end

--- a/spec/models/post_tag_spec.rb
+++ b/spec/models/post_tag_spec.rb
@@ -1,0 +1,111 @@
+RSpec.describe PostTag do
+  let(:author) { create(:user) }
+  let(:post) { create(:post, user: author) }
+  let(:tag) { create(:label) }
+
+  def read_to(user, reply)
+    post.mark_read(user, at_time: reply.created_at)
+  end
+
+  describe "#revealed_to?" do
+    it "reveals a non-spoiler tagging to anyone, including logged out" do
+      tagging = PostTag.create!(post: post, tag: tag)
+      expect(tagging.revealed_to?(nil)).to eq(true)
+      expect(tagging.revealed_to?(create(:user))).to eq(true)
+    end
+
+    it "hides a spoiler tagging from a logged out viewer" do
+      tagging = PostTag.create!(post: post, tag: tag, spoiler: true)
+      expect(tagging.revealed_to?(nil)).to eq(false)
+    end
+
+    it "always reveals to the post author" do
+      tagging = PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: 99)
+      expect(tagging.revealed_to?(author)).to eq(true)
+    end
+
+    it "hides from a reader who has not reached the threshold" do
+      replies = create_list(:reply, 3, post: post, user: author)
+      tagging = PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: 2)
+      reader = create(:user)
+      read_to(reader, replies.first)
+
+      expect(tagging.revealed_to?(reader)).to eq(false)
+    end
+
+    it "reveals to a reader who has passed the threshold" do
+      replies = create_list(:reply, 3, post: post, user: author)
+      tagging = PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: 1)
+      reader = create(:user)
+      read_to(reader, replies.last)
+
+      expect(tagging.revealed_to?(reader)).to eq(true)
+    end
+
+    it "hides from a reader who has never opened the post" do
+      create_list(:reply, 2, post: post, user: author)
+      tagging = PostTag.create!(post: post, tag: tag, spoiler: true)
+      expect(tagging.revealed_to?(create(:user))).to eq(false)
+    end
+
+    it "with no threshold reveals only at the end of the post" do
+      replies = create_list(:reply, 3, post: post, user: author)
+      tagging = PostTag.create!(post: post, tag: tag, spoiler: true)
+      reader = create(:user)
+
+      read_to(reader, replies.first)
+      expect(tagging.revealed_to?(reader)).to eq(false)
+
+      read_to(reader, replies.last)
+      expect(tagging.reload.revealed_to?(reader)).to eq(true)
+    end
+  end
+
+  describe "validations" do
+    it "rejects a reveal threshold without the spoiler flag" do
+      tagging = PostTag.new(post: post, tag: tag, spoiler: false, reveal_after_reply_order: 3)
+      expect(tagging).not_to be_valid
+    end
+
+    it "rejects a negative reveal threshold" do
+      tagging = PostTag.new(post: post, tag: tag, spoiler: true, reveal_after_reply_order: -1)
+      expect(tagging).not_to be_valid
+    end
+  end
+
+  describe "post-level helpers" do
+    it "splits visible tags by type and counts what stays hidden" do
+      replies = create_list(:reply, 3, post: post, user: author)
+      label = create(:label)
+      setting = create(:setting)
+      warning = create(:content_warning)
+      PostTag.create!(post: post, tag: label)
+      PostTag.create!(post: post, tag: setting, spoiler: true, reveal_after_reply_order: 3)
+      PostTag.create!(post: post, tag: warning)
+
+      reader = create(:user)
+      read_to(reader, replies.first)
+
+      expect(post.visible_tags_for(reader, Label)).to eq([label])
+      expect(post.visible_tags_for(reader, ContentWarning)).to eq([warning])
+      expect(post.visible_tags_for(reader, Setting)).to be_empty
+      expect(post.hidden_spoiler_tag_count_for(reader)).to eq(1)
+    end
+
+    it "shows the author everything with nothing hidden" do
+      PostTag.create!(post: post, tag: tag, spoiler: true)
+      expect(post.visible_tags_for(author, Label)).to eq([tag])
+      expect(post.hidden_spoiler_tag_count_for(author)).to eq(0)
+    end
+  end
+
+  describe "reverse lookup" do
+    it "excludes spoilered taggings" do
+      visible = PostTag.create!(post: post, tag: tag)
+      other_post = create(:post)
+      PostTag.create!(post: other_post, tag: tag, spoiler: true)
+
+      expect(PostTag.for_reverse_lookup.where(tag_id: tag.id)).to eq([visible])
+    end
+  end
+end

--- a/spec/models/post_tag_spec.rb
+++ b/spec/models/post_tag_spec.rb
@@ -61,6 +61,27 @@ RSpec.describe PostTag do
     end
   end
 
+  describe "reveal threshold" do
+    it "fixes a nil threshold at the post's current end so visibility does not flip-flop" do
+      replies = create_list(:reply, 3, post: post, user: author)
+      tagging = PostTag.create!(post: post, tag: tag, spoiler: true)
+      expect(tagging.reveal_after_reply_order).to eq(replies.last.reply_order)
+
+      reader = create(:user)
+      read_to(reader, replies.last)
+      expect(tagging.revealed_to?(reader)).to eq(true)
+
+      create(:reply, post: post, user: author)
+      expect(tagging.reload.revealed_to?(reader)).to eq(true)
+    end
+
+    it "leaves an explicit threshold alone" do
+      create_list(:reply, 3, post: post, user: author)
+      tagging = PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: 1)
+      expect(tagging.reveal_after_reply_order).to eq(1)
+    end
+  end
+
   describe "validations" do
     it "rejects a reveal threshold without the spoiler flag" do
       tagging = PostTag.new(post: post, tag: tag, spoiler: false, reveal_after_reply_order: 3)

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Setting do
       expect(setting.save).to eq(false)
       expect(setting.parent_settings.count).to eq(0)
       expect(setting.parent_settings.size).to eq(1)
-      expect(Tag::SettingTag.count).to eq(0)
+      expect(Tag::MetaTag.count).to eq(0)
     end
 
     it "creates tags on valid create" do
@@ -17,7 +17,7 @@ RSpec.describe Setting do
       expect(setting.save).to eq(true)
       expect(setting.parent_settings.count).to eq(1)
       expect(setting.parent_settings.size).to eq(1)
-      expect(Tag::SettingTag.count).to eq(1)
+      expect(Tag::MetaTag.count).to eq(1)
     end
   end
 end

--- a/spec/models/tag/meta_tag_spec.rb
+++ b/spec/models/tag/meta_tag_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe Tag::MetaTag do
+  describe "validations" do
+    it "rejects an edge between different tag types" do
+      edge = Tag::MetaTag.new(parent_tag: create(:setting), child_tag: create(:label))
+      expect(edge).not_to be_valid
+      expect(edge.errors.full_messages.join).to include("same type")
+    end
+
+    it "rejects a self-implication" do
+      setting = create(:setting)
+      edge = Tag::MetaTag.new(parent_tag: setting, child_tag: setting)
+      expect(edge).not_to be_valid
+      expect(edge.errors.full_messages.join).to include("cannot imply itself")
+    end
+
+    it "rejects a direct cycle" do
+      parent = create(:setting)
+      child = create(:setting)
+      Tag::MetaTag.create!(parent_tag: parent, child_tag: child)
+
+      reverse = Tag::MetaTag.new(parent_tag: child, child_tag: parent)
+      expect(reverse).not_to be_valid
+      expect(reverse.errors.full_messages.join).to include("loop")
+    end
+
+    it "rejects an indirect cycle" do
+      a = create(:setting)
+      b = create(:setting)
+      c = create(:setting)
+      Tag::MetaTag.create!(parent_tag: a, child_tag: b)
+      Tag::MetaTag.create!(parent_tag: b, child_tag: c)
+
+      closing = Tag::MetaTag.new(parent_tag: c, child_tag: a)
+      expect(closing).not_to be_valid
+    end
+
+    it "allows a diamond, which is not a cycle" do
+      top = create(:setting)
+      left = create(:setting)
+      right = create(:setting)
+      bottom = create(:setting)
+      Tag::MetaTag.create!(parent_tag: top, child_tag: left)
+      Tag::MetaTag.create!(parent_tag: top, child_tag: right)
+      Tag::MetaTag.create!(parent_tag: left, child_tag: bottom)
+
+      expect(Tag::MetaTag.new(parent_tag: right, child_tag: bottom)).to be_valid
+    end
+  end
+
+  describe "traversal" do
+    it "walks descendants transitively" do
+      a = create(:setting)
+      b = create(:setting)
+      c = create(:setting)
+      Tag::MetaTag.create!(parent_tag: a, child_tag: b)
+      Tag::MetaTag.create!(parent_tag: b, child_tag: c)
+
+      expect(a.descendant_ids).to match_array([b.id, c.id])
+      expect(c.ancestor_ids).to match_array([a.id, b.id])
+    end
+
+    it "ignores suggested edges" do
+      parent = create(:setting)
+      child = create(:setting)
+      Tag::MetaTag.create!(parent_tag: parent, child_tag: child, suggested: true)
+
+      expect(parent.descendant_ids).to be_empty
+    end
+
+    it "terminates on a pre-existing cycle" do
+      a = create(:setting)
+      b = create(:setting)
+      Tag::MetaTag.create!(parent_tag: a, child_tag: b)
+      # Bypasses the validation the way an import or an older row would.
+      Tag::MetaTag.new(parent_tag: b, child_tag: a).save!(validate: false)
+
+      expect { Timeout.timeout(5) { a.descendant_ids } }.not_to raise_error
+      expect(a.descendant_ids).to include(b.id)
+    end
+  end
+end

--- a/spec/models/tag/meta_tag_spec.rb
+++ b/spec/models/tag/meta_tag_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Tag::MetaTag do
 
       reverse = Tag::MetaTag.new(parent_tag: child, child_tag: parent)
       expect(reverse).not_to be_valid
-      expect(reverse.errors.full_messages.join).to include("loop")
+      expect(reverse.errors.full_messages.join).to include("cycle")
     end
 
     it "rejects an indirect cycle" do

--- a/spec/models/tag/meta_tag_spec.rb
+++ b/spec/models/tag/meta_tag_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe Tag::MetaTag do
       expect(closing).not_to be_valid
     end
 
+    it "rejects an edge that would close a cycle through a suggested edge" do
+      a = create(:setting)
+      b = create(:setting)
+      Tag::MetaTag.create!(parent_tag: a, child_tag: b, suggested: true)
+
+      expect(Tag::MetaTag.new(parent_tag: b, child_tag: a)).not_to be_valid
+    end
+
     it "allows a diamond, which is not a cycle" do
       top = create(:setting)
       left = create(:setting)

--- a/spec/models/tag_graph_spec.rb
+++ b/spec/models/tag_graph_spec.rb
@@ -1,0 +1,109 @@
+RSpec.describe Tag do
+  describe "synonyms" do
+    it "rejects a merger of a different type" do
+      label = create(:label)
+      setting = create(:setting, canonical: true)
+      label.merger = setting
+      expect(label).not_to be_valid
+      expect(label.errors.full_messages.join).to include("same type")
+    end
+
+    it "rejects a merger that is not itself canonical" do
+      target = create(:label)
+      tag = create(:label)
+      tag.merger = target
+      expect(tag).not_to be_valid
+      expect(tag.errors.full_messages.join).to include("canonical")
+    end
+
+    it "rejects a tag that is both canonical and a synonym" do
+      target = create(:label, canonical: true)
+      tag = create(:label, canonical: true)
+      tag.merger = target
+      expect(tag).not_to be_valid
+    end
+
+    it "reports whether a tag is a synonym" do
+      target = create(:label, canonical: true)
+      tag = create(:label)
+      expect(tag).not_to be_synonym
+      tag.update!(merger: target)
+      expect(tag.reload).to be_synonym
+    end
+
+    it "resolves canonical_tag through the merger" do
+      target = create(:label, canonical: true)
+      tag = create(:label)
+      tag.update!(merger: target)
+      expect(tag.canonical_tag).to eq(target)
+      expect(target.canonical_tag).to eq(target)
+    end
+  end
+
+  describe "#merge_as_synonym" do
+    let(:target) { create(:label, name: 'Bar Fight') }
+    let(:loser) { create(:label, name: 'Barfight') }
+
+    it "re-points taggings and keeps the loser as a synonym" do
+      post = create(:post, labels: [loser])
+      target.merge_as_synonym(loser)
+
+      expect(post.reload.labels).to eq([target])
+      expect(loser.reload.merger).to eq(target)
+      expect(loser).not_to be_canonical
+      expect(target.reload).to be_canonical
+      expect(Tag.find_by(id: loser.id)).to be_present
+    end
+
+    it "drops taggings that would collide" do
+      post = create(:post, labels: [target, loser])
+      expect { target.merge_as_synonym(loser) }.to change { PostTag.count }.by(-1)
+      expect(post.reload.labels).to eq([target])
+    end
+
+    it "keeps synonym chains one level deep" do
+      grand_loser = create(:label)
+      loser.update!(canonical: true)
+      grand_loser.update!(merger: loser)
+
+      target.merge_as_synonym(loser)
+
+      expect(grand_loser.reload.merger).to eq(target)
+      expect(loser.reload.merger).to eq(target)
+    end
+
+    it "refuses to merge across types" do
+      setting = create(:setting)
+      expect { setting.merge_as_synonym(target) }.to raise_error(ArgumentError)
+    end
+
+    it "refuses to merge a tag into itself" do
+      expect { target.merge_as_synonym(target) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#merge_with" do
+    it "destroys the loser" do
+      target = create(:label)
+      loser = create(:label)
+      post = create(:post, labels: [loser])
+
+      target.merge_with(loser)
+
+      expect(Tag.find_by(id: loser.id)).to be_nil
+      expect(post.reload.labels).to eq([target])
+    end
+  end
+
+  describe "scopes" do
+    it "awaiting_wrangling excludes synonyms, unwrangleable and canonical tags" do
+      plain = create(:label)
+      create(:label, canonical: true)
+      create(:label, unwrangleable: true)
+      canonical = create(:label, canonical: true)
+      create(:label).update!(merger: canonical)
+
+      expect(Label.awaiting_wrangling).to eq([plain])
+    end
+  end
+end

--- a/spec/models/tag_suggestion_spec.rb
+++ b/spec/models/tag_suggestion_spec.rb
@@ -88,6 +88,23 @@ RSpec.describe TagSuggestion do
       expect(TagSuggestion.new(post: post, user: reader, tag: tag)).not_to be_valid
     end
 
+    it "refuses a gallery group, which cannot be applied to a post" do
+      group = create(:gallery_group)
+      expect(TagSuggestion.new(post: post, user: reader, tag: group)).not_to be_valid
+    end
+
+    it "does not raise when endorsing on a post that stopped accepting suggestions" do
+      create_list(:reply, 2, post: post, user: author)
+      PostTag.create!(post: post, tag: tag, spoiler: true)
+      post.update!(allow_tag_suggestions: false)
+
+      expect {
+        record, outcome = TagSuggestion.submit(post: post, user: reader, tag: tag)
+        expect(outcome).to eq(:not_accepted)
+        expect(record).to be_nil
+      }.not_to raise_error
+    end
+
     it "enforces a per-post pending cap" do
       described_class::MAX_PENDING_PER_POST.times do
         TagSuggestion.create!(post: post, user: create(:user), tag: create(:label))

--- a/spec/models/tag_suggestion_spec.rb
+++ b/spec/models/tag_suggestion_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe TagSuggestion do
     it "refuses suggestions from the post's own author" do
       record = TagSuggestion.new(post: post, user: author, tag: tag)
       expect(record).not_to be_valid
-      expect(record.errors.full_messages.join).to include("your own post")
+      expect(record.errors.full_messages.join).to include("tag their own post directly")
     end
 
     it "refuses when the author has turned suggestions off" do

--- a/spec/models/tag_suggestion_spec.rb
+++ b/spec/models/tag_suggestion_spec.rb
@@ -1,0 +1,129 @@
+RSpec.describe TagSuggestion do
+  let(:author) { create(:user) }
+  let(:reader) { create(:user) }
+  let(:post) { create(:post, user: author) }
+  let(:tag) { create(:label) }
+
+  describe ".submit" do
+    it "creates a pending suggestion and notifies the author" do
+      record, outcome = TagSuggestion.submit(post: post, user: reader, tag: tag)
+
+      expect(outcome).to eq(:created)
+      expect(record).to be_pending
+      expect(Notification.where(user: author, notification_type: :tag_suggested)).to be_present
+    end
+
+    it "accepts a proposed new tag name" do
+      record, outcome = TagSuggestion.submit(post: post, user: reader, tag_type: 'Label', tag_name: 'Brand New')
+      expect(outcome).to eq(:created)
+      expect(record.tag_display_name).to eq('Brand New')
+    end
+
+    it "tells the suggester when the tag is already visibly applied" do
+      PostTag.create!(post: post, tag: tag)
+      record, outcome = TagSuggestion.submit(post: post, user: reader, tag: tag)
+
+      expect(outcome).to eq(:already_visible)
+      expect(record).to be_nil
+    end
+
+    context "when the collision is invisible to the suggester" do
+      it "records an endorsement rather than revealing a hidden spoiler tagging" do
+        create_list(:reply, 3, post: post, user: author)
+        PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: 3)
+
+        record, outcome = TagSuggestion.submit(post: post, user: reader, tag: tag)
+
+        expect(outcome).to eq(:endorsed)
+        expect(record).to be_endorsed
+        expect(record).not_to be_actionable
+      end
+
+      it "silently dedupes against a standing rejection rather than revealing it" do
+        TagSuggestion.create!(post: post, user: create(:user), tag: tag, status: :rejected)
+
+        record, outcome = TagSuggestion.submit(post: post, user: reader, tag: tag)
+
+        expect(outcome).to eq(:silently_deduped)
+        expect(record).to be_nil
+      end
+
+      it "silently dedupes against another reader's pending suggestion" do
+        TagSuggestion.create!(post: post, user: create(:user), tag: tag)
+
+        _record, outcome = TagSuggestion.submit(post: post, user: reader, tag: tag)
+
+        expect(outcome).to eq(:silently_deduped)
+      end
+
+      it "blocks a rejected tag re-proposed by name rather than by id" do
+        named = create(:label, name: 'Spoilery')
+        TagSuggestion.create!(post: post, user: create(:user), tag: named, status: :rejected)
+
+        _record, outcome = TagSuggestion.submit(post: post, user: reader, tag_type: 'Label', tag_name: 'spoilery')
+
+        expect(outcome).to eq(:endorsed).or eq(:silently_deduped)
+      end
+    end
+  end
+
+  describe "validations" do
+    it "rejects a suggestion naming both an existing tag and a new name" do
+      record = TagSuggestion.new(post: post, user: reader, tag: tag, tag_type: 'Label', tag_name: 'x')
+      expect(record).not_to be_valid
+    end
+
+    it "rejects a suggestion naming neither" do
+      expect(TagSuggestion.new(post: post, user: reader)).not_to be_valid
+    end
+
+    it "refuses suggestions from the post's own author" do
+      record = TagSuggestion.new(post: post, user: author, tag: tag)
+      expect(record).not_to be_valid
+      expect(record.errors.full_messages.join).to include("your own post")
+    end
+
+    it "refuses when the author has turned suggestions off" do
+      post.update!(allow_tag_suggestions: false)
+      expect(TagSuggestion.new(post: post, user: reader, tag: tag)).not_to be_valid
+    end
+
+    it "enforces a per-post pending cap" do
+      described_class::MAX_PENDING_PER_POST.times do
+        TagSuggestion.create!(post: post, user: create(:user), tag: create(:label))
+      end
+      expect(TagSuggestion.new(post: post, user: reader, tag: tag)).not_to be_valid
+    end
+  end
+
+  describe "resolution" do
+    it "accepting applies the tag to the post" do
+      record = TagSuggestion.create!(post: post, user: reader, tag: tag)
+      record.accept!(resolver: author)
+
+      expect(post.reload.labels).to eq([tag])
+      expect(record.reload).to be_accepted
+    end
+
+    it "accepting a proposed name creates the tag attributed to the suggester" do
+      record = TagSuggestion.create!(post: post, user: reader, tag_type: 'Label', tag_name: 'Fresh')
+      record.accept!(resolver: author)
+
+      created = Label.find_by(name: 'Fresh')
+      expect(created.user).to eq(reader)
+      expect(post.reload.labels).to eq([created])
+    end
+
+    it "rejecting blocks the tag for everyone until allowed again" do
+      record = TagSuggestion.create!(post: post, user: reader, tag: tag)
+      record.reject!(resolver: author)
+
+      _other, outcome = TagSuggestion.submit(post: post, user: create(:user), tag: tag)
+      expect(outcome).to eq(:silently_deduped)
+
+      record.allow_again!
+      _retry, retry_outcome = TagSuggestion.submit(post: post, user: create(:user), tag: tag)
+      expect(retry_outcome).to eq(:created)
+    end
+  end
+end

--- a/spec/models/tag_suggestion_spec.rb
+++ b/spec/models/tag_suggestion_spec.rb
@@ -105,6 +105,19 @@ RSpec.describe TagSuggestion do
       expect(record.reload).to be_accepted
     end
 
+    it "accepting carries the suggested spoiler settings onto the tagging" do
+      create_list(:reply, 3, post: post, user: author)
+      record = TagSuggestion.create!(
+        post: post, user: reader, tag: tag,
+        spoiler: true, reveal_after_reply_order: 2,
+      )
+      record.accept!(resolver: author)
+
+      tagging = PostTag.find_by(post: post, tag: tag)
+      expect(tagging).to be_spoiler
+      expect(tagging.reveal_after_reply_order).to eq(2)
+    end
+
     it "accepting a proposed name creates the tag attributed to the suggester" do
       record = TagSuggestion.create!(post: post, user: reader, tag_type: 'Label', tag_name: 'Fresh')
       record.accept!(resolver: author)

--- a/spec/models/tag_wrangling_performance_spec.rb
+++ b/spec/models/tag_wrangling_performance_spec.rb
@@ -1,0 +1,127 @@
+# Guards against the query patterns that make these features expensive: reveal
+# resolution per tagging, scope resolution per tag, and unbounded growth in the
+# wrangling queue. These assert query counts rather than wall time so they fail
+# deterministically in CI.
+RSpec.describe "tag wrangling performance" do # rubocop:disable RSpec/DescribeClass
+  let(:author) { create(:user) }
+  let(:reader) { create(:user) }
+
+  describe "spoiler reveal resolution" do
+    it "resolves a post's visible tags in a constant number of queries" do
+      post = create(:post, user: author)
+      replies = create_list(:reply, 5, post: post, user: author)
+      10.times { PostTag.create!(post: post, tag: create(:label), spoiler: true, reveal_after_reply_order: 2) }
+      post.mark_read(reader, at_time: replies.last.created_at)
+
+      loaded = Post.find(post.id)
+      queries = count_queries { loaded.visible_post_tags_for(reader) }
+
+      # post_tags + tags + post_view + reply lookup, and nothing per tagging.
+      expect(queries.size).to be <= 5
+    end
+
+    it "does not grow with the number of taggings" do
+      post = create(:post, user: author)
+      replies = create_list(:reply, 3, post: post, user: author)
+      post.mark_read(reader, at_time: replies.last.created_at)
+
+      3.times { PostTag.create!(post: post, tag: create(:label), spoiler: true) }
+      small = count_queries { Post.find(post.id).visible_post_tags_for(reader) }.size
+
+      20.times { PostTag.create!(post: post, tag: create(:label), spoiler: true) }
+      large = count_queries { Post.find(post.id).visible_post_tags_for(reader) }.size
+
+      expect(large).to eq(small)
+    end
+
+    it "resolves the reader's position once per post, not once per tagging" do
+      post = create(:post, user: author)
+      replies = create_list(:reply, 3, post: post, user: author)
+      post.mark_read(reader, at_time: replies.last.created_at)
+      5.times { PostTag.create!(post: post, tag: create(:label), spoiler: true) }
+
+      loaded = Post.find(post.id)
+      loaded.read_reply_order_for(reader)
+      queries = count_queries { 5.times { loaded.read_reply_order_for(reader) } }
+
+      expect(queries).to be_empty
+    end
+  end
+
+  describe "wrangler scope resolution" do
+    it "walks the setting hierarchy in a bounded number of queries" do
+      wrangler = create(:wrangler_user)
+      root = create(:setting)
+      WranglingAssignment.create!(user: wrangler, setting: root)
+
+      parent = root
+      10.times do
+        child = create(:setting)
+        Tag::MetaTag.create!(parent_tag: parent, child_tag: child)
+        parent = child
+      end
+
+      queries = count_queries { WranglingAssignment.scope_ids_for(wrangler) }
+
+      # One for the assignments, one to load the settings, one recursive CTE.
+      expect(queries.size).to be <= 4
+    end
+
+    it "uses a single recursive query regardless of depth" do
+      root = create(:setting)
+      parent = root
+      3.times do
+        child = create(:setting)
+        Tag::MetaTag.create!(parent_tag: parent, child_tag: child)
+        parent = child
+      end
+      shallow = count_queries { root.descendant_ids }.size
+
+      15.times do
+        child = create(:setting)
+        Tag::MetaTag.create!(parent_tag: parent, child_tag: child)
+        parent = child
+      end
+      deep = count_queries { root.descendant_ids }.size
+
+      expect(deep).to eq(shallow)
+      expect(deep).to eq(1)
+    end
+  end
+
+  describe "wrangling queue" do
+    it "computes coverage without scanning per tag" do
+      create_list(:label, 15).each { |tag| create(:post, labels: [tag]) }
+
+      queries = count_queries { TagWrangling::Coverage.new.tap(&:percentage).remaining_tags }
+
+      expect(queries.size).to be <= 5
+    end
+
+    it "clusters duplicates without a query per tag" do
+      %w[Bar Fight Bars Fights barfight].each_with_index do |name, index|
+        create(:label, name: "#{name}#{index}")
+      end
+      create(:label, name: 'Bar Fight')
+      create(:label, name: 'bar fights')
+
+      queries = count_queries { TagWrangling::DuplicateClusters.new.clusters }
+
+      expect(queries.size).to be <= 3
+    end
+  end
+
+  describe "reverse tag lookup" do
+    it "filters spoilered taggings in the query rather than in Ruby" do
+      tag = create(:label)
+      create_list(:post, 3, labels: [tag])
+      spoilered = create(:post)
+      PostTag.create!(post: spoilered, tag: tag, spoiler: true)
+
+      queries = count_queries { PostTag.for_reverse_lookup.where(tag_id: tag.id).pluck(:post_id) }
+
+      expect(queries.size).to eq(1)
+      expect(queries.first).to match(/spoiler/i)
+    end
+  end
+end

--- a/spec/models/tag_wrangling_performance_spec.rb
+++ b/spec/models/tag_wrangling_performance_spec.rb
@@ -6,45 +6,42 @@ RSpec.describe "tag wrangling performance" do # rubocop:disable RSpec/DescribeCl
   let(:author) { create(:user) }
   let(:reader) { create(:user) }
 
-  describe "spoiler reveal resolution" do
-    it "resolves a post's visible tags in a constant number of queries" do
+  describe "spoiler tag display" do
+    it "loads a post's taggings in a constant number of queries" do
       post = create(:post, user: author)
-      replies = create_list(:reply, 5, post: post, user: author)
-      10.times { PostTag.create!(post: post, tag: create(:label), spoiler: true, reveal_after_reply_order: 2) }
-      post.mark_read(reader, at_time: replies.last.created_at)
+      10.times { PostTag.create!(post: post, tag: create(:label), spoiler: true) }
 
       loaded = Post.find(post.id)
-      queries = count_queries { loaded.visible_post_tags_for(reader) }
+      reader.id # instantiate the let before measuring
+      queries = count_queries { loaded.displayable_post_tags.each { |pt| pt.expanded_for?(reader) } }
 
-      # post_tags + tags + post_view + reply lookup, and nothing per tagging.
-      expect(queries.size).to be <= 5
+      # post_tags plus tags, and nothing per tagging.
+      expect(queries.size).to be <= 3
     end
 
     it "does not grow with the number of taggings" do
       post = create(:post, user: author)
-      replies = create_list(:reply, 3, post: post, user: author)
-      post.mark_read(reader, at_time: replies.last.created_at)
-
+      reader.id # instantiate the let before measuring
       3.times { PostTag.create!(post: post, tag: create(:label), spoiler: true) }
-      small = count_queries { Post.find(post.id).visible_post_tags_for(reader) }.size
+      small = count_queries { Post.find(post.id).displayable_post_tags.map { |pt| pt.expanded_for?(reader) } }.size
 
       20.times { PostTag.create!(post: post, tag: create(:label), spoiler: true) }
-      large = count_queries { Post.find(post.id).visible_post_tags_for(reader) }.size
+      large = count_queries { Post.find(post.id).displayable_post_tags.map { |pt| pt.expanded_for?(reader) } }.size
 
       expect(large).to eq(small)
     end
 
-    it "resolves the reader's position once per post, not once per tagging" do
+    it "reads no post view state when resolving display" do
       post = create(:post, user: author)
-      replies = create_list(:reply, 3, post: post, user: author)
-      post.mark_read(reader, at_time: replies.last.created_at)
-      5.times { PostTag.create!(post: post, tag: create(:label), spoiler: true) }
+      create_list(:reply, 3, post: post, user: author)
+      PostTag.create!(post: post, tag: create(:label), spoiler: true)
 
       loaded = Post.find(post.id)
-      loaded.read_reply_order_for(reader)
-      queries = count_queries { 5.times { loaded.read_reply_order_for(reader) } }
+      reader.id # instantiate the let before measuring
+      loaded.displayable_post_tags.to_a
+      queries = count_queries { loaded.displayable_post_tags.each { |pt| pt.expanded_for?(reader) } }
 
-      expect(queries).to be_empty
+      expect(queries.join).not_to match(/post_views/i)
     end
   end
 

--- a/spec/models/wrangling_assignment_spec.rb
+++ b/spec/models/wrangling_assignment_spec.rb
@@ -1,0 +1,119 @@
+RSpec.describe WranglingAssignment do
+  let(:wrangler) { create(:wrangler_user) }
+
+  describe ".scope_ids_for" do
+    it "is empty for a user with no assignments" do
+      expect(WranglingAssignment.scope_ids_for(wrangler)).to be_empty
+      expect(WranglingAssignment.scope_ids_for(nil)).to be_empty
+    end
+
+    it "includes descendants of an assigned setting" do
+      parent = create(:setting)
+      child = create(:setting)
+      grandchild = create(:setting)
+      Tag::MetaTag.create!(parent_tag: parent, child_tag: child)
+      Tag::MetaTag.create!(parent_tag: child, child_tag: grandchild)
+      WranglingAssignment.create!(user: wrangler, setting: parent)
+
+      expect(WranglingAssignment.scope_ids_for(wrangler)).to match_array([parent.id, child.id, grandchild.id])
+    end
+
+    it "does not include ancestors of an assigned setting" do
+      parent = create(:setting)
+      child = create(:setting)
+      Tag::MetaTag.create!(parent_tag: parent, child_tag: child)
+      WranglingAssignment.create!(user: wrangler, setting: child)
+
+      expect(WranglingAssignment.scope_ids_for(wrangler)).to eq([child.id])
+    end
+  end
+
+  describe ".reassign_for_merge" do
+    it "moves the assignment onto the surviving setting and notifies" do
+      loser = create(:setting)
+      winner = create(:setting)
+      WranglingAssignment.create!(user: wrangler, setting: loser)
+
+      WranglingAssignment.reassign_for_merge(source: loser, target: winner)
+
+      expect(wrangler.reload.wrangled_settings).to eq([winner])
+      expect(Notification.where(user: wrangler, notification_type: :wrangling_scope_merged)).to be_present
+    end
+
+    it "collapses two wranglers onto the survivor and notifies both" do
+      other = create(:wrangler_user)
+      loser = create(:setting)
+      winner = create(:setting)
+      WranglingAssignment.create!(user: wrangler, setting: loser)
+      WranglingAssignment.create!(user: other, setting: winner)
+
+      WranglingAssignment.reassign_for_merge(source: loser, target: winner)
+
+      expect(winner.reload.wranglers).to match_array([wrangler, other])
+      expect(Notification.where(notification_type: :wrangling_scope_merged).count).to eq(2)
+    end
+
+    it "drops a duplicate rather than violating uniqueness" do
+      loser = create(:setting)
+      winner = create(:setting)
+      WranglingAssignment.create!(user: wrangler, setting: loser)
+      WranglingAssignment.create!(user: wrangler, setting: winner)
+
+      expect { WranglingAssignment.reassign_for_merge(source: loser, target: winner) }
+        .to change { WranglingAssignment.count }.by(-1)
+    end
+
+    it "runs through a synonym merge" do
+      loser = create(:setting)
+      winner = create(:setting)
+      WranglingAssignment.create!(user: wrangler, setting: loser)
+
+      winner.merge_as_synonym(loser)
+
+      expect(wrangler.reload.wrangled_settings).to eq([winner])
+    end
+  end
+
+  describe "permissions" do
+    it "lets a wrangler wrangle an assigned setting but not an unassigned one" do
+      assigned = create(:setting)
+      unassigned = create(:setting)
+      WranglingAssignment.create!(user: wrangler, setting: assigned)
+
+      expect(assigned.wrangleable_by?(wrangler)).to eq(true)
+      expect(unassigned.wrangleable_by?(wrangler)).to eq(false)
+    end
+
+    it "lets a wrangler wrangle a label co-tagged with an assigned setting" do
+      setting = create(:setting)
+      label = create(:label)
+      create(:post, settings: [setting], labels: [label])
+      WranglingAssignment.create!(user: wrangler, setting: setting)
+
+      expect(label.wrangleable_by?(wrangler)).to eq(true)
+      expect(create(:label).wrangleable_by?(wrangler)).to eq(false)
+    end
+
+    it "gives admins global wrangling without assignments" do
+      admin = create(:admin_user)
+      expect(create(:content_warning).wrangleable_by?(admin)).to eq(true)
+    end
+
+    it "denies non-wranglers" do
+      expect(create(:setting).wrangleable_by?(create(:user))).to eq(false)
+      expect(create(:setting).wrangleable_by?(create(:mod_user))).to eq(false)
+    end
+
+    it "gates hierarchy editing on wrangling rights" do
+      setting = create(:setting)
+      expect(setting.hierarchy_editable_by?(setting.user)).to eq(false)
+      WranglingAssignment.create!(user: wrangler, setting: setting)
+      expect(setting.hierarchy_editable_by?(wrangler)).to eq(true)
+    end
+
+    it "does not allow hierarchy editing on flat tag types" do
+      warning = create(:content_warning)
+      expect(warning.hierarchy_editable_by?(create(:admin_user))).to eq(false)
+    end
+  end
+end

--- a/spec/models/wrangling_assignment_spec.rb
+++ b/spec/models/wrangling_assignment_spec.rb
@@ -18,6 +18,24 @@ RSpec.describe WranglingAssignment do
       expect(WranglingAssignment.scope_ids_for(wrangler)).to match_array([parent.id, child.id, grandchild.id])
     end
 
+    it "excludes descendants reachable only through a suggested edge" do
+      parent = create(:setting)
+      child = create(:setting)
+      Tag::MetaTag.create!(parent_tag: parent, child_tag: child, suggested: true)
+      WranglingAssignment.create!(user: wrangler, setting: parent)
+
+      expect(WranglingAssignment.scope_ids_for(wrangler)).to eq([parent.id])
+      expect(parent.child_settings).to be_empty
+    end
+
+    it "memoizes the resolved scope on the user" do
+      setting = create(:setting)
+      WranglingAssignment.create!(user: wrangler, setting: setting)
+      wrangler.wrangling_scope_ids
+
+      expect(count_queries { 5.times { wrangler.wrangling_scope_ids } }).to be_empty
+    end
+
     it "does not include ancestors of an assigned setting" do
       parent = create(:setting)
       child = create(:setting)

--- a/spec/screenshot_themes.rb
+++ b/spec/screenshot_themes.rb
@@ -1,0 +1,112 @@
+#!/usr/bin/env ruby
+# Script to generate screenshots of all themes on continuity and thread pages.
+# Run with: bundle exec rspec spec/screenshot_themes.rb
+#
+# Produces screenshots in tmp/theme_screenshots/
+
+require 'rails_helper'
+
+THEMES = {
+  # name => layout value
+  'Default' => nil,
+  'Dark' => 'dark',
+  'Iconless' => 'iconless',
+  'Starry' => 'starry',
+  'Starry Dark' => 'starrydark',
+  'Starry Light' => 'starrylight',
+  'Monochrome' => 'monochrome',
+  'Milky River' => 'river',
+}.freeze
+
+AUTO_THEMES = {
+  'Default (Auto)' => 'auto_default',
+  'Starry (Auto)' => 'auto_starry',
+  'Starry Light (Auto)' => 'auto_starrylight',
+  'Monochrome (Auto)' => 'auto_monochrome',
+  'Milky River (Auto)' => 'auto_river',
+  'Iconless (Auto)' => 'auto_iconless',
+}.freeze
+
+RSpec.describe "Theme screenshots", type: :system, js: true do
+  let(:screenshot_dir) { Rails.root.join('tmp', 'theme_screenshots') }
+
+  let(:user) { create(:user, password: 'knownpass') }
+  let(:board) { create(:board, creator: user, name: "Example Continuity") }
+  let!(:post_obj) do
+    Audited.audit_class.as_user(user) do
+      post = create(:post,
+        user: user,
+        board: board,
+        subject: "Example Thread",
+        content: "<p>This is an example post with <b>bold</b> and <i>italic</i> text.</p><blockquote>A blockquote for testing color.</blockquote>",
+      )
+      create(:reply, post: post, user: user, content: "<p>A reply to test the thread view styling.</p>")
+      create(:reply, post: post, user: user, content: "<p>Another reply with <a href='#'>a link</a> for contrast testing.</p>")
+      post
+    end
+  end
+
+  before(:all) do
+    FileUtils.mkdir_p(Rails.root.join('tmp', 'theme_screenshots'))
+  end
+
+  def set_color_scheme(scheme)
+    page.driver.browser.execute_cdp(
+      'Emulation.setEmulatedMedia',
+      features: [{ name: 'prefers-color-scheme', value: scheme }],
+    )
+  end
+
+  def take_themed_screenshot(name, path)
+    slug = name.downcase.gsub(/[^a-z0-9]+/, '_').gsub(/^_|_$/, '')
+    filename = screenshot_dir.join("#{slug}_#{path.tr('/', '_')}.png")
+    page.save_screenshot(filename)
+    puts "  Saved: #{filename}"
+  end
+
+  def login_with_theme(layout)
+    user.update!(layout: layout)
+    visit root_path
+    fill_in "Username", with: user.username
+    fill_in "Password", with: 'knownpass'
+    click_button "Log in"
+  end
+
+  THEMES.each do |name, layout|
+    it "screenshots #{name} theme" do
+      login_with_theme(layout)
+
+      # Continuity page
+      visit continuity_path(board)
+      take_themed_screenshot(name, "continuity")
+
+      # Thread page
+      visit post_path(post_obj)
+      take_themed_screenshot(name, "thread")
+    end
+  end
+
+  AUTO_THEMES.each do |name, layout|
+    it "screenshots #{name} in light mode" do
+      login_with_theme(layout)
+      set_color_scheme('light')
+
+      visit continuity_path(board)
+      take_themed_screenshot("#{name} light", "continuity")
+
+      visit post_path(post_obj)
+      take_themed_screenshot("#{name} light", "thread")
+    end
+
+    it "screenshots #{name} in dark mode" do
+      login_with_theme(layout)
+      set_color_scheme('dark')
+
+      visit continuity_path(board)
+      take_themed_screenshot("#{name} dark", "continuity")
+
+      visit post_path(post_obj)
+      take_themed_screenshot("#{name} dark", "thread")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,6 +72,7 @@ require 'support/spec_request_helper'
 require 'support/spec_test_helper'
 require 'support/api_test_helper'
 require 'support/posts_controller_shared'
+require 'support/query_counter'
 require 'capybara/rspec'
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -184,7 +184,7 @@ RSpec.configure do |config|
     driven_by :selenium, using: :headless_chrome, options: { timeout: 120 } do |options|
       # Lets a machine without Chrome in a standard location point at one, e.g.
       # a Chrome for Testing download. shell.nix already exports CHROME_BIN.
-      options.binary = ENV['CHROME_BIN'] if ENV['CHROME_BIN'].present? && File.exist?(ENV['CHROME_BIN'].to_s)
+      options.binary = ENV.fetch('CHROME_BIN', nil) if ENV['CHROME_BIN'].present? && File.exist?(ENV['CHROME_BIN'].to_s)
       options.add_argument('--no-sandbox')
       options.add_argument('--disable-dev-shm-usage')
       options.add_argument("--user-data-dir=#{ENV['CHROMEDRIVER_CONFIG']}") if ENV['CHROMEDRIVER_CONFIG']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -182,6 +182,9 @@ RSpec.configure do |config|
 
   config.before(:each, :js, type: :system) do
     driven_by :selenium, using: :headless_chrome, options: { timeout: 120 } do |options|
+      # Lets a machine without Chrome in a standard location point at one, e.g.
+      # a Chrome for Testing download. shell.nix already exports CHROME_BIN.
+      options.binary = ENV['CHROME_BIN'] if ENV['CHROME_BIN'].present? && File.exist?(ENV['CHROME_BIN'].to_s)
       options.add_argument('--no-sandbox')
       options.add_argument('--disable-dev-shm-usage')
       options.add_argument("--user-data-dir=#{ENV['CHROMEDRIVER_CONFIG']}") if ENV['CHROMEDRIVER_CONFIG']

--- a/spec/support/query_counter.rb
+++ b/spec/support/query_counter.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module QueryCounter
+  IGNORED = /\A\s*(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE SAVEPOINT|SHOW|SET)\b/i
+
+  def count_queries
+    queries = []
+    subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |_name, _start, _finish, _id, payload|
+      next if payload[:cached]
+      next if payload[:name] == 'SCHEMA'
+      next if payload[:sql].match?(IGNORED)
+      queries << payload[:sql]
+    end
+    yield
+    queries
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+end
+
+RSpec.configure do |config|
+  config.include QueryCounter
+end

--- a/spec/system/tags/suggestions_spec.rb
+++ b/spec/system/tags/suggestions_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe "Suggesting tags" do
     visit stats_post_path(post)
     click_link 'Suggest a tag'
 
-    select 'Bar Fight', from: 'tag_suggestion_tag_id'
+    select 'Label', from: 'tag_suggestion_tag_type'
+    fill_in 'tag_suggestion_tag_name', with: 'Bar Fight'
     fill_in 'tag_suggestion_note', with: 'There is a bar fight in chapter two.'
     click_button 'Suggest'
 

--- a/spec/system/tags/suggestions_spec.rb
+++ b/spec/system/tags/suggestions_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Suggesting tags" do
 
     login(author)
     visit tag_suggestions_path
-    within(find('tr', text: 'Declined')) { click_button 'Decline' }
+    within('tr', text: 'Declined') { click_button 'Decline' }
     expect(page).to have_text('Nobody can suggest it on this post again.')
 
     relogin_as(other_reader)
@@ -54,7 +54,7 @@ RSpec.describe "Suggesting tags" do
 
     relogin_as(author)
     visit tag_suggestions_path
-    within(find('tr', text: 'Declined')) { click_button 'Allow again' }
+    within('tr', text: 'Declined') { click_button 'Allow again' }
     expect(page).to have_text('can be suggested again')
     expect(TagSuggestion.find_by(id: suggestion.id)).to be_nil
   end
@@ -92,13 +92,13 @@ RSpec.describe "Suggesting tags" do
     post.mark_read(reader, at_time: replies.first.created_at)
     visit stats_post_path(post)
 
-    expect(page).not_to have_text('Late Reveal')
     expect(page).to have_text('1 tag hidden until you have read further.')
+    expect(page).to have_no_text('Late Reveal')
 
     post.mark_read(reader, at_time: replies.last.created_at, force: true)
     visit stats_post_path(post)
 
     expect(page).to have_text('Late Reveal')
-    expect(page).not_to have_text('hidden until you have read further')
+    expect(page).to have_no_text('hidden until you have read further')
   end
 end

--- a/spec/system/tags/suggestions_spec.rb
+++ b/spec/system/tags/suggestions_spec.rb
@@ -1,0 +1,104 @@
+RSpec.describe "Suggesting tags" do
+  def relogin_as(user)
+    page.driver.submit :delete, logout_path, {}
+    login(user)
+  end
+
+  scenario "A reader suggests a tag and the author accepts it" do
+    author = create(:user, username: 'author')
+    reader = create(:user, username: 'reader')
+    post = create(:post, user: author, subject: 'Sample post')
+    tag = create(:label, name: 'Bar Fight')
+
+    login(reader)
+    visit stats_post_path(post)
+    click_link 'Suggest a tag'
+
+    select 'Bar Fight', from: 'tag_suggestion_tag_id'
+    fill_in 'tag_suggestion_note', with: 'There is a bar fight in chapter two.'
+    click_button 'Suggest'
+
+    expect(page).to have_text('Thanks — your suggestion has been sent to the author.')
+
+    relogin_as(author)
+    visit tag_suggestions_path
+
+    row = find('tr', text: 'Bar Fight')
+    within(row) do
+      expect(page).to have_text('reader')
+      expect(page).to have_text('There is a bar fight in chapter two.')
+      click_button 'Add'
+    end
+
+    expect(page).to have_text('Added Bar Fight.')
+    expect(post.reload.labels).to eq([tag])
+  end
+
+  scenario "A declined tag cannot be suggested again until the author allows it" do
+    author = create(:user)
+    reader = create(:user)
+    other_reader = create(:user)
+    post = create(:post, user: author)
+    tag = create(:label, name: 'Declined')
+    suggestion = TagSuggestion.create!(post: post, user: reader, tag: tag)
+
+    login(author)
+    visit tag_suggestions_path
+    within(find('tr', text: 'Declined')) { click_button 'Decline' }
+    expect(page).to have_text('Nobody can suggest it on this post again.')
+
+    relogin_as(other_reader)
+    expect {
+      TagSuggestion.submit(post: post, user: other_reader, tag: tag)
+    }.not_to change { TagSuggestion.count }
+
+    relogin_as(author)
+    visit tag_suggestions_path
+    within(find('tr', text: 'Declined')) { click_button 'Allow again' }
+    expect(page).to have_text('can be suggested again')
+    expect(TagSuggestion.find_by(id: suggestion.id)).to be_nil
+  end
+
+  scenario "An author sees an endorsement rather than a duplicate suggestion" do
+    author = create(:user)
+    reader = create(:user)
+    post = create(:post, user: author)
+    create_list(:reply, 3, post: post, user: author)
+    tag = create(:label, name: 'Hidden Twist')
+    PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: 3)
+
+    # The reader has not read far enough to see the tagging, so their suggestion
+    # must not reveal that it already exists.
+    TagSuggestion.submit(post: post, user: reader, tag: tag)
+
+    login(author)
+    visit tag_suggestions_path
+
+    within('table', text: 'Endorsements') do
+      expect(page).to have_text('Hidden Twist')
+    end
+    expect(page).to have_text('it just means the tag reads the way you intended')
+  end
+
+  scenario "A spoiler tag stays hidden until the reader has read far enough" do
+    author = create(:user)
+    reader = create(:user)
+    post = create(:post, user: author)
+    replies = create_list(:reply, 3, post: post, user: author)
+    tag = create(:label, name: 'Late Reveal')
+    PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: replies.last.reply_order)
+
+    login(reader)
+    post.mark_read(reader, at_time: replies.first.created_at)
+    visit stats_post_path(post)
+
+    expect(page).not_to have_text('Late Reveal')
+    expect(page).to have_text('1 tag hidden until you have read further.')
+
+    post.mark_read(reader, at_time: replies.last.created_at, force: true)
+    visit stats_post_path(post)
+
+    expect(page).to have_text('Late Reveal')
+    expect(page).not_to have_text('hidden until you have read further')
+  end
+end

--- a/spec/system/tags/suggestions_spec.rb
+++ b/spec/system/tags/suggestions_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Suggesting tags" do
     fill_in 'tag_suggestion_note', with: 'There is a bar fight in chapter two.'
     click_button 'Suggest'
 
-    expect(page).to have_text('Thanks — your suggestion has been sent to the author.')
+    expect(page).to have_text('Suggestion recorded. The post author will review it.')
 
     relogin_as(author)
     visit tag_suggestions_path
@@ -27,10 +27,10 @@ RSpec.describe "Suggesting tags" do
     within(row) do
       expect(page).to have_text('reader')
       expect(page).to have_text('There is a bar fight in chapter two.')
-      click_button 'Add'
+      click_button 'Apply'
     end
 
-    expect(page).to have_text('Added Bar Fight.')
+    expect(page).to have_text('Tag Bar Fight applied.')
     expect(post.reload.labels).to eq([tag])
   end
 
@@ -45,7 +45,7 @@ RSpec.describe "Suggesting tags" do
     login(author)
     visit tag_suggestions_path
     within('tr', text: 'Declined') { click_button 'Decline' }
-    expect(page).to have_text('Nobody can suggest it on this post again.')
+    expect(page).to have_text('It cannot be suggested on this post again.')
 
     relogin_as(other_reader)
     expect {
@@ -54,8 +54,8 @@ RSpec.describe "Suggesting tags" do
 
     relogin_as(author)
     visit tag_suggestions_path
-    within('tr', text: 'Declined') { click_button 'Allow again' }
-    expect(page).to have_text('can be suggested again')
+    within('tr', text: 'Declined') { click_button 'Permit again' }
+    expect(page).to have_text('may be suggested again')
     expect(TagSuggestion.find_by(id: suggestion.id)).to be_nil
   end
 
@@ -77,7 +77,7 @@ RSpec.describe "Suggesting tags" do
     within('table', text: 'Endorsements') do
       expect(page).to have_text('Hidden Twist')
     end
-    expect(page).to have_text('it just means the tag reads the way you intended')
+    expect(page).to have_text('No action is required')
   end
 
   scenario "A spoiler tag stays hidden until the reader has read far enough" do
@@ -92,7 +92,7 @@ RSpec.describe "Suggesting tags" do
     post.mark_read(reader, at_time: replies.first.created_at)
     visit stats_post_path(post)
 
-    expect(page).to have_text('1 tag hidden until you have read further.')
+    expect(page).to have_text('1 spoiler tag hidden until you have read further into this post.')
     expect(page).to have_no_text('Late Reveal')
 
     post.mark_read(reader, at_time: replies.last.created_at, force: true)

--- a/spec/system/tags/suggestions_spec.rb
+++ b/spec/system/tags/suggestions_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Suggesting tags" do
     expect(page).to have_text('No action is required')
   end
 
-  scenario "A spoiler tag stays hidden until the reader has read far enough" do
+  scenario "A spoiler tag stays collapsed until the reader reveals it" do
     author = create(:user)
     reader = create(:user)
     post = create(:post, user: author)
@@ -90,16 +90,29 @@ RSpec.describe "Suggesting tags" do
     PostTag.create!(post: post, tag: tag, spoiler: true, reveal_after_reply_order: replies.last.reply_order)
 
     login(reader)
-    post.mark_read(reader, at_time: replies.first.created_at)
     visit stats_post_path(post)
 
-    expect(page).to have_text('1 spoiler tag hidden until you have read further into this post.')
-    expect(page).to have_no_text('Late Reveal')
+    expect(page).to have_selector('details.spoiler-tags')
+    expect(page).to have_text('1 spoiler tag')
+    expect(page).to have_no_selector('details.spoiler-tags[open]')
 
-    post.mark_read(reader, at_time: replies.last.created_at, force: true)
+    # The name is present in the document but not displayed until expanded.
+    find('details.spoiler-tags summary').click
+    expect(page).to have_link('Late Reveal')
+    expect(page).to have_text("from reply #{replies.last.reply_order}")
+  end
+
+  scenario "A reader who opts in sees spoiler tags already expanded" do
+    author = create(:user)
+    reader = create(:user, reveal_spoiler_tags: true)
+    post = create(:post, user: author)
+    tag = create(:label, name: 'Opted In')
+    PostTag.create!(post: post, tag: tag, spoiler: true)
+
+    login(reader)
     visit stats_post_path(post)
 
-    expect(page).to have_text('Late Reveal')
-    expect(page).to have_no_text('hidden until you have read further')
+    expect(page).to have_link('Opted In')
+    expect(page).to have_no_selector('details.spoiler-tags')
   end
 end

--- a/spec/system/tags/wrangling_spec.rb
+++ b/spec/system/tags/wrangling_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe "Wrangling tags" do
     expect(page).to have_text('Tag Wrangling')
     expect(page).to have_text('taggings use a canonical tag')
 
-    within('table', text: 'Possible Duplicates') do
+    within('table', text: 'Candidate Duplicates') do
       expect(page).to have_link('Bar Fight')
       expect(page).to have_link('bar fights')
     end
 
-    within(table_titled('Awaiting Review')) do
-      within('tr', text: 'Bar Fight', match: :prefer_exact) { click_button 'Canonical' }
+    within(table_titled('Unreviewed Tags')) do
+      within('tr', text: 'Bar Fight', match: :prefer_exact) { click_button 'Mark canonical' }
     end
 
-    expect(page).to have_text('Bar Fight marked canonical.')
+    expect(page).to have_text('Tag Bar Fight marked canonical.')
     expect(duplicate.reload).to be_canonical
   end
 
@@ -41,7 +41,7 @@ RSpec.describe "Wrangling tags" do
     login(wrangler)
     visit tag_wranglings_path
 
-    within(table_titled('Awaiting Review')) do
+    within(table_titled('Unreviewed Tags')) do
       row = find('tr', text: 'Looser')
       within(row) do
         fill_in 'merger_id', with: keeper.id
@@ -49,7 +49,7 @@ RSpec.describe "Wrangling tags" do
       end
     end
 
-    expect(page).to have_text('Looser is now a synonym of Keeper.')
+    expect(page).to have_text('Tag Looser is now a synonym of Keeper.')
     expect(loser.reload.merger).to eq(keeper)
     expect(tagged_post.reload.labels).to eq([keeper])
   end

--- a/spec/system/tags/wrangling_spec.rb
+++ b/spec/system/tags/wrangling_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe "Wrangling tags" do
+  scenario "A wrangler works through their queue" do
+    wrangler = create(:wrangler_user, username: 'wrangler')
+    setting = create(:setting, name: 'Sample Setting')
+    create(:wrangling_assignment, user: wrangler, setting: setting)
+
+    duplicate = create(:label, name: 'Bar Fight')
+    variant = create(:label, name: 'bar fights')
+    create(:post, settings: [setting], labels: [duplicate])
+    create(:post, settings: [setting], labels: [variant])
+
+    login(wrangler)
+    visit tag_wranglings_path
+
+    expect(page).to have_text('Tag Wrangling')
+    expect(page).to have_text('taggings use a canonical tag')
+
+    within('table', text: 'Possible Duplicates') do
+      expect(page).to have_link('Bar Fight')
+      expect(page).to have_link('bar fights')
+    end
+
+    within(table_titled('Awaiting Review')) do
+      within(find('tr', text: 'Bar Fight', match: :prefer_exact)) { click_button 'Canonical' }
+    end
+
+    expect(page).to have_text('Bar Fight marked canonical.')
+    expect(duplicate.reload).to be_canonical
+  end
+
+  scenario "A wrangler merges a duplicate into its canonical form" do
+    wrangler = create(:wrangler_user)
+    setting = create(:setting)
+    create(:wrangling_assignment, user: wrangler, setting: setting)
+
+    keeper = create(:label, name: 'Keeper')
+    loser = create(:label, name: 'Looser')
+    create(:post, settings: [setting], labels: [keeper])
+    tagged_post = create(:post, settings: [setting], labels: [loser])
+
+    login(wrangler)
+    visit tag_wranglings_path
+
+    within(table_titled('Awaiting Review')) do
+      row = find('tr', text: 'Looser')
+      within(row) do
+        fill_in 'merger_id', with: keeper.id
+        click_button 'Merge'
+      end
+    end
+
+    expect(page).to have_text('Looser is now a synonym of Keeper.')
+    expect(loser.reload.merger).to eq(keeper)
+    expect(tagged_post.reload.labels).to eq([keeper])
+  end
+
+  scenario "An ordinary user cannot reach the queue" do
+    login
+    visit tag_wranglings_path
+
+    expect(page).to have_text('You do not have permission to wrangle tags.')
+  end
+end

--- a/spec/system/tags/wrangling_spec.rb
+++ b/spec/system/tags/wrangling_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Wrangling tags" do
     end
 
     within(table_titled('Awaiting Review')) do
-      within(find('tr', text: 'Bar Fight', match: :prefer_exact)) { click_button 'Canonical' }
+      within('tr', text: 'Bar Fight', match: :prefer_exact) { click_button 'Canonical' }
     end
 
     expect(page).to have_text('Bar Fight marked canonical.')


### PR DESCRIPTION
Implements [RFC 001: Tag Wrangling Interfaces](doc/rfcs/001-tag-wrangling.md). The RFC is included as a commit, so the specification is reviewable alongside the implementation.

The spoiler design in section 6.3 was **revised after reader feedback** partway through this branch; section 5 below records what changed and why, since the earlier model is what most people saw first.

## 1. Tag graph

Adds `canonical`, `merger_id`, and `unwrangleable` to `tags`. Synonymy is a pointer rather than a table. Chains are one level deep by validation and resolve in a single join.

**`canonical` gates no behaviour.** Search, filtering, autocomplete, and display treat canonical and non-canonical tags identically; the column records that a human has reviewed the tag. `merger_id` is the only column that alters behaviour, and it is set only by an explicit merge.

This invariant is what makes an un-backfilled rollout viable. Every tag begins non-canonical, so the queue initially contains the entire corpus, which is a backlog rather than a defect only while the invariant holds. Any later proposal to gate behaviour on `canonical` must revisit this first.

`merge_as_synonym` re-points every tagging and leaves the superseded tag resolvable. The destructive `merge_with` is retained as an admin-only action, now with a self-merge guard.

## 2. Implication and hierarchy

`Tag::SettingTag` becomes `Tag::MetaTag`, giving `Label` the hierarchy `Setting` already had. No migration was required: `tag_tags` was always generic, and only the model restricted it to Settings.

Cycle-closing edges are rejected by model validation, checked against suggested edges as well as confirmed ones so that confirming a proposal can never create a cycle. Traversal uses a cycle-detecting recursive CTE regardless, so rows predating the validation cannot cause non-termination. The previously unused `tag_tags.suggested` column is adopted as the proposed-but-unconfirmed state and made NOT NULL.

## 3. Roles and scoping

Adds a `WRANGLER` role scoped by `WranglingAssignment(user, setting)`. A Setting is the structural analogue of an AO3 fandom, being the world a post is set in, whereas a Board is a posting venue. Assignments cascade to descendant Settings. Merging two Settings merges the assignments onto the survivor and notifies both wranglers.

Global wrangling, covering cross-setting `Label`s and all `ContentWarning`s, is an admin capability rather than a third role. The permission is named separately from the role holding it, so promotion to a role later is a small change.

Because assignments cascade, editing the hierarchy became privilege-granting: attaching X below Y confers Y's wrangler authority over X. `parent_settings` editing is restricted to wranglers, and the field is hidden from users who cannot use it.

## 4. Spoiler taggings

`spoiler` and `reveal_after_reply_order` are added to `post_tags`, not to `tags`. `Character Death` is not inherently a disclosure; it is a disclosure on a given post.

**A spoiler tagging is one the reader expands.** It renders collapsed inside `%details`/`%summary`, matching the pattern already used for author content warnings at `app/views/posts/show.haml:35`, so it works with no JavaScript. `users.reveal_spoiler_tags` lets a reader opt out of collapsing entirely. Nothing in the feature reads the reader's position in the post.

`reveal_after_reply_order` is **descriptive, not a gate**: it records the reply from which a tag applies and is shown as "from reply N" once revealed. This distinguishes an element running through a whole thread from one arriving late, which flat tagging cannot express.

**`ContentWarning` taggings cannot be spoilered**, enforced by validation. A warning the reader must first discover cannot warn them.

**Spoilered taggings are excluded from tag-to-post listings entirely.** Filtering per viewer would be correct but would make every listing depend on the requesting user's state across every post in the result set. The tradeoff is explicit and warrants review: a spoilered post does not appear under a tag it holds. This is the one part of the feature the client is not trusted with; the API likewise redacts rather than omits, so array lengths continue to describe the post accurately.

## 5. What changed after reader feedback

The first version of this branch gated reveal on reading position: a tagging became visible once the reader passed the reply it described. Readers rejected that, and the RFC and implementation now reflect it:

1. **It served nobody.** A reader avoiding disclosure does not read tags; a reader who wants warnings does. A tag appearing only after the material has been read assists neither.
2. **It leaked by omission.** Auto-revealing after the fact tells the reader something the author did not choose to tell them: if `Character Death` appears and no further tag follows, the reader has learned it happened only once. Withholding a tag until it is redundant converts it into a statement about the rest of the post.
3. **It read as backwards.** "Hidden until you have read far enough" parses naturally as a warning arriving after the content it warns about.

Removing the gate also removed the dependency on `post_views.read_at` and a caveat that came with it, whereby a reader who opened a post while it was short and returned much later resolved to a position they had not reached.

## 6. Tag suggestions

Readers may propose tags on posts they do not own; authors decide. A declined tag is blocked on that post for all users rather than only the original suggester, since per-suggester blocking permits an author to be asked the same question by a succession of readers. Rejection is reversible.

The disclosure risk is not the suggestion but the deduplication response. "That tag is already on this post" discloses a collapsed spoiler tagging; "that tag was already declined" discloses the author's decision. Deduplication is read-state aware and fails open: any collision the suggester is not entitled to observe returns the ordinary confirmation.

Where the collision is a tagging the suggester cannot see, the record is stored as an **endorsement**, requiring no author action. Endorsement is also the correct presentation to the author, since reporting a redundant suggestion would invite the inference that the spoiler tagging had been disclosed.

Suggestions name a tag type and name; an existing tag with that type and name is suggested as that tag. `GalleryGroup` is not offered, as those tags attach to galleries rather than posts.

Authors retain the decision on `ContentWarning` suggestions. Mods cannot override a rejection.

## 7. Testing

- 2916 examples. Coverage 96.08% line, 88.42% branch, against a 95.2 / 88.1 gate.
- Performance regression specs assert query counts rather than wall time, so they fail deterministically: tagging display is constant with respect to tagging count and reads no post-view state, scope resolution is a single recursive query regardless of depth, and reverse lookup filters in SQL.
- System specs cover the wrangling queue, the suggestion round trip, rejection blocking, endorsements, collapsed spoiler tags, and the reader opt-out.
- `spec/spec_helper.rb` honours `CHROME_BIN`, so system specs can run against a Chrome for Testing installation. `shell.nix` already exported the variable; the export was previously inert.

CI is the authority on test status here. Locally, a set of system specs unrelated to this branch (`users/profile_edit`, `replies` multi-editor, `bookmarks/search`) flake under load: they pass in isolation, fail on differing assertions between runs, and failed more often on the base commit than on this branch. Nothing in this diff touches those code paths.

A code review pass over this branch found a set of defects that are fixed here, the most serious being that the reverse-lookup exclusion above was specified and scoped but never actually called, so spoilered posts appeared under their tags; and that accepting a suggested spoiler tag dropped the spoiler flag, leaving spoiler taggings uncreatable from any interface.

## 8. Points for reviewer attention

1. **`permitted_params` in `TagsController` now permits `:name` for wranglers.** Previously admins and the tag creator only, so a wrangler's rename was silently discarded while the flash reported success. `:user_id` is unchanged. This is a permission change beyond the RFC's scope.
2. **A spoilered post does not appear under that tag**, per section 4. Authors should understand they are trading discoverability for non-disclosure.
3. **This branch carries the `shell.nix` Ruby 3.4.10 fix**, which is independent and could land separately. `main` pins 3.4.10 while `shell.nix` provided 3.4.8, so nix-based setup is currently broken on main.
4. The oauth-era migration still declares `ActiveRecord::Migration[5.2]`. Untouched here; worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QXpiZgXgTEjc7DUU9xddD
